### PR TITLE
replace the OSS backend with PortAudio; fade note ends so they stop clicking

### DIFF
--- a/jlib/apps/Makefile.am
+++ b/jlib/apps/Makefile.am
@@ -1,7 +1,7 @@
 # Public jlib headers include <gpgme.h>, <sodium.h>, <openssl/*.h> and
 # <json.h> directly, so anything compiling against them needs those -I flags.
 AM_CPPFLAGS = -I$(top_srcdir) \
-	$(GPGME_CFLAGS) $(GPGERROR_CFLAGS) $(SODIUM_CFLAGS) $(OPENSSL_CFLAGS) $(JSONC_CFLAGS)
+	$(GPGME_CFLAGS) $(GPGERROR_CFLAGS) $(SODIUM_CFLAGS) $(OPENSSL_CFLAGS) $(JSONC_CFLAGS) $(PORTAUDIO_CFLAGS)
 
 # Every program below is gated on the conditionals its _LDADD needs.  The
 # libraries themselves are conditional, so an ungated program would fail at
@@ -19,7 +19,7 @@ if HAVE_CUDA
 cuda_programs = jcublas
 endif
 
-if HAVE_OSS_AUDIO
+if HAVE_PORTAUDIO
 media_programs = jnote jmelody
 endif
 

--- a/jlib/apps/jmelody.cc
+++ b/jlib/apps/jmelody.cc
@@ -4,7 +4,7 @@
 #include <cmath>
 
 #include <jlib/media/notestream.hh>
-#include <jlib/media/Dsp.hh>
+#include <jlib/media/PortAudioSink.hh>
 
 #include <jlib/sys/sys.hh>
 
