### PR TITLE
Bring the raster hyper plots to colour parity

### DIFF
--- a/jlib/apps/Hyper.hh
+++ b/jlib/apps/Hyper.hh
@@ -23,6 +23,7 @@
 #ifndef JLIB_APPS_HYPER_HH
 #define JLIB_APPS_HYPER_HH
 
+#include <jlib/apps/color.hh>
 #include <jlib/math/math.hh>
 #include <jlib/util/util.hh>
 
@@ -33,13 +34,7 @@ using namespace jlib::math;
 
 const long double PI = 3.14159265358979323846264338;
 
-template<class O>
-struct triple {
-    O r;
-    O g;
-    O b;
-};
-
+using apps::triple;
 template<typename T, typename Plot>
 class HyperPlot : public Plot {
 public:
@@ -49,8 +44,9 @@ public:
 
     virtual void change(uint n);
     virtual void draw();
-    virtual void draw_point(std::pair<uint,uint> point);
-    virtual void draw_line(std::pair<uint,uint> p1, std::pair<uint,uint> p2);
+    virtual void draw_point(std::pair<uint,uint> point, uint index);
+    virtual void draw_line(std::pair<uint,uint> p1, std::pair<uint,uint> p2,
+                           uint i1, uint i2);
     virtual void set_color(const triple<T>& color) = 0;
 
     void key_pressed(unsigned char key,int x,int y);
@@ -62,10 +58,15 @@ protected:
     void initialize_rotation(uint n);
     void initialize_glazzies(uint n);
 
-    std::vector< triple<T> > colors;
-    uint i;
+    /**
+     * One hue per vertex, numbered across every object in the plot.
+     *
+     * See apps/color.hh: hues rather than triples so edges can blend without
+     * washing out to grey, spaced by the golden ratio so neighbours stay
+     * distinguishable and the figure comes up the same every run.
+     */
+    std::vector<T> hues;
     uint r;
-    bool first;
 
     matrix<T> rotate;
     matrix<T> back_rotate;
@@ -83,7 +84,6 @@ inline
 HyperPlot<T,Plot>::HyperPlot(uint n, std::vector< std::pair<T,T> > c, uint w, uint h) 
     : Plot(n, c, w, h),
       r(n),
-      first(true),
       rotate(matrix<T>::identity(n+1)),
       back_rotate(matrix<T>::identity(n+1)),
       waiting(false),
@@ -163,56 +163,58 @@ void HyperPlot<T,Plot>::initialize(uint n) {
 template<typename T, typename Plot>
 inline
 void HyperPlot<T,Plot>::draw() {
-    i = 0;
+    // Colours are per vertex and have to exist before anything is drawn.
+    // draw_point used to generate them as it went, on the first frame only,
+    // which needed a flag to say which frame that was and a counter to say
+    // which vertex; an index on the primitives replaces both.
+    uint n = 0;
+    typename Plot::objref o = this->objects.begin();
+    for(; o != this->objects.end(); o++)
+        n += (*o)->size();
+
+    while(hues.size() < n)
+        hues.push_back(apps::golden_hue<T>(hues.size()));
 
     Plot::draw();
-
-    if(first) first = false;
 }
 
 template<typename T, typename Plot>
 inline
 void HyperPlot<T,Plot>::change(uint n) {
     Plot::change(n);
-    first = true;
-    colors.clear();
+    hues.clear();
 }
 
 
 template<typename T, typename Plot>
 inline
-void HyperPlot<T,Plot>::draw_point(std::pair<uint,uint> point) {
-    if(first) {
-        triple<T> color; color.r = 0; color.b = 0; color.g = 0;
+void HyperPlot<T,Plot>::draw_point(std::pair<uint,uint> point, uint index) {
+    this->set_color(apps::hsv(hues[index]));
 
-        const T MIN = 1.5;
-        while(color.r + color.b + color.g < MIN) {
-            color.r = static_cast<T>(std::rand() % 256) / 255.0;
-            color.g = static_cast<T>(std::rand() % 256) / 255.0;
-            color.b = static_cast<T>(std::rand() % 256) / 255.0;
-        }
-        
-        colors.push_back(color);
-    } 
-
-    Plot::draw_point(point);
-
-    i++;
+    Plot::draw_point(point, index);
 }
 
 template<typename T, typename Plot>
 inline
-void HyperPlot<T,Plot>::draw_line(std::pair<uint,uint> p1, std::pair<uint,uint> p2) {
-    triple<T> color = colors[i-1];
-    //set_foreground(color.r, color.g, color.b);
+void HyperPlot<T,Plot>::draw_line(std::pair<uint,uint> p1, std::pair<uint,uint> p2,
+                                  uint i1, uint i2) {
+    // The whole edge, in the blend of its two endpoints.
+    //
+    // This used to draw half an edge, p1 to the midpoint, in p1's colour, and
+    // rely on the edge being reached again from the other end to fill in the
+    // rest.  The halves met at a hard seam in the middle, which is what made
+    // the wireframe look assembled from pieces.
+    //
+    // Blending on the colour wheel rather than in RGB: averaging channels
+    // drives every edge toward grey, which is what the old random triples did
+    // whenever two colours were combined.
+    std::vector<T> h;
+    h.push_back(hues[i1]);
+    h.push_back(hues[i2]);
 
-    this->set_color(color);
+    this->set_color(apps::hsv(apps::hue_mean(h)));
 
-    std::pair<uint,uint> mid; 
-    mid.first = (p1.first + p2.first) / 2;
-    mid.second = (p1.second + p2.second) / 2;
-
-    Plot::draw_line(p1, mid);
+    Plot::draw_line(p1, p2, i1, i2);
 }
 
 template<typename T, typename Plot>
@@ -267,7 +269,6 @@ void HyperPlot<T,Plot>::key_pressed(unsigned char key, int x, int y) {
         // nesting from the highest dimension still shows while everything
         // below it stays parallel -- which is why it is the default.
         this->cycle_projection_mode();
-        this->first = true;
 /*
     } else if(key == 'y' || key == 'h') {
         T x = (key == 't' ? 0.1 : -0.1);

--- a/jlib/apps/Makefile.am
+++ b/jlib/apps/Makefile.am
@@ -58,7 +58,7 @@ dist_pkgdata_DATA = wow-buttons-ps3.map wow-axes-ps3.map \
                     ksp-axes-ps3.map ksp-buttons-ps3.map \
                     tor-axes-ps3.map tor-buttons-ps3.map
 
-EXTRA_DIST = Hyper.hh
+EXTRA_DIST = Hyper.hh color.hh
 
 JCRYPT_LA  = $(top_builddir)/jlib/crypt/libjcrypt.la
 JNET_LA    = $(top_builddir)/jlib/net/libjnet.la

--- a/jlib/apps/color.hh
+++ b/jlib/apps/color.hh
@@ -1,0 +1,123 @@
+/* -*- mode: C++ c-basic-offset: 4 -*-
+ *
+ * Copyright (c) 1999 Joe Yandle <joey@divisionbyzero.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+#ifndef JLIB_APPS_COLOR_HH
+#define JLIB_APPS_COLOR_HH
+
+#include <cmath>
+#include <vector>
+
+namespace jlib {
+namespace apps {
+
+const long double PI = 3.14159265358979323846264338;
+
+template<class O>
+struct triple {
+    O r;
+    O g;
+    O b;
+};
+
+/**
+ * A hue, at full saturation and value.
+ *
+ * Colours are kept as hues rather than triples so they can be combined
+ * without washing out.  Averaging in RGB drives every channel toward its
+ * mean: four random corners average to a standard deviation of about 0.14
+ * around 0.5, so everything built from several vertices came out the same
+ * olive grey no matter which vertices it joined.  A hue has nowhere to
+ * collapse to -- combining hues always gives another fully saturated colour.
+ */
+template<typename O>
+inline
+triple<O> hsv(O h) {
+    h -= std::floor(h);
+
+    const O sector = h * 6;
+    const int i = static_cast<int>(std::floor(sector));
+    const O f = sector - i;
+
+    const O q = 1 - f;
+    const O t = f;
+
+    triple<O> c;
+    switch(i % 6) {
+    case 0: c.r = 1; c.g = t; c.b = 0; break;
+    case 1: c.r = q; c.g = 1; c.b = 0; break;
+    case 2: c.r = 0; c.g = 1; c.b = t; break;
+    case 3: c.r = 0; c.g = q; c.b = 1; break;
+    case 4: c.r = t; c.g = 0; c.b = 1; break;
+    default: c.r = 1; c.g = 0; c.b = q; break;
+    }
+
+    return c;
+}
+
+/**
+ * Where a set of hues sits on the colour wheel.
+ *
+ * The mean direction, not the arithmetic mean: hues wrap, so averaging 0.9
+ * and 0.1 numerically gives 0.5 -- cyan from two reds.  Summing unit vectors
+ * and taking the angle gets the answer that agrees with the wheel.
+ *
+ * Hues spread evenly around the wheel sum to nothing and have no mean
+ * direction at all.  That is a real ambiguity rather than a numerical one, so
+ * it falls back to the first instead of pretending otherwise.
+ */
+template<typename O>
+inline
+O hue_mean(const std::vector<O>& h) {
+    if(h.empty()) return 0;
+
+    O x = 0, y = 0;
+    for(unsigned int k = 0; k < h.size(); k++) {
+        x += std::cos(2 * PI * h[k]);
+        y += std::sin(2 * PI * h[k]);
+    }
+
+    if(std::sqrt(x * x + y * y) < 1e-9)
+        return h[0];
+
+    const O a = std::atan2(y, x) / (2 * PI);
+
+    return a - std::floor(a);
+}
+
+/**
+ * The hue for vertex i, spaced by the golden ratio.
+ *
+ * Successive vertices land as far apart on the wheel as they can, so
+ * neighbours stay distinguishable at any dimensionality, and the figure comes
+ * up the same colours every run -- which matters when comparing two builds by
+ * eye.  Random hues clump: at 32 vertices some pair is almost always within a
+ * couple of degrees.
+ */
+template<typename O>
+inline
+O golden_hue(unsigned int i) {
+    const O golden = 0.6180339887498948;
+
+    return std::fmod(i * golden, 1.0);
+}
+
+}
+}
+
+#endif

--- a/jlib/apps/jhardhyper.cc
+++ b/jlib/apps/jhardhyper.cc
@@ -30,6 +30,7 @@
 #include <unistd.h>
 
 
+#include <jlib/apps/color.hh>
 #include <jlib/math/math.hh>
 #include <jlib/math/Plot.hh>
 #include <jlib/math/dump.hh>
@@ -50,7 +51,7 @@ using namespace jlib::math;
 
 typedef GLdouble T;
 
-const long double PI = 3.14159265358979323846264338;
+using apps::PI;
 
 
 
@@ -523,77 +524,10 @@ math::vertex<T> HPlot<T>::transform(const math::vertex<T>& vertex) const {
 
 typedef HPlot<T> PlotType;
 
-template<class O>
-struct triple {
-    O r;
-    O g;
-    O b;
-};
+using apps::triple;
+using apps::hsv;
+using apps::hue_mean;
 
-/**
- * A hue, at full saturation and value.
- *
- * Colours are kept as hues rather than triples so they can be combined
- * without washing out.  Averaging in RGB drives every channel toward its
- * mean: four random corners average to a standard deviation of about 0.14
- * around 0.5, so every face came out the same olive grey no matter which
- * vertices it joined.  A hue has nowhere to collapse to -- the result of
- * combining hues is always another fully saturated colour.
- */
-template<typename O>
-inline
-triple<O> hsv(O h) {
-    h -= std::floor(h);
-
-    const O sector = h * 6;
-    const int i = static_cast<int>(std::floor(sector));
-    const O f = sector - i;
-
-    const O q = 1 - f;
-    const O t = f;
-
-    triple<O> c;
-    switch(i % 6) {
-    case 0: c.r = 1; c.g = t; c.b = 0; break;
-    case 1: c.r = q; c.g = 1; c.b = 0; break;
-    case 2: c.r = 0; c.g = 1; c.b = t; break;
-    case 3: c.r = 0; c.g = q; c.b = 1; break;
-    case 4: c.r = t; c.g = 0; c.b = 1; break;
-    default: c.r = 1; c.g = 0; c.b = q; break;
-    }
-
-    return c;
-}
-
-/**
- * Where a set of hues sits on the colour wheel.
- *
- * The mean direction, not the arithmetic mean: hues wrap, so averaging 0.9
- * and 0.1 numerically gives 0.5 -- cyan from two reds.  Summing unit vectors
- * and taking the angle gets the answer that agrees with the wheel.
- *
- * Corners spread evenly around the wheel sum to nothing and have no mean
- * direction at all.  That is a real ambiguity rather than a numerical one, so
- * it falls back to the first corner instead of pretending otherwise.
- */
-template<typename O>
-inline
-O hue_mean(const std::vector<O>& h) {
-    if(h.empty()) return 0;
-
-    O x = 0, y = 0;
-    for(uint k = 0; k < h.size(); k++) {
-        x += std::cos(2 * PI * h[k]);
-        y += std::sin(2 * PI * h[k]);
-    }
-
-    if(std::sqrt(x * x + y * y) < 1e-9)
-        return h[0];
-
-    const O a = std::atan2(y, x) / (2 * PI);
-
-    return a - std::floor(a);
-}
 
 template<typename T, typename Plot>
 class HyperPlot : public Plot {
@@ -689,11 +623,8 @@ void HyperPlot<T,Plot>::draw() {
     for(; o != this->objects.end(); o++)
         n += (*o)->size();
 
-    while(hues.size() < n) {
-        const T golden = 0.6180339887498948;
-
-        hues.push_back(std::fmod(hues.size() * golden, 1.0));
-    }
+    while(hues.size() < n)
+        hues.push_back(apps::golden_hue<T>(hues.size()));
 
     Plot::draw();
 }

--- a/jlib/apps/jhyper.cc
+++ b/jlib/apps/jhyper.cc
@@ -48,15 +48,16 @@ public:
     }
 
     void draw() {
-        i = 0;
-        
-        jlib::x::Plot<T>::draw();
-        
+        // Up through HyperPlot rather than straight to the backend.  This
+        // used to skip it and keep the colour bookkeeping itself -- zeroing
+        // the vertex counter on the way in and clearing the first-frame flag
+        // on the way out -- which is exactly the work HyperPlot::draw does
+        // now that the primitives carry a vertex index.
+        HyperPlot<T, PlotType>::draw();
+
         this->set_foreground(255, 255, 255);
         this->move(25, 25);
         this->draw_string("N=" + jlib::util::string_value(this->D) + " R=" + util::string_value(this->r) + " T=" + util::string_value((int)this->m_timeout)+"us");
-        
-        if(first) first = false;
     }
 
     void set_color(const triple<T>& color) {

--- a/jlib/glfw/Plot.hh
+++ b/jlib/glfw/Plot.hh
@@ -54,8 +54,9 @@ public:
          std::string title = "jlib::glfw::Plot");
 
     virtual void draw();
-    virtual void draw_point(std::pair<uint,uint> p);
-    virtual void draw_line(std::pair<uint,uint> p1, std::pair<uint,uint> p2);
+    virtual void draw_point(std::pair<uint,uint> p, uint index);
+    virtual void draw_line(std::pair<uint,uint> p1, std::pair<uint,uint> p2,
+                           uint i1, uint i2);
 
 protected:
     /**
@@ -104,7 +105,7 @@ Plot<T>::Plot(uint n, std::vector< std::pair<T,T> > c, uint w, uint h, std::stri
 
 template<typename T>
 inline
-void Plot<T>::draw_point(std::pair<uint,uint> p) {
+void Plot<T>::draw_point(std::pair<uint,uint> p, uint) {
     glBegin(GL_POINTS);
     glVertex2i(p.first, p.second);
     glEnd();
@@ -113,7 +114,8 @@ void Plot<T>::draw_point(std::pair<uint,uint> p) {
 
 template<typename T>
 inline
-void Plot<T>::draw_line(std::pair<uint,uint> p1, std::pair<uint,uint> p2) {
+void Plot<T>::draw_line(std::pair<uint,uint> p1, std::pair<uint,uint> p2,
+                        uint, uint) {
     glBegin(GL_LINES);
     glVertex2i(p1.first, p1.second);
     glVertex2i(p2.first, p2.second);

--- a/jlib/glx/Plot.hh
+++ b/jlib/glx/Plot.hh
@@ -39,8 +39,9 @@ public:
     Plot(uint n, std::vector< std::pair<T,T> > c, uint w=400, uint h=400);
 
     virtual void draw();
-    virtual void draw_point(std::pair<uint,uint> p);
-    virtual void draw_line(std::pair<uint,uint> p1, std::pair<uint,uint> p2);
+    virtual void draw_point(std::pair<uint,uint> p, uint index);
+    virtual void draw_line(std::pair<uint,uint> p1, std::pair<uint,uint> p2,
+                           uint i1, uint i2);
 
 protected:
     void on_configure(int width, int height);
@@ -61,7 +62,7 @@ Plot<T>::Plot(uint n, std::vector< std::pair<T,T> > c, uint w, uint h)
 
 template<typename T>
 inline
-void Plot<T>::draw_point(std::pair<uint,uint> p) {
+void Plot<T>::draw_point(std::pair<uint,uint> p, uint) {
     glBegin(GL_POINTS);
     glVertex2i(p.first, p.second);
     glEnd();
@@ -70,7 +71,8 @@ void Plot<T>::draw_point(std::pair<uint,uint> p) {
 
 template<typename T>
 inline
-void Plot<T>::draw_line(std::pair<uint,uint> p1, std::pair<uint,uint> p2) {
+void Plot<T>::draw_line(std::pair<uint,uint> p1, std::pair<uint,uint> p2,
+                        uint, uint) {
     glBegin(GL_LINES);
     glVertex2i(p1.first, p1.second);
     glVertex2i(p2.first, p2.second);

--- a/jlib/math/Plot.hh
+++ b/jlib/math/Plot.hh
@@ -103,8 +103,18 @@ public:
     uint D;
 
     virtual void change(uint n);
-    virtual void draw_point(std::pair<uint,uint> p) = 0;
-    virtual void draw_line(std::pair<uint,uint> p1, std::pair<uint,uint> p2)=0;
+    /**
+     * A vertex and an edge, each told which object vertices they came from.
+     *
+     * The index is what lets a subclass colour an endpoint.  Without it the
+     * only thing an override could reach was a counter incremented by
+     * draw_point, so an edge could only be drawn in the colour of whichever
+     * end came through first -- which is why edges used to be drawn in halves.
+     * Indices are numbered across every object in the plot.
+     */
+    virtual void draw_point(std::pair<uint,uint> p, uint index) = 0;
+    virtual void draw_line(std::pair<uint,uint> p1, std::pair<uint,uint> p2,
+                           uint i1, uint i2) = 0;
 
 protected:
     bool visible(math::vertex<T> vertex) const;
@@ -165,6 +175,9 @@ typename Plot<T>::objref Plot<T>::add(const object<T>& o) {
 template<typename T>
 inline
 void Plot<T>::draw() {
+    // Vertices are numbered across every object in the plot.
+    uint base = 0;
+
     objref i = objects.begin();
     for(; i != objects.end(); i++) {
         object<T>& object = **i;
@@ -187,17 +200,21 @@ void Plot<T>::draw() {
 
             /* if(!visible(tv1)) continue; */
 
-            draw_point(p1);
+            draw_point(p1, base + j);
 
-            // Adjacency is symmetric, so this draws each edge twice, once
-            // from each end.  draw_line() in Hyper.hh relies on that: it draws
-            // half an edge in the colour of the vertex it started from, which
-            // is how an edge comes out blending its two endpoints.
+            // Once per edge, not once per endpoint.  Adjacency is symmetric,
+            // so walking it reaches every edge from both ends; that used to be
+            // load-bearing, because half an edge was drawn from each end in
+            // that end's colour and the two halves met in the middle.  An edge
+            // now carries both its endpoints and is drawn whole, so the second
+            // visit would be drawing it again.
             const std::vector<uint>& adjacent = object.adjacent(j);
             for(uint k = 0; k < adjacent.size(); k++) {
+                if(adjacent[k] < j) continue;
+
                 /* if(!visible(tv2)) continue; */
 
-                draw_line(p1, mapped[adjacent[k]]);
+                draw_line(p1, mapped[adjacent[k]], base + j, base + adjacent[k]);
             }
         }
     }

--- a/jlib/x/Plot.hh
+++ b/jlib/x/Plot.hh
@@ -37,8 +37,9 @@ public:
     Plot(uint n, std::vector< std::pair<T,T> > c, uint w=400, uint h=400);
 
     virtual void draw();
-    virtual void draw_point(std::pair<uint,uint> p);
-    virtual void draw_line(std::pair<uint,uint> p1, std::pair<uint,uint> p2);
+    virtual void draw_point(std::pair<uint,uint> p, uint index);
+    virtual void draw_line(std::pair<uint,uint> p1, std::pair<uint,uint> p2,
+                           uint i1, uint i2);
 
 protected:
     void on_configure(int width, int height);
@@ -59,14 +60,15 @@ Plot<T>::Plot(uint n, std::vector< std::pair<T,T> > c, uint w, uint h)
 
 template<typename T>
 inline
-void Plot<T>::draw_point(std::pair<uint,uint> p) {
+void Plot<T>::draw_point(std::pair<uint,uint> p, uint) {
     Window::draw_point(p);
 }
 
 
 template<typename T>
 inline
-void Plot<T>::draw_line(std::pair<uint,uint> p1, std::pair<uint,uint> p2) {
+void Plot<T>::draw_line(std::pair<uint,uint> p1, std::pair<uint,uint> p2,
+                        uint, uint) {
     Window::draw_line(p1, p2);
 }
 


### PR DESCRIPTION
jhardhyper got hues and blended edges when solid rendering landed; jglfwhyper,
jhyper and jglxhyper still had the 1999 random-RGB scheme and the half-edge
seam.  This is the 2021 TODO at the top of Hyper.hh, taken at its word:

    each vertex gets a color ... the edges should blend the colors of the
    verticies in the line between them.  if am using HSV colors then i can
    just add the hues (letting them overflow) to get the color of the
    blended line.

    macOS  24 tests, 23 pass, 1 skip
    Linux  25 tests, 23 pass, 2 skip   (X11 and GLX build here only)

colour

    Hues rather than RGB triples.  Averaging channels drives every result
    toward grey -- measured on the face work, mean saturation 0.375 against
    1.000 for a hue blend -- so anything built from more than one vertex came
    out the same olive no matter which vertices it joined.  A hue has nowhere
    to collapse to.

    Blended by mean direction on the wheel, not arithmetic mean: hues wrap, so
    averaging 0.9 and 0.1 numerically gives cyan from two reds.  Hues spread
    evenly around the wheel have no mean direction at all, which falls back to
    the first rather than pretending.

    Spaced by the golden ratio instead of drawn at random.  Successive
    vertices land as far apart as they can at any D, and the figure comes up
    the same every run, which matters when comparing two builds by eye.

edges

    Drawn whole, once, in the blend of their endpoints.  They used to be drawn
    in halves -- p1 to the midpoint in p1's colour, relying on the edge being
    reached again from the other end -- and the halves met at a hard seam in
    the middle.  That is what made the wireframe look assembled from pieces.

    The halves existed because a backend had no way to tell which vertices an
    edge joined.  The only thing an override could reach was a counter that
    draw_point incremented, so an edge could only take the colour of whichever
    end came through first.  The primitives now carry vertex indices, numbered
    across every object in the plot, and the counter and its first-frame flag
    are gone.

    Since adjacency is symmetric, walking it reaches every edge from both
    ends.  That used to be load-bearing and is now just a second draw, so the
    loop skips the reverse visit.

not gradient

    jhardhyper interpolates along each edge; these get one blended colour for
    the whole edge.  Colours are set through set_color, a single-colour call
    each app implements, so interpolating would mean pushing colour down into
    all three backends -- and X11 could not use it anyway, since a line takes
    one GC foreground.  The blend is what the TODO asked for.

shared

    hsv, hue_mean and golden_hue live in a new jlib/apps/color.hh rather than
    being copied.  jhardhyper does not include Hyper.hh -- it keeps its own
    HyperPlot, which reduces N to 3 rather than to 2 -- so without a shared
    header the colour maths would exist twice.  Its local copies are gone.

    jhyper::draw() called x::Plot<T>::draw() directly, skipping
    HyperPlot::draw() and doing the colour bookkeeping itself.  It calls up
    through HyperPlot now.  Nothing else had reached into that state.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
