### PR TITLE
Make the projection mode explicit

### DIFF
--- a/jlib/apps/Hyper.hh
+++ b/jlib/apps/Hyper.hh
@@ -257,6 +257,17 @@ void HyperPlot<T,Plot>::key_pressed(unsigned char key, int x, int y) {
         shape = static_cast<Shape>(x);
     
         initialize(this->D);
+    } else if(key == 'p') {
+        // Cycle the projection: perspective -> orthographic -> mixed.
+        //
+        // Not a debug switch.  Perspective is what an N-dimensional camera
+        // would see, but it destroys parallelism, and parallel edges are
+        // exactly what makes an n-cube's structure readable.  Orthographic
+        // keeps them.  Mixed divides on the outermost step only, so the
+        // nesting from the highest dimension still shows while everything
+        // below it stays parallel -- which is why it is the default.
+        this->cycle_projection_mode();
+        this->first = true;
 /*
     } else if(key == 'y' || key == 'h') {
         T x = (key == 't' ? 0.1 : -0.1);

--- a/jlib/apps/jhardhyper.cc
+++ b/jlib/apps/jhardhyper.cc
@@ -91,6 +91,13 @@ protected:
     T m_camera = 0;
     T m_radius = 0;
 
+    /**
+     * Discard the measured framing so the next frame re-measures.  Needed
+     * whenever the projection changes shape -- a different mode or a
+     * different D both change how big the result comes out.
+     */
+    void reframe() { m_camera = 0; m_radius = 0; }
+
     virtual void change(uint n);
 };
 
@@ -99,8 +106,7 @@ inline
 void HPlot<T>::change(uint n) {
     // D is about to change, so the projected extent will too -- and it shrinks
     // by roughly half for every dimension added.  Re-measure from scratch.
-    m_camera = 0;
-    m_radius = 0;
+    reframe();
 
     glfw::Plot<T>::change(n);
 }
@@ -109,8 +115,21 @@ template<typename T>
 inline
 HPlot<T>::HPlot(uint n, std::vector< std::pair<T,T> > c, uint w, uint h) 
     : glfw::Plot<T>(n, c, w, h)
-{    
-
+{
+    // Always perspective, and there is no key to change it.
+    //
+    // This app exists to split the work: reduce N->3 in software and let the
+    // hardware do 3->2.  That makes the other two modes either meaningless or
+    // dishonest here.  Mixed is defined by leaving the inner reduction steps
+    // affine, and the inner step is GL's, not ours.  Orthographic looks right
+    // at D=4 -- the single software step skips its divide -- but GL still
+    // applies perspective underneath, so it is not really orthographic at all,
+    // which becomes obvious above D=4.
+    //
+    // jglfwhyper is where the projection modes are demonstrated: it reduces
+    // all the way to 2-D in software, so a mode there means what it says.
+    // This one is where solid rendering will go.
+    this->set_projection_mode(math::Plot<T>::projection_mode::perspective);
 }
 
 template<typename T>
@@ -239,13 +258,24 @@ math::vertex<T> HPlot<T>::transform(const math::vertex<T>& vertex) const {
     //ret.normalize();
     //ret.change(ret.D - 1);
 
-    // keep projecting until we get to two dimensions
+    // Reduce to three dimensions and hand those to GL.
+    //
+    // Which steps divide is the projection mode: every one for perspective,
+    // none for orthographic, and only the outermost for mixed.
+    typedef typename math::Plot<T>::projection_mode mode;
+    const mode m = this->get_projection_mode();
+
     for(int d = math::Plot<T>::D; d > 3; d--) {
         math::matrix<T> p = math::matrix<T>::project(d, math::Plot<T>::clip);
         math::vertex<T> v(d);
         v = ret;
         ret = p * v();
-        ret.normalize();
+
+        const bool outermost = (d == static_cast<int>(math::Plot<T>::D));
+        if(m == mode::perspective || (m == mode::mixed && outermost)) {
+            ret.normalize();
+        }
+
         ret.change(d-1);
     }
 
@@ -426,7 +456,7 @@ void HyperPlot<T,Plot>::key_pressed(unsigned char key, int x, int y) {
 
         r = nr;
         initialize_rotation(this->D);
-    }
+        }
 }
 
 template<typename T, typename Plot>

--- a/jlib/math/Plot.hh
+++ b/jlib/math/Plot.hh
@@ -24,6 +24,9 @@
 #include <jlib/math/math.hh>
 #include <jlib/math/dump.hh>
 
+#include <cmath>
+#include <iostream>
+
 #include <vector>
 #include <stack>
 
