### PR TITLE
render 4-D objects as translucent solids in jhardhyper

### DIFF
--- a/jlib/apps/jhardhyper.cc
+++ b/jlib/apps/jhardhyper.cc
@@ -19,6 +19,7 @@
  * XXX TODO fix this by printing the matrix contents out in a machine readable format.  correct for the different column layout, then get the same results from jhyper.  be rotating in all planes from the beginning. at some point the two modelview matricies will diverge, use this as a debugger to find out when/where it broke
  */
 
+#include <algorithm>
 #include <chrono>
 #include <cmath>
 #include <iostream>
@@ -61,8 +62,31 @@ public:
 
     virtual void draw();
 
-    virtual void draw_point(math::vertex<T> p);
-    virtual void draw_line(math::vertex<T> p1, math::vertex<T> p2);
+    /**
+     * A vertex and an edge, each told which object vertices they came from.
+     *
+     * The index is what lets a subclass colour an endpoint.  Without it the
+     * only thing an override could reach was a counter incremented by
+     * draw_point, so an edge could only be drawn in the colour of whichever
+     * end came first -- which is why edges used to be drawn in halves.
+     */
+    virtual void draw_point(const math::vertex<T>& p, uint index);
+    virtual void draw_line(const math::vertex<T>& p1, const math::vertex<T>& p2,
+                           uint i1, uint i2);
+
+    /**
+     * One face, as a polygon with a normal.
+     *
+     * index[k] is the object vertex that corner[k] came from, numbered across
+     * every object in the plot, so a subclass can colour a face from whatever
+     * it keeps per vertex.  The geometry here ignores it.
+     */
+    virtual void draw_face(const std::vector< math::vertex<T> >& corner,
+                           const math::vertex<T>& normal,
+                           const std::vector<uint>& index);
+
+    /** Solid faces as well as the wireframe.  The o key toggles it. */
+    bool m_solid = true;
 
 protected:
     virtual math::vertex<T> transform(const math::vertex<T>& v) const;
@@ -128,8 +152,16 @@ HPlot<T>::HPlot(uint n, std::vector< std::pair<T,T> > c, uint w, uint h)
     //
     // jglfwhyper is where the projection modes are demonstrated: it reduces
     // all the way to 2-D in software, so a mode there means what it says.
-    // This one is where solid rendering will go.
+    // This one is where the solid rendering is.
     this->set_projection_mode(math::Plot<T>::projection_mode::perspective);
+
+    // glfw::Plot leaves lighting alone, because a wireframe has no normals and
+    // enabling it there only makes glColor inert.  Faces do have normals, so
+    // this one needs it -- in the two-sided form, since a projected hypercube
+    // shows both sides of every face.  It stays disabled except during the
+    // face pass, so the edges and points keep their flat colours.
+    gl::lights::init(true);
+    glDisable(GL_LIGHTING);
 }
 
 template<typename T>
