### PR TITLE
Enumerate the 2-faces of cuboid

### DIFF
--- a/jlib/math/matrix.hh
+++ b/jlib/math/matrix.hh
@@ -249,6 +249,14 @@ public:
     /** Each edge once, rather than once per endpoint. */
     const std::vector<edge_type>& get_edges() const;
 
+    /**
+     * The faces, built on first use.
+     *
+     * Deferred rather than built in the constructor because there are a lot
+     * of them: an n-cube has C(n,2)*2^(n-2), which is 372736 at n=14 -- a
+     * dimensionality wireframe rendering handles comfortably, and four times
+     * the vertex count.  Nothing should pay for faces it never draws.
+     */
     const std::vector<face_type>& get_faces() const;
 
     void change(uint n);
@@ -259,10 +267,21 @@ protected:
     /** Record an edge between two vertices, in both directions. */
     void connect(uint a, uint b);
 
+    /**
+     * Fill faces.  Called at most once, from get_faces().
+     *
+     * The base has none: a shape is a 1-skeleton unless a subclass says
+     * otherwise, and enumerating 2-faces is specific to the shape.
+     */
+    virtual void build_faces() const {}
+
     std::vector<vertex<T> > v;
     std::vector< std::vector<uint> > adj;
     std::vector<edge_type> edges;
-    std::vector<face_type> faces;
+
+    // mutable so get_faces() can stay const
+    mutable std::vector<face_type> faces;
+    mutable bool faces_built;
 };
 
 
@@ -270,6 +289,9 @@ template<typename T>
 class cuboid : public object<T> {
 public:
     cuboid(uint n);
+
+protected:
+    virtual void build_faces() const;
 };
 
 
@@ -1078,7 +1100,8 @@ const T* vertex<T>::data() const {
 template<typename T>
 inline
 object<T>::object(uint n) 
-    : D(n)
+    : D(n),
+      faces_built(false)
 {
 }
 
@@ -1126,6 +1149,11 @@ const std::vector<typename object<T>::edge_type>& object<T>::get_edges() const {
 template<typename T>
 inline
 const std::vector<typename object<T>::face_type>& object<T>::get_faces() const {
+    if(!faces_built) {
+        faces_built = true;
+        build_faces();
+    }
+
     return faces;
 }
 
@@ -1177,6 +1205,51 @@ cuboid<T>::cuboid(uint n)
             const uint n = i ^ (1u << j);
             if(i < n)
                 this->connect(i, n);
+        }
+    }
+}
+
+
+/**
+ * The 2-faces of an n-cube.
+ *
+ * A face is fixed by choosing two axes to leave free and pinning the other
+ * n-2 coordinates to a particular sign pattern, so there are C(n,2)*2^(n-2)
+ * of them: 6 for a cube, 24 for a tesseract, 80 for a 5-cube.
+ *
+ * Vertex i is the bit pattern i, so a face's four corners are the base
+ * pattern with the two free bits taking all four combinations.  They are
+ * emitted 00, 10, 11, 01 -- around the square rather than across it, so the
+ * loop is a real quad and not a bowtie.
+ *
+ * No attempt is made to wind them consistently outward.  A hypercube reduced
+ * to three dimensions is a shadow, not a solid: faces turn inside out as it
+ * rotates, and both sides are seen.  Normals are computed per frame from the
+ * projected positions, and lighting is two-sided.
+ */
+template<typename T>
+inline
+void cuboid<T>::build_faces() const {
+    const uint count = 1u << this->D;
+
+    for(uint a = 0; a < this->D; a++) {
+        for(uint b = a + 1; b < this->D; b++) {
+            const uint bit_a = 1u << a;
+            const uint bit_b = 1u << b;
+
+            for(uint base = 0; base < count; base++) {
+                // one face per assignment of the other n-2 coordinates
+                if((base & bit_a) != 0 || (base & bit_b) != 0)
+                    continue;
+
+                typename object<T>::face_type f;
+                f.push_back(base);
+                f.push_back(base | bit_a);
+                f.push_back(base | bit_a | bit_b);
+                f.push_back(base | bit_b);
+
+                this->faces.push_back(f);
+            }
         }
     }
 }

--- a/tests/math_object_test.cc
+++ b/tests/math_object_test.cc
@@ -15,6 +15,7 @@
 
 #include <iomanip>
 #include <iostream>
+#include <map>
 #include <set>
 
 using namespace jlib::math;
@@ -75,6 +76,51 @@ int main() {
                 if(a[k] >= c.size()) ++oob;
         }
         check("out-of-range indices", oob, 0);