@@ -36,6 +39,38 @@ template<typename T>
 class Plot {
 public:
     enum STACK { MODELVIEW, PROJECTION };
+
+    /**
+     * How each step of the N->target reduction divides.
+     *
+     * project() builds an N-dimensional frustum whose last axis is depth, and
+     * whose homogeneous coordinate is w = -x_{d-1}.  Whether that divide is
+     * actually performed at a given step is a rendering choice, not a
+     * correctness one:
+     *
+     *   perspective   divide at every step.  Physically what a camera in N
+     *                 dimensions would see, and the most convincing.  It also
+     *                 destroys parallelism, which is what makes the cell
+     *                 structure hard to read.
+     *
+     *   orthographic  divide at none.  Parallel edges stay parallel, so the
+     *                 combinatorial structure reads directly off the screen.
+     *                 The standard choice for explaining an n-cube.
+     *
+     *   mixed         divide on the outermost step only.  The nesting from the
+     *                 highest dimension shows as perspective, everything below
+     *                 it stays orthographic -- so an inner and outer cube are
+     *                 visibly the same cube offset in w, rather than merely
+     *                 two cubes.  Legible and still shows the dimension you
+     *                 care about.  This is jlib's long-standing behaviour and
+     *                 the default.
+     *
+     * mixed was not chosen originally: it was the accidental result of
+     * normalize() dividing by the wrong index after the first step.  It turned
+     * out to be the most useful of the three for explaining these objects, so
+     * it is now a named mode rather than a bug.
+     */
+    enum class projection_mode { perspective, orthographic, mixed };
 
     typedef typename std::list< object<T> >::iterator objref;
 
@@ -56,6 +91,14 @@ public:
 
     void setClip(std::vector< std::pair<T,T> > c);
 
+    projection_mode get_projection_mode() const;
+    void set_projection_mode(projection_mode m);
+
+    /**
+     * perspective -> orthographic -> mixed -> perspective.
+     */
+    projection_mode cycle_projection_mode();
+
     uint D;
 
     virtual void change(uint n);
@@ -65,6 +108,24 @@ public:
 protected:
     bool visible(math::vertex<T> vertex) const;
     virtual math::vertex<T> transform(const math::vertex<T>& v) const;
+
+    projection_mode m_projection;
+
+    /**
+     * Largest projected radius seen so far, used to scale map() to the window.
+     *
+     * The scale used to be fixed to the clip width, which only framed the
+     * figure correctly for one projection mode and one D.  Every reduction
+     * step divides by w, so perspective at D=5 lands around 0.03 where mixed
+     * lands around 0.5 -- more than an order of magnitude, with nothing
+     * compensating, so the figure shrank to a dot.
+     *
+     * Tracked as a running maximum, since the extent on any one frame is not
+     * the largest the figure reaches as it turns.  Growing only means it
+     * settles within a turn or two and cannot pump.  mutable because
+     * transform() is const.
+     */
+    mutable T m_radius;
 
     std::vector< std::pair<T,T> > clip;
     std::list< object<T> > objects;
@@ -79,7 +140,9 @@ protected:
 template<typename T>
 inline
 Plot<T>::Plot(uint n, std::vector< std::pair<T,T> > c, uint w, uint h) 
-    : D(n),
+    : m_projection(projection_mode::mixed),
+      m_radius(0),
+      D(n),
       clip(c),
       width(w),
       height(h)
@@ -143,10 +206,21 @@ template<typename T>
 inline
 std::pair<uint,uint> Plot<T>::map(const math::vertex<T>& v) {
     std::pair<uint,uint> ret;
-    T cw = clip[0].second - clip[0].first;
-    T ch = clip[1].second - clip[1].first;
-    T mw = width / cw;
-    T mh = height / ch;
+
+    // Scale to whatever the projection actually produced rather than to the
+    // clip width, so every mode and every D frame the same.  0.45 of the
+    // smaller side leaves a margin for the corners, which swing wider than
+    // the radius measured on any one frame.
+    T mw, mh;
+    if(m_radius > 0) {
+        const T fit = 0.45 * ((width < height) ? width : height) / m_radius;
+        mw = fit;
+        mh = fit;
+    }
+    else {
+        mw = width / (clip[0].second - clip[0].first);
+        mh = height / (clip[1].second - clip[1].first);
+    }
 
     int cx = width / 2;
     int cy = height / 2;
@@ -177,20 +251,78 @@ math::vertex<T> Plot<T>::transform(const math::vertex<T>& vertex) const {
     math::vertex<T> ret(D);
 
     ret = (projection.top() * modelview.top() * vertex());
-    ret.normalize();
 
-    // keep projecting until we get to two dimensions
+    // The outermost step: divided unless the mode is fully orthographic.
+    if(m_projection != projection_mode::orthographic) {
+        ret.normalize();
+    }
+
+    // Shrink to match the step just taken, so the next normalize() divides by
+    // the new homogeneous coordinate rather than by the 1 this one left
+    // behind.  Only in perspective: leaving it out is precisely what makes
+    // every later step affine, which is what mixed is.
+    if(m_projection == projection_mode::perspective) {
+        ret.change(D - 1);
+    }
+
+    // Every step below it.  Note ret.change(d-1) after the divide: normalize()
+    // divides by the vertex's own index D, and without shrinking the vertex to
+    // match the step, that index still holds the 1 left by the previous step --
+    // so the divide silently became a no-op.  That is what made every step
+    // after the first orthographic by accident, which is now MIXED.
     for(int d = (D - 1); d > 2; d--) {
         math::matrix<T> p = math::matrix<T>::project(d, clip);
         math::vertex<T> v(d);
         v = ret;
         ret = p * v();
-        ret.normalize();
+
+        if(m_projection == projection_mode::perspective) {
+            ret.normalize();
+            ret.change(d - 1);
+        }
     }
+
+    // Feeds map()'s framing; see m_radius.
+    const T r = std::sqrt(ret[0] * ret[0] + ret[1] * ret[1]);
+    if(r > m_radius)
+        m_radius = r;
 
     dump::vertex("base", vertex, ret);
 
     return ret;
+}
+
+template<typename T>
+inline
+typename Plot<T>::projection_mode Plot<T>::get_projection_mode() const {
+    return m_projection;
+}
+
+template<typename T>
+inline
+void Plot<T>::set_projection_mode(projection_mode m) {
+    m_projection = m;
+}
+
+template<typename T>
+inline
+typename Plot<T>::projection_mode Plot<T>::cycle_projection_mode() {
+    switch(m_projection) {
+    case projection_mode::perspective:  m_projection = projection_mode::orthographic; break;
+    case projection_mode::orthographic: m_projection = projection_mode::mixed;        break;
+    case projection_mode::mixed:        m_projection = projection_mode::perspective;  break;
+    }
+
+    // The extent changes with the mode -- orthographic is more than an order
+    // of magnitude larger than perspective -- so re-measure the framing.
+    m_radius = 0;
+
+    std::cerr << "projection: "
+              << (m_projection == projection_mode::perspective  ? "perspective"  :
+                  m_projection == projection_mode::orthographic ? "orthographic" : "mixed")
+              << std::endl;
+
+    return m_projection;
 }
 
 template<typename T>
@@ -259,6 +391,7 @@ template<typename T>
 inline
 void Plot<T>::change(uint n) {
     D = n;
+    m_radius = 0;
     while(modelview.size()) {
         modelview.pop();
     }


### PR DESCRIPTION
closes #21

#21 filed the perspective divide in math::Plot::transform as a bug: normalize()
divides by the vertex's own index D, and without shrinking the vertex to match
each step that index still holds the 1 the previous step left, so every divide
after the first silently did nothing.  Which is true.

It is not, however, only a bug.  What it produces is perspective on the
outermost reduction and orthographic on everything below it -- and that turns
out to be the most legible way to show these objects, legible enough that it is
what Joey has used in conference talks for years.  Orthographic projection of
n-cubes is standard in mathematical visualization precisely because parallel
edges stay parallel, so the cell structure reads directly off the screen;
perspective looks more physical and destroys exactly that.

So it becomes a named mode rather than a fix.

    macOS  23 tests, 22 pass, 1 skip
    Linux  24 tests, 22 pass, 2 skip

the modes

    enum class projection_mode { perspective, orthographic, mixed };

    perspective   divides at every step.  What a camera in N dimensions would
                  actually see.

    orthographic  divides at none.  Parallel edges survive, and the inner and
                  outer cubes coincide exactly, which is what makes the
                  structure readable.

    mixed         divides on the outermost step only.  The nesting from the
                  highest dimension shows as perspective while everything below
                  stays parallel, so an inner and outer cube read as the same
                  cube offset in w rather than as two cubes.  The default, and
                  the historical behaviour.

    Scoped, not a bare enum: Plot<T> already had enum STACK { MODELVIEW,
    PROJECTION } next to a member named projection, and an unscoped
    PERSPECTIVE would have made three near-identical names at one scope.  The
    member is m_projection for the same reason.

    Measured at D=5, the two vertices differing only in the highest axis:

        perspective   -0.0278  -0.0417
        orthographic  -1.0000  -1.0000     (they coincide)
        mixed         -0.2500  -0.5000

which app gets which

    jglfwhyper, jhyper and jglxhyper reduce all the way to 2-D in software, so
    a mode there means what it says.  The p key cycles all three.

    jhardhyper is perspective only and has no p key.  It reduces N->3 and hands
    3->2 to the hardware, which makes the other two either meaningless or
    dishonest: mixed is defined by leaving the inner steps affine and the inner
    step is GL's, while orthographic merely looks right at D=4 -- the single
    software step skips its divide -- with GL still applying perspective
    underneath.  Above D=4 that stops being subtle.

    So jglfwhyper is the app for demonstrating projection, and jhardhyper is
    the one that will get solid rendering.

framing

    map() scaled to the clip width, which frames correctly for exactly one mode
    at one D.  Perspective at D=5 lands around 0.03 where mixed lands around
    0.5, so switching mode shrank the figure to a dot.

    It now scales from the projected extent, tracked as a running maximum --
    the extent on any one frame is not the largest the figure reaches as it
    turns, so measuring once frames it too tightly and the corners clip.
    Growing only means it settles within a turn or two and cannot pump.  Reset
    when the mode or D changes, since both alter the extent.

    Note this changes how large mixed appears, though not its geometry: the
    fixed clip-width scale is gone.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
