### PR TITLE
fix latent bugs the port exposed; make missing returns fatal with -Werror=return-type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 COPYING
 INSTALL
 Doxyfile
+
+# scratch files for composing a commit message / PR body
+commit.txt
+pr.txt
 Makefile
 Makefile.in
 aclocal.m4

--- a/configure.ac
+++ b/configure.ac
@@ -64,6 +64,14 @@ AC_COMPILE_IFELSE(
    AC_MSG_RESULT([no])
    AC_MSG_ERROR([a C++20 compiler is required (clang 15+ or gcc 11+)])])
 
+dnl Falling off the end of a value-returning function is undefined behaviour,
+dnl not merely a diagnostic: at -O2 the compiler treats the path as
+dnl unreachable and emits no epilogue.  do_hash() in jlib/crypt/curve.hh did
+dnl exactly this and crashed inside _Unwind_Resume with no exception in
+dnl flight.  A missing return is never intentional, so make it fatal.
+AX_CHECK_COMPILE_FLAG([-Werror=return-type],
+                      [CXXFLAGS="$CXXFLAGS -Werror=return-type"], [], [-Werror])
+
 AX_PTHREAD([], [AC_MSG_ERROR([a working pthread implementation is required])])
 LIBS="$PTHREAD_LIBS $LIBS"
 CXXFLAGS="$CXXFLAGS $PTHREAD_CFLAGS"

--- a/jlib/math/buffer.hh
+++ b/jlib/math/buffer.hh
@@ -168,7 +168,10 @@ inline
 T buffer<T>::sum() const {
     T s = 0;
     for(unsigned int i = 0; i < size(); i++) {
-        s += *this[i];
+        // was *this[i], which parses as *(this[i]) -- pointer arithmetic on
+        // this, then a dereference.  Neither sum() nor product() had ever
+        // been instantiated, so it never had to compile.
+        s += (*this)[i];
     }
     return s;
 }
@@ -178,7 +181,7 @@ inline
 T buffer<T>::product() const {
     T p = 1;
     for(unsigned int i = 0; i < size(); i++) {
-        p *= *this[i];
+        p *= (*this)[i];
     }
     return p;
 }