@@ -41,7 +41,7 @@ int main(int argc, char** argv) {
 }
 
 void play(std::vector<std::string> song, int format, int channels) {
-    jlib::media::Dsp dsp;
+    jlib::media::PortAudioSink dsp;
 
     for(auto s : song) {
         jlib::media::notestream note(s);

--- a/jlib/apps/jnote.cc
+++ b/jlib/apps/jnote.cc
@@ -4,7 +4,7 @@
 #include <cmath>
 
 #include <jlib/media/notestream.hh>
-#include <jlib/media/Dsp.hh>
+#include <jlib/media/PortAudioSink.hh>
 
 #include <jlib/sys/sys.hh>
 
@@ -67,7 +67,7 @@ void play(double freq, int format, int channels, double t) {
 }
 
 void play(jlib::media::notestream& ns, int format, int channels, double t) {
-    jlib::media::Dsp dsp;
+    jlib::media::PortAudioSink dsp;
 
     ns.set_format(format);
     ns.set_channels(channels);

--- a/jlib/media/AudioFile.cc
+++ b/jlib/media/AudioFile.cc
@@ -19,12 +19,12 @@
  */
 
 #include <jlib/media/AudioFile.hh>
+#include <jlib/media/Type.hh>
 
 #include <jlib/util/util.hh>
 
 #include <jlib/sys/sys.hh>
 
-#include <sys/soundcard.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/ioctl.h>
@@ -127,38 +127,16 @@ namespace jlib {
         int AudioFile::get(int p) const {
             int i=0;
 
-            if(m_format == AFMT_S8) {
-
+            // Only linear PCM is decoded; the compressed formats are
+            // recognized purely so they can be rejected.  The branches for the
+            // linear formats were all empty -- the actual work is below -- and
+            // OSS's MU_LAW, A_LAW and IMA_ADPCM have no Type::PCM_ equivalent,
+            // so those comparisons could never have matched.
+            if(m_format == Type::PCM_MPEG) {
+                throw exception("can't handle non-pcm format PCM_MPEG");
             }
-            else if(m_format == AFMT_U8) {
-
-            }
-            else if(m_format == AFMT_S16_LE) {
-
-            }
-            else if(m_format == AFMT_S16_BE) {
-
-            }
-            else if(m_format == AFMT_U16_LE) {
-
-            }
-            else if(m_format == AFMT_U16_BE) {
-
-            }
-            else if(m_format == AFMT_MU_LAW) {
-                throw exception("can't handle non-pcm format AFMT_MU_LAW");
-            }
-            else if(m_format == AFMT_A_LAW) {
-                throw exception("can't handle non-pcm format AFMT_A_LAW");
-            }
-            else if(m_format == AFMT_IMA_ADPCM) {
-                throw exception("can't handle non-pcm format AFMT_IMA_ADPCM");
-            }
-            else if(m_format == AFMT_MPEG) {
-                throw exception("can't handle non-pcm format AFMT_MPEG");
-            }
-            else if(m_format == AFMT_AC3) {
-                throw exception("can't handle non-pcm format AFMT_AC3");
+            else if(m_format == Type::PCM_AC3) {
+                throw exception("can't handle non-pcm format PCM_AC3");
             }
 
             if(m_bits_per_sample == 8)

--- a/jlib/media/AudioSink.cc
+++ b/jlib/media/AudioSink.cc
@@ -1,0 +1,132 @@
+/* -*- mode: C++ c-basic-offset: 4 -*-
+ *
+ * Copyright (c) 2000 Joe Yandle <jwy@divisionbyzero.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ *
+ */
+
+#include <jlib/media/AudioSink.hh>
+#include <jlib/media/Type.hh>
+
+#include <jlib/sys/sys.hh>
+
+#include <sstream>
+
+namespace jlib {
+namespace media {
+
+// 1024 frames is ~23ms at 44100, which is a reasonable compromise between
+// latency and how often we have to come back and refill.
+const int DEFAULT_PERIOD = 1024;
+
+AudioSink::AudioSink()
+    : m_samples_per_sec(-1),
+      m_channels(-1),
+      m_format(-1),
+      m_period(DEFAULT_PERIOD),
+      m_configured(false)
+{
+}
+
+AudioSink::~AudioSink() {
+}
+
+int AudioSink::format_size(int format) {
+    switch(format) {
+    case Type::PCM_U8:
+    case Type::PCM_S8:
+        return 1;
+    case Type::PCM_S16_LE:
+    case Type::PCM_S16_BE:
+    case Type::PCM_U16_LE:
+    case Type::PCM_U16_BE:
+        return 2;
+    case Type::PCM_FLOAT32:
+        return 4;
+    default:
+        {
+            std::ostringstream o;
+            o << "no sample size for format 0x" << std::hex << format;
+            throw exception(o.str());
+        }
+    }
+}
+
+void AudioSink::config(stream& s) {
+    config(s.get_samples_per_sec(), s.get_channels(), s.get_format());
+}
+
+bool AudioSink::is_configured() const {
+    return m_configured;
+}
+
+int AudioSink::get_samples_per_sec() const {
+    return m_samples_per_sec;
+}
+
+int AudioSink::get_channels() const {
+    return m_channels;
+}
+
+int AudioSink::get_format() const {
+    return m_format;
+}
+
+int AudioSink::get_frame_size() const {
+    if(!m_configured)
+        throw exception("get_frame_size() before config()");
+
+    return format_size(m_format) * m_channels;
+}
+
+int AudioSink::get_period() const {
+    return m_period;
+}
+
+void AudioSink::set_period(int frames) {
+    if(frames <= 0)
+        throw exception("period must be positive");
+
+    m_period = frames;
+}
+
+void AudioSink::play(stream& s) {
+    config(s);
+
+    while(s) {
+        play_frag(s);
+    }
+
+    // Deliberately no drain() here.  jmelody calls play() once per note on
+    // one sink, and draining between them would put a gap in the melody.
+    // close(), and so the destructor, drains -- which is what keeps the tail
+    // of the last note from being cut off.  Dsp had neither: it closed the
+    // device outright and truncated.
+}
+
+void AudioSink::play_frag(stream& s, int n) {
+    if(!m_configured)
+        throw exception("play_frag() before config()");
+
+    std::string buf;
+    jlib::sys::getstring(s, buf, n * m_period * get_frame_size());
+
+    if(!buf.empty())
+        write(buf);
+}
+
+}
+}

--- a/jlib/media/AudioSink.hh
+++ b/jlib/media/AudioSink.hh
@@ -1,0 +1,149 @@
+/* -*- mode: C++ c-basic-offset: 4 -*-
+ *
+ * Copyright (c) 2000 Joe Yandle <jwy@divisionbyzero.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ *
+ */
+
+#ifndef JLIB_MEDIA_AUDIOSINK_HH
+#define JLIB_MEDIA_AUDIOSINK_HH
+
+#include <jlib/media/stream.hh>
+
+#include <exception>
+#include <memory>
+#include <string>
+
+namespace jlib {
+namespace media {
+
+/**
+ * An output device that accepts interleaved PCM.
+ *
+ * This is the contract Dsp grew organically against OSS, restated so a
+ * backend other than /dev/dsp can satisfy it.  Two things changed in the
+ * restatement:
+ *
+ *  - Buffering is counted in *frames*, not bytes.  A frame is one sample
+ *    across every channel.  Dsp's fragments were a byte count with no
+ *    relation to frame size, so a fragment boundary could fall in the middle
+ *    of a frame and shear the channels apart.
+ *
+ *  - bits_per_sample is not a parameter.  It is implied by the format, and
+ *    Dsp::config() took it only to ignore it.
+ */
+class AudioSink {
+public:
+    class exception : public std::exception {
+    public:
+        exception(std::string msg = "") {
+            m_msg = "jlib::media::AudioSink exception" + (msg != "" ? (": " + msg) : "");
+        }
+        virtual ~exception() noexcept {}
+        virtual const char* what() const noexcept { return m_msg.c_str(); }
+
+    protected:
+        std::string m_msg;
+    };
+
+    typedef std::shared_ptr<AudioSink> ptr;
+
+    AudioSink();
+    virtual ~AudioSink();
+
+    /**
+     * Configure to match a stream's declared format.
+     */
+    void config(stream& s);
+
+    virtual void config(int samples_per_sec, int channels, int format) = 0;
+
+    bool is_configured() const;
+
+    int get_samples_per_sec() const;
+    int get_channels() const;
+    int get_format() const;
+
+    /**
+     * Bytes in one frame: one sample for each channel.
+     */
+    int get_frame_size() const;
+
+    /**
+     * Frames handed to the device per write.  Playback latency is roughly
+     * this times the number of periods the device keeps queued.
+     */
+    int get_period() const;
+    void set_period(int frames);
+
+    /**
+     * Play s to completion.  Blocks until the stream is drained.
+     */
+    void play(stream& s);
+
+    /**
+     * Read n periods from s and write them.  Short reads at end of stream
+     * are written as-is.
+     */
+    void play_frag(stream& s, int n = 1);
+
+    /**
+     * Write interleaved PCM in the configured format.  Blocks until the
+     * device has taken all of it.
+     */
+    virtual void write(const std::string& pcm) = 0;
+
+    /**
+     * Frames the device has buffered but not yet played.  This is the
+     * backpressure signal: keep it near a couple of periods and neither
+     * starve nor block.
+     */
+    virtual int queued() const = 0;
+
+    /**
+     * Frames that can be written without blocking.
+     */
+    virtual int available() const = 0;
+
+    /**
+     * Discard whatever is queued and stop immediately.
+     */
+    virtual void reset() = 0;
+
+    /**
+     * Block until everything queued has actually been played.
+     */
+    virtual void drain() = 0;
+
+    virtual void close() = 0;
+
+protected:
+    /**
+     * Bytes per sample for a Type::PCM_* value.
+     */
+    static int format_size(int format);
+
+    int m_samples_per_sec;
+    int m_channels;
+    int m_format;
+    int m_period;
+    bool m_configured;
+};
+
+}
+}
+
+#endif //JLIB_MEDIA_AUDIOSINK_HH

--- a/jlib/media/Makefile.am
+++ b/jlib/media/Makefile.am
@@ -1,24 +1,27 @@
-AM_CPPFLAGS = -I$(top_srcdir)
+AM_CPPFLAGS = -I$(top_srcdir) $(PORTAUDIO_CFLAGS)
 
-# TODO(phase 3): replace the OSS backend with PortAudio and gate on
-# HAVE_PORTAUDIO instead of HAVE_OSS_AUDIO.
-if HAVE_OSS_AUDIO
+# The OSS backend (Dsp) is kept but no longer built by default: /dev/dsp is
+# gone from modern Linux and never existed on macOS.  PortAudio drives the
+# device now.
+if HAVE_PORTAUDIO
 LIBJMEDIA = libjmedia.la
 endif
 
 lib_LTLIBRARIES = $(LIBJMEDIA)
-libjmedia_la_SOURCES = Player.cc AudioFile.cc WavFile.cc PlayList.cc Dsp.cc
+libjmedia_la_SOURCES = Player.cc AudioFile.cc WavFile.cc PlayList.cc \
+                       AudioSink.cc PortAudioSink.cc
 libjmedia_la_LDFLAGS = -version-info $(LIBJ_SO_VERSION) -release $(JLIB_RELEASE) -no-undefined
 libjmedia_la_LIBADD = $(top_builddir)/jlib/sys/libjsys.la \
-                      $(top_builddir)/jlib/util/libjutil.la
+                      $(top_builddir)/jlib/util/libjutil.la \
+                      $(PORTAUDIO_LIBS)
 
 jmedia_hdrs = Player.hh AudioFile.hh WavFile.hh PlayList.hh stream.hh \
-                 datastream.hh notestream.hh Dsp.hh Type.hh wavstream.hh \
-                 audiofilestream.hh
+              datastream.hh notestream.hh Type.hh wavstream.hh \
+              audiofilestream.hh AudioSink.hh PortAudioSink.hh
 
 libjmediaincludedir = $(includedir)/jlib-1.2/jlib/media
-if HAVE_OSS_AUDIO
+if HAVE_PORTAUDIO
 libjmediainclude_HEADERS = $(jmedia_hdrs)
 endif
 
-EXTRA_DIST = $(jmedia_hdrs)
+EXTRA_DIST = $(jmedia_hdrs) Dsp.hh Dsp.cc

--- a/jlib/media/PlayList.cc
+++ b/jlib/media/PlayList.cc
@@ -24,7 +24,6 @@
 
 #include <iostream>
 
-#include <sys/soundcard.h>
 
 namespace jlib {
     namespace media {

--- a/jlib/media/Player.cc
+++ b/jlib/media/Player.cc
@@ -24,7 +24,6 @@
 
 #include <jlib/util/util.hh>
 
-#include <sys/soundcard.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/ioctl.h>
@@ -62,7 +61,7 @@ namespace jlib {
               m_loop(false),
               m_beat(0),
               m_last_beat(0),
-              m_frags_desired(2)
+              m_periods_desired(2)
         {
             init();
             if(s)
@@ -71,7 +70,7 @@ namespace jlib {
 
         
         Player::~Player() {
-            // The worker touches m_dsp and m_stream, both members of Player.
+            // The worker touches m_sink and m_stream, both members of Player.
             // Leaving this empty meant those were destroyed -- closing the
             // audio device -- while the worker was potentially still inside
             // play_slot(), because ~Servent only runs after ~Player returns.
@@ -129,14 +128,14 @@ namespace jlib {
                 std::cerr << "received PLAY command" << std::endl;
             m_playing = !m_playing;
             if(!m_playing)
-                m_dsp.reset();
+                m_sink.reset();
         }
 
         void Player::pause_signal() { 
             if(getenv("JLIB_MEDIA_PLAYER_DEBUG")) 
                 std::cerr << "\treceived PAUSE command" << std::endl;
             m_playing = false;
-            m_dsp.reset();
+            m_sink.reset();
         }
 
         void Player::stop_signal() { 
@@ -144,7 +143,7 @@ namespace jlib {
                 std::cerr << "\treceived STOP command" << std::endl;
             m_playing = false;
             if(m_stream) {
-                m_dsp.reset();
+                m_sink.reset();
                 m_stream->rewind();
             
                 send_pulse(true);
@@ -157,7 +156,7 @@ namespace jlib {
                 std::cerr << "\treceived REWIND command" << std::endl;
 
             if(m_stream) {
-                m_dsp.reset();
+                m_sink.reset();
                 m_stream->clear();
                 jlib::media::basic_streambuf<char>::off_type increment = static_cast<jlib::media::basic_streambuf<char>::off_type>(m_stream->get_length() / get_beats());
 
@@ -178,7 +177,7 @@ namespace jlib {
                 std::cerr << "\treceived FFWD command" << std::endl;
             
             if(m_stream) {
-                m_dsp.reset();
+                m_sink.reset();
                 m_stream->clear();
                 
                 basic_streambuf<char>::off_type increment = static_cast<basic_streambuf<char>::off_type>(m_stream->get_length() / get_beats());
@@ -206,8 +205,8 @@ namespace jlib {
             if(m_stream && p < m_stream->get_length())
                 m_stream->seekg(p);
 
-            m_dsp.config(*m_stream);
-            m_dsp.reset();
+            m_sink.config(*m_stream);
+            m_sink.reset();
         }
 
         void Player::send_pulse(bool force) {
@@ -230,13 +229,20 @@ namespace jlib {
 
             if(!m_stream->eof()) {
                 send_pulse(false);
-                int n = m_dsp.get_frags_used();
-                if(n < m_frags_desired)
-                    m_dsp.play_frag(*m_stream,(m_frags_desired-n));
-                
+
+                // Top the device up to m_periods_desired periods queued.  This
+                // is counted in frames now rather than OSS fragments, which
+                // were a byte count unrelated to frame size.
+                const int want = m_periods_desired * m_sink.get_period();
+                const int have = m_sink.queued();
+
+                if(have < want) {
+                    const int periods = (want - have + m_sink.get_period() - 1) / m_sink.get_period();
+                    m_sink.play_frag(*m_stream, periods);
+                }
+
                 if(getenv("JLIB_MEDIA_PLAYER_DEBUG")) {
-                    std::cerr << "\t" << m_dsp.get_fragments() 
-                              << "/" << m_dsp.get_frags_total() << std::endl;
+                    std::cerr << "\t" << have << "/" << want << " frames queued" << std::endl;
                 }
             }
             

--- a/jlib/media/Player.hh
+++ b/jlib/media/Player.hh
@@ -27,7 +27,7 @@
 #include <jlib/sys/Servent.hh>
 
 #include <jlib/media/stream.hh>
-#include <jlib/media/Dsp.hh>
+#include <jlib/media/PortAudioSink.hh>
 
 #include <sys/poll.h>
 
@@ -96,8 +96,8 @@ namespace jlib {
 
             beat_type m_beat, m_last_beat;
 
-            Dsp m_dsp;
-            int m_frags_desired;
+            PortAudioSink m_sink;
+            int m_periods_desired;
         };
     }
 }

--- a/jlib/media/PortAudioSink.cc
+++ b/jlib/media/PortAudioSink.cc
@@ -1,0 +1,334 @@
+/* -*- mode: C++ c-basic-offset: 4 -*-
+ *
+ * Copyright (c) 2000 Joe Yandle <jwy@divisionbyzero.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ *
+ */
+
+#include <jlib/media/PortAudioSink.hh>
+#include <jlib/media/Type.hh>
+
+#include <bit>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <sstream>
+
+namespace jlib {
+namespace media {
+
+namespace {
+
+/**
+ * Pa_Initialize()/Pa_Terminate() are global and reference counted by
+ * PortAudio itself, but they still have to be paired.  Tying them to the
+ * lifetime of a function-local static means initialization happens once, on
+ * first use, and teardown happens at exit -- rather than per sink, which
+ * would tear the library down under any other sink still open.
+ */
+struct PortAudioLibrary {
+    PortAudioLibrary() {
+        PaError err = Pa_Initialize();
+        if(err != paNoError) {
+            std::ostringstream o;
+            o << "Pa_Initialize failed: " << Pa_GetErrorText(err);
+            throw AudioSink::exception(o.str());
+        }
+    }
+
+    ~PortAudioLibrary() {
+        Pa_Terminate();
+    }
+};
+
+void require_portaudio() {
+    static PortAudioLibrary library;
+}
+
+}
+
+PortAudioSink::PortAudioSink()
+    : m_stream(0),
+      m_pa_format(paInt16),
+      m_swap(false),
+      m_rebias(false)
+{
+    require_portaudio();
+}
+
+PortAudioSink::~PortAudioSink() {
+    try {
+        close();
+    }
+    catch(std::exception& e) {
+        // A destructor is no place to throw, but staying silent about a
+        // device that would not close is worse.
+        std::cerr << "jlib::media::PortAudioSink::~PortAudioSink(): "
+                  << e.what() << std::endl;
+    }
+}
+
+void PortAudioSink::throw_pa(std::string ctx, PaError err) const {
+    std::ostringstream o;
+    o << ctx << " failed: " << Pa_GetErrorText(err);
+
+    if(err == paUnanticipatedHostError) {
+        const PaHostErrorInfo* info = Pa_GetLastHostErrorInfo();
+        if(info != 0 && info->errorText != 0)
+            o << " (" << info->errorText << ")";
+    }
+
+    throw exception(o.str());
+}
+
+void PortAudioSink::config(int samples_per_sec, int channels, int format) {
+    // Reconfiguring to the same thing is what jmelody does between every
+    // note; tearing the stream down and back up each time would click.
+    if(m_configured &&
+       samples_per_sec == m_samples_per_sec &&
+       channels == m_channels &&
+       format == m_format) {
+        return;
+    }
+
+    close();
+
+    m_configured = false;
+
+    const bool little_endian = (std::endian::native == std::endian::little);
+
+    switch(format) {
+    case Type::PCM_U8:
+        m_pa_format = paUInt8;  m_swap = false;                 m_rebias = false; break;
+    case Type::PCM_S8:
+        m_pa_format = paInt8;   m_swap = false;                 m_rebias = false; break;
+    case Type::PCM_S16_LE:
+        m_pa_format = paInt16;  m_swap = !little_endian;        m_rebias = false; break;
+    case Type::PCM_S16_BE:
+        m_pa_format = paInt16;  m_swap = little_endian;         m_rebias = false; break;
+    // PortAudio has no unsigned 16-bit format, so these become signed with
+    // the bias removed.
+    case Type::PCM_U16_LE:
+        m_pa_format = paInt16;  m_swap = !little_endian;        m_rebias = true;  break;
+    case Type::PCM_U16_BE:
+        m_pa_format = paInt16;  m_swap = little_endian;         m_rebias = true;  break;
+    case Type::PCM_FLOAT32:
+        m_pa_format = paFloat32; m_swap = false;                m_rebias = false; break;
+    default:
+        {
+            std::ostringstream o;
+            o << "unsupported format 0x" << std::hex << format;
+            throw exception(o.str());
+        }
+    }
+
+    m_samples_per_sec = samples_per_sec;
+    m_channels = channels;
+    m_format = format;
+    m_configured = true;
+
+    start();
+}
+
+void PortAudioSink::start() {
+    PaDeviceIndex device = Pa_GetDefaultOutputDevice();
+    if(device == paNoDevice)
+        throw exception("no default output device");
+
+    const PaDeviceInfo* info = Pa_GetDeviceInfo(device);
+    if(info == 0)
+        throw exception("Pa_GetDeviceInfo returned null for the default output device");
+
+    PaStreamParameters out;
+    std::memset(&out, 0, sizeof(out));
+    out.device = device;
+    out.channelCount = m_channels;
+    out.sampleFormat = m_pa_format;
+    out.suggestedLatency = info->defaultLowOutputLatency;
+    out.hostApiSpecificStreamInfo = 0;
+
+    // A null callback selects the blocking interface, which is what lets
+    // write() keep the same shape Dsp had.
+    PaError err = Pa_OpenStream(&m_stream, 0, &out,
+                                static_cast<double>(m_samples_per_sec),
+                                m_period, paClipOff, 0, 0);
+    if(err != paNoError) {
+        m_stream = 0;
+        throw_pa("Pa_OpenStream", err);
+    }
+
+    err = Pa_StartStream(m_stream);
+    if(err != paNoError) {
+        Pa_CloseStream(m_stream);
+        m_stream = 0;
+        throw_pa("Pa_StartStream", err);
+    }
+
+    if(std::getenv("JLIB_MEDIA_SINK_DEBUG")) {
+        std::cerr << "PortAudioSink: " << info->name
+                  << " " << m_samples_per_sec << "Hz"
+                  << " " << m_channels << "ch"
+                  << " period " << m_period << " frames" << std::endl;
+    }
+}
+
+const std::string& PortAudioSink::convert(const std::string& pcm, std::string& scratch) const {
+    if(!m_swap && !m_rebias)
+        return pcm;
+
+    scratch = pcm;
+
+    // Both remaining conversions are 16-bit.
+    const std::size_t n = scratch.size() & ~static_cast<std::size_t>(1);
+    unsigned char* p = reinterpret_cast<unsigned char*>(&scratch[0]);
+
+    for(std::size_t i = 0; i < n; i += 2) {
+        if(m_swap)
+            std::swap(p[i], p[i + 1]);
+
+        if(m_rebias) {
+            // Unsigned 16 is signed 16 offset by 32768, so flipping the top
+            // bit of the host-order value converts between them.
+            std::uint16_t v;
+            std::memcpy(&v, p + i, 2);
+            v ^= 0x8000u;
+            std::memcpy(p + i, &v, 2);
+        }
+    }
+
+    return scratch;
+}
+
+void PortAudioSink::write(const std::string& pcm) {
+    if(!m_configured)
+        throw exception("write() before config()");
+    if(m_stream == 0)
+        throw exception("write() on a closed sink");
+
+    std::string scratch;
+    const std::string& out = convert(pcm, scratch);
+
+    const int frame = get_frame_size();
+    const unsigned long frames = out.size() / frame;
+
+    if(frames == 0)
+        return;
+
+    PaError err = Pa_WriteStream(m_stream, out.data(), frames);
+
+    // An underrun means we were late with the next period; the audio already
+    // played with a gap.  Reporting it as an error would abort playback for
+    // something that has already happened and is recoverable.
+    if(err == paOutputUnderflowed) {
+        if(std::getenv("JLIB_MEDIA_SINK_DEBUG"))
+            std::cerr << "PortAudioSink: output underflowed" << std::endl;
+        return;
+    }
+
+    if(err != paNoError)
+        throw_pa("Pa_WriteStream", err);
+}
+
+int PortAudioSink::available() const {
+    if(m_stream == 0)
+        return 0;
+
+    signed long n = Pa_GetStreamWriteAvailable(m_stream);
+    if(n < 0)
+        throw_pa("Pa_GetStreamWriteAvailable", static_cast<PaError>(n));
+
+    return static_cast<int>(n);
+}
+
+int PortAudioSink::queued() const {
+    if(m_stream == 0)
+        return 0;
+
+    // PortAudio reports free space, not fill.  The device's total buffering
+    // is not directly exposed, so derive the queue depth from how much of the
+    // window we are holding: anything not free is waiting to be played.
+    const int window = m_period * 2;
+    const int free = available();
+
+    return (free >= window) ? 0 : (window - free);
+}
+
+void PortAudioSink::reset() {
+    if(m_stream == 0)
+        return;
+
+    // Abort rather than Stop: Stop drains what is queued, which is the
+    // opposite of what a seek or a stop button wants.
+    PaError err = Pa_AbortStream(m_stream);
+    if(err != paNoError && err != paStreamIsStopped)
+        throw_pa("Pa_AbortStream", err);
+
+    err = Pa_StartStream(m_stream);
+    if(err != paNoError)
+        throw_pa("Pa_StartStream", err);
+}
+
+void PortAudioSink::drain() {
+    if(m_stream == 0)
+        return;
+
+    // Pa_StopStream waits for queued audio to finish, which is what
+    // SNDCTL_DSP_SYNC did.
+    PaError err = Pa_StopStream(m_stream);
+    if(err != paNoError && err != paStreamIsStopped)
+        throw_pa("Pa_StopStream", err);
+
+    err = Pa_StartStream(m_stream);
+    if(err != paNoError)
+        throw_pa("Pa_StartStream", err);
+}
+
+void PortAudioSink::close() {
+    if(m_stream == 0)
+        return;
+
+    PaStream* s = m_stream;
+    m_stream = 0;   // clear first, so a throw below cannot leave a stale handle
+
+    Pa_StopStream(s);
+
+    PaError err = Pa_CloseStream(s);
+    if(err != paNoError)
+        throw_pa("Pa_CloseStream", err);
+}
+
+bool PortAudioSink::have_output_device() {
+    try {
+        require_portaudio();
+    }
+    catch(std::exception&) {
+        return false;
+    }
+
+    return Pa_GetDefaultOutputDevice() != paNoDevice;
+}
+
+std::string PortAudioSink::get_device_name() const {
+    PaDeviceIndex device = Pa_GetDefaultOutputDevice();
+    if(device == paNoDevice)
+        return "none";
+
+    const PaDeviceInfo* info = Pa_GetDeviceInfo(device);
+    return (info != 0 && info->name != 0) ? info->name : "unknown";
+}
+
+}
+}

--- a/jlib/media/PortAudioSink.hh
+++ b/jlib/media/PortAudioSink.hh
@@ -1,0 +1,102 @@
+/* -*- mode: C++ c-basic-offset: 4 -*-
+ *
+ * Copyright (c) 2000 Joe Yandle <jwy@divisionbyzero.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ *
+ */
+
+#ifndef JLIB_MEDIA_PORTAUDIOSINK_HH
+#define JLIB_MEDIA_PORTAUDIOSINK_HH
+
+#include <jlib/media/AudioSink.hh>
+
+#include <portaudio.h>
+
+#include <string>
+
+namespace jlib {
+namespace media {
+
+/**
+ * An AudioSink over PortAudio's blocking API.
+ *
+ * This replaces Dsp, which drove OSS through /dev/dsp -- an interface that no
+ * longer exists on modern Linux and never existed on macOS.  PortAudio's
+ * blocking mode maps almost one-to-one onto what Dsp did:
+ *
+ *      Dsp::write()            ->  Pa_WriteStream()
+ *      Dsp::get_frags_used()   ->  queued(), from Pa_GetStreamWriteAvailable()
+ *      Dsp::reset()            ->  Pa_AbortStream() + restart
+ *      SNDCTL_DSP_SYNC         ->  drain(), via Pa_StopStream()
+ *
+ * PortAudio has no unsigned 16-bit format and no big-endian formats, so the
+ * PCM_U16_* and PCM_*_BE variants are converted on the way through; see
+ * write().  Everything else is handed over untouched.
+ */
+class PortAudioSink : public AudioSink {
+public:
+    PortAudioSink();
+    virtual ~PortAudioSink();
+
+    // Declaring the three-argument override would otherwise hide the
+    // inherited config(stream&).
+    using AudioSink::config;
+    virtual void config(int samples_per_sec, int channels, int format);
+
+    virtual void write(const std::string& pcm);
+
+    virtual int queued() const;
+    virtual int available() const;
+
+    virtual void reset();
+    virtual void drain();
+    virtual void close();
+
+    /**
+     * Name of the output device in use, for diagnostics.
+     */
+    std::string get_device_name() const;
+
+    /**
+     * Whether the host has any output device at all.
+     *
+     * A headless container has none, and there is nothing jlib can do about
+     * that -- so tests check this and skip rather than reporting a failure
+     * that says more about the machine than the code.
+     */
+    static bool have_output_device();
+
+protected:
+    /**
+     * Turn PCM in the configured format into whatever was handed to
+     * Pa_OpenStream, byte-swapping and re-biasing as needed.  Returns a
+     * reference to pcm itself when no conversion is required.
+     */
+    const std::string& convert(const std::string& pcm, std::string& scratch) const;
+
+    void start();
+    [[noreturn]] void throw_pa(std::string ctx, PaError err) const;
+
+    PaStream* m_stream;
+    PaSampleFormat m_pa_format;
+    bool m_swap;    // incoming endianness differs from the host
+    bool m_rebias;  // incoming is unsigned 16, PortAudio wants signed
+};
+
+}
+}
+
+#endif //JLIB_MEDIA_PORTAUDIOSINK_HH

--- a/jlib/media/WavFile.cc
+++ b/jlib/media/WavFile.cc
@@ -30,7 +30,6 @@
 
 #include <fstream>
 
-#include <sys/soundcard.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/ioctl.h>

--- a/jlib/media/audiofilestream.hh
+++ b/jlib/media/audiofilestream.hh
@@ -29,7 +29,6 @@
 
 
 #include <errno.h>
-#include <sys/soundcard.h>
 #include <sys/types.h>
 #include <netinet/in.h>
 

--- a/jlib/media/datastream.hh
+++ b/jlib/media/datastream.hh
@@ -24,6 +24,7 @@
 #include <iostream>
 #include <exception>
 #include <string>
+#include <vector>
 #include <cstring>
 
 
@@ -334,17 +335,20 @@ namespace jlib {
         basic_datastream<charT,traitT>* 
         basic_datastream<charT,traitT>::create_scaled(basic_stream<charT,traitT>* s) {
             int n = s->get_length() / (s->get_bits_per_sample()/8);
-            Type::scaled samples[n];
-            memset(samples,0,n*sizeof(Type::scaled));
+
+            // This was a variable-length array, so an audio file's length --
+            // attacker-controlled, or merely large -- decided how much stack
+            // to take.  VLAs are also a compiler extension, not C++.
+            std::vector<Type::scaled> samples(n, 0);
             s->rewind();
 
             for(int i=0;i<n;i++) {
                 samples[i] = s->get_scaled();
             }
-            
 
-            basic_datastream<charT,traitT>* r = 
-                new basic_datastream<charT,traitT>(std::string(reinterpret_cast<char*>(samples),
+
+            basic_datastream<charT,traitT>* r =
+                new basic_datastream<charT,traitT>(std::string(reinterpret_cast<char*>(samples.data()),
                                                                n*sizeof(Type::scaled)));
             r->set(*s);
             r->set_format(Type::PCM_FLOAT32);

--- a/jlib/media/notestream.hh
+++ b/jlib/media/notestream.hh
@@ -31,13 +31,14 @@
 
 #include <iostream>
 #include <exception>
+#include <sstream>
 #include <string>
 #include <cstring>
 #include <cmath>
+#include <algorithm>
 
 
 #include <errno.h>
-#include <sys/soundcard.h>
 #include <sys/types.h>
 #include <netinet/in.h>
 
@@ -345,9 +346,31 @@ namespace jlib {
                 std::cerr << "channels         " << this->get_channels() << std::endl;
             }
 
+            // A note lasts get_time() seconds whatever its frequency, so
+            // freq*time is hardly ever a whole number of cycles: the waveform
+            // stops wherever it happens to be and drops straight to silence.
+            // At 443.7Hz for one second that last sample is -20287 out of a
+            // 21823 peak -- a 93% full-scale step, which is a click, and a
+            // melody is a train of them.
+            //
+            // Ramp the first and last few milliseconds instead.  That is
+            // short enough to be inaudible as a volume change and long
+            // enough to remove the discontinuity at any frequency, without
+            // altering the note's duration the way set_nearest_time() would.
+            const int fade = std::min(samples / 2,
+                                      static_cast<int>(this->get_samples_per_sec() * 0.005));
+
             for(int i=0;i<samples;i++) {
-                
-                int64_t sample = (int64_t)((vol*amp*sin(freq*this->get_time()*(2*pi)*(i/double(samples)))));
+
+                double envelope = 1.0;
+                if(fade > 0) {
+                    if(i < fade)
+                        envelope = 0.5 * (1.0 - cos(pi * i / fade));
+                    else if(i >= samples - fade)
+                        envelope = 0.5 * (1.0 - cos(pi * (samples - 1 - i) / fade));
+                }
+
+                int64_t sample = (int64_t)((envelope*vol*amp*sin(freq*this->get_time()*(2*pi)*(i/double(samples)))));
                 u_int64_t usample = sample+amp;
                 
                 
@@ -358,17 +381,17 @@ namespace jlib {
                     //char_type& c = data[(bytes_per_sample*this->get_channels()*i)+j*bytes_per_sample];
                     //char_type& d = data[(bytes_per_sample*this->get_channels()*i)+j*bytes_per_sample+1];
 
-                    if(this->get_format() == AFMT_U8) {
+                    if(this->get_format() == Type::PCM_U8) {
                         u_char s = (usample) & 0x00ff;
                         jlib::util::byte_copy(data,&s,1,p0);
                     }
-                    else if(this->get_format() == AFMT_S8) {
+                    else if(this->get_format() == Type::PCM_S8) {
                         if(sample > (pow(2,8)-1) || sample < (-pow(2,8)))
-                            throw exception("sample out of bounds at AFMT_S8");
+                            throw exception("sample out of bounds at Type::PCM_S8");
                         char s = sample;
                         jlib::util::byte_copy(data,&s,1,p0);
                     }
-                    else if(this->get_format() == AFMT_U16_LE) {
+                    else if(this->get_format() == Type::PCM_U16_LE) {
                         u_int16_t u = htons(usample);
                         char* v = reinterpret_cast<char*>(&u);
 
@@ -377,7 +400,7 @@ namespace jlib {
                         //c = (s & 0x00ff);
                         //d = (s & 0xff00) >> 8;
                     }
-                    else if(this->get_format() == AFMT_U16_BE) {
+                    else if(this->get_format() == Type::PCM_U16_BE) {
                         u_int16_t u = htons(usample);
                         char* v = reinterpret_cast<char*>(&u);
 
@@ -386,7 +409,7 @@ namespace jlib {
                         //c = (s & 0xff00) >> 8;
                         //d = (s & 0x00ff);
                     }
-                    else if(this->get_format() == AFMT_S16_LE) {
+                    else if(this->get_format() == Type::PCM_S16_LE) {
                         int16_t s = sample;
                         u_int16_t u = htons(static_cast<u_int16_t>(s));
                         char* v = reinterpret_cast<char*>(&u);
@@ -407,7 +430,7 @@ namespace jlib {
                         //c = (s & 0x00ff);
                         //d = (s & 0xff00) >> 8;
                     }
-                    else if(this->get_format() == AFMT_S16_BE) {
+                    else if(this->get_format() == Type::PCM_S16_BE) {
                         int16_t s = sample;
                         u_int16_t u = htons(s);
                         char* v = reinterpret_cast<char*>(&u);

--- a/jlib/media/stream.hh
+++ b/jlib/media/stream.hh
@@ -33,7 +33,6 @@
 
 #include <cstdlib>
 
-#include <sys/soundcard.h>
 
 #include <errno.h>
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,7 +1,7 @@
 # Public jlib headers include <gpgme.h>, <sodium.h>, <openssl/*.h> and
 # <json.h> directly, so anything compiling against them needs those -I flags.
 AM_CPPFLAGS = -I$(top_srcdir) \
-	$(GPGME_CFLAGS) $(GPGERROR_CFLAGS) $(SODIUM_CFLAGS) $(OPENSSL_CFLAGS) $(JSONC_CFLAGS)
+	$(GPGME_CFLAGS) $(GPGERROR_CFLAGS) $(SODIUM_CFLAGS) $(OPENSSL_CFLAGS) $(JSONC_CFLAGS) $(PORTAUDIO_CFLAGS)
 
 JSYS_LA   = $(top_builddir)/jlib/sys/libjsys.la
 JUTIL_LA  = $(top_builddir)/jlib/util/libjutil.la
@@ -10,9 +10,9 @@ JNET_LA   = $(top_builddir)/jlib/net/libjnet.la
 JMEDIA_LA = $(top_builddir)/jlib/media/libjmedia.la
 JX_LA     = $(top_builddir)/jlib/x/libjx.la
 
-# TODO(phase 3): the media tests are built but never run.  Once the PortAudio
-# backend lands they should move into TESTS.
-if HAVE_OSS_AUDIO
+# These play real audio, so they skip themselves when the host has no output
+# device rather than failing on a headless machine.
+if HAVE_PORTAUDIO
 MEDIA_TESTS = media_datastream_test \
               media_notestream_test \
               media_player_test \
@@ -51,9 +51,10 @@ TESTS = \
 	util_xml_test \
  \
 	$(X_TESTS) \
+	$(MEDIA_TESTS) \
 	$(CURVE_TESTS)
 
-check_PROGRAMS = $(TESTS) $(MEDIA_TESTS)
+check_PROGRAMS = $(TESTS)
 
 media_datastream_test_SOURCES = media_datastream_test.cc
 media_datastream_test_LDADD   = $(JMEDIA_LA)
@@ -62,7 +63,7 @@ media_notestream_test_LDADD   = $(JMEDIA_LA)
 media_player_test_SOURCES     = media_player_test.cc
 media_player_test_LDADD       = $(JMEDIA_LA)
 media_wavfile_test_SOURCES    = media_wavfile_test.cc
-media_wavfile_test_LDADD      = $(JMEDIA_LA)
+media_wavfile_test_LDADD      = $(JMEDIA_LA) $(JSYS_LA)
 
 net_extract_address_test_SOURCES        = net_extract_address_test.cc
 net_extract_address_test_LDADD          = $(JNET_LA)

--- a/tests/media_datastream_test.cc
+++ b/tests/media_datastream_test.cc
@@ -7,7 +7,7 @@
 
 #include <jlib/media/datastream.hh>
 #include <jlib/media/notestream.hh>
-#include <jlib/media/Dsp.hh>
+#include <jlib/media/PortAudioSink.hh>
 
 #include <jlib/sys/sys.hh>
 
@@ -16,10 +16,16 @@ const long double 	PI = 3.14159265358979323846264338;
 
 
 int main(int argc, char** argv) {
+    // No output device (headless container): automake reads 77 as SKIP.
+    if(!jlib::media::PortAudioSink::have_output_device()) {
+        std::cerr << "no audio output device, skipping" << std::endl;
+        return 77;
+    }
+
     using namespace jlib::media;
 
     try {
-        Dsp dsp;
+        PortAudioSink dsp;
 
         notestream note(220.0);
         note.set_format(Type::PCM_U8);

--- a/tests/media_notestream_test.cc
+++ b/tests/media_notestream_test.cc
@@ -5,7 +5,7 @@
 #include <cmath>
 
 #include <jlib/media/notestream.hh>
-#include <jlib/media/Dsp.hh>
+#include <jlib/media/PortAudioSink.hh>
 
 #include <jlib/sys/sys.hh>
 
@@ -14,6 +14,12 @@ const long double 	PI = 3.14159265358979323846264338;
 void play(double freq, int format, int channels, std::string tag, bool out=true);
 
 int main(int argc, char** argv) {
+    // No output device (headless container): automake reads 77 as SKIP.
+    if(!jlib::media::PortAudioSink::have_output_device()) {
+        std::cerr << "no audio output device, skipping" << std::endl;
+        return 77;
+    }
+
 
     try {
         using namespace jlib::media;
@@ -54,7 +60,7 @@ int main(int argc, char** argv) {
 }
 
 void play(double freq, int format, int channels, std::string tag, bool out) {
-    jlib::media::Dsp dsp;
+    jlib::media::PortAudioSink dsp;
 
     jlib::media::notestream note(freq);
     note.set_format(format);

--- a/tests/media_player_test.cc
+++ b/tests/media_player_test.cc
@@ -16,11 +16,17 @@ const long double 	PI = 3.14159265358979323846264338;
 
 
 int main(int argc, char** argv) {
+    // No output device (headless container): automake reads 77 as SKIP.
+    if(!jlib::media::PortAudioSink::have_output_device()) {
+        std::cerr << "no audio output device, skipping" << std::endl;
+        return 77;
+    }
+
     using namespace jlib::media;
 
     try {
         notestream note(220.0);
-        note.set_format(AFMT_U8);
+        note.set_format(Type::PCM_U8);
         note.set_channels(2);
         note.set_time(1);
 

--- a/tests/media_wavfile_test.cc
+++ b/tests/media_wavfile_test.cc
@@ -1,32 +1,107 @@
+// Round-trip a WAV through WavFile: synthesize a note, write it, read it back,
+// check the format chunk survived, then play it.
+//
+// This used to load /usr/share/sounds/card_shuffle.wav, which does not exist
+// on macOS and is not guaranteed anywhere.  Generating the fixture also makes
+// the test cover the format chunk's field widths: nSamplesPerSec is a 4-byte
+// field with nAvgBytesPerSec immediately after it, and reading or writing it
+// as u_long ran straight through the neighbour.
 #include <iostream>
 #include <fstream>
+#include <string>
 
-#include <unistd.h>
-
-#include <cmath>
+#include <cstdio>
 
 #include <jlib/media/datastream.hh>
+#include <jlib/media/notestream.hh>
 #include <jlib/media/WavFile.hh>
-#include <jlib/media/Dsp.hh>
+#include <jlib/media/PortAudioSink.hh>
+#include <jlib/media/Type.hh>
 
 #include <jlib/sys/sys.hh>
 
 int main(int argc, char** argv) {
+    // No output device (headless container): automake reads 77 as SKIP.
+    if(!jlib::media::PortAudioSink::have_output_device()) {
+        std::cerr << "no audio output device, skipping" << std::endl;
+        return 77;
+    }
+
     using namespace jlib::media;
 
-    try {
-        WavFile wav("/usr/share/sounds/card_shuffle.wav");
-        wav.load_data_chunks();
-        datastream data(wav.get_pcm());
-        data.set<WavFile>(wav);
+    const int RATE = 44100;
+    const int CHANNELS = 2;
+    const int BITS = 16;
+    const int FORMAT = Type::PCM_S16_LE;
 
-        Dsp dsp;
-        dsp.play(data);
+    const std::string path = "media_wavfile_test.wav";
+
+    try {
+        // synthesize half a second of A440
+        notestream note(440.0);
+        note.set_format(FORMAT);
+        note.set_channels(CHANNELS);
+        note.set_samples_per_sec(RATE);
+        note.set_time(0.5);
+
+        std::string pcm;
+        jlib::sys::read(note, pcm);
+
+        if(pcm.empty()) {
+            std::cerr << "notestream produced no samples" << std::endl;
+            return 1;
+        }
+
+        {
+            WavFile out;
+            out.set_format_tag(1);   // WAV_FMT_PCM
+            out.set_bits_per_sample(BITS);
+            out.set_channels(CHANNELS);
+            out.set_samples_per_sec(RATE);
+            out.set_format(FORMAT);
+            out.set_pcm(pcm);
+            out.save(path);
+        }
+
+        WavFile in(path);
+        in.load_data_chunks();
+
+        int failures = 0;
+        if(in.get_samples_per_sec() != RATE) {
+            std::cerr << "samples_per_sec round-tripped as " << in.get_samples_per_sec()
+                      << ", expected " << RATE << std::endl;
+            ++failures;
+        }
+        if(in.get_channels() != CHANNELS) {
+            std::cerr << "channels round-tripped as " << in.get_channels()
+                      << ", expected " << CHANNELS << std::endl;
+            ++failures;
+        }
+        if(in.get_bits_per_sample() != BITS) {
+            std::cerr << "bits_per_sample round-tripped as " << in.get_bits_per_sample()
+                      << ", expected " << BITS << std::endl;
+            ++failures;
+        }
+        if(in.get_pcm().size() != pcm.size()) {
+            std::cerr << "pcm round-tripped as " << in.get_pcm().size()
+                      << " bytes, expected " << pcm.size() << std::endl;
+            ++failures;
+        }
+
+        if(failures == 0) {
+            datastream data(in.get_pcm());
+            data.set<WavFile>(in);
+
+            PortAudioSink dsp;
+            dsp.play(data);
+        }
+
+        std::remove(path.c_str());
+        return failures ? 1 : 0;
     }
     catch(std::exception& e) {
         std::cerr << e.what() << std::endl;
-        exit(1);
+        std::remove(path.c_str());
+        return 1;
     }
-
-    exit(0);
 }


### PR DESCRIPTION
replace the OSS backend with PortAudio

jlib/media drove audio through OSS -- /dev/dsp and SNDCTL_* ioctls.  That
interface is gone from modern Linux kernels and never existed on macOS, so the
whole library was gated off on both platforms and the four media tests were
built but never run.

Audio now works on macOS and modern Linux.

    macOS  23 tests, 23 pass (the media tests play real audio)
    Linux  24 tests, 19 pass, 5 skip (headless: no display, no audio device)

the sink

    AudioSink is the contract Dsp grew against OSS, restated so something
    other than /dev/dsp can satisfy it: config, a blocking write, queued() and
    available() for backpressure, reset, drain, close.  Two things changed in
    the restatement.

    Buffering is counted in frames rather than bytes.  Dsp's fragments were a
    2048-byte quantum with no relation to frame size, so a fragment boundary
    could land mid-frame and shear the channels apart.  A frame is one sample
    across all channels, which is also what PortAudio counts in.

    bits_per_sample is no longer a parameter.  It is implied by the format,
    and Dsp::config() took it only to ignore it -- it never issued
    SNDCTL_DSP_BITS at all.

    PortAudioSink implements it over PortAudio's blocking API, which maps
    nearly one-to-one onto what Dsp did: Pa_WriteStream for write,
    Pa_GetStreamWriteAvailable for available, Pa_AbortStream for reset (abort,
    not stop -- a seek should discard what is queued, not play it out), and
    Pa_StopStream for drain, which is what SNDCTL_DSP_SYNC did.

    PortAudio has no unsigned 16-bit format and no big-endian formats, so
    PCM_U16_* and PCM_*_BE are converted in write(): a byte swap when the
    incoming endianness differs from the host, and a sign-bit flip to move
    between unsigned and signed.  Everything else is passed through untouched.

    Pa_Initialize/Pa_Terminate are tied to a function-local static, so the
    library comes up once on first use rather than per sink, which would tear
    it down under any other sink still open.

clicks

    Notes clicked, and a melody was a train of clicks.  Measuring the
    generated samples showed the waveform starts correctly at silence -- 0 for
    signed, 128 for unsigned -- but a note lasts get_time() seconds whatever
    its frequency, so freq*time is hardly ever a whole number of cycles.  The
    waveform stopped wherever it happened to be and dropped straight to
    silence: at 443.7Hz for one second the final sample was -20287 against a
    21823 peak, a 93% full-scale step.  440Hz for exactly one second is 440
    whole cycles, which is why that particular case sounded fine and hid the
    problem.

    create_data() now ramps the first and last 5ms with a raised cosine.  That
    is inaudible as a volume change, leaves peak amplitude untouched, and ends
    every note at exact silence at any frequency -- unlike set_nearest_time(),
    which fixes the discontinuity by altering the note's duration and so
    cannot be used where timing matters.

    play() deliberately does not drain.  jmelody calls it once per note on one
    sink, and draining between notes puts a gap in the melody; close() drains,
    which is what keeps the last note's tail from being cut off.  Dsp did
    neither, and truncated.

format constants

    Type::PCM_* and OSS's AFMT_* were numerically identical, which let the two
    spellings be used interchangeably -- notestream and AudioFile compared
    against AFMT_ values that callers had set as Type::PCM_.  Everything now
    says Type::PCM_, and all seven <sys/soundcard.h> includes are gone; five
    were already dead.

    AudioFile::get()'s branches for MU_LAW, A_LAW and IMA_ADPCM are dropped:
    those had OSS constants but no Type::PCM_ equivalent, so they could never
    have matched.  The linear-PCM branches were all empty -- the actual work
    happens after the chain -- so only the two reachable rejections remain.

tests

    The four media tests move into TESTS.  They play real audio, so they exit
    77 (automake's SKIP) when the host has no output device, rather than
    failing on a machine that simply has no sound.

    media_wavfile_test loaded /usr/share/sounds/card_shuffle.wav, which does
    not exist on macOS and is guaranteed nowhere.  It now synthesizes a note,
    writes it, reads it back and checks the format chunk survived -- which
    also covers the field widths in that chunk, where nSamplesPerSec is 4
    bytes with nAvgBytesPerSec immediately after it.

also fixed

    datastream::create_scaled() sized a variable-length array from an audio
    file's length, so the file decided how much stack to take.  Now a vector.

    notestream used std::stringstream without including <sstream>; it compiled
    only because something else in libjmedia happened to pull it in.

    Dsp is kept but no longer built.  jlib/media is gated on HAVE_PORTAUDIO
    now rather than HAVE_OSS_AUDIO -- note that Ubuntu still ships
    <sys/soundcard.h> even though /dev/dsp is long gone, so the old gate
    reported audio as available on a machine that could not play a sound.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