+
+        // faces: C(n,2) * 2^(n-2)
+        const long faces = (static_cast<long>(n) * (n - 1) / 2) * (1L << (n - 2));
+        check("faces", c.get_faces().size(), faces);
+
+        long wrong_size = 0, face_oob = 0;
+        std::map<std::pair<uint,uint>, long> sides;
+        for(uint f = 0; f < c.get_faces().size(); f++) {
+            const std::vector<uint>& face = c.get_faces()[f];
+
+            if(face.size() != 4) ++wrong_size;
+
+            for(uint k = 0; k < face.size(); k++) {
+                if(face[k] >= c.size()) ++face_oob;
+
+                // consecutive corners, wrapping -- a face is a loop
+                const uint x = face[k];
+                const uint y = face[(k + 1) % face.size()];
+                sides[x < y ? std::make_pair(x, y) : std::make_pair(y, x)]++;
+            }
+        }
+        check("faces that are not quads", wrong_size, 0);
+        check("out-of-range face indices", face_oob, 0);
+
+        // Every side of every face must be a real edge of the cube.  This is
+        // what catches a bowtie: 00,10,01,11 traverses two diagonals, which
+        // are not edges.
+        std::set<std::pair<uint,uint> > real;
+        for(uint e = 0; e < c.get_edges().size(); e++)
+            real.insert(c.get_edges()[e]);
+
+        long not_an_edge = 0;
+        for(std::map<std::pair<uint,uint>, long>::iterator u = sides.begin();
+            u != sides.end(); u++)
+            if(real.find(u->first) == real.end()) ++not_an_edge;
+        check("face sides that are not edges", not_an_edge, 0);
+
+        // and every edge lies in exactly n-1 faces: fix the edge's axis, and
+        // any one of the remaining n-1 axes completes a face
+        long wrong_share = 0;
+        for(std::map<std::pair<uint,uint>, long>::iterator u = sides.begin();
+            u != sides.end(); u++)
+            if(u->second != static_cast<long>(n) - 1) ++wrong_share;
+        check("edges used by wrong face count", wrong_share, 0);
+        check("edges covered by faces", sides.size(), edges);
 
         std::cout << "\n";
     }


### PR DESCRIPTION
closes #30

#29 gave math::object a faces member and left it empty.  This fills it for
cuboid, which is the shape with a closed form and the one solid rendering will
be developed against.

    macOS  24 tests, 23 pass, 1 skip
    Linux  25 tests, 23 pass, 2 skip

the enumeration

    A 2-face of an n-cube is fixed by choosing two axes to leave free and
    pinning the other n-2 coordinates to a sign pattern, so there are
    C(n,2)*2^(n-2): 6 for a cube, 24 for a tesseract, 80 for a 5-cube.

    #29 made vertex i the bit pattern i, which makes this fall out.  The four
    corners are the base pattern with the two free bits taking all four
    combinations, and they are emitted 00, 10, 11, 01 -- around the square
    rather than across it, so the loop is a quad and not a bowtie.

built on first use

    get_faces() now builds through a protected virtual build_faces(), called at
    most once; faces and the built flag are mutable so get_faces() stays const.
    The base builds nothing, so a shape is a 1-skeleton until a subclass says
    otherwise, and #31 only has to override one method.

    Deferred rather than eager because faces outnumber vertices by a lot at the
    dimensionalities this now reaches.  A 14-cube is 372736 faces, four times
    its vertex count, and #29 just made D=14 a dimensionality the wireframe
    renders smoothly.  Measured, it is 4ms to construct and 19ms to build the
    faces, so an app that only draws wireframe would spend most of its startup
    on geometry it never touches.  The second call is free.

winding

    Not consistently outward, and deliberately.  A hypercube reduced to three
    dimensions is a shadow rather than a solid: faces turn inside out as it
    rotates and both sides are seen, so an outward orientation is not
    well-defined to begin with.  #33 computes normals per frame from the
    projected positions and lighting is two-sided, which is the arrangement
    that handles this correctly.

tests

    math_object_test checks a cuboid at n=2..5 for C(n,2)*2^(n-2) faces, every
    face a quad, every index in range, and every side of every face a real edge
    of the cube -- that last one is what would catch a bowtie ordering, since a
    bowtie's sides are diagonals.

    It also checks that every edge lies in exactly n-1 faces (fix the edge's
    axis, and any one of the remaining axes completes a face) and that the
    faces between them cover every edge.  Together those say the faces are
    attached to the 1-skeleton the way the shape requires, not merely that
    there are the right number of them.

not covered

    pyramoid, spheroid and staroid still have no faces and inherit the empty
    base.  pyramoid is #31; spheroid and staroid need real tessellation first,
    which is #35.

    object::change() re-dimensions the vertices without updating D, which is
    inconsistent but harmless today since nothing calls it.  Left alone rather
    than fixed here: for a cuboid the vertex count is fixed at construction, so
    a D that moved independently of it would make face enumeration emit
    out-of-range indices.  Worth deciding separately whether change() should
    reject a dimension change or rebuild the topology.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