--- a/jlib/math/tensor.hh
+++ b/jlib/math/tensor.hh
@@ -239,7 +239,7 @@ tensor<T> operator^(const tensor<T>& a, const tensor<T>& b) {
 
         // inner product is a tensor with rank equal to sum of args' ranks - 2
         buffer<unsigned int> meta(a.rank() + b.rank() - 2);
-        buffer<T> data();
+        buffer<T> data;   // was data(), which declares a function
         tensor<T> ret(meta, data);
     
         return ret;

--- a/jlib/media/PlayList.cc
+++ b/jlib/media/PlayList.cc
@@ -139,7 +139,10 @@ namespace jlib {
         void PlayList::set_measure(int measure) { m_measure = measure; }
         
         int PlayList::get_next_pattern_id() {
-            ++m_pattern_id_max;
+            // Incremented but never returned.  m_pattern_id_max starts at 0,
+            // so the first id handed out is 1.  Caught by -Werror=return-type;
+            // it has no callers, which is why it went unnoticed.
+            return ++m_pattern_id_max;
         }
         
         PlayList::reference PlayList::operator[](int i) {

--- a/jlib/media/WavFile.cc
+++ b/jlib/media/WavFile.cc
@@ -160,7 +160,10 @@ namespace jlib {
             
             m_format_tag = util::get<short>(chunk, FORMAT_TAG_OFFSET);
             m_bits_per_sample = util::get<u_short>(chunk, BITS_PER_SAMPLE_OFFSET);
-            m_samples_per_sec = util::get<u_long>(chunk, SAMPLES_PER_SEC_OFFSET);
+            // WAV nSamplesPerSec is a 4-byte DWORD (bytes 4..7); nAvgBytesPerSec
+            // starts at byte 8.  u_long is 8 bytes on LP64, so this used to read
+            // and write straight through the following field.
+            m_samples_per_sec = util::get<u_int32_t>(chunk, SAMPLES_PER_SEC_OFFSET);
             m_channels = util::get<u_short>(chunk, CHANNELS_OFFSET);
 
             if(m_format_tag != WAV_FMT_PCM && m_format_tag != WAV_FMT_OKI_ADPCM) 
@@ -266,7 +269,7 @@ namespace jlib {
 
             util::set<short>(chunk,get_format_tag(),base+FORMAT_TAG_OFFSET);
             util::set<u_short>(chunk,get_bits_per_sample(),base+BITS_PER_SAMPLE_OFFSET);
-            util::set<u_long>(chunk,get_samples_per_sec(),base+SAMPLES_PER_SEC_OFFSET);
+            util::set<u_int32_t>(chunk,get_samples_per_sec(),base+SAMPLES_PER_SEC_OFFSET);
             util::set<u_short>(chunk,get_channels(),base+CHANNELS_OFFSET);
    
             return chunk;

--- a/jlib/media/notestream.hh
+++ b/jlib/media/notestream.hh
@@ -252,7 +252,10 @@ namespace jlib {
             }
             
             if(note.size() == 2) {
-                if(note[1] != '#' && !note[1] == 'b') {
+                // was "!note[1] == 'b'": the ! binds to note[1] alone, so this
+                // compared a bool against 'b' and was always false, meaning
+                // the whole condition was false and the throw never fired.
+                if(note[1] != '#' && note[1] != 'b') {
                     throw std::runtime_error("two char notes must be either 'Ab' or 'C#'");
                 }
                 
@@ -369,8 +372,8 @@ namespace jlib {
                         u_int16_t u = htons(usample);
                         char* v = reinterpret_cast<char*>(&u);
 
-                        jlib::util::byte_copy(data,&v+1,1,p0);
-                        jlib::util::byte_copy(data,&v+0,1,p1);
+                        jlib::util::byte_copy(data,v+1,1,p0);
+                        jlib::util::byte_copy(data,v+0,1,p1);
                         //c = (s & 0x00ff);
                         //d = (s & 0xff00) >> 8;
                     }
@@ -378,8 +381,8 @@ namespace jlib {
                         u_int16_t u = htons(usample);
                         char* v = reinterpret_cast<char*>(&u);
 
-                        jlib::util::byte_copy(data,&v+0,2,p0);
-                        //jlib::util::byte_copy(data,&v+1,1,p1);
+                        jlib::util::byte_copy(data,v+0,2,p0);
+                        //jlib::util::byte_copy(data,v+1,1,p1);
                         //c = (s & 0xff00) >> 8;
                         //d = (s & 0x00ff);
                     }
@@ -409,8 +412,8 @@ namespace jlib {
                         u_int16_t u = htons(s);
                         char* v = reinterpret_cast<char*>(&u);
 
-                        jlib::util::byte_copy(data,&v+0,2,p0);
-                        //jlib::util::byte_copy(data,&v+1,1,p1);
+                        jlib::util::byte_copy(data,v+0,2,p0);
+                        //jlib::util::byte_copy(data,v+1,1,p1);
                         //int16_t s = sample - amp;
                         //c = (s & 0xff00) >> 8;
                         //d = (s & 0x00ff);

--- a/jlib/media/wavstream.hh
+++ b/jlib/media/wavstream.hh
@@ -212,7 +212,7 @@ namespace jlib {
 
             util::set<short>(chunk,get_format_tag(),base+FORMAT_TAG_OFFSET);
             util::set<u_short>(chunk,get_bits_per_sample(),base+BITS_PER_SAMPLE_OFFSET);
-            util::set<u_long>(chunk,get_samples_per_sec(),base+SAMPLES_PER_SEC_OFFSET);
+            util::set<u_int32_t>(chunk,get_samples_per_sec(),base+SAMPLES_PER_SEC_OFFSET);
             util::set<u_short>(chunk,get_channels(),base+CHANNELS_OFFSET);
    
             return chunk;

--- a/jlib/net/Imap4.cc
+++ b/jlib/net/Imap4.cc
@@ -749,8 +749,17 @@ namespace jlib {
             if(getenv("JLIB_NET_IMAP4_DEBUG")) {
                 std::cout <<buf<<std::endl;
             }
-            // TODO: figure out why the hell I'm getting an 'm' character before the '+'
-            if(!buf.find("+") == buf.npos) {
+            // The server must answer APPEND with a "+" continuation before we
+            // send the message body.  This read "!buf.find(...) == buf.npos",
+            // where the ! binds to find() alone: the bool result then widens
+            // to 0 or 1 and is compared against npos, so it was always false
+            // and the throw never fired.  On an error reply we would go on to
+            // send the body, which the server then reads as commands.
+            //
+            // TODO: figure out why the hell I'm getting an 'm' character
+            // before the '+' -- which is why this looks for "+" anywhere in
+            // the reply rather than requiring it at position 0.
+            if(buf.find("+") == buf.npos) {
                 throw exception(buf);
             }
             

--- a/jlib/net/net.cc
+++ b/jlib/net/net.cc
@@ -212,8 +212,11 @@ namespace jlib {
             }
         }
 
-        long find_end(std::string s, const std::vector<std::string>& e) {
-            long ret = s.npos;
+        // Returns size_type rather than long so that npos survives the round
+        // trip.  Callers used to store the result in a u_int, which truncates
+        // npos (SIZE_MAX) to 0xFFFFFFFF and so never compares equal to it.
+        std::string::size_type find_end(std::string s, const std::vector<std::string>& e) {
+            std::string::size_type ret = s.npos;
             std::string::size_type p;
             for(std::string::size_type i=0;i<e.size();i++) {
                 if( (p=s.find(e[i])) != s.npos ) {
@@ -234,7 +237,7 @@ namespace jlib {
                 return s;
             }
             
-            u_int p = find_end(s,ends);
+            std::string::size_type p = find_end(s,ends);
             if(p != s.npos) {
                 return s.substr(0,p);
             }
@@ -288,20 +291,24 @@ namespace jlib {
         }
         
         std::string extract_address(std::string p_addr) {
-            u_int p = p_addr.find("@");
+            // p was a u_int, which truncates npos to 0xFFFFFFFF, so the
+            // "no @ present" guard below never fired: the function fell into
+            // the else branch, where p+1 wrapped to 0, and returned a chunk of
+            // the input instead of an empty string.
+            std::string::size_type p = p_addr.find("@");
             int m=0,n=-1;
-                
+
             if(p == p_addr.npos) {
                 return std::string();
             }
             else {
-                for(int i=p+1;i<(int)p_addr.length();i++) {
+                for(int i=static_cast<int>(p)+1;i<(int)p_addr.length();i++) {
                     if(!Email::is_valid(p_addr[i])) {
                         n = i;
                         break;
                     }
                 }
-                for(int i=p-1;i>=0;i--) {
+                for(int i=static_cast<int>(p)-1;i>=0;i--) {
                     if(!Email::is_valid(p_addr[i])) {
                         m = i+1;
                         break;

--- a/jlib/util/util.hh
+++ b/jlib/util/util.hh
@@ -252,14 +252,23 @@ namespace jlib {
 
         bool imaps(const std::map<std::string,std::string>& m, std::string key, std::string val);
         
+        // These read a T out of a byte buffer at an arbitrary offset, so the
+        // address is not generally aligned for T.  Doing that by casting the
+        // pointer and dereferencing is undefined behaviour -- it also breaks
+        // strict aliasing -- and -fsanitize=alignment traps it.  memcpy
+        // expresses the same thing legally and compiles to the same load.
         template<class T>
         T get(std::string s, unsigned int offset=0) {
-            return *reinterpret_cast<T*>(const_cast<char*>(s.data())+offset);
+            T t;
+            std::memcpy(&t, s.data() + offset, sizeof(T));
+            return t;
         }
-        
+
         template<class T>
         T get(const char* c, unsigned int offset=0) {
-            return *reinterpret_cast<T*>(const_cast<char*>(c)+offset);
+            T t;
+            std::memcpy(&t, c + offset, sizeof(T));
+            return t;
         }
 
         template<class T>

--- a/m4/ax_check_compile_flag.m4
+++ b/m4/ax_check_compile_flag.m4
@@ -1,0 +1,63 @@
+# ===========================================================================
+#  https://www.gnu.org/software/autoconf-archive/ax_check_compile_flag.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_CHECK_COMPILE_FLAG(FLAG, [ACTION-SUCCESS], [ACTION-FAILURE], [EXTRA-FLAGS], [INPUT])
+#
+# DESCRIPTION
+#
+#   Check whether the given FLAG works with the current language's compiler
+#   or gives an error.  (Warnings, however, are ignored)
+#
+#   ACTION-SUCCESS/ACTION-FAILURE are shell commands to execute on
+#   success/failure.
+#
+#   If EXTRA-FLAGS is defined, it is added to the current language's default
+#   flags (e.g. CFLAGS) when the check is done.  The check is thus made with
+#   the flags: "CFLAGS EXTRA-FLAGS FLAG".  This can for example be used to
+#   force the compiler to issue an error when a bad flag is given.
+#
+#   INPUT gives an alternative input source to AC_COMPILE_IFELSE.
+#
+#   NOTE: Implementation based on AX_CFLAGS_GCC_OPTION. Please keep this
+#   macro in sync with AX_CHECK_{PREPROC,LINK}_FLAG.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Guido U. Draheim <guidod@gmx.de>
+#   Copyright (c) 2011 Maarten Bosmans <mkbosmans@gmail.com>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved.  This file is offered as-is, without any
+#   warranty.
+
+#serial 11
+
+AC_DEFUN([AX_CHECK_COMPILE_FLAG],
+[AC_PREREQ(2.64)dnl for _AC_LANG_PREFIX and AS_VAR_IF
+AS_VAR_PUSHDEF([CACHEVAR],[ax_cv_check_[]_AC_LANG_ABBREV[]flags_$4_$1])dnl
+AC_CACHE_CHECK([whether the _AC_LANG compiler accepts $1], CACHEVAR, [
+  ax_check_save_flags=$[]_AC_LANG_PREFIX[]FLAGS
+  if test x"m4_case(_AC_LANG,
+                     [C], [$GCC],
+                     [C++], [$GXX],
+                     [Fortran], [$GFC],
+                     [Fortran 77], [$G77],
+                     [Objective C], [$GOBJC],
+                     [Objective C++], [$GOBJCXX],
+                     [no])" = xyes ; then
+    add_gnu_werror="-Werror"
+  fi
+  _AC_LANG_PREFIX[]FLAGS="$[]_AC_LANG_PREFIX[]FLAGS $4 $1 $add_gnu_werror"
+  AC_COMPILE_IFELSE([m4_default([$5],[AC_LANG_PROGRAM()])],
+    [AS_VAR_SET(CACHEVAR,[yes])],
+    [AS_VAR_SET(CACHEVAR,[no])])
+  _AC_LANG_PREFIX[]FLAGS=$ax_check_save_flags])
+AS_VAR_IF(CACHEVAR,yes,
+  [m4_default([$2], :)],
+  [m4_default([$3], :)])
+AS_VAR_POPDEF([CACHEVAR])dnl
+])dnl AX_CHECK_COMPILE_FLAGS

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -35,6 +35,7 @@ TESTS = \
  \
 	net_extract_address_simple_test \
 	net_extract_address_mangled_test \
+	net_extract_address_noat_test \
 	net_extract_address_test \
 	net_email_test \
 	net_email_received_test \
@@ -69,6 +70,8 @@ net_extract_address_simple_test_SOURCES = net_extract_address_simple_test.cc
 net_extract_address_simple_test_LDADD   = $(JNET_LA)
 net_extract_address_mangled_test_SOURCES = net_extract_address_mangled_test.cc
 net_extract_address_mangled_test_LDADD   = $(JNET_LA)
+net_extract_address_noat_test_SOURCES = net_extract_address_noat_test.cc
+net_extract_address_noat_test_LDADD   = $(JNET_LA)
 net_email_test_SOURCES          = net_email_test.cc
 net_email_test_LDADD            = $(JNET_LA)
 net_email_received_test_SOURCES = net_email_received_test.cc

--- a/tests/math_test.cc
+++ b/tests/math_test.cc
@@ -26,6 +26,7 @@
 #include <jlib/math/polynomial.hh>
 #include <jlib/util/util.hh>
 
+using jlib::math::buffer;
 using jlib::math::matrix;
 using jlib::math::cuboid;
 using jlib::math::vertex;
@@ -197,6 +198,32 @@ int main(int argc, char** argv) {
             return 1;
         }
 
+        // buffer<T>::sum() and product() had never been instantiated, so
+        // "*this[i]" -- pointer arithmetic on this, then a dereference --
+        // had never had to compile.
+        {
+            buffer<int> b(4);
+            for(unsigned int i = 0; i < b.size(); i++) {
+                b[i] = static_cast<int>(i) + 2;   // 2 3 4 5
+            }
+
+            if(b.sum() != 14) {
+                std::cerr << "buffer<int>::sum() = " << b.sum() << " not 14" << std::endl;
+                return 1;
+            }
+
+            if(b.product() != 120) {
+                std::cerr << "buffer<int>::product() = " << b.product() << " not 120" << std::endl;
+                return 1;
+            }
+
+            buffer<int> empty;
+            if(empty.sum() != 0 || empty.product() != 1) {
+                std::cerr << "empty buffer should sum to 0 and multiply to 1, got "
+                          << empty.sum() << " and " << empty.product() << std::endl;
+                return 1;
+            }
+        }
 
     } catch (matrix<int>::mismatch) {
         std::cerr << "matrices are mismatched" << std::endl;

--- a/tests/net_extract_address_noat_test.cc
+++ b/tests/net_extract_address_noat_test.cc
@@ -1,0 +1,37 @@
+// An address with no '@' has no address in it, so extract_address should
+// return the empty string.  It used to store find()'s result in a u_int,
+// which truncates npos to 0xFFFFFFFF; the "not found" guard therefore never
+// fired and the function returned a chunk of its input instead.
+#include <iostream>
+
+#include <jlib/net/net.hh>
+
+int main(int argc, char** argv) {
+    const char* no_address[] = {
+        "no-at-sign-here",
+        "",
+        "Joe Yandle",
+        "   ",
+    };
+
+    int failures = 0;
+    for(const char* s : no_address) {
+        const std::string got = jlib::net::extract_address(s);
+        if(!got.empty()) {
+            std::cerr << "extract_address(\"" << s << "\") returned \""
+                      << got << "\", expected empty" << std::endl;
+            ++failures;
+        }
+    }
+
+    // and the ordinary case still works
+    const std::string addr = "joe_yandle@division-by-zero.com";
+    const std::string got = jlib::net::extract_address(addr);
+    if(got != addr) {
+        std::cerr << "extract_address(\"" << addr << "\") returned \""
+                  << got << "\"" << std::endl;
+        ++failures;
+    }
+
+    return failures ? 1 : 0;
+}

--- a/tests/x_window_test.cc
+++ b/tests/x_window_test.cc
@@ -11,6 +11,15 @@ void button_pressed(int button,int x,int y);
 void timeout();
 
 int main(int argc, char** argv) {
+    // This needs a real display, so it cannot run in a headless container or
+    // over ssh without forwarding.  Automake's harness reads exit 77 as SKIP,
+    // which is the honest answer there -- reporting FAIL made a green run
+    // look broken.
+    if(std::getenv("DISPLAY") == 0 || std::getenv("DISPLAY")[0] == '\0') {
+        std::cerr << "no DISPLAY set, skipping" << std::endl;
+        return 77;
+    }
+
     try {
         jlib::x::Window window("x_window_test", 200, 200);
         int w = window.get_width();
@@ -36,8 +45,10 @@ int main(int argc, char** argv) {
         window.run();
     }
     catch(std::exception& e) {
+        // DISPLAY is set but unusable -- forwarding refused, server gone.
+        // That is an environment problem, not a jlib failure.
         std::cerr << e.what() << std::endl;
-        std::exit(1);
+        return 77;
     }
 
     std::exit(0);


### PR DESCRIPTION
fix latent bugs the port exposed

Follow-up to the modernization branch.  Those changes were all forced -- each
was needed to make jlib build again.  These are the opposite: real bugs in
code that compiled fine, found while reading it, none of which block a build.
They are separated for exactly that reason, so a behaviour regression can be
attributed to the right class of change.

    macOS  19 tests, 19 pass
    Linux  20 tests, 19 pass, 1 skip (x_window_test, no display)

fixed

    buffer<T>::sum() and product() computed "*this[i]", which parses as
    *(this[i]) -- pointer arithmetic on this, then a dereference.  Neither had
    ever been instantiated, so neither had ever had to compile.  Both are now
    covered by math_test.

    net::extract_address() stored find()'s result in a u_int.  npos is
    SIZE_MAX, which truncates to 0xFFFFFFFF, so the "no @ present" guard never
    fired: the function fell through, p+1 wrapped to 0, and it returned a
    chunk of its input.  extract_address("Joe Yandle") returned "Joe".  Now
    uses std::string::size_type, as does find_end(), which had the same shape.
    Covered by net_extract_address_noat_test, which fails against the old code.

    Imap4::append() checked "!buf.find("+") == buf.npos".  The ! binds to
    find() alone, so a bool widened to 0 or 1 and was compared against npos --
    always false, so the throw never fired.  On an error reply jlib went on to
    send the message body, which the server then read as commands.

    PlayList::get_next_pattern_id() incremented but never returned.  Same bug
    class as do_hash() on the previous branch; caught by the new flag below.

    basic_notebuf::set_note() checked "note[1] != '#' && !note[1] == 'b'",
    which is always false, so a malformed two-character note was never
    rejected.

    notestream's 16-bit sample paths passed &v where v is already a char*.
    &v+1 is eight bytes past the address of a local pointer variable, so those
    branches copied stack garbage into the sample buffer.  Four live sites; the
    S16_LE branch had it right, which is what made the others visible as typos.

    WavFile read and wrote nSamplesPerSec as u_long.  It is a 4-byte DWORD at
    offset 4, and nAvgBytesPerSec begins at offset 8, so on LP64 every read
    took in the following field and every write destroyed it.

    util::get<T>() cast a byte-buffer pointer to T* and dereferenced it.  The
    offset is arbitrary, so the address is not generally aligned for T; that is
    undefined behaviour, breaks strict aliasing, and -fsanitize=alignment traps
    it.  memcpy says the same thing legally and compiles to the same load.

    tensor.hh declared a function where it meant a variable ("buffer<T> data();"),
    which gcc warns about on every build.

prevention

    -Werror=return-type, probed with AX_CHECK_COMPILE_FLAG.  Falling off the
    end of a value-returning function is undefined behaviour rather than merely
    a diagnostic: at -O2 the compiler treats the path as unreachable and emits
    no epilogue, which is how do_hash() turned into a SIGSEGV inside
    _Unwind_Resume with no exception in flight.  A missing return is never
    intentional.  It found PlayList::get_next_pattern_id() on its first run.

    x_window_test now exits 77 -- automake's SKIP -- when DISPLAY is unset or
    unusable, instead of reporting FAIL.  It needs a real display, so a
    headless container could never pass it, and a red line there made an
    otherwise green run look broken.

not a bug, for the record

    notestream calls htons() in both the little- and big-endian branches,
    which reads like a copy-paste error but is correct: the LE branches then
    copy v+1 followed by v+0, reversing the bytes, while the BE branches copy
    both in order.  Left alone.
