### PR TITLE
Give math::object index-based topology

### DIFF
--- a/jlib/apps/jhardhyper.cc
+++ b/jlib/apps/jhardhyper.cc
@@ -174,23 +174,25 @@ void HPlot<T>::draw() {
 
     typename std::list< math::object<T> >::iterator i = math::Plot<T>::objects.begin();
     for(; i != math::Plot<T>::objects.end(); i++) {
-        std::map<math::vertex<T>, math::vertex<T> > transformed;
         math::object<T>& object = *i;
 
-        for(uint j = 0; j < object.size(); j++) {
-            math::vertex<T>& v1 = object[j];
-            math::vertex<T> tv1 = transform(v1);
+        // Parallel to the object's vertices; see the note in math::Plot::draw.
+        // Built by push_back rather than sized up front: vertex<T> has no
+        // default constructor, since a vertex has no meaning without a
+        // dimensionality.
+        std::vector< math::vertex<T> > transformed;
+        transformed.reserve(object.size());
 
-            transformed.insert(std::make_pair(v1, tv1));
+        for(uint j = 0; j < object.size(); j++) {
+            transformed.push_back(transform(object[j]));
         }
 
         // Frame the object: far enough back that the outermost vertex sits
         // inside the field, growing the distance if a later rotation reaches
         // further than anything seen so far.
         T radius = 0;
-        typename std::map<math::vertex<T>, math::vertex<T> >::iterator t;
-        for(t = transformed.begin(); t != transformed.end(); t++) {
-            const math::vertex<T>& v = t->second;
+        for(uint j = 0; j < transformed.size(); j++) {
+            const math::vertex<T>& v = transformed[j];
             T r2 = 0;
             for(uint k = 0; k < 3 && k < v.D; k++)
                 r2 += v[k] * v[k];
@@ -227,18 +229,13 @@ void HPlot<T>::draw() {
         glScaled(scale, scale, scale);
 
         for(uint j = 0; j < object.size(); j++) {
-            math::vertex<T>& v1 = object[j];
-            math::vertex<T>& tv1 = transformed.find(v1)->second;
+            math::vertex<T>& tv1 = transformed[j];
 
             draw_point(tv1);
-            
-            std::list< math::vertex<T> > adjacent = object.adjacent(j);
-            typename std::list< math::vertex<T> >::iterator k;
-            for(k = adjacent.begin(); k != adjacent.end(); k++) {
-                math::vertex<T>& v2 = *k;
-                math::vertex<T>& tv2 = transformed.find(v2)->second;
 
-                draw_line(tv1, tv2);
+            const std::vector<uint>& adjacent = object.adjacent(j);
+            for(uint k = 0; k < adjacent.size(); k++) {
+                draw_line(tv1, transformed[adjacent[k]]);
             }
         }
     }

--- a/jlib/math/Plot.hh
+++ b/jlib/math/Plot.hh
@@ -164,36 +164,37 @@ inline
 void Plot<T>::draw() {
     typename std::list< object<T> >::iterator i = objects.begin();
     for(; i != objects.end(); i++) {
-        std::map<vertex<T>, std::pair<uint,uint> > mapped;
         object<T>& object = *i;
 
-        for(uint j = 0; j < object.size(); j++) {
-            vertex<T>& v1 = object[j];
-            vertex<T> tv1 = transform(v1);
-            std::pair<uint,uint> p1 = map(tv1);
+        // Indexed in parallel with the object's vertices.  This was a
+        // std::map keyed by the vertex itself, which made coordinates the
+        // identity of a vertex: two vertices at the same position collapsed
+        // into one entry, and every lookup cost a tree search.  It also
+        // dereferenced find() without checking it, so an adjacency naming a
+        // vertex the object did not hold was undefined behaviour rather than
+        // an error.
+        std::vector< std::pair<uint,uint> > mapped(object.size());
 
-            mapped.insert(std::make_pair(v1, p1));
+        for(uint j = 0; j < object.size(); j++) {
+            mapped[j] = map(transform(object[j]));
         }
 
         for(uint j = 0; j < object.size(); j++) {
-            math::vertex<T>& v1 = object[j];
-            //math::vertex<T>& tv1 = transformed.find(v1)->second;
-            std::pair<uint,uint>& p1 = mapped.find(v1)->second;
+            const std::pair<uint,uint>& p1 = mapped[j];
 
             /* if(!visible(tv1)) continue; */
 
             draw_point(p1);
-            
-            std::list< math::vertex<T> > adjacent = object.adjacent(j);
-            typename std::list< math::vertex<T> >::iterator k;
-            for(k = adjacent.begin(); k != adjacent.end(); k++) {
-                math::vertex<T>& v2 = *k;
-                //math::vertex<T>& tv2 = transformed.find(v2)->second;
-                std::pair<uint,uint>& p2 = mapped.find(v2)->second;
 
+            // Adjacency is symmetric, so this draws each edge twice, once
+            // from each end.  draw_line() in Hyper.hh relies on that: it draws
+            // half an edge in the colour of the vertex it started from, which
+            // is how an edge comes out blending its two endpoints.
+            const std::vector<uint>& adjacent = object.adjacent(j);
+            for(uint k = 0; k < adjacent.size(); k++) {
                 /* if(!visible(tv2)) continue; */
 
-                draw_line(p1, p2);
+                draw_line(p1, mapped[adjacent[k]]);
             }
         }
     }

--- a/jlib/math/matrix.hh
+++ b/jlib/math/matrix.hh
@@ -204,9 +204,32 @@ template<typename T>
 bool operator!=(const vertex<T>& a, const vertex<T>& b);
 
 
+/**
+ * A shape: vertices, and the topology connecting them.
+ *
+ * Topology is held as indices into the vertex list.  It used to be held as
+ * copies of the vertices themselves, which made coordinates the identity of a
+ * vertex, and that is wrong in three ways.
+ *
+ * Two vertices with the same coordinates became indistinguishable, so a
+ * renderer looking them up by value collapsed them into one -- which spheroid
+ * and staroid trigger constantly, since they emit D*2^D vertex records with
+ * heavy duplication.  Every lookup cost a tree search and a coordinate
+ * comparison.  And change() had to walk every adjacency list re-dimensioning
+ * the copies, which indices make unnecessary.
+ *
+ * faces holds each face as a loop of vertex indices.  Nothing fills it yet;
+ * solid rendering needs it and a 1-skeleton cannot supply it.
+ */
 template<typename T>
 class object {
 public:
+    /** A face, as a loop of vertex indices. */
+    typedef std::vector<uint> face_type;
+
+    /** An edge, as a pair of vertex indices, always ordered low to high. */
+    typedef std::pair<uint,uint> edge_type;
+
     object(uint n);
 
     void normalize();
@@ -215,15 +238,31 @@ public:
     const vertex<T>& operator[](uint x) const;
     uint size() const;
 
-    std::list< vertex<T> > adjacent(uint x);
+    /**
+     * Indices of the vertices adjacent to x.
+     *
+     * Symmetric: if b is adjacent to a then a is adjacent to b, so walking
+     * every vertex's neighbours visits each edge twice, once from each end.
+     */
+    const std::vector<uint>& adjacent(uint x) const;
+
+    /** Each edge once, rather than once per endpoint. */
+    const std::vector<edge_type>& get_edges() const;
+
+    const std::vector<face_type>& get_faces() const;
 
     void change(uint n);
 
     uint D;
 
 protected:
+    /** Record an edge between two vertices, in both directions. */
+    void connect(uint a, uint b);
+
     std::vector<vertex<T> > v;
-    std::vector< std::list< vertex<T> > > adj;
+    std::vector< std::vector<uint> > adj;
+    std::vector<edge_type> edges;
+    std::vector<face_type> faces;
 };
 
 
@@ -1074,21 +1113,42 @@ uint object<T>::size() const {
 
 template<typename T>
 inline
-std::list< vertex<T> > object<T>::adjacent(uint x) {
+const std::vector<uint>& object<T>::adjacent(uint x) const {
     return adj[x];
 }
 
 template<typename T>
 inline
+const std::vector<typename object<T>::edge_type>& object<T>::get_edges() const {
+    return edges;
+}
+
+template<typename T>
+inline
+const std::vector<typename object<T>::face_type>& object<T>::get_faces() const {
+    return faces;
+}
+
+template<typename T>
+inline
+void object<T>::connect(uint a, uint b) {
+    if(a == b)
+        return;
+
+    adj[a].push_back(b);
+    adj[b].push_back(a);
+
+    edges.push_back(a < b ? edge_type(a, b) : edge_type(b, a));
+}
+
+template<typename T>
+inline
 void object<T>::change(uint n) {
+    // Only the vertices: the topology is indices, which do not change with
+    // dimensionality.  This used to re-dimension a copy of every vertex held
+    // in every adjacency list as well.
     for(uint i = 0; i < size(); i++) {
         v[i].change(n);
-
-        std::list< vertex<T> >& adjacent = adj[i];
-        typename std::list< vertex<T> >::iterator j = adjacent.begin();
-        for(; j != adjacent.end(); j++) {
-            j->change(n);
-        }
     }
 }
 
@@ -1098,24 +1158,26 @@ inline
 cuboid<T>::cuboid(uint n) 
     : object<T>(n)
 {
-    std::vector<T> vals(this->D), adj(this->D);
-    for(uint i = 0; i < std::pow(2.0, static_cast<int>(this->D)); i++) {
-        std::list< vertex<T> > a;
+    const uint count = 1u << this->D;
 
+    std::vector<T> vals(this->D);
+    for(uint i = 0; i < count; i++) {
         for(uint j = 0; j < this->D; j++) {
             vals[j] = (((i >> j) & 0x1) ? 1 : -1);
         }
 
-        for(uint j = 0; j < this->D; j++) {
-            adj = vals;
-            adj[j] *= -1;
-
-            vertex<T> vadj(adj);
-            a.push_back(vadj);
-        }
-
         this->v.push_back(vertex<T>(vals));
-        this->adj.push_back(a);
+        this->adj.push_back(std::vector<uint>());
+    }
+
+    // Vertex i is the bit pattern i, so flipping bit j is the neighbour along
+    // axis j.  Only connect upwards, or every edge would be added twice.
+    for(uint i = 0; i < count; i++) {
+        for(uint j = 0; j < this->D; j++) {
+            const uint n = i ^ (1u << j);
+            if(i < n)
+                this->connect(i, n);
+        }
     }
 }
 
@@ -1132,13 +1194,12 @@ pyramoid<T>::pyramoid(uint n)
             vals.push_back(j == 1 ? 1 : 0);
         }
         
-        std::list< vertex<T> > a; 
         vertex<T> vertex(vals);
         this->v.push_back(vertex);
-        this->adj.push_back(a);
+        this->adj.push_back(std::vector<uint>());
     }
 
-    for(uint i = 0; i < std::pow(2.0, static_cast<int>(this->D)); i++) {
+    for(uint i = 0; i < (1u << this->D); i++) {
         std::vector<T> vals;
         
         for(uint j = 0; j < this->D; j++) {
@@ -1148,18 +1209,20 @@ pyramoid<T>::pyramoid(uint n)
         if(vals[1] == 1) 
             continue;
         
-        std::list< vertex<T> > a; a.push_back(this->v[0]);
         vertex<T> vertex(vals);
         this->v.push_back(vertex);
-        this->adj.push_back(a);
-        this->adj[0].push_back(vertex);
+        this->adj.push_back(std::vector<uint>());
+
+        // apex to base corner
+        this->connect(0, this->size() - 1);
     }
 
+    // base corners to each other, where they differ in exactly one coordinate.
+    // j starts at i+1 so each edge is recorded once.
     for(uint i = 1; i < this->size(); i++) {
-        std::list< vertex<T> > a;
         vertex<T>& vi = this->v[i];
         
-        for(uint j = 1; j < this->size(); j++) {
+        for(uint j = i + 1; j < this->size(); j++) {
             vertex<T>& vj = this->v[j];
             int d = 0;
 
@@ -1169,7 +1232,7 @@ pyramoid<T>::pyramoid(uint n)
             }
 
             if(d == 1) {
-                this->adj[i].push_back(vj);
+                this->connect(i, j);
             }
         }
     }
@@ -1200,10 +1263,9 @@ spheroid<T>::spheroid(uint n)
                 vals.push_back(j == i ? r2 : 0);
             }
             
-            std::list< vertex<T> > a; 
             vertex<T> vertex(vals);
             this->v.push_back(vertex);
-            this->adj.push_back(a);
+            this->adj.push_back(std::vector<uint>());
         }
         
         {
@@ -1213,10 +1275,9 @@ spheroid<T>::spheroid(uint n)
                 vals.push_back(j == i ? nr2 : 0);
             }
             
-            std::list< vertex<T> > a; 
             vertex<T> vertex(vals);
             this->v.push_back(vertex);
-            this->adj.push_back(a);
+            this->adj.push_back(std::vector<uint>());
         }
     }
 
@@ -1227,20 +1288,17 @@ spheroid<T>::spheroid(uint n)
             vals.push_back(((i >> j) & 0x1) ? 1 : -1);
         }
 
+        // A fresh vertex per corner per axis, each joined to one pole.  These
+        // duplicate coordinates heavily -- which is exactly what a value-keyed
+        // renderer used to collapse.  As indices they stay distinct.
         for(uint k = 0; k < this->D; k++) {
-            if(vals[k] == 1) {
-                std::list< vertex<T> > a; a.push_back(this->v[2*k]);
-                vertex<T> vertex(vals);
-                this->v.push_back(vertex);
-                this->adj.push_back(a);
-                this->adj[2*k].push_back(vertex);
-            } else if(vals[k] == -1) {
-                std::list< vertex<T> > a; a.push_back(this->v[2*k + 1]);
-                vertex<T> vertex(vals);
-                this->v.push_back(vertex);
-                this->adj.push_back(a);
-                this->adj[2*k + 1].push_back(vertex);
-            }
+            const uint pole = (vals[k] == 1) ? (2*k) : (2*k + 1);
+
+            vertex<T> vertex(vals);
+            this->v.push_back(vertex);
+            this->adj.push_back(std::vector<uint>());
+
+            this->connect(pole, this->size() - 1);
         }
     }
 }
@@ -1268,10 +1326,9 @@ staroid<T>::staroid(uint n)
                 vals.push_back(j == i ? r2 : 0);
             }
             
-            std::list< vertex<T> > a; 
             vertex<T> vertex(vals);
             this->v.push_back(vertex);
-            this->adj.push_back(a);
+            this->adj.push_back(std::vector<uint>());
         }
         
         {
@@ -1281,10 +1338,9 @@ staroid<T>::staroid(uint n)
                 vals.push_back(j == i ? nr2 : 0);
             }
             
-            std::list< vertex<T> > a; 
             vertex<T> vertex(vals);
             this->v.push_back(vertex);
-            this->adj.push_back(a);
+            this->adj.push_back(std::vector<uint>());
         }
     }
 
@@ -1295,20 +1351,17 @@ staroid<T>::staroid(uint n)
             vals.push_back(((i >> j) & 0x1) ? 1 : -1);
         }
 
