### PR TITLE
make the media tests silent by default; add float32 generation; round instead of truncate

### DIFF
--- a/jlib/apps/jmelody.cc
+++ b/jlib/apps/jmelody.cc
@@ -15,7 +15,7 @@ int main(int argc, char** argv) {
     try {
         using namespace jlib::media;
 
-        int format = Type::PCM_S16_LE;
+        int format = Type::PCM_FLOAT32;
         int channels = 2;
         std::string note;
         double t = 5;

--- a/jlib/media/notestream.hh
+++ b/jlib/media/notestream.hh
@@ -370,7 +370,20 @@ namespace jlib {
                         envelope = 0.5 * (1.0 - cos(pi * (samples - 1 - i) / fade));
                 }
 
-                int64_t sample = (int64_t)((envelope*vol*amp*sin(freq*this->get_time()*(2*pi)*(i/double(samples)))));
+                // The waveform in [-1,1], before it is committed to any
+                // particular sample format.  PCM_FLOAT32 wants exactly this;
+                // the integer formats scale and quantize it below.
+                const double raw =
+                    envelope*vol*sin(freq*this->get_time()*(2*pi)*(i/double(samples)));
+
+                // Round rather than truncate.  A cast truncates toward zero,
+                // which both doubles the worst-case quantization error and
+                // makes it asymmetric: every value in (-1,1) collapses to 0,
+                // so the waveform sits flat through each zero crossing
+                // instead of passing through it.  That deadband is crossover
+                // distortion, and at 8 bits -- where the whole signal is only
+                // ~170 levels wide -- it is clearly audible.
+                int64_t sample = std::llround(raw * amp);
                 u_int64_t usample = sample+amp;
                 
                 
@@ -390,6 +403,16 @@ namespace jlib {
                             throw exception("sample out of bounds at Type::PCM_S8");
                         char s = sample;
                         jlib::util::byte_copy(data,&s,1,p0);
+                    }
+                    else if(this->get_format() == Type::PCM_FLOAT32) {
+                        // The shortest branch here, and the only one that
+                        // quantizes nothing: no bias, no byte order, no
+                        // clipping.  It is also what the hardware actually
+                        // wants -- CoreAudio works in float32 internally, and
+                        // PortAudio treats paFloat32 as its native format --
+                        // so this is the one path with no conversion at all.
+                        Type::scaled f = static_cast<Type::scaled>(raw);
+                        jlib::util::byte_copy(data, &f, sizeof(f), p0);
                     }
                     else if(this->get_format() == Type::PCM_U16_LE) {
                         u_int16_t u = htons(usample);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -3,6 +3,8 @@
 AM_CPPFLAGS = -I$(top_srcdir) \
 	$(GPGME_CFLAGS) $(GPGERROR_CFLAGS) $(SODIUM_CFLAGS) $(OPENSSL_CFLAGS) $(JSONC_CFLAGS) $(PORTAUDIO_CFLAGS)
 
+EXTRA_DIST = audio_test.hh
+
 JSYS_LA   = $(top_builddir)/jlib/sys/libjsys.la
 JUTIL_LA  = $(top_builddir)/jlib/util/libjutil.la
 JCRYPT_LA = $(top_builddir)/jlib/crypt/libjcrypt.la
@@ -57,11 +59,11 @@ TESTS = \
 check_PROGRAMS = $(TESTS)
 
 media_datastream_test_SOURCES = media_datastream_test.cc
-media_datastream_test_LDADD   = $(JMEDIA_LA)
+media_datastream_test_LDADD   = $(JMEDIA_LA) $(JSYS_LA)
 media_notestream_test_SOURCES = media_notestream_test.cc
-media_notestream_test_LDADD   = $(JMEDIA_LA)
+media_notestream_test_LDADD   = $(JMEDIA_LA) $(JSYS_LA)
 media_player_test_SOURCES     = media_player_test.cc
-media_player_test_LDADD       = $(JMEDIA_LA)
+media_player_test_LDADD       = $(JMEDIA_LA) $(JSYS_LA)
 media_wavfile_test_SOURCES    = media_wavfile_test.cc
 media_wavfile_test_LDADD      = $(JMEDIA_LA) $(JSYS_LA)
 

--- a/tests/audio_test.hh
+++ b/tests/audio_test.hh
@@ -1,0 +1,151 @@
+/* -*- mode: C++ c-basic-offset: 4 -*-
+ *
+ * Test-only helpers for the media tests.
+ *
+ * These tests are silent by default.  What they are actually testing is the
+ * PCM the stream layer produces, and that can be checked without opening an
+ * output device -- so `make check` no longer plays anything, which is both
+ * faster and considerably kinder to whoever is sitting in front of the
+ * machine.
+ *
+ *     ./media_notestream_test              verify only, no sound
+ *     ./media_notestream_test --play       play the clean formats
+ *     ./media_notestream_test --play-all   play every format, including the
+ *                                          8-bit ones, which are audibly
+ *                                          rough by nature
+ *
+ * Note there is deliberately no locking here.  Audio output is exclusive, but
+ * `make check` never passes --play, so nothing it runs opens a device; the
+ * only way to overlap playback is to background several tests by hand.
+ */
+
+#ifndef JLIB_TESTS_AUDIO_TEST_HH
+#define JLIB_TESTS_AUDIO_TEST_HH
+
+#include <jlib/media/Type.hh>
+
+#include <iostream>
+#include <string>
+
+#include <cstring>
+
+namespace jlib {
+namespace tests {
+
+enum audio_mode {
+    AUDIO_SILENT,    // verify the samples, open no device
+    AUDIO_PLAY,      // play the formats that sound clean
+    AUDIO_PLAY_ALL   // play everything, warts included
+};
+
+inline audio_mode get_audio_mode(int argc, char** argv) {
+    for(int i = 1; i < argc; i++) {
+        const std::string arg = argv[i];
+        if(arg == "--play-all")
+            return AUDIO_PLAY_ALL;
+        if(arg == "--play")
+            return AUDIO_PLAY;
+    }
+    return AUDIO_SILENT;
+}
+
+/**
+ * Is this format one of the ones worth putting through a speaker by default?
+ *
+ * The 8- and 16-bit unsigned formats are correct but coarse -- 8 bits is
+ * ~48dB of signal-to-noise and the quantization staircase is plainly
+ * audible -- so they are reserved for --play-all rather than inflicted on
+ * anyone running --play.
+ */
+inline bool is_clean_format(int format) {
+    return format == jlib::media::Type::PCM_S16_LE ||
+           format == jlib::media::Type::PCM_FLOAT32;
+}
+
+inline bool should_play(audio_mode mode, int format) {
+    if(mode == AUDIO_SILENT)
+        return false;
+    if(mode == AUDIO_PLAY_ALL)
+        return true;
+    return is_clean_format(format);
+}
+
+/**
+ * Check generated PCM without playing it: non-empty, a whole number of
+ * frames, and silent at both ends.
+ *
+ * That last one is the interesting property. A note lasts a fixed time
+ * whatever its frequency, so freq*time is rarely a whole number of cycles;
+ * without the envelope the waveform stops mid-swing and drops straight to
+ * silence, which clicks. Checking both endpoints is what keeps that fixed.
+ */
+inline bool check_pcm(const std::string& pcm, int format, int channels,
+                      const std::string& tag)
+{
+    int width = 0;
+    switch(format) {
+    case jlib::media::Type::PCM_U8:
+    case jlib::media::Type::PCM_S8:       width = 1; break;
+    case jlib::media::Type::PCM_S16_LE:
+    case jlib::media::Type::PCM_S16_BE:
+    case jlib::media::Type::PCM_U16_LE:
+    case jlib::media::Type::PCM_U16_BE:   width = 2; break;
+    case jlib::media::Type::PCM_FLOAT32:  width = 4; break;
+    default:
+        std::cerr << tag << ": unknown format 0x" << std::hex << format << std::endl;
+        return false;
+    }
+
+    if(pcm.empty()) {
+        std::cerr << tag << ": produced no samples" << std::endl;
+        return false;
+    }
+
+    const std::size_t frame = static_cast<std::size_t>(width) * channels;
+    if(pcm.size() % frame != 0) {
+        std::cerr << tag << ": " << pcm.size() << " bytes is not a whole number of "
+                  << frame << "-byte frames" << std::endl;
+        return false;
+    }
+
+    // Silence is 0 for the signed and float formats, and the midpoint for
+    // the unsigned ones -- so compare the first sample against the last
+    // rather than against a constant.
+    const unsigned char* p = reinterpret_cast<const unsigned char*>(pcm.data());
+    const std::size_t last = pcm.size() - frame;
+
+    if(format == jlib::media::Type::PCM_FLOAT32) {
+        // Compare as values, not bytes. The envelope drives the final sample
+        // to zero while sin() is still negative, so it lands on -0.0, whose
+        // sign bit differs from +0.0 even though the two are equal and
+        // equally silent.
+        float first_v = 0, last_v = 0;
+        std::memcpy(&first_v, p, sizeof(first_v));
+        std::memcpy(&last_v, p + last, sizeof(last_v));
+
+        if(first_v != last_v) {
+            std::cerr << tag << ": starts at " << first_v << " and ends at "
+                      << last_v << " -- the note will click" << std::endl;
+            return false;
+        }
+
+        return true;
+    }
+
+    for(std::size_t i = 0; i < static_cast<std::size_t>(width); i++) {
+        if(p[i] != p[last + i]) {
+            std::cerr << tag << ": starts and ends at different levels"
+                      << " (byte " << i << ": " << (int)p[i]
+                      << " vs " << (int)p[last + i] << ")"
+                      << " -- the note will click" << std::endl;
+            return false;
+        }
+    }
+
+    return true;
+}
+
+}
+}
+
+#endif //JLIB_TESTS_AUDIO_TEST_HH

--- a/tests/media_datastream_test.cc
+++ b/tests/media_datastream_test.cc
@@ -9,6 +9,8 @@
 #include <jlib/media/notestream.hh>
 #include <jlib/media/PortAudioSink.hh>
 
+#include "audio_test.hh"
+
 #include <jlib/sys/sys.hh>
 
 const long double 	PI = 3.14159265358979323846264338;
@@ -16,23 +18,39 @@ const long double 	PI = 3.14159265358979323846264338;
 
 
 int main(int argc, char** argv) {
-    // No output device (headless container): automake reads 77 as SKIP.
-    if(!jlib::media::PortAudioSink::have_output_device()) {
+    using namespace jlib::media;
+    using namespace jlib::tests;
+
+    const audio_mode mode = get_audio_mode(argc, argv);
+
+    if(mode != AUDIO_SILENT && !PortAudioSink::have_output_device()) {
         std::cerr << "no audio output device, skipping" << std::endl;
         return 77;
     }
 
-    using namespace jlib::media;
-
     try {
-        PortAudioSink dsp;
+        const int format = Type::PCM_U8;
 
         notestream note(220.0);
-        note.set_format(Type::PCM_U8);
+        note.set_format(format);
         note.set_channels(1);
         note.set_time(0.5);
 
-        dsp.play(note);
+        std::string pcm;
+        jlib::sys::read(note, pcm);
+
+        if(!check_pcm(pcm, format, 1, "datastream U8"))
+            return 1;
+
+        if(should_play(mode, format)) {
+                notestream again(220.0);
+            again.set_format(format);
+            again.set_channels(1);
+            again.set_time(0.5);
+
+            PortAudioSink dsp;
+            dsp.play(again);
+        }
     }
     catch(std::exception& e) {
         std::cerr << e.what() << std::endl;

--- a/tests/media_notestream_test.cc
+++ b/tests/media_notestream_test.cc
@@ -1,75 +1,78 @@
+// Verify the PCM notestream generates, for every format it supports.
+//
+// Silent by default -- pass --play for the clean formats, or --play-all for
+// every one of them.  See audio_test.hh.
 #include <iostream>
-
-#include <unistd.h>
-
-#include <cmath>
+#include <string>
 
 #include <jlib/media/notestream.hh>
 #include <jlib/media/PortAudioSink.hh>
+#include <jlib/media/Type.hh>
 
 #include <jlib/sys/sys.hh>
 
-const long double 	PI = 3.14159265358979323846264338;
+#include "audio_test.hh"
 
-void play(double freq, int format, int channels, std::string tag, bool out=true);
+using namespace jlib::media;
+using namespace jlib::tests;
 
-int main(int argc, char** argv) {
-    // No output device (headless container): automake reads 77 as SKIP.
-    if(!jlib::media::PortAudioSink::have_output_device()) {
-        std::cerr << "no audio output device, skipping" << std::endl;
-        return 77;
-    }
-
-
-    try {
-        using namespace jlib::media;
-        
-        play(110, Type::PCM_U8, 1, "Type::PCM_U8");
-        play(220, Type::PCM_U8, 2, "Type::PCM_U8");
-//         play(55, Type::PCM_S8, 1, "Type::PCM_S8");
-//         play(55, Type::PCM_S8, 2, "Type::PCM_S8");
-        play(440, Type::PCM_S16_LE, 1, "Type::PCM_S16_LE");
-        play(880, Type::PCM_S16_LE, 2, "Type::PCM_S16_LE");
-        //play(110, Type::PCM_U16_LE, 1, "Type::PCM_U16_LE");
-        //play(110, Type::PCM_U16_LE, 2, "Type::PCM_U16_LE");
-//         play(110, Type::PCM_S16_BE, 1, "Type::PCM_S16_BE");
-//         play(110, Type::PCM_S16_BE, 2, "Type::PCM_S16_BE");
-//         play(110, Type::PCM_U16_BE, 1, "Type::PCM_U16_BE");
-//         play(110, Type::PCM_U16_BE, 2, "Type::PCM_U16_BE");
-
-        /*
-        std::cout << "\"mary had a little lamb\" in c major:" << std::endl;
-        double c = jlib::media::basic_notebuf<char>::get_freq(4,220);
-        double b = jlib::media::basic_notebuf<char>::get_freq(2,220);
-        double a = jlib::media::basic_notebuf<char>::get_freq(0,220);
-        play(c, Type::PCM_S16_LE, 2, "Type::PCM_S16_LE", false);
-        play(b, Type::PCM_S16_LE, 2, "Type::PCM_S16_LE", false);
-        play(a, Type::PCM_S16_LE, 2, "Type::PCM_S16_LE", false);
-        play(b, Type::PCM_S16_LE, 2, "Type::PCM_S16_LE", false);
-        play(c, Type::PCM_S16_LE, 2, "Type::PCM_S16_LE", false);
-        play(c, Type::PCM_S16_LE, 2, "Type::PCM_S16_LE", false);
-        play(c, Type::PCM_S16_LE, 2, "Type::PCM_S16_LE", false);
-        */
-    }
-    catch(std::exception& e) {
-        std::cerr << e.what() << std::endl;
-        exit(1);
-    }
-
-    exit(0);
-}
-
-void play(double freq, int format, int channels, std::string tag, bool out) {
-    jlib::media::PortAudioSink dsp;
-
-    jlib::media::notestream note(freq);
+static int check(double freq, int format, int channels,
+                 const std::string& tag, audio_mode mode)
+{
+    notestream note(freq);
     note.set_format(format);
     note.set_channels(channels);
     note.set_time(0.25);
 
-    dsp.play(note);
+    std::string pcm;
+    jlib::sys::read(note, pcm);
 
-    if(out)
-        std::cout << tag << ": " << (channels > 1 ? "stereo" : "mono") << std::endl;
+    const std::string label =
+        tag + " " + (channels > 1 ? "stereo" : "mono");
 
+    if(!check_pcm(pcm, format, channels, label))
+        return 1;
+
+    if(should_play(mode, format)) {
+        notestream again(freq);
+        again.set_format(format);
+        again.set_channels(channels);
+        again.set_time(0.25);
+
+        PortAudioSink dsp;
+        dsp.play(again);
+    }
+
+    std::cout << label << ": " << pcm.size() << " bytes ok" << std::endl;
+    return 0;
+}
+
+int main(int argc, char** argv) {
+    const audio_mode mode = get_audio_mode(argc, argv);
+
+    if(mode != AUDIO_SILENT && !PortAudioSink::have_output_device()) {
+        std::cerr << "no audio output device, skipping" << std::endl;
+        return 77;
+    }
+
+    int failures = 0;
+
+    try {
+        failures += check(110, Type::PCM_U8,      1, "Type::PCM_U8", mode);
+        failures += check(220, Type::PCM_U8,      2, "Type::PCM_U8", mode);
+        failures += check(110, Type::PCM_S8,      1, "Type::PCM_S8", mode);
+        failures += check(440, Type::PCM_S16_LE,  1, "Type::PCM_S16_LE", mode);
+        failures += check(880, Type::PCM_S16_LE,  2, "Type::PCM_S16_LE", mode);
+        failures += check(440, Type::PCM_S16_BE,  1, "Type::PCM_S16_BE", mode);
+        failures += check(440, Type::PCM_U16_LE,  1, "Type::PCM_U16_LE", mode);
+        failures += check(440, Type::PCM_U16_BE,  1, "Type::PCM_U16_BE", mode);
+        failures += check(440, Type::PCM_FLOAT32, 1, "Type::PCM_FLOAT32", mode);
+        failures += check(880, Type::PCM_FLOAT32, 2, "Type::PCM_FLOAT32", mode);
+    }
+    catch(std::exception& e) {
+        std::cerr << e.what() << std::endl;
+        return 1;
+    }
+
+    return failures ? 1 : 0;
 }

--- a/tests/media_player_test.cc
+++ b/tests/media_player_test.cc
@@ -8,21 +8,33 @@
 #include <jlib/media/datastream.hh>
 #include <jlib/media/notestream.hh>
 #include <jlib/media/Player.hh>
+#include <jlib/media/PortAudioSink.hh>
 
 #include <jlib/sys/sys.hh>
+
+#include "audio_test.hh"
 
 const long double 	PI = 3.14159265358979323846264338;
 
 
 
 int main(int argc, char** argv) {
-    // No output device (headless container): automake reads 77 as SKIP.
-    if(!jlib::media::PortAudioSink::have_output_device()) {
-        std::cerr << "no audio output device, skipping" << std::endl;
+    using namespace jlib::media;
+    using namespace jlib::tests;
+
+    // Player drives a real device, so unlike the other media tests there is
+    // nothing to verify without one.  Silent by default means skip.
+    const audio_mode mode = get_audio_mode(argc, argv);
+
+    if(mode == AUDIO_SILENT) {
+        std::cerr << "Player needs a device; pass --play to exercise it" << std::endl;
         return 77;
     }
 
-    using namespace jlib::media;
+    if(!PortAudioSink::have_output_device()) {
+        std::cerr << "no audio output device, skipping" << std::endl;
+        return 77;
+    }
 
     try {
         notestream note(220.0);

--- a/tests/media_wavfile_test.cc
+++ b/tests/media_wavfile_test.cc
@@ -16,18 +16,22 @@
 #include <jlib/media/notestream.hh>
 #include <jlib/media/WavFile.hh>
 #include <jlib/media/PortAudioSink.hh>
+
+#include "audio_test.hh"
 #include <jlib/media/Type.hh>
 
 #include <jlib/sys/sys.hh>
 
 int main(int argc, char** argv) {
-    // No output device (headless container): automake reads 77 as SKIP.
-    if(!jlib::media::PortAudioSink::have_output_device()) {
+    using namespace jlib::media;
+    using namespace jlib::tests;
+
+    const audio_mode mode = get_audio_mode(argc, argv);
+
+    if(mode != AUDIO_SILENT && !PortAudioSink::have_output_device()) {
         std::cerr << "no audio output device, skipping" << std::endl;
         return 77;
     }
-
-    using namespace jlib::media;
 
     const int RATE = 44100;
     const int CHANNELS = 2;
@@ -88,8 +92,8 @@ int main(int argc, char** argv) {
             ++failures;
         }
 
-        if(failures == 0) {
-            datastream data(in.get_pcm());
+        if(failures == 0 && should_play(mode, FORMAT)) {
+                datastream data(in.get_pcm());
             data.set<WavFile>(in);
 
             PortAudioSink dsp;


### PR DESCRIPTION
make the media tests silent by default, and add float32 generation

Follow-up to the PortAudio work.  Running `make check` played every media
test at full volume, several at once under -j, which is both unpleasant and a
bad way to treat a laptop speaker.

    macOS  23 tests, 22 pass, 1 skip
    Linux  24 tests, 22 pass, 2 skip

silent by default

    What these tests are actually exercising is the PCM the stream layer
    produces, and that can be checked without opening an output device.  So
    they no longer open one unless asked:

        ./media_notestream_test              verify only, no sound
        ./media_notestream_test --play       the clean formats
        ./media_notestream_test --play-all   every format, 8-bit included

    make check passes no flag, so the suite is silent and faster.

    This turned out to be the better test rather than merely the quieter one.
    Each format is now checked for being non-empty, a whole number of frames,
    and -- the interesting one -- starting and ending at the same level, which
    is the property that keeps notes from clicking.  Previously the assertion
    was only "it did not throw".

    Format coverage went up while doing this: S8, S16_BE, U16_LE and U16_BE
    were all commented out in the notestream test and are now checked, along
    with the new float32.

    media_player_test skips when silent.  It drives a real device through
    Player, so unlike the others there is nothing to verify without one.

float32

    Type declared PCM_FLOAT32 and PortAudioSink already mapped it to
    paFloat32, but notestream could not generate it -- create_data() threw
    "bad format".  So the one format the hardware actually prefers, and the
    only one that quantizes nothing, was unreachable.

    It is now the shortest branch in the dispatch: no bias, no byte order, no
    clipping.  jmelody defaults to it.

    PortAudio has no float64, incidentally; paFloat32 is as wide as it goes.

round instead of truncate

    Sample quantization was a cast, which truncates toward zero.  That both
    doubles the worst-case error and makes it asymmetric: every value in
    (-1,1) collapses to 0, so the waveform sits flat through each zero
    crossing rather than passing through it.  That deadband is crossover
    distortion, and at 8 bits -- where the whole signal spans only ~170 levels
    -- it is audible.  std::llround now.

    Worth recording what this is *not*: the 8-bit formats still sound coarse,
    and that is inherent.  Eight bits is ~48dB of signal-to-noise, and
    measuring the generated samples showed the waveform is clean -- maximum
    adjacent jump of 2-3 levels at 110Hz and 220Hz, matching the theoretical
    sine slope of 1.33 and 2.66 exactly, with no discontinuity and no
    wraparound.  Dither would help and is the obvious next lever; the
    truncation above was a real defect on top of it.

no lock

    An earlier version of this took an flock so concurrent tests would not
    overlap their output.  Silence by default removes the problem it solved:
    make check never passes --play, so nothing it runs opens a device at all.
    Dropped rather than kept for a case that now requires deliberately
    backgrounding tests by hand.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