@@ -145,7 +177,7 @@ void HPlot<T>::on_configure(int width, int height) {
 
 template<typename T>
 inline
-void HPlot<T>::draw_point(math::vertex<T> p) {
+void HPlot<T>::draw_point(const math::vertex<T>& p, uint) {
     glBegin(GL_POINTS);
     //glVertex3d(p[0], p[1], p[2]);
     glVertex4dv(p.data());
@@ -154,7 +186,8 @@ void HPlot<T>::draw_point(math::vertex<T> p) {
 
 template<typename T>
 inline
-void HPlot<T>::draw_line(math::vertex<T> p1, math::vertex<T> p2) {
+void HPlot<T>::draw_line(const math::vertex<T>& p1, const math::vertex<T>& p2,
+                         uint, uint) {
     glBegin(GL_LINES);
     //std::cout << "HPlot<T>::draw_line: p1.D: " << p1.D << "\n" << static_cast< math::matrix<T> >(p1) << std::endl
     //          << "p2.D: " << p2.D << "\n" << static_cast< math::matrix<T> >(p2) << std::endl;
@@ -169,12 +202,88 @@ void HPlot<T>::draw_line(math::vertex<T> p1, math::vertex<T> p2) {
 
 template<typename T>
 inline
+void HPlot<T>::draw_face(const std::vector< math::vertex<T> >& corner,
+                         const math::vertex<T>& normal,
+                         const std::vector<uint>&) {
+    glNormal3d(normal[0], normal[1], normal[2]);
+
+    glBegin(GL_POLYGON);
+    for(uint k = 0; k < corner.size(); k++)
+        glVertex4dv(corner[k].data());
+    glEnd();
+}
+
+/**
+ * The normal of a projected face, or false if it has none.
+ *
+ * A function of where the face landed, not of the source geometry: the object
+ * turns in N dimensions and re-projects every frame, so the 3-D orientation of
+ * a face is only known after the reduction.
+ *
+ * Faces going edge-on is routine rather than exceptional here -- a hypercube
+ * shows several every turn, and a whole cell flattens whenever the rotation
+ * takes it perpendicular to the projection.  The cross product vanishes there
+ * and the direction is genuinely undefined, so those are skipped.
+ */
+template<typename T>
+inline
+bool face_normal(const std::vector< math::vertex<T> >& corner,
+                 math::vertex<T>& normal) {
+    if(corner.size() < 3)
+        return false;
+
+    T a[3], b[3];
+    for(uint k = 0; k < 3; k++) {
+        a[k] = corner[1][k] - corner[0][k];
+        b[k] = corner[corner.size() - 1][k] - corner[0][k];
+    }
+
+    T n[3];
+    n[0] = a[1] * b[2] - a[2] * b[1];
+    n[1] = a[2] * b[0] - a[0] * b[2];
+    n[2] = a[0] * b[1] - a[1] * b[0];
+
+    const T len = std::sqrt(n[0] * n[0] + n[1] * n[1] + n[2] * n[2]);
+
+    // Purely relative, with no absolute floor.
+    //
+    // len is an area, and the figure shrinks by roughly a third per dimension
+    // as each reduction step divides by w -- so the area of a face falls by
+    // about a factor of ten per dimension.  An absolute cutoff of 1e-6 is
+    // nowhere near the geometry at D=4, where a face measures 2e-1, but it
+    // passes straight through it around D=8 and swallows the figure whole:
+    // measured, it discarded 60% of the faces at D=9, 99.7% at D=10 and every
+    // last one from D=11 up.  That is what made the solid disappear at high D
+    // while the wireframe carried on.
+    //
+    // Dividing by the edge lengths gives the sine of the angle between them,
+    // which says whether the face has a direction without saying anything
+    // about its size.  That is the actual question, and it rejected nothing
+    // at any D from 4 to 12 except genuinely edge-on faces.
+    const T scale = std::sqrt((a[0] * a[0] + a[1] * a[1] + a[2] * a[2]) *
+                              (b[0] * b[0] + b[1] * b[1] + b[2] * b[2]));
+
+    if(scale <= 0 || len / scale < 1e-6)
+        return false;
+
+    for(uint k = 0; k < 3; k++)
+        normal[k] = n[k] / len;
+
+    return true;
+}
+
+template<typename T>
+inline
 void HPlot<T>::draw() {
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
-    typename std::list< math::object<T> >::iterator i = math::Plot<T>::objects.begin();
+    // Vertices are numbered across every object, matching the counter
+    // draw_point keeps, so a subclass can index one colour table with either.
+    uint base = 0;
+
+    typename math::Plot<T>::objref i = math::Plot<T>::objects.begin();
     for(; i != math::Plot<T>::objects.end(); i++) {
-        math::object<T>& object = *i;
+        math::object<T>& object = **i;
 
         // Parallel to the object's vertices; see the note in math::Plot::draw.
         // Built by push_back rather than sized up front: vertex<T> has no
@@ -228,17 +337,120 @@ void HPlot<T>::draw() {
                   0, 1, 0);
         glScaled(scale, scale, scale);
 
+        // Depth cue: fade toward the background with distance.
+        //
+        // Everything is translucent and drawn from every angle, so without
+        // this the far side of the figure is exactly as bright as the near
+        // side and the eye has nothing to order them by -- which is the one
+        // thing stopping the reduction at three dimensions was supposed to
+        // buy.  The figure is normalized to unit radius, so it spans one
+        // either side of the camera's focus; the far bound goes a little past
+        // that so the back does not go fully black.
+        const GLfloat fog[4] = { 0, 0, 0, 1 };
+        glFogfv(GL_FOG_COLOR, fog);
+        glFogi(GL_FOG_MODE, GL_LINEAR);
+        glFogf(GL_FOG_START, static_cast<GLfloat>(m_camera - 1.0));
+        glFogf(GL_FOG_END, static_cast<GLfloat>(m_camera + 1.8));
+        glEnable(GL_FOG);
+
+        // Solid faces first, then the wireframe over them.
+        //
+        // Everything here is translucent, so there is no opaque pass to
+        // establish depth against.  The faces sort back to front and do not
+        // write depth, which is what makes overlapping faces blend in the
+        // right order; the edges and points then draw against an untouched
+        // depth buffer and none of them are hidden.  Losing the wireframe
+        // inside the solid would defeat the point -- the edges are how you
+        // follow a cell through an eversion.
+        if(m_solid && math::Plot<T>::D >= 3 && !object.get_faces().empty()) {
+            const std::vector<typename math::object<T>::face_type>& faces =
+                object.get_faces();
+
+            // Depth of a face is its centroid's z.  The modelview applies a
+            // uniform positive scale and a translation along z, so ordering
+            // by z here is the same as ordering by eye-space depth.
+            std::vector< std::pair<T,uint> > order;
+            order.reserve(faces.size());
+
+            for(uint f = 0; f < faces.size(); f++) {
+                T z = 0;
+                for(uint k = 0; k < faces[f].size(); k++)
+                    z += transformed[faces[f][k]][2];
+
+                order.push_back(std::make_pair(z / faces[f].size(), f));
+            }
+
+            // ascending z: the camera looks down -z, so smallest is farthest
+            std::sort(order.begin(), order.end());
+
+            glEnable(GL_LIGHTING);
+            glEnable(GL_BLEND);
+            glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+            glDisable(GL_CULL_FACE);
+            glDepthMask(GL_FALSE);
+
+            std::vector< math::vertex<T> > corner;
+            std::vector<uint> index;
+            math::vertex<T> normal(3);
+
+            for(uint o = 0; o < order.size(); o++) {
+                const typename math::object<T>::face_type& face =
+                    faces[order[o].second];
+
+                corner.clear();
+                index.clear();
+                for(uint k = 0; k < face.size(); k++) {
+                    corner.push_back(transformed[face[k]]);
+                    index.push_back(base + face[k]);
+                }
+
+                if(face_normal(corner, normal))
+                    draw_face(corner, normal, index);
+            }
+
+            glDepthMask(GL_TRUE);
+            glDisable(GL_BLEND);
+            glDisable(GL_LIGHTING);
+        }
+
+        // Smooth shading so an edge blends between its endpoints' colours
+        // along its length, and antialiasing so it does not come out as a
+        // jagged hairline over the faces.
+        glShadeModel(GL_SMOOTH);
+        glEnable(GL_BLEND);
+        glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+        glEnable(GL_LINE_SMOOTH);
+        glHint(GL_LINE_SMOOTH_HINT, GL_NICEST);
+        glEnable(GL_POINT_SMOOTH);
+        glHint(GL_POINT_SMOOTH_HINT, GL_NICEST);
+        glLineWidth(2.0);
+        glPointSize(5.0);
+
         for(uint j = 0; j < object.size(); j++) {
-            math::vertex<T>& tv1 = transformed[j];
+            draw_point(transformed[j], base + j);
 
-            draw_point(tv1);
-
+            // Once per edge, not once per endpoint.  Adjacency is symmetric,
+            // so walking it visits every edge from both ends; that used to be
+            // load-bearing, because half an edge was drawn from each end in
+            // that end's colour.  An edge now carries both endpoints and
+            // blends across, so the second visit is pure overdraw.
             const std::vector<uint>& adjacent = object.adjacent(j);
             for(uint k = 0; k < adjacent.size(); k++) {
-                draw_line(tv1, transformed[adjacent[k]]);
+                if(adjacent[k] < j) continue;
+
+                draw_line(transformed[j], transformed[adjacent[k]],
+                          base + j, base + adjacent[k]);
             }
         }
+
+        glDisable(GL_POINT_SMOOTH);
+        glDisable(GL_LINE_SMOOTH);
+        glDisable(GL_BLEND);
+
+        base += object.size();
     }
+
+    glDisable(GL_FOG);
 
 	this->flush();
 
@@ -290,6 +502,71 @@ struct triple {
     O b;
 };
 
+/**
+ * A hue, at full saturation and value.
+ *
+ * Colours are kept as hues rather than triples so they can be combined
+ * without washing out.  Averaging in RGB drives every channel toward its
+ * mean: four random corners average to a standard deviation of about 0.14
+ * around 0.5, so every face came out the same olive grey no matter which
+ * vertices it joined.  A hue has nowhere to collapse to -- the result of
+ * combining hues is always another fully saturated colour.
+ */
+template<typename O>
+inline
+triple<O> hsv(O h) {
+    h -= std::floor(h);
+
+    const O sector = h * 6;
+    const int i = static_cast<int>(std::floor(sector));
+    const O f = sector - i;
+
+    const O q = 1 - f;
+    const O t = f;
+
+    triple<O> c;
+    switch(i % 6) {
+    case 0: c.r = 1; c.g = t; c.b = 0; break;
+    case 1: c.r = q; c.g = 1; c.b = 0; break;
+    case 2: c.r = 0; c.g = 1; c.b = t; break;
+    case 3: c.r = 0; c.g = q; c.b = 1; break;
+    case 4: c.r = t; c.g = 0; c.b = 1; break;
+    default: c.r = 1; c.g = 0; c.b = q; break;
+    }
+
+    return c;
+}
+
+/**
+ * Where a set of hues sits on the colour wheel.
+ *
+ * The mean direction, not the arithmetic mean: hues wrap, so averaging 0.9
+ * and 0.1 numerically gives 0.5 -- cyan from two reds.  Summing unit vectors
+ * and taking the angle gets the answer that agrees with the wheel.
+ *
+ * Corners spread evenly around the wheel sum to nothing and have no mean
+ * direction at all.  That is a real ambiguity rather than a numerical one, so
+ * it falls back to the first corner instead of pretending otherwise.
+ */
+template<typename O>
+inline
+O hue_mean(const std::vector<O>& h) {
+    if(h.empty()) return 0;
+
+    O x = 0, y = 0;
+    for(uint k = 0; k < h.size(); k++) {
+        x += std::cos(2 * PI * h[k]);
+        y += std::sin(2 * PI * h[k]);
+    }
+
+    if(std::sqrt(x * x + y * y) < 1e-9)
+        return h[0];
+
+    const O a = std::atan2(y, x) / (2 * PI);
+
+    return a - std::floor(a);
+}
+
 template<typename T, typename Plot>
 class HyperPlot : public Plot {
 public:
@@ -297,8 +574,12 @@ public:
 
     virtual void change(uint n);
     virtual void draw();
-    virtual void draw_point(math::vertex<T> point);
-    virtual void draw_line(math::vertex<T> p1, math::vertex<T> p2);
+    virtual void draw_point(const math::vertex<T>& point, uint index);
+    virtual void draw_line(const math::vertex<T>& p1, const math::vertex<T>& p2,
+                           uint i1, uint i2);
+    virtual void draw_face(const std::vector< math::vertex<T> >& corner,
+                           const math::vertex<T>& normal,
+                           const std::vector<uint>& index);
 
     void key_pressed(unsigned char key,int x,int y);
     void button_pressed(int button, int state, int x, int y);
@@ -309,10 +590,16 @@ protected:
     void initialize_rotation(uint n);
     void initialize_glazzies(uint n);
 
-    std::vector< triple<T> > colors;
-    uint i;
+    /**
+     * One hue per vertex, numbered across every object in the plot.
+     *
+     * Spaced by the golden ratio rather than chosen at random.  Successive
+     * hues then land as far apart on the wheel as they can, so neighbouring
+     * vertices stay distinguishable at any D, and the figure comes up the
+     * same colours every run -- which matters when comparing two builds.
+     */
+    std::vector<T> hues;
     uint r;
-    bool first;
 
     matrix<T> rotate;
     matrix<T> back_rotate;
@@ -329,7 +616,6 @@ inline
 HyperPlot<T,Plot>::HyperPlot(uint n, std::vector< std::pair<T,T> > c, uint w, uint h) 
     : Plot(n, c, w, h),
       r(n),
-      first(true),
       rotate(matrix<T>::identity(n+1)),
       back_rotate(matrix<T>::identity(n+1)),
       waiting(false),
@@ -366,63 +652,97 @@ void HyperPlot<T,Plot>::initialize(uint n) {
 template<typename T, typename Plot>
 inline
 void HyperPlot<T,Plot>::draw() {
-    i = 0;
+    // Colours are per vertex and have to exist before anything is drawn.
+    // draw_point used to generate them as it went, on the first frame only,
+    // which worked while points were the first thing drawn -- the face pass
+    // now runs ahead of them and would have read an empty table.
+    uint n = 0;
+    typename Plot::objref o = this->objects.begin();
+    for(; o != this->objects.end(); o++)
+        n += (*o)->size();
+
+    while(hues.size() < n) {
+        const T golden = 0.6180339887498948;
+
+        hues.push_back(std::fmod(hues.size() * golden, 1.0));
+    }
 
     Plot::draw();
-
-    if(first) first = false;
 }
 
 template<typename T, typename Plot>
 inline
 void HyperPlot<T,Plot>::change(uint n) {
     Plot::change(n);
-    first = true;
-    colors.clear();
+    hues.clear();
 }
 
 
 template<typename T, typename Plot>
 inline
-void HyperPlot<T,Plot>::draw_point(math::vertex<T> point) {
-    if(first) {
-        triple<T> color; color.r = 0; color.b = 0; color.g = 0;
+void HyperPlot<T,Plot>::draw_point(const math::vertex<T>& point, uint index) {
+    const triple<T> c = hsv(hues[index]);
 
-        const T MIN = 0.666;
-        while(color.r + color.b + color.g < MIN) {
-            color.r = static_cast<T>(std::rand() % 256) / 255.0;
-            color.g = static_cast<T>(std::rand() % 256) / 255.0;
-            color.b = static_cast<T>(std::rand() % 256) / 255.0;
-        }
-        
-        colors.push_back(color);
-    } 
+    glColor4f(c.r, c.g, c.b, 1.0);
 
-    Plot::draw_point(point);
-
-    i++;
+    Plot::draw_point(point, index);
 }
 
+
+/**
+ * A face in the blend of its corners' colours, translucent.
+ *
+ * No attempt to wind the faces outward: a hypercube reduced to three
+ * dimensions is a shadow rather than a solid, so faces turn inside out as it
+ * everts and both sides are seen.  Two-sided lighting and a material set on
+ * GL_FRONT_AND_BACK are what make that come out right regardless of which way
+ * a given face happens to be facing this frame.
+ */
 template<typename T, typename Plot>
 inline
-void HyperPlot<T,Plot>::draw_line(math::vertex<T> p1, math::vertex<T> p2) {
-    triple<T> color = colors[i-1];
-    //set_foreground(color.r, color.g, color.b);
+void HyperPlot<T,Plot>::draw_face(const std::vector< math::vertex<T> >& corner,
+                                  const math::vertex<T>& normal,
+                                  const std::vector<uint>& index) {
+    std::vector<T> h;
+    for(uint k = 0; k < index.size(); k++)
+        if(index[k] < hues.size())
+            h.push_back(hues[index[k]]);
+
+    const triple<T> color = hsv(hue_mean(h));
+
+    // Low enough that a 4-cube is four or five faces deep in places and still
+    // reads as separate surfaces rather than a solid block.
     GLfloat fcolors[4];
-    fcolors[0] = color.r; fcolors[1] = color.g; fcolors[2] = color.b; fcolors[3] = 1.0;
-    glColor3fv(fcolors);
+    fcolors[0] = color.r; fcolors[1] = color.g; fcolors[2] = color.b;
+    fcolors[3] = 0.18;
+
+    glColor4fv(fcolors);
     glMaterialfv(GL_FRONT_AND_BACK, GL_AMBIENT_AND_DIFFUSE, fcolors);
 
-    // This used to print every coordinate of every vertex on every frame,
-    // which made the app unusably slow.  JLIB_PLOT_DUMP captures one frame to
-    // a file instead; see jlib/math/dump.hh.
-    math::vertex<T> mid(p2.D);
-    for(unsigned int i = 0; i < mid.D; i++) {
-        mid[i] = (p1[i] + p2[i]) / 2;
-    }
+    Plot::draw_face(corner, normal, index);
+}
 
-    Plot::draw_line(p1, mid);
-    //Plot::draw_line(p1, p2);
+template<typename T, typename Plot>
+inline
+void HyperPlot<T,Plot>::draw_line(const math::vertex<T>& p1, const math::vertex<T>& p2,
+                                  uint i1, uint i2) {
+    // A colour at each end and let the rasterizer interpolate.
+    //
+    // This used to draw half an edge, from p1 to the midpoint, in p1's
+    // colour, and rely on the edge being visited again from the other end to
+    // fill in the rest.  The two halves met at the midpoint with a hard seam,
+    // which is what made the wireframe look like it was assembled from
+    // separate pieces.  Interpolating across the whole edge blends the two
+    // hues the way the 2021 design asked for, and needs one pass.
+    const triple<T> c1 = hsv(hues[i1]);
+    const triple<T> c2 = hsv(hues[i2]);
+
+    glBegin(GL_LINES);
+    glColor4f(c1.r, c1.g, c1.b, 1.0);
+    glVertex4dv(p1.data());
+    glColor4f(c2.r, c2.g, c2.b, 1.0);
+    glVertex4dv(p2.data());
+    glEnd();
 }
 
 template<typename T, typename Plot>
@@ -445,6 +765,9 @@ void HyperPlot<T,Plot>::key_pressed(unsigned char key, int x, int y) {
             return;
 
         initialize(d);
+    } else if(key == 'o') {
+        this->m_solid = !this->m_solid;
+        this->draw();
     } else if(key == 'r' || key == 'f') {
         uint nr = (key == 'r' ? r + 1 : r - 1);
 

--- a/jlib/math/Plot.hh
+++ b/jlib/math/Plot.hh
@@ -27,6 +27,7 @@
 #include <cmath>
 #include <iostream>
 
+#include <memory>
 #include <vector>
 #include <stack>
 
@@ -72,7 +73,7 @@ public:
      */
     enum class projection_mode { perspective, orthographic, mixed };
 
-    typedef typename std::list< object<T> >::iterator objref;
+    typedef typename std::list< std::shared_ptr< object<T> > >::iterator objref;
 
     Plot(uint n, std::vector< std::pair<T,T> > c, uint w, uint h);
     virtual ~Plot() {}
@@ -128,7 +129,9 @@ protected:
     mutable T m_radius;
 
     std::vector< std::pair<T,T> > clip;
-    std::list< object<T> > objects;
+    // Held by pointer so a shape keeps its type.  These used to be stored by
+    // value, which sliced every subclass down to the base on the way in.
+    std::list< std::shared_ptr< object<T> > > objects;
     std::stack< matrix<T> > modelview;
     std::stack< matrix<T> > projection;
     STACK current;
@@ -155,16 +158,16 @@ Plot<T>::Plot(uint n, std::vector< std::pair<T,T> > c, uint w, uint h)
 template<typename T>
 inline
 typename Plot<T>::objref Plot<T>::add(const object<T>& o) {
-    return objects.insert(objects.end(), o);
+    return objects.insert(objects.end(), o.clone());
 }
 
 
 template<typename T>
 inline
 void Plot<T>::draw() {
-    typename std::list< object<T> >::iterator i = objects.begin();
+    objref i = objects.begin();
     for(; i != objects.end(); i++) {
-        object<T>& object = *i;
+        object<T>& object = **i;
 
         // Indexed in parallel with the object's vertices.  This was a
         // std::map keyed by the vertex itself, which made coordinates the

--- a/jlib/math/matrix.hh
+++ b/jlib/math/matrix.hh
@@ -24,6 +24,7 @@
 #include <jlib/math/buffer.hh>
 
 #include <iostream>
+#include <memory>
 #include <iomanip>
 #include <exception>
 #include <vector>
@@ -231,6 +232,17 @@ public:
     typedef std::pair<uint,uint> edge_type;
 
     object(uint n);
+    virtual ~object() {}
+
+    /**
+     * A copy that keeps its actual type.
+     *
+     * Plot stores objects by value, so handing it a cuboid used to slice off
+     * everything but the base -- including build_faces(), which left the copy
+     * a 1-skeleton no matter what was added.  Shapes differ only in how they
+     * are built, so this is the one thing they need to carry.
+     */
+    virtual std::shared_ptr< object<T> > clone() const;
 
     void normalize();
     
@@ -290,6 +302,8 @@ class cuboid : public object<T> {
 public:
     cuboid(uint n);
 
+    virtual std::shared_ptr< object<T> > clone() const;
+
 protected:
     virtual void build_faces() const;
 };
@@ -299,6 +313,8 @@ template<typename T>
 class pyramoid : public object<T> {
 public:
     pyramoid(uint n);
+
+    virtual std::shared_ptr< object<T> > clone() const;
 };
 
 
@@ -306,12 +322,16 @@ template<typename T>
 class staroid : public object<T> {
 public:
     staroid(uint n);
+
+    virtual std::shared_ptr< object<T> > clone() const;
 };
 
 template<typename T>
 class spheroid : public object<T> {
 public:
     spheroid(uint n);
+
+    virtual std::shared_ptr< object<T> > clone() const;
 };
 
 
@@ -1148,6 +1168,13 @@ const std::vector<typename object<T>::edge_type>& object<T>::get_edges() const {
 
 template<typename T>
 inline
+std::shared_ptr< object<T> > object<T>::clone() const {
+    return std::make_shared< object<T> >(*this);
+}
+
+
+template<typename T>
+inline
 const std::vector<typename object<T>::face_type>& object<T>::get_faces() const {
     if(!faces_built) {
         faces_built = true;
@@ -1178,6 +1205,13 @@ void object<T>::change(uint n) {
     for(uint i = 0; i < size(); i++) {
         v[i].change(n);
     }
+}
+
+
+template<typename T>
+inline
+std::shared_ptr< object<T> > cuboid<T>::clone() const {
+    return std::make_shared< cuboid<T> >(*this);
 }
 
 
@@ -1257,6 +1291,13 @@ void cuboid<T>::build_faces() const {
 
 template<typename T>
 inline
+std::shared_ptr< object<T> > pyramoid<T>::clone() const {
+    return std::make_shared< pyramoid<T> >(*this);
+}
+
+
+template<typename T>
+inline
 pyramoid<T>::pyramoid(uint n) 
     : object<T>(n)
 {
@@ -1310,6 +1351,13 @@ pyramoid<T>::pyramoid(uint n)
         }
     }
 
+}
+
+
+template<typename T>
+inline
+std::shared_ptr< object<T> > spheroid<T>::clone() const {
+    return std::make_shared< spheroid<T> >(*this);
 }
 
 
@@ -1375,6 +1423,13 @@ spheroid<T>::spheroid(uint n)
         }
     }
 }
+
+template<typename T>
+inline
+std::shared_ptr< object<T> > staroid<T>::clone() const {
+    return std::make_shared< staroid<T> >(*this);
+}
+
 
 template<typename T>
 inline


### PR DESCRIPTION
render 4-D objects as translucent solids

closes #32, closes #33, closes #34

The headline goal, and the reason the geometry work in #29 and #30 was done.
jhardhyper reduces N dimensions to 3 in software and hands real 3-D to the
hardware, so it is the app that can show solids; jglfwhyper reduces all the way
to 2-D and stays the wireframe demonstration of the projection modes.

    macOS  24 tests, 23 pass, 1 skip
    Linux  25 tests, 23 pass, 2 skip

faces reach the renderer

    math::Plot stored objects in a std::list<object<T>> -- by value.  Adding a
    cuboid sliced it to the base, whose build_faces() does nothing, so
    get_faces() came back empty and the face pass never ran.  Faces built
    lazily need the dynamic type to survive add(), and it did not.

    object<T> gains a virtual clone() and Plot holds shared_ptr, so a shape
    keeps its type.  This was silently discarding any subclass behaviour, not
    only faces, and #31 would have hit it identically.

drawing them

    Three passes: faces back to front, then edges, then points.  Everything is
    translucent and there is no opaque pass to establish depth against, so the
    faces sort by centroid depth and do not write depth, and the wireframe
    draws against an untouched buffer.  Keeping the edges visible through the
    solid is the point -- they are how you follow a cell through an eversion.

    Normals come from the projected positions and are recomputed every frame,
    since the object turns in N dimensions and re-projects; a face's 3-D
    orientation is only known after the reduction.  No attempt to wind them
    outward: a hypercube reduced to three dimensions is a shadow rather than a
    solid, faces turn inside out as it everts, and both sides are seen.
    Two-sided lighting and GL_FRONT_AND_BACK materials handle that, and
    lighting is enabled only for the face pass so the edges keep glColor.

the epsilon that ate the solid

    Rejecting a face whose normal is too short is necessary -- faces go edge-on
    constantly -- but the first cut of the test had an absolute floor of 1e-6
    in front of the relative one.

    len is an area, and every reduction step divides by w, so the figure
    shrinks by about a third per dimension and a face's area by about a factor
    of ten.  At D=4 a face measures 2e-1 and the floor is irrelevant; the
    threshold passes through the geometry around D=8 and swallows it whole.
    Measured: 60% of faces discarded at D=9, 99.7% at D=10, all of them from
    D=11 up.  The solid vanished at high D while the wireframe carried on.

    Dividing by the edge lengths instead gives the sine of the angle between
    them, which asks whether the face has a direction without asking how big it
    is.  That is the real question, and it rejects nothing from D=4 to D=12
    beyond genuinely edge-on faces.

colour

    Hues rather than RGB triples, blended by mean direction on the colour
    wheel.  Averaging in RGB drives every channel toward its mean -- four
    random corners land within about 0.14 of grey -- so every face came out the
    same olive no matter which vertices it joined.  Measured, mean saturation
    goes from 0.375 to 1.000.  Circular rather than arithmetic mean because
    hues wrap: averaging 0.9 and 0.1 numerically gives cyan from two reds.
    Corners spread evenly around the wheel have no mean direction at all, which
    falls back to the first corner rather than pretending; no face hits that at
    D=4 or 5.

    Hues are spaced by the golden ratio, so successive vertices land as far
    apart as they can at any D and the figure comes up the same every run,
    which matters when comparing two builds by eye.

edges

    They were drawn in halves: p1 to the midpoint in p1's colour, relying on
    the edge being visited again from the other end.  The halves met at a hard
    seam, which is what made the wireframe look assembled from pieces.  The
    primitives now carry the vertex indices they join, so an edge takes a
    colour at each end and the rasterizer interpolates -- the hue blending the
    2021 design asked for, in one pass instead of two.

    That also retired the counter draw_point kept purely so draw_line could
    guess an endpoint colour, and the first-frame flag beside it.

    Antialiased, two pixels wide, points at five.  Linear fog to black over the
    measured camera distance gives the depth cue: without it the far side is
    exactly as bright as the near side and the eye has nothing to order them
    by, which is the one thing stopping at three dimensions was supposed to
    buy.

not covered

    math::Plot::draw is untouched, so jglfwhyper is unchanged and the raster
    backends have no draw_face.  Whether they get one as a wireframe outline is
    still open.

    Faces stack up fast: measured along an average line of sight, 2.4 deep at
    D=4, 16 at D=7 and 119 at D=10.  Per-face alpha is fixed at 0.18 and reads
    well across that range in practice, but holding total accumulated opacity
    constant instead is the principled version if it ever stops looking right.

    Drawing slows down at high D, but not in the face pass.  Counted at D=10,
    with 1024 vertices and 11520 faces: the corner vectors cost 6 allocations
    for the whole frame, because the vector is reused across faces and a
    vertex copy allocates nothing -- buffer holds a shared_ptr to its array, so
    copying one is a refcount bump.  The transform loop costs 99329, or 97 per
    vertex, mostly from rebuilding matrix::project(d, clip) per vertex per
    reduction step when it only depends on d and the clip volume.  Hoisting it
    out of the vertex loop gives bit-identical output for 29% fewer allocations
    and 65% fewer bytes.  That, and the rest of the copying in the plot path,
    is #47.

    Copy-constructing a vertex aliases the original rather than copying it,
    while assigning one deep-copies.  Nothing here is affected -- the corner
    vectors are only ever read -- but the asymmetry is a trap and is #48.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