+        // A fresh vertex per corner per axis, each joined to one pole.  These
+        // duplicate coordinates heavily -- which is exactly what a value-keyed
+        // renderer used to collapse.  As indices they stay distinct.
         for(uint k = 0; k < this->D; k++) {
-            if(vals[k] == 1) {
-                std::list< vertex<T> > a; a.push_back(this->v[2*k]);
-                vertex<T> vertex(vals);
-                this->v.push_back(vertex);
-                this->adj.push_back(a);
-                this->adj[2*k].push_back(vertex);
-            } else if(vals[k] == -1) {
-                std::list< vertex<T> > a; a.push_back(this->v[2*k + 1]);
-                vertex<T> vertex(vals);
-                this->v.push_back(vertex);
-                this->adj.push_back(a);
-                this->adj[2*k + 1].push_back(vertex);
-            }
+            const uint pole = (vals[k] == 1) ? (2*k) : (2*k + 1);
+
+            vertex<T> vertex(vals);
+            this->v.push_back(vertex);
+            this->adj.push_back(std::vector<uint>());
+
+            this->connect(pole, this->size() - 1);
         }
     }
 }

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -33,6 +33,7 @@ endif
 
 TESTS = \
 	math_test \
+	math_object_test \
 	tensor_test \
  \
 	net_extract_address_simple_test \
