### PR TITLE
Fix jhardhyper's projection

### DIFF
--- a/jlib/apps/Hyper.hh
+++ b/jlib/apps/Hyper.hh
@@ -82,7 +82,7 @@ template<typename T, typename Plot>
 inline
 HyperPlot<T,Plot>::HyperPlot(uint n, std::vector< std::pair<T,T> > c, uint w, uint h) 
     : Plot(n, c, w, h),
-      r(n - 1),
+      r(n),
       first(true),
       rotate(matrix<T>::identity(n+1)),
       back_rotate(matrix<T>::identity(n+1)),
@@ -98,7 +98,14 @@ HyperPlot<T,Plot>::HyperPlot(uint n, std::vector< std::pair<T,T> > c, uint w, ui
 template<typename T, typename Plot>
 inline
 void HyperPlot<T,Plot>::initialize(uint n) {
-    r = n - 1;
+    // Rotate in every plane, including those touching the highest axis.
+    //
+    // This defaulted to n-1, so a 4-cube's planes were only ever (0,1), (0,2)
+    // and (1,2): nothing rotated through the fourth dimension, the two nested
+    // cubes tumbled rigidly together, and the figure never everted -- which is
+    // the entire thing a hypercube viewer exists to show.  The f key still
+    // lowers it if you want the shell on its own.
+    r = n;
     r2 = (n < 8 ? 3 : (1.1 * std::sqrt(static_cast<T>(n))));
 
     switch(shape) {

--- a/jlib/apps/jgltorus.cc
+++ b/jlib/apps/jgltorus.cc
@@ -58,11 +58,11 @@ GLdouble inner_z_rad = 0;
 GLdouble bounce_rad = 0;
 GLdouble color_rad = 0;
 
-GLdouble outer_inc = 0.001;
-GLdouble inner_x_inc = 0.002;
-GLdouble inner_y_inc = 0.004;
-GLdouble inner_z_inc = 0.006;
-GLdouble bounce_inc = 0.001;
+GLdouble outer_inc = 0.010;
+GLdouble inner_x_inc = 0.020;
+GLdouble inner_y_inc = 0.040;
+GLdouble inner_z_inc = 0.060;
+GLdouble bounce_inc = 0.010;
 GLdouble color_inc = 0.001;
 
 GLdouble inner = 0.17;

--- a/jlib/apps/jhardhyper.cc
+++ b/jlib/apps/jhardhyper.cc
@@ -20,6 +20,7 @@
  */
 
 #include <chrono>
+#include <cmath>
 #include <iostream>
 #include <thread>
 
@@ -30,6 +31,7 @@
 
 #include <jlib/math/math.hh>
 #include <jlib/math/Plot.hh>
+#include <jlib/math/dump.hh>
 #include <jlib/glfw/Plot.hh>
 
 #include <vector>
@@ -46,6 +48,8 @@ using namespace jlib;
 using namespace jlib::math;
 
 typedef GLdouble T;
+
+const long double PI = 3.14159265358979323846264338;
 
 
 
@@ -68,7 +72,38 @@ protected:
     // glut::Main::default_reshape used gluPerspective(80, aspect, 0.1, 50),
     // which is what glu::projection::perspective sets up.
     virtual void on_configure(int width, int height);
+
+    /**
+     * Distance to put the GL camera at, worked out from how big the object
+     * actually came out.
+     *
+     * It cannot be a constant.  Every reduction step divides by w, so the
+     * projected object shrinks by roughly half per step: a 4-cube lands at
+     * half-extent 0.5 and a 5-cube at about 0.25, while a fixed camera stays
+     * put -- so the figure receded as D went up.
+     *
+     * Tracked as a running maximum rather than measured once.  The extent at
+     * frame zero is not the largest the figure reaches as it turns, so a
+     * one-shot measurement frames it too tightly and the corners clip.  Only
+     * ever moving back means it settles within a turn or two and never
+     * breathes.  change() resets it, so the e and d keys re-frame.
+     */
+    T m_camera = 0;
+    T m_radius = 0;
+
+    virtual void change(uint n);
 };
+
+template<typename T>
+inline
+void HPlot<T>::change(uint n) {
+    // D is about to change, so the projected extent will too -- and it shrinks
+    // by roughly half for every dimension added.  Re-measure from scratch.
+    m_camera = 0;
+    m_radius = 0;
+
+    glfw::Plot<T>::change(n);
+}
 
 template<typename T>
 inline
@@ -85,7 +120,6 @@ void HPlot<T>::on_configure(int width, int height) {
     this->height = height;
 
     glu::projection::perspective(width, height);
-    glLoadIdentity();
 
     this->draw();
 }
@@ -131,6 +165,48 @@ void HPlot<T>::draw() {
             transformed.insert(std::make_pair(v1, tv1));
         }
 
+        // Frame the object: far enough back that the outermost vertex sits
+        // inside the field, growing the distance if a later rotation reaches
+        // further than anything seen so far.
+        T radius = 0;
+        typename std::map<math::vertex<T>, math::vertex<T> >::iterator t;
+        for(t = transformed.begin(); t != transformed.end(); t++) {
+            const math::vertex<T>& v = t->second;
+            T r2 = 0;
+            for(uint k = 0; k < 3 && k < v.D; k++)
+                r2 += v[k] * v[k];
+            if(r2 > radius) radius = r2;
+        }
+        radius = std::sqrt(radius);
+
+        if(radius > m_radius)
+            m_radius = radius;
+
+        // Scale the figure to a fixed size rather than moving the camera to
+        // meet it.
+        //
+        // Chasing it with the camera works until about D=7: each reduction
+        // step divides by w, so by then the object is down to a radius of
+        // ~0.06, the camera closes to ~0.12, and the near half of the figure
+        // crosses gluPerspective's near plane at 0.1 and clips.  Normalizing
+        // instead keeps the camera at a comfortable distance for every D, and
+        // has the object appear the same size throughout.
+        const T scale = (m_radius > 0) ? (1.0 / m_radius) : 1.0;
+
+        // 80 degree vertical field, so a half-angle of 40; 0.6 leaves room for
+        // the corners, which swing wider than the radius on any one frame.
+        const T half_field = std::tan(40.0 * PI / 180.0);
+        m_camera = 1.0 / (0.6 * half_field);
+
+        // The 3-D camera, set here rather than through the N-D lookAt so it
+        // is not scaled by the perspective divide.  See initialize_glazzies.
+        glMatrixMode(GL_MODELVIEW);
+        glLoadIdentity();
+        gluLookAt(0, 0, m_camera,
+                  0, 0, 0,
+                  0, 1, 0);
+        glScaled(scale, scale, scale);
+
         for(uint j = 0; j < object.size(); j++) {
             math::vertex<T>& v1 = object[j];
             math::vertex<T>& tv1 = transformed.find(v1)->second;
@@ -149,6 +225,8 @@ void HPlot<T>::draw() {
     }
 
 	this->flush();
+
+    math::dump::frame_done();
 }
 
 template<typename T>
@@ -171,12 +249,12 @@ math::vertex<T> HPlot<T>::transform(const math::vertex<T>& vertex) const {
         ret.change(d-1);
     }
 
+    math::dump::vertex("hard", vertex, ret);
+
     return ret;
 }
 
 typedef HPlot<T> PlotType;
-
-const long double PI = 3.14159265358979323846264338;
 
 template<class O>
 struct triple {
@@ -223,7 +301,7 @@ template<typename T, typename Plot>
 inline
 HyperPlot<T,Plot>::HyperPlot(uint n, std::vector< std::pair<T,T> > c, uint w, uint h) 
     : Plot(n, c, w, h),
-      r(n - 1),
+      r(n),
       first(true),
       rotate(matrix<T>::identity(n+1)),
       back_rotate(matrix<T>::identity(n+1)),
@@ -238,7 +316,14 @@ HyperPlot<T,Plot>::HyperPlot(uint n, std::vector< std::pair<T,T> > c, uint w, ui
 template<typename T, typename Plot>
 inline
 void HyperPlot<T,Plot>::initialize(uint n) {
-    r = n - 1;
+    // Rotate in every plane, including those touching the highest axis.
+    //
+    // This defaulted to n-1, so a 4-cube's planes were only ever (0,1), (0,2)
+    // and (1,2): nothing rotated through the fourth dimension, the two nested
+    // cubes tumbled rigidly together, and the figure never everted -- which is
+    // the entire thing a hypercube viewer exists to show.  The f key still
+    // lowers it if you want the shell on its own.
+    r = n;
 
     initialize_glazzies(n);
     this->setClip(clip);
@@ -301,19 +386,14 @@ void HyperPlot<T,Plot>::draw_line(math::vertex<T> p1, math::vertex<T> p2) {
     glColor3fv(fcolors);
     glMaterialfv(GL_FRONT_AND_BACK, GL_AMBIENT_AND_DIFFUSE, fcolors);
 
-    if(p1[p1.D] != 1)
-        std::cout << "draw_line: p1[p1.D] = " << p1[p1.D] << std::endl;
-    if(p2[p2.D] != 1)
-        std::cout << "draw_line: p2[p2.D] = " << p2[p2.D] << std::endl;
-
+    // This used to print every coordinate of every vertex on every frame,
+    // which made the app unusably slow.  JLIB_PLOT_DUMP captures one frame to
+    // a file instead; see jlib/math/dump.hh.
     math::vertex<T> mid(p2.D);
-    std::cout << std::fixed;
     for(unsigned int i = 0; i < mid.D; i++) {
         mid[i] = (p1[i] + p2[i]) / 2;
-        std::cout << std::setw(5) << std::setprecision(2) << p1[i] << " "  << std::setw(5) << std::setprecision(2)<< p2[i] << " "  << std::setw(5) << std::setprecision(2)<< mid[i] << std::endl;
-    } 
-    std::cout << std::endl;
-   
+    }
+
     Plot::draw_line(p1, mid);
     //Plot::draw_line(p1, p2);
 }
@@ -392,10 +472,13 @@ void HyperPlot<T,Plot>::initialize_rotation(uint n) {
 template<typename T, typename Plot>
 inline
 void HyperPlot<T,Plot>::initialize_glazzies(uint n) {
+    const T r2 = 3;
+    const T r22 = r2 / 2;
+
     clip.clear();
-    clip.push_back(std::make_pair(-3, 3));
-    clip.push_back(std::make_pair(-3, 3));
-    
+    clip.push_back(std::make_pair(-r22, r22));
+    clip.push_back(std::make_pair(-r22, r22));
+
     eye.change(n);
     eye[0] = 0;
     eye[1] = 0;
@@ -408,10 +491,38 @@ void HyperPlot<T,Plot>::initialize_glazzies(uint n) {
     center[0] = 0;
     center[1] = 0;
 
-    for(uint i = 2; i < n; i++) {
-        clip.push_back(std::make_pair(-3, 3));
-        i == 2 ? eye[i] = 3 : eye[i] = 0;
-        //eye[i] = 2.5;
+    // Axis 2 is not projected away here: this reduction stops at three
+    // dimensions and hands x, y, z to OpenGL.  So its clip entry is only ever
+    // a frustum extent, and its eye offset exists to put the object in front
+    // of the GL camera, which sits at the origin looking down -z.
+    // Axis 2 gets NO eye offset, unlike the axes above it.
+    //
+    // This reduction stops at three dimensions and hands x, y, z to OpenGL,
+    // which applies its own perspective.  Putting the 3-D camera distance
+    // into the N-D lookAt means it is applied *before* the 4-D divide and
+    // scaled by it -- and then GL divides x,y by that already-divided z, so
+    // the w cancels out exactly and the 4-D perspective has no effect on
+    // apparent size.  The inner and outer cubes come out identical.
+    //
+    // The 3-D camera belongs in GL, after the reduction; see on_configure.
+    if(n > 2) {
+        clip.push_back(std::make_pair(-r22, r22));
+        eye[2] = 0;
+        up[2] = 0;
+        center[2] = 0;
+    }
+
+    // Every axis above the third *is* projected away, and each needs a
+    // frustum wholly in front of the eye.
+    //
+    // This used to push (-3, 3) -- a negative near plane -- and leave eye[i]
+    // at 0 for every axis but the second.  project() yields w = -x_{d-1}, so
+    // a hypercube spanning +-1 about an eye of 0 gives w = -+1: the
+    // perspective divide then flips sign for half the vertices and mirrors
+    // them through the origin, with the two halves straddling the camera.
+    for(uint i = 3; i < n; i++) {
+        clip.push_back(std::make_pair(r22, 3*r22));
+        eye[i] = r2;
         up[i] = 0;
         center[i] = 0;
     }

--- a/jlib/math/Makefile.am
+++ b/jlib/math/Makefile.am
@@ -4,4 +4,4 @@ AM_CPPFLAGS = -I$(top_srcdir)
 # _SOURCES were all .hh files, which builds no objects and cannot be linked.
 
 libjmathincludedir = $(includedir)/jlib-1.2/jlib/math
-libjmathinclude_HEADERS = math.hh buffer.hh tensor.hh matrix.hh Plot.hh polynomial.hh
+libjmathinclude_HEADERS = math.hh dump.hh buffer.hh tensor.hh matrix.hh Plot.hh polynomial.hh

--- a/jlib/math/Plot.hh
+++ b/jlib/math/Plot.hh
@@ -22,6 +22,7 @@
 #define JLIB_MATH_PLOT_HH
 
 #include <jlib/math/math.hh>
+#include <jlib/math/dump.hh>
 
 #include <vector>
 #include <stack>
@@ -133,6 +134,8 @@ void Plot<T>::draw() {
             }
         }
     }
+
+    dump::frame_done();
 }
 
 
@@ -184,6 +187,8 @@ math::vertex<T> Plot<T>::transform(const math::vertex<T>& vertex) const {
         ret = p * v();
         ret.normalize();
     }
+
+    dump::vertex("base", vertex, ret);
 
     return ret;
 }

--- a/jlib/math/dump.hh
+++ b/jlib/math/dump.hh
@@ -1,0 +1,119 @@
+/* -*- mode: C++ c-basic-offset: 4 -*-
+ *
+ * Copyright (c) 1999 Joe Yandle <joey@divisionbyzero.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ *
+ */
+
+#ifndef JLIB_MATH_DUMP_HH
+#define JLIB_MATH_DUMP_HH
+
+#include <jlib/math/matrix.hh>
+
+#include <cstdlib>
+#include <fstream>
+#include <iomanip>
+#include <string>
+
+namespace jlib {
+namespace math {
+
+/**
+ * Write one frame of projected coordinates to a file, for comparing one
+ * projection pipeline against another.
+ *
+ * Set JLIB_PLOT_DUMP to a path and the first frame's source and transformed
+ * vertices are written there, then the file is closed and every later call is
+ * a no-op.  One frame only, because the objects rotate: two runs are only
+ * comparable at the same rotation, and frame zero is the one state both
+ * pipelines are guaranteed to share.
+ *
+ * This exists because "does it look right" is a poor oracle for a projection
+ * chain.  The perspective divide being a no-op after the first step, and half
+ * the vertices being mirrored through the origin by a frustum that straddles
+ * the eye, both look like "wrong somehow" -- and fixing only one of them looks
+ * like no improvement at all, which is how a correct fix comes to be doubted.
+ */
+namespace dump {
+
+inline std::ofstream* stream() {
+    static bool tried = false;
+    static std::ofstream* out = 0;
+
+    if(!tried) {
+        tried = true;
+        const char* path = std::getenv("JLIB_PLOT_DUMP");
+        if(path != 0 && path[0] != '\0') {
+            out = new std::ofstream(path);
+            if(!out->good()) {
+                delete out;
+                out = 0;
+            }
+        }
+    }
+
+    return out;
+}
+
+inline bool active() {
+    return stream() != 0;
+}
+
+/**
+ * Called once the first frame is complete; closes the file so later frames,
+ * at other rotations, do not append to it.
+ */
+inline void frame_done() {
+    std::ofstream* out = stream();
+    if(out != 0) {
+        out->flush();
+        out->close();
+    }
+}
+
+/**
+ * One source vertex and what the projection chain made of it.
+ */
+template<typename T>
+inline void vertex(const std::string& tag,
+                   const math::vertex<T>& src,
+                   const math::vertex<T>& dst)
+{
+    std::ofstream* out = stream();
+    if(out == 0 || !out->is_open())
+        return;
+
+    *out << tag << "  src";
+    for(unsigned int i = 0; i < src.D; i++)
+        *out << " " << std::fixed << std::setprecision(6) << src[i];
+
+    *out << "  ->  dst";
+    for(unsigned int i = 0; i < dst.D; i++)
+        *out << " " << std::fixed << std::setprecision(6) << dst[i];
+
+    // The homogeneous coordinate: it should be 1 after a correct divide, and
+    // its sign is what flips when the frustum straddles the eye.
+    *out << "  w " << std::fixed << std::setprecision(6) << dst[dst.D];
+
+    *out << "\n";
+}
+
+}
+
+}
+}
+
+#endif //JLIB_MATH_DUMP_HH


### PR DESCRIPTION
closes #22

jhardhyper renders 4D+ objects by reducing N->3 in software and letting the GPU
do 3->2 with real depth -- the architecture the whole solid-rendering goal rests
on.  It has looked wrong since it was written.  It does not any more.

Four separate faults, which is why it stayed unresolved: each one alone leaves
the figure looking broken, so fixing any single one produced no visible
improvement.  That is also how the 2021 TODO at the top of the file came to
suspect a fix that was in fact correct.

    macOS  23 tests, 22 pass, 1 skip
    Linux  24 tests, 22 pass, 2 skip

the frustum straddled the eye

    initialize_glazzies pushed clip = (-3, 3) for every axis -- a negative near
    plane -- and set an eye offset on axis 2 alone, leaving every projected
    axis at 0.

    project() yields w = -x_{d-1}, so a hypercube spanning +-1 about an eye of
    0 gives w = -+1: the perspective divide flips sign for half the vertices
    and mirrors them through the origin, with the two halves ending up on
    opposite sides of the camera.  Visible in the dump as src (-1,-1) landing
    at (+1,+1) for one half and (-1,-1) for the other, at z +4 and -4.

    Now near and far are both positive and every projected axis gets the eye
    offset, matching the scheme in Hyper.hh.

the perspective divide happened twice

    Not previously filed; found from the observation that the inner and outer
    cubes came out exactly the same size.

    The 3-D camera distance was going into the N-D lookAt, so it was applied
    before the 4-D divide and scaled by it.  The reduction then produced
    (0.25, 0.25, -1) and (0.5, 0.5, -2) -- and GL divides x,y by that
    already-divided z, so 0.25/1 and 0.5/2 both come out at 0.25.  The w
    cancelled exactly and the 4-D perspective had no effect on apparent size
    whatsoever.

    The 3-D camera belongs in GL, after the reduction.  Axis 2 now takes no eye
    offset and gluLookAt does the job, so the reduction yields a genuine 3-D
    solid centred on the origin -- 0.25 and 0.5 -- and GL applies ordinary
    perspective to it.

    jglfwhyper never showed this because it reduces all the way to 2-D, so GL
    applies no second perspective and there is nothing to cancel.  It looked
    correct by accident, and would have acquired the bug the moment it stopped
    at three dimensions.

nothing rotated through the highest axis

    r defaulted to n-1 against a loop condition of j < r, so a 4-cube's planes
    were only ever (0,1), (0,2) and (1,2).  Nothing touched axis 3: the nested
    cubes tumbled rigidly together and the figure never everted, which is the
    entire thing a hypercube viewer exists to show.  The comment on that line
    already said "change this to n to rotate in all dimensions".

    Defaults to n now, in Hyper.hh as well so the other three apps get it.  The
    f key still lowers it.  This also satisfies "be rotating in all planes from
    the beginning" from the 2021 TODO.

the figure was not framed

    The GL camera sat at a fixed z=3 while the projected object shrank by
    roughly half per reduction step -- half-extent 0.5 at D=4, ~0.25 at D=5 --
    so it receded as D rose.  jglfwhyper hides this by rescaling to the window
    in map() every frame.

    Moving the camera to meet it works up to about D=7, at which point four
    divides leave a radius near 0.06, the camera closes to ~0.12, and the near
    half of the figure crosses gluPerspective's near plane at 0.1 and clips.

    So the object is normalized to unit radius in the modelview instead and the
    camera stays put.  That holds for any D and gives a consistent apparent
    size.  The radius is tracked as a running maximum, since the extent on any
    one frame is not the largest the figure reaches as it turns -- measuring
    once frames it too tightly and the corners clip.  Growing only means it
    settles within a turn or two and cannot pump.  change() resets it, so e
    and d re-frame.

jlib/math/dump.hh

    Set JLIB_PLOT_DUMP to a path and the first frame's source and projected
    vertices are written there.  One frame only: the objects rotate, so two
    runs are comparable only at the same rotation.

    This exists because "does it look right" is a bad oracle for a projection
    chain, and it is what actually settled the two bugs above -- the sign flip
    and the cancelled divide are both obvious in the numbers and ambiguous on
    screen.  It replaces the per-frame std::cout dump in jhardhyper, which
    printed every coordinate of every vertex on every frame and made the app
    unusably slow.

also

    jgltorus rotates ten times faster; the old rates were barely perceptible.

not addressed here

    math::Plot::transform still has the no-op perspective divide (#21), so
    jglfwhyper, jhyper and jglxhyper remain affine after their first projection
    step.  jhardhyper is unaffected -- it has had that fix since 2021, which is
    what this branch confirms.  #20 and #28 follow.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