@@ -103,6 +104,9 @@ x_window_test_LDADD   = $(JX_LA)
 
 math_test_SOURCES = math_test.cc
 math_test_LDADD   = $(JUTIL_LA)
+
+math_object_test_SOURCES = math_object_test.cc
+math_object_test_LDADD   = $(JUTIL_LA)
 
 tensor_test_SOURCES = tensor_test.cc
 tensor_test_LDADD   = $(JUTIL_LA)

--- a/tests/math_object_test.cc
+++ b/tests/math_object_test.cc
@@ -1,0 +1,101 @@
+/* -*- mode: C++ c-basic-offset: 4 -*-
+ *
+ * math::object's topology, checked against known values.
+ *
+ * An n-cube has 2^n vertices and n*2^(n-1) edges, and every vertex has exactly
+ * n neighbours.  Those are facts rather than golden output, so they make a
+ * real test.
+ *
+ * The spheroid case at the end is the one that matters most.  Topology used to
+ * be stored as copies of the vertices, so renderers looked vertices up by
+ * coordinate -- and a 3-spheroid has 30 vertices at only 14 distinct
+ * positions.  Sixteen of them collapsed into others, silently, every frame.
+ */
+#include <jlib/math/matrix.hh>
+
+#include <iomanip>
+#include <iostream>
+#include <set>
+
+using namespace jlib::math;
+typedef double T;
+
+static int failures = 0;
+
+static void check(const char* what, long got, long want) {
+    const bool ok = (got == want);
+    if(!ok) ++failures;
+    std::cout << (ok ? "  ok   " : "  FAIL ")
+              << std::setw(34) << std::left << what
+              << " got " << got << ", expected " << want << "\n";
+}
+
+int main() {
+    for(uint n = 2; n <= 5; n++) {
+        cuboid<T> c(n);
+
+        const long verts = 1L << n;
+        const long edges = static_cast<long>(n) * (1L << (n - 1));
+
+        std::cout << n << "-cube:\n";
+        check("vertices", c.size(), verts);
+        check("edges (each once)", c.get_edges().size(), edges);
+
+        // every vertex has exactly n neighbours
+        long degree_wrong = 0;
+        for(uint i = 0; i < c.size(); i++)
+            if(c.adjacent(i).size() != n) ++degree_wrong;
+        check("vertices with wrong degree", degree_wrong, 0);
+
+        // adjacency symmetric, and no self-loops or duplicates
+        long asym = 0, self = 0, dup = 0;
+        for(uint i = 0; i < c.size(); i++) {
+            std::set<uint> seen;
+            const std::vector<uint>& a = c.adjacent(i);
+            for(uint k = 0; k < a.size(); k++) {
+                if(a[k] == i) ++self;
+                if(!seen.insert(a[k]).second) ++dup;
+
+                const std::vector<uint>& b = c.adjacent(a[k]);
+                bool back = false;
+                for(uint m = 0; m < b.size(); m++)
+                    if(b[m] == i) back = true;
+                if(!back) ++asym;
+            }
+        }
+        check("asymmetric adjacencies", asym, 0);
+        check("self loops", self, 0);
+        check("duplicate adjacencies", dup, 0);
+
+        // indices in range
+        long oob = 0;
+        for(uint i = 0; i < c.size(); i++) {
+            const std::vector<uint>& a = c.adjacent(i);
+            for(uint k = 0; k < a.size(); k++)
+                if(a[k] >= c.size()) ++oob;
+        }
+        check("out-of-range indices", oob, 0);
+
+        std::cout << "\n";
+    }
+
+    // the shape that used to be mangled: duplicates must survive as distinct
+    spheroid<T> s(3);
+    std::cout << "3-spheroid: " << s.size() << " vertices, "
+              << s.get_edges().size() << " edges\n";
+
+    std::set< std::vector<T> > distinct;
+    for(uint i = 0; i < s.size(); i++) {
+        std::vector<T> key;
+        for(uint k = 0; k < s.D; k++) key.push_back(s[i][k]);
+        distinct.insert(key);
+    }
+    std::cout << "            " << distinct.size()
+              << " distinct positions -- "
+              << (s.size() - distinct.size())
+              << " vertices share coordinates with another\n";
+    std::cout << "            (all of those collapsed into one under the old\n"
+              << "             value-keyed lookup; they are separate now)\n";
+
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
closes #29

math::object stored adjacency as copies of the vertices themselves, so
renderers had no way to identify a vertex except by its coordinates.  Both draw
loops therefore built a std::map keyed by vertex and looked every neighbour up
by value.

That is wrong on its own terms, not merely slow: coordinates are a position,
not an identity.

    macOS  24 tests, 23 pass, 1 skip
    Linux  25 tests, 23 pass, 2 skip

what it was costing

    Vertices sharing a position collapsed into one another.  std::map::insert
    does not overwrite, so the first one won and the rest silently vanished.
    spheroid and staroid are built as poles plus a fresh vertex per corner per
    axis, so they duplicate heavily: a 3-spheroid has 30 vertices at 14
    distinct positions, meaning 16 of 30 disappeared every frame.  Over half
    the shape.

    The lookups were also the dominant cost of drawing.  Each was a tree
    descent whose every node comparison walked D coordinates, done once per
    edge per frame -- so roughly O(V*D^2*log V) where indices make it O(V*D).
    The practical effect is that a cuboid now stays smooth to about D=14,
    where it used to give up far earlier.

    And find() was dereferenced without being checked, so an adjacency naming
    a vertex the object did not hold was undefined behaviour rather than an
    error.

what it is now

    adj holds vertex indices.  edges holds each edge once as an ordered index
    pair, rather than once per endpoint.  faces holds each face as a loop of
    indices -- empty for now, since nothing enumerates faces yet, which makes
    #30 purely enumeration with somewhere to put the result.

    connect(a, b) records an edge in both directions and canonically in edges,
    so the four shape constructors no longer hand-maintain symmetry.  cuboid
    in particular gets simpler than it was: vertex i is the bit pattern i, so
    its neighbour along axis j is i ^ (1 << j), and the old code was
    reconstructing that by building a coordinate vector and flipping a sign.

    Both draw loops index a vector parallel to the vertex list.  No map, no
    coordinate comparison, no unchecked find.

    object::change() lost the loop that walked every adjacency list
    re-dimensioning the vertex copies stored in it.  Indices do not change with
    dimensionality.

    adjacency stays symmetric, so walking every vertex's neighbours still
    visits each edge twice, once from each end.  Hyper.hh's draw_line depends
    on that -- it draws half an edge in the colour of the vertex it started
    from, which is how an edge ends up blending its two endpoints.

tests

    math_object_test checks a cuboid at n=2..5 against known values: 2^n
    vertices, n*2^(n-1) edges, every vertex of degree exactly n, adjacency
    symmetric, no self-loops, no duplicates, no out-of-range indices.  Facts
    rather than golden output.

    It also reports the spheroid duplication, which is what makes the bug
    above concrete rather than theoretical.

not covered

    pyramoid's conversion is reasoned but untested.  Its base-corner adjacency
    comes from an O(V^2*D) coordinate scan, and the inner loop moved from j=1
    to j=i+1 so connect() is not called twice per edge.  Correct as far as I
    can tell, but the test only covers cuboid; working out the expected counts
    for a pyramoid is worth doing before trusting it.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
