### PR TITLE
Draw tori in n dimensions

### DIFF
--- a/jlib/apps/jhardhyper.cc
+++ b/jlib/apps/jhardhyper.cc
@@ -76,18 +76,50 @@ public:
                            uint i1, uint i2);
 
     /**
-     * One face, as a polygon with a normal.
+     * One face, as a polygon with a normal per corner.
+     *
+     * normal is 3 values per corner, parallel to corner: flat shading repeats
+     * the face's own normal, smooth shading gives each corner the mean of the
+     * faces meeting there.
      *
      * index[k] is the object vertex that corner[k] came from, numbered across
      * every object in the plot, so a subclass can colour a face from whatever
      * it keeps per vertex.  The geometry here ignores it.
      */
     virtual void draw_face(const std::vector< math::vertex<T> >& corner,
-                           const math::vertex<T>& normal,
+                           const std::vector<T>& normal,
                            const std::vector<uint>& index);
 
     /** Solid faces as well as the wireframe.  The o key toggles it. */
     bool m_solid = true;
+
+    /**
+     * Draw the edges and vertices over the faces.
+     *
+     * Right when the edges are the structure, as on a hypercube, where they
+     * are 2% of the projected surface.  A tessellated surface's edges are
+     * just where the mesh was cut: a 32x32 torus puts 2048 of them over the
+     * same area, covering 21% of it, and what you see is the mesh rather than
+     * the shape.  Set from the shape, and the l key overrides it.
+     */
+    bool m_wire = true;
+
+    /**
+     * Per-face alpha.
+     *
+     * A hypercube is a shadow to see into; a surface is a surface, and wants
+     * to read as one while still showing where it passes through itself.
+     */
+    T m_alpha = 0.18;
+
+    /**
+     * Average the normals of the faces meeting at a vertex.
+     *
+     * Right for a surface, wrong for a hypercube: its faces meet at right
+     * angles, so averaging would round off corners that are not round.  Set
+     * from the shape, and the m key overrides it to compare.
+     */
+    bool m_smooth = false;
 
 protected:
     virtual math::vertex<T> transform(const math::vertex<T>& v) const;
@@ -212,13 +244,13 @@ void HPlot<T>::draw_line(const math::vertex<T>& p1, const math::vertex<T>& p2,
 template<typename T>
 inline
 void HPlot<T>::draw_face(const std::vector< math::vertex<T> >& corner,
-                         const math::vertex<T>& normal,
+                         const std::vector<T>& normal,
                          const std::vector<uint>&) {
-    glNormal3d(normal[0], normal[1], normal[2]);
-
     glBegin(GL_POLYGON);
-    for(uint k = 0; k < corner.size(); k++)
+    for(uint k = 0; k < corner.size(); k++) {
+        glNormal3d(normal[3 * k], normal[3 * k + 1], normal[3 * k + 2]);
         glVertex4dv(corner[k].data());
+    }
     glEnd();
 }
 
@@ -398,20 +430,94 @@ void HPlot<T>::draw() {
             // Depth of a face is its centroid's z.  The modelview applies a
             // uniform positive scale and a translation along z, so ordering
             // by z here is the same as ordering by eye-space depth.
+            //
+            // The normals are wanted here too rather than at draw time,
+            // because a vertex normal is the average over the faces meeting
+            // at it and that cannot be known one face at a time.
             std::vector< std::pair<T,uint> > order;
             order.reserve(faces.size());
 
+            std::vector<T> fnormal(3 * faces.size(), 0);
+            std::vector<bool> flat(faces.size(), false);
+
+            std::vector< math::vertex<T> > fcorner;
+            math::vertex<T> fn(3);
+
             for(uint f = 0; f < faces.size(); f++) {
                 T z = 0;
-                for(uint k = 0; k < faces[f].size(); k++)
+                fcorner.clear();
+                for(uint k = 0; k < faces[f].size(); k++) {
                     z += transformed[faces[f][k]][2];
+                    fcorner.push_back(transformed[faces[f][k]]);
+                }
 
                 order.push_back(std::make_pair(z / faces[f].size(), f));
+
+                if(face_normal(fcorner, fn)) {
+                    flat[f] = true;
+                    for(uint k = 0; k < 3; k++) fnormal[3 * f + k] = fn[k];
+                }
+            }
+
+            // Vertex normals: the mean of the faces meeting at a vertex,
+            // which is what makes a curved surface shade as curved rather
+            // than as the flat quads it is made of.
+            //
+            // Aligned before averaging, and only where the shape is really a
+            // surface.  A hypercube's faces meet at right angles and its
+            // shadow everts, so averaging there would round off corners that
+            // are not round and cancel to nothing wherever two faces face
+            // opposite ways.  A torus is a genuine surface with consistent
+            // winding, so its faces agree -- except along the fold curves,
+            // where the projection reverses orientation.  Taking the first
+            // face at each vertex as the reference and flipping the rest to
+            // agree keeps the average meaningful across a fold; the fold
+            // itself then reads as a crease, which is what it is.
+            std::vector<T> vnormal;
+            if(m_smooth) {
+                vnormal.assign(3 * object.size(), 0);
+                std::vector<bool> seen(object.size(), false);
+
+                for(uint f = 0; f < faces.size(); f++) {
+                    if(!flat[f]) continue;
+
+                    for(uint k = 0; k < faces[f].size(); k++) {
+                        const uint v = faces[f][k];
+
+                        T dot = 0;
+                        for(uint x = 0; x < 3; x++)
+                            dot += vnormal[3 * v + x] * fnormal[3 * f + x];
+
+                        const T sign = (seen[v] && dot < 0) ? -1.0 : 1.0;
+                        seen[v] = true;
+
+                        for(uint x = 0; x < 3; x++)
+                            vnormal[3 * v + x] += sign * fnormal[3 * f + x];
+                    }
+                }
+
+                for(uint v = 0; v < object.size(); v++) {
+                    T len = 0;
+                    for(uint x = 0; x < 3; x++)
+                        len += vnormal[3 * v + x] * vnormal[3 * v + x];
+                    len = std::sqrt(len);
+
+                    // A vertex whose faces cancel has no mean direction; the
+                    // face normal is used for it instead, at draw time.
+                    if(len < 1e-12) { seen[v] = false; continue; }
+
+                    for(uint x = 0; x < 3; x++) vnormal[3 * v + x] /= len;
+                }
+
+                for(uint v = 0; v < object.size(); v++)
+                    if(!seen[v])
+                        for(uint x = 0; x < 3; x++) vnormal[3 * v + x] = 0;
             }
 
             // ascending z: the camera looks down -z, so smallest is farthest
             std::sort(order.begin(), order.end());
 
+            glShadeModel(GL_SMOOTH);
             glEnable(GL_LIGHTING);
             glEnable(GL_BLEND);
             glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
@@ -420,26 +526,59 @@ void HPlot<T>::draw() {
 
             std::vector< math::vertex<T> > corner;
             std::vector<uint> index;
-            math::vertex<T> normal(3);
+            std::vector<T> normal;
 
             for(uint o = 0; o < order.size(); o++) {
-                const typename math::object<T>::face_type& face =
-                    faces[order[o].second];
+                const uint f = order[o].second;
+                if(!flat[f]) continue;
+
+                const typename math::object<T>::face_type& face = faces[f];
 
                 corner.clear();
                 index.clear();
+                normal.clear();
+
                 for(uint k = 0; k < face.size(); k++) {
-                    corner.push_back(transformed[face[k]]);
-                    index.push_back(base + face[k]);
+                    const uint v = face[k];
+
+                    corner.push_back(transformed[v]);
+                    index.push_back(base + v);
+
+                    // Per corner where the surface has a mean direction there,
+                    // and the face's own normal otherwise -- which covers both
+                    // the flat-shaded shapes and the cancelled vertices.
+                    T len = 0;
+                    if(m_smooth)
+                        for(uint x = 0; x < 3; x++)
+                            len += vnormal[3 * v + x] * vnormal[3 * v + x];
+
+                    if(len > 0) {
+                        // to the side this face is facing, so a fold creases
+                        // rather than shading through itself
+                        T dot = 0;
+                        for(uint x = 0; x < 3; x++)
+                            dot += vnormal[3 * v + x] * fnormal[3 * f + x];
+
+                        const T sign = (dot < 0) ? -1.0 : 1.0;
+                        for(uint x = 0; x < 3; x++)
+                            normal.push_back(sign * vnormal[3 * v + x]);
+                    } else {
+                        for(uint x = 0; x < 3; x++)
+                            normal.push_back(fnormal[3 * f + x]);
+                    }
                 }
 
-                if(face_normal(corner, normal))
-                    draw_face(corner, normal, index);
+                draw_face(corner, normal, index);
             }
 
             glDepthMask(GL_TRUE);
             glDisable(GL_BLEND);
             glDisable(GL_LIGHTING);
+        }
+
+        if(!m_wire) {
+            base += object.size();
+            continue;
         }
 
         // Smooth shading so an edge blends between its endpoints' colours
@@ -540,7 +679,7 @@ public:
     virtual void draw_line(const math::vertex<T>& p1, const math::vertex<T>& p2,
                            uint i1, uint i2);
     virtual void draw_face(const std::vector< math::vertex<T> >& corner,
-                           const math::vertex<T>& normal,
+                           const std::vector<T>& normal,
                            const std::vector<uint>& index);
 
     void key_pressed(unsigned char key,int x,int y);
@@ -627,9 +766,31 @@ void HyperPlot<T,Plot>::initialize(uint n) {
         // 1024 quads, which is where a hypercube sits at D=10.
         torus<T> object(n, 2, 32);
         this->add(object);
+
+        // Hue from the position around the first circle, rather than one per
+        // vertex from the golden ratio.
+        //
+        // Scattered hues are right when vertices are landmarks -- a
+        // hypercube has sixteen of them and each is somewhere in particular.
+        // A mesh vertex is just where the surface got sampled, so scattering
+        // hues across 1024 of them gives every face four unrelated corners to
+        // blend and the surface renders as coloured static.
+        //
+        // The wrap is exact and free: position around a circle is cyclic and
+        // so is hue, so the last band meets the first with no seam.
+        hues.clear();
+        for(uint i = 0; i < object.size(); i++)
+            hues.push_back(static_cast<T>(i % object.M) / object.M);
+
         break;
     }
     }
+
+    // A surface shades smoothly, reads better without its own mesh drawn over
+    // it, and wants to look more solid than a shadow does.
+    this->m_smooth = (m_shape == TORUS);
+    this->m_wire   = (m_shape != TORUS);
+    this->m_alpha  = (m_shape == TORUS ? 0.5 : 0.18);
 }
 
 template<typename T, typename Plot>
@@ -681,7 +842,7 @@ void HyperPlot<T,Plot>::draw_point(const math::vertex<T>& point, uint index) {
 template<typename T, typename Plot>
 inline
 void HyperPlot<T,Plot>::draw_face(const std::vector< math::vertex<T> >& corner,
-                                  const math::vertex<T>& normal,
+                                  const std::vector<T>& normal,
                                   const std::vector<uint>& index) {
     std::vector<T> h;
     for(uint k = 0; k < index.size(); k++)
@@ -694,7 +855,7 @@ void HyperPlot<T,Plot>::draw_face(const std::vector< math::vertex<T> >& corner,
     // reads as separate surfaces rather than a solid block.
     GLfloat fcolors[4];
     fcolors[0] = color.r; fcolors[1] = color.g; fcolors[2] = color.b;
-    fcolors[3] = 0.18;
+    fcolors[3] = static_cast<GLfloat>(this->m_alpha);
 
     glColor4fv(fcolors);
     glMaterialfv(GL_FRONT_AND_BACK, GL_AMBIENT_AND_DIFFUSE, fcolors);
@@ -745,6 +906,12 @@ void HyperPlot<T,Plot>::key_pressed(unsigned char key, int x, int y) {
             return;
 
         initialize(d);
+    } else if(key == 'l') {
+        this->m_wire = !this->m_wire;
+        this->draw();
+    } else if(key == 'm') {
+        this->m_smooth = !this->m_smooth;
+        this->draw();
     } else if(key == 't') {
         m_shape = (m_shape == CUBOID ? TORUS : CUBOID);
         initialize(this->D);

--- a/jlib/apps/jhardhyper.cc
+++ b/jlib/apps/jhardhyper.cc
@@ -544,6 +544,13 @@ public:
                            const std::vector<uint>& index);
 
     void key_pressed(unsigned char key,int x,int y);
+
+    /**
+     * A hypercube is a solid whose shadow is a shadow; the flat torus is a
+     * surface that cannot exist in three dimensions at all.  Both want the
+     * same pipeline and show different things through it.
+     */
+    enum Shape { CUBOID, TORUS };
     void button_pressed(int button, int state, int x, int y);
     void on_timeout();
 
@@ -562,6 +569,7 @@ protected:
      */
     std::vector<T> hues;
     uint r;
+    Shape m_shape = CUBOID;
 
     matrix<T> rotate;
     matrix<T> back_rotate;
@@ -607,8 +615,21 @@ void HyperPlot<T,Plot>::initialize(uint n) {
     initialize_rotation(n);
     (*this) * matrix<T>::lookAt(n, eye, up, center);
 
-    cuboid<T> object(n);
-    this->add(object);
+    switch(m_shape) {
+    case CUBOID: {
+        cuboid<T> object(n);
+        this->add(object);
+        break;
+    }
+    case TORUS: {
+        // k=2 regardless of n, so the mesh does not grow with dimension: the
+        // same surface, turning in more planes.  32 around each circle is
+        // 1024 quads, which is where a hypercube sits at D=10.
+        torus<T> object(n, 2, 32);
+        this->add(object);
+        break;
+    }
+    }
 }
 
 template<typename T, typename Plot>
@@ -724,6 +745,9 @@ void HyperPlot<T,Plot>::key_pressed(unsigned char key, int x, int y) {
             return;
 
         initialize(d);
+    } else if(key == 't') {
+        m_shape = (m_shape == CUBOID ? TORUS : CUBOID);
+        initialize(this->D);
     } else if(key == 'z' || key == 'x') {
         this->m_zoom *= (key == 'z' ? 1.15 : 1.0 / 1.15);
         this->draw();

--- a/jlib/apps/jhardhyper.cc
+++ b/jlib/apps/jhardhyper.cc
@@ -113,6 +113,48 @@ public:
     T m_alpha = 0.18;
 
     /**
+     * Hold the total accumulated opacity constant instead of the per-face
+     * value, using how deeply the faces actually stack this frame.
+     *
+     * A 2-torus is a surface: 1.8 faces along a line of sight, so what you
+     * set is roughly what you get.  A 3-torus is not a surface -- its faces
+     * are interior scaffold, 18 deep at the coarsest useful mesh -- and the
+     * same alpha there accumulates to 0.97 and hides everything it is meant
+     * to show.  Solving 1-(1-a)^depth for a fixed total gives
+     * a = 1-(1-m_alpha)^(1.8/depth), which leaves a surface where it was and
+     * thins everything denser in proportion.
+     *
+     * Off for the hypercube, whose look is already settled.
+     */
+    bool m_adapt = false;
+
+    /** Faces along a line of sight, measured each frame. */
+    T m_depth = 1.8;
+
+    /** Stereographic outermost step; see transform().  The h key. */
+    bool m_stereo = false;
+
+    /** Frustum offset for the steps after a stereographic one. */
+    T m_eye_offset = 0;
+
+    /**
+     * Extent of the stereographic image, measured each frame.
+     *
+     * It has to be measured, and it has to be measured every frame.  The
+     * perspective steps that follow assume a figure of about unit radius --
+     * that is what the eye offset and the clip volume are sized for -- but
+     * the stereographic image breathes as the figure turns, between about 1
+     * and 5 at D=6, because how much it magnifies depends on how close the
+     * figure passes to the pole.  Left unscaled, parts of it arrive within
+     * 0.36 of the eye where the frustum's near plane is at 1.5, and dividing
+     * by w then magnifies them by an order of magnitude relative to the far
+     * side: the figure appears to sweep forward and swallow the camera.
+     *
+     * mutable because transform() is const, as with the framing radius.
+     */
+    mutable T m_stereo_scale = 1;
+
+    /**
      * Average the normals of the faces meeting at a vertex.
      *
      * Right for a surface, wrong for a hypercube: its faces meet at right
@@ -330,6 +372,42 @@ void HPlot<T>::draw() {
         // Built by push_back rather than sized up front: vertex<T> has no
         // default constructor, since a vertex has no meaning without a
         // dimensionality.
+        // How big the stereographic image comes out this frame, before
+        // anything downstream assumes a size.  A separate pass because
+        // transform() works a vertex at a time and this is a property of all
+        // of them; the percentile is for the same reason the framing uses one,
+        // that a vertex approaching the pole runs off on its own.
+        if(m_stereo && math::Plot<T>::D > 3) {
+            const int d = math::Plot<T>::D;
+
+            std::vector<T> radii;
+            radii.reserve(object.size());
+
+            for(uint j = 0; j < object.size(); j++) {
+                math::vertex<T> p(d);
+                p = math::Plot<T>::modelview.top() * object[j]();
+
+                T denom = 1 - p[d - 1];
+                if(denom < 0.05) denom = 0.05;
+
+                T r = 0;
+                for(int i = 0; i < d - 1; i++) {
+                    const T x = p[i] / denom;
+                    r += x * x;
+                }
+
+                radii.push_back(r);
+            }
+
+            std::sort(radii.begin(), radii.end());
+
+            const uint at = static_cast<uint>(radii.size() * 0.98);
+            const T r = radii.empty()
+                ? 1 : std::sqrt(radii[std::min<uint>(at, radii.size() - 1)]);
+
+            m_stereo_scale = (r > 1e-9) ? r : 1;
+        }
+
         std::vector< math::vertex<T> > transformed;
         transformed.reserve(object.size());
 
@@ -340,15 +418,31 @@ void HPlot<T>::draw() {
         // Frame the object: far enough back that the outermost vertex sits
         // inside the field, growing the distance if a later rotation reaches
         // further than anything seen so far.
-        T radius = 0;
+        // The outermost vertex, or near enough.
+        //
+        // Under stereographic projection a vertex approaching the pole runs
+        // off toward infinity, and since the framing only ever grows, one of
+        // them would shrink the figure to a dot and keep it there.  Taking a
+        // high percentile instead lets a handful diverge without dragging the
+        // rest with them; the divergence is still drawn, just not framed for.
+        std::vector<T> radii;
+        radii.reserve(transformed.size());
+
         for(uint j = 0; j < transformed.size(); j++) {
             const math::vertex<T>& v = transformed[j];
             T r2 = 0;
             for(uint k = 0; k < 3 && k < v.D; k++)
                 r2 += v[k] * v[k];
-            if(r2 > radius) radius = r2;
+            radii.push_back(r2);
         }
-        radius = std::sqrt(radius);
+
+        std::sort(radii.begin(), radii.end());
+
+        const uint at = m_stereo
+            ? static_cast<uint>(radii.size() * 0.98)
+            : (radii.empty() ? 0 : radii.size() - 1);
+
+        T radius = radii.empty() ? 0 : std::sqrt(radii[std::min<uint>(at, radii.size() - 1)]);
 
         if(radius > m_radius)
             m_radius = radius;
@@ -514,6 +608,29 @@ void HPlot<T>::draw() {
                         for(uint x = 0; x < 3; x++) vnormal[3 * v + x] = 0;
             }
 
+            // How deeply the faces stack: total projected area over the area
+            // they cover.  A face crossing a given line of sight contributes
+            // to both, so the ratio is the mean number along one.  Scale-free,
+            // so measuring before GL scales the figure is fine.
+            if(m_adapt) {
+                T area = 0;
+                for(uint f = 0; f < faces.size(); f++) {
+                    T a = 0;
+                    for(uint k = 0; k < faces[f].size(); k++) {
+                        const math::vertex<T>& p = transformed[faces[f][k]];
+                        const math::vertex<T>& q =
+                            transformed[faces[f][(k + 1) % faces[f].size()]];
+
+                        a += p[0] * q[1] - q[0] * p[1];
+                    }
+                    area += std::fabs(a) / 2;
+                }
+
+                const T disc = PI * m_radius * m_radius;
+
+                m_depth = (disc > 0 && area > disc) ? (area / disc) : 1.8;
+            }
+
             // ascending z: the camera looks down -z, so smallest is farthest
             std::sort(order.begin(), order.end());
 
@@ -642,7 +759,58 @@ math::vertex<T> HPlot<T>::transform(const math::vertex<T>& vertex) const {
     typedef typename math::Plot<T>::projection_mode mode;
     const mode m = this->get_projection_mode();
 
-    for(int d = math::Plot<T>::D; d > 3; d--) {
+    // Stereographic for the outermost step, when the shape allows it.
+    //
+    // Only from a sphere: the map sends a point of the unit sphere S^(d-1) to
+    // the plane through its equator, along the line from the north pole,
+    //
+    //     x_i' = x_i / (1 - x_(d-1))
+    //
+    // which needs |x| = 1 to mean anything.  The torus is built on the unit
+    // sphere and rotation preserves it, so it qualifies; a hypercube does not,
+    // and its vertices sit at radius sqrt(n).
+    //
+    // The reason to want it is that stereographic projection sends circles to
+    // circles.  The Clifford torus is ruled by the Hopf fibres, so at D=4 they
+    // come through as Villarceau circles -- linked circles lying on an
+    // ordinary donut -- which perspective projection does not show.
+    //
+    // Note the eye offset has to be zero for this to work at all: any
+    // translation before the divide moves the figure off the sphere.  That is
+    // why initialize_glazzies zeroes it in this mode and the offset for the
+    // remaining perspective steps is applied afterwards, below, once the
+    // sphere is no longer needed.
+    int d = math::Plot<T>::D;
+
+    if(m_stereo && d > 3) {
+        const T pole = ret[d - 1];
+
+        // Clamped: a point reaching the pole projects to infinity.  That
+        // divergence is the eversion rather than a fault, so it is bounded
+        // instead of dropped, and the framing uses a percentile so a few
+        // vertices on their way out cannot carry the whole figure with them.
+        T denom = 1 - pole;
+        if(denom < 0.05) denom = 0.05;
+
+        // Normalized to about unit radius, so the perspective steps that
+        // follow get the size of figure their frustum was built for.  A
+        // uniform scale, so it changes nothing about the shape.
+        math::vertex<T> s(d - 1);
+        for(int i = 0; i < d - 1; i++)
+            s[i] = ret[i] / (denom * m_stereo_scale);
+
+        // Now put it in front of the frustums the remaining steps use.  The
+        // eye offset could not be applied before the divide without spoiling
+        // the sphere, so it lands here instead.
+        for(int i = 3; i < d - 1; i++)
+            s[i] += m_eye_offset;
+
+        ret = s;
+        ret.change(d - 1);
+        d--;
+    }
+
+    for(; d > 3; d--) {
         math::matrix<T> p = math::matrix<T>::project(d, math::Plot<T>::clip);
         math::vertex<T> v(d);
         v = ret;
@@ -710,6 +878,9 @@ protected:
     uint r;
     Shape m_shape = CUBOID;
 
+    /** Circles in the torus.  Only 2 makes a surface; see initialize(). */
+    uint m_circles = 2;
+
     matrix<T> rotate;
     matrix<T> back_rotate;
     bool waiting;
@@ -738,6 +909,8 @@ HyperPlot<T,Plot>::HyperPlot(uint n, std::vector< std::pair<T,T> > c, uint w, ui
 template<typename T, typename Plot>
 inline
 void HyperPlot<T,Plot>::initialize(uint n) {
+    bool surface = false;
+
     // Rotate in every plane, including those touching the highest axis.
     //
     // This defaulted to n-1, so a 4-cube's planes were only ever (0,1), (0,2)
@@ -761,11 +934,26 @@ void HyperPlot<T,Plot>::initialize(uint n) {
         break;
     }
     case TORUS: {
-        // k=2 regardless of n, so the mesh does not grow with dimension: the
-        // same surface, turning in more planes.  32 around each circle is
-        // 1024 quads, which is where a hypercube sits at D=10.
-        torus<T> object(n, 2, 32);
+        // Circles, not dimensions: k=2 is a surface whatever n is, so the
+        // mesh does not grow when the figure turns in more planes.
+        uint k = m_circles;
+        if(k < 1) k = 1;
+        if(2 * k > n) k = n / 2;
+        if(k < 1) k = 1;
+
+        // m^k vertices, so the samples per circle have to come down as
+        // circles go up or the mesh explodes: 32 per circle is 1024 at k=2
+        // and 32768 at k=3.  Holding m^k near 1024 gives 32, 10, 6, 4.
+        uint m = static_cast<uint>(std::lround(std::pow(1024.0, 1.0 / k)));
+        if(m < 3) m = 3;
+        if(m > 64) m = 64;
+
+        torus<T> object(n, k, m);
         this->add(object);
+
+        std::cout << "torus: " << k << " circles, " << m << " per circle, "
+                  << object.size() << " vertices, "
+                  << object.get_faces().size() << " faces" << std::endl;
 
         // Hue from the position around the first circle, rather than one per
         // vertex from the golden ratio.
@@ -782,15 +970,19 @@ void HyperPlot<T,Plot>::initialize(uint n) {
         for(uint i = 0; i < object.size(); i++)
             hues.push_back(static_cast<T>(i % object.M) / object.M);
 
+        surface = (object.K == 2);
         break;
     }
     }
 
-    // A surface shades smoothly, reads better without its own mesh drawn over
-    // it, and wants to look more solid than a shadow does.
-    this->m_smooth = (m_shape == TORUS);
-    this->m_wire   = (m_shape != TORUS);
+    // Only a 2-torus is a surface.  Above that the faces are interior
+    // scaffold: there is nothing for smooth normals to smooth, the edges are
+    // structure again rather than a mesh laid over something, and the faces
+    // stack deeply enough that the alpha has to be measured rather than set.
+    this->m_smooth = surface;
+    this->m_wire   = !surface;
     this->m_alpha  = (m_shape == TORUS ? 0.5 : 0.18);
+    this->m_adapt  = (m_shape == TORUS);
 }
 
 template<typename T, typename Plot>
@@ -855,7 +1047,12 @@ void HyperPlot<T,Plot>::draw_face(const std::vector< math::vertex<T> >& corner,
     // reads as separate surfaces rather than a solid block.
     GLfloat fcolors[4];
     fcolors[0] = color.r; fcolors[1] = color.g; fcolors[2] = color.b;
-    fcolors[3] = static_cast<GLfloat>(this->m_alpha);
+    // Thinned by how deeply the faces stack, when the shape needs it.
+    const T alpha = this->m_adapt
+        ? 1 - std::pow(1 - this->m_alpha, 1.8 / this->m_depth)
+        : this->m_alpha;
+
+    fcolors[3] = static_cast<GLfloat>(alpha);
 
     glColor4fv(fcolors);
     glMaterialfv(GL_FRONT_AND_BACK, GL_AMBIENT_AND_DIFFUSE, fcolors);
@@ -906,6 +1103,24 @@ void HyperPlot<T,Plot>::key_pressed(unsigned char key, int x, int y) {
             return;
 
         initialize(d);
+    } else if(key == 'h') {
+        // Only from the sphere; a hypercube is not on one.
+        if(m_shape == TORUS) {
+            this->m_stereo = !this->m_stereo;
+            this->reframe();
+            initialize(this->D);
+
+            std::cout << "projection: "
+                      << (this->m_stereo ? "stereographic" : "perspective")
+                      << std::endl;
+        }
+    } else if(key == 'k' || key == 'j') {
+        const uint want = (key == 'k' ? m_circles + 1 : m_circles - 1);
+
+        if(want >= 1 && 2 * want <= this->D) {
+            m_circles = want;
+            if(m_shape == TORUS) initialize(this->D);
+        }
     } else if(key == 'l') {
         this->m_wire = !this->m_wire;
         this->draw();
@@ -1025,10 +1240,17 @@ void HyperPlot<T,Plot>::initialize_glazzies(uint n) {
     // them through the origin, with the two halves straddling the camera.
     for(uint i = 3; i < n; i++) {
         clip.push_back(std::make_pair(r22, 3*r22));
-        eye[i] = r2;
+
+        // Zero under stereographic projection: it needs the figure on the
+        // unit sphere, and a translation would take it off.  transform()
+        // applies the offset after the divide instead, for whatever
+        // perspective steps remain.
+        eye[i] = (this->m_stereo ? 0 : r2);
         up[i] = 0;
         center[i] = 0;
     }
+
+    this->m_eye_offset = r2;
 }
 
 

--- a/jlib/apps/jhardhyper.cc
+++ b/jlib/apps/jhardhyper.cc
@@ -131,6 +131,9 @@ public:
     /** Faces along a line of sight, measured each frame. */
     T m_depth = 1.8;
 
+    /** Projected face area this frame, summed over every object. */
+    mutable T m_area = 0;
+
     /** Stereographic outermost step; see transform().  The h key. */
     bool m_stereo = false;
 
@@ -359,6 +362,8 @@ template<typename T>
 inline
 void HPlot<T>::draw() {
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+
+    m_area = 0;
 
     // Vertices are numbered across every object, matching the counter
     // draw_point keeps, so a subclass can index one colour table with either.
@@ -626,9 +631,13 @@ void HPlot<T>::draw() {
                     area += std::fabs(a) / 2;
                 }
 
-                const T disc = PI * m_radius * m_radius;
-
-                m_depth = (disc > 0 && area > disc) ? (area / disc) : 1.8;
+                // Accumulated across every object rather than set from this
+                // one.  Nested tori all lie along the same lines of sight, so
+                // what matters for alpha is their total: four surfaces at 1.8
+                // deep each stack 7 deep, and treating each as though it were
+                // alone would let them accumulate to near opacity.  Read a
+                // frame late, which is invisible at these rotation rates.
+                m_area += area;
             }
 
             // ascending z: the camera looks down -z, so smallest is farthest
@@ -733,6 +742,13 @@ void HPlot<T>::draw() {
         glDisable(GL_BLEND);
 
         base += object.size();
+    }
+
+    // The frame's total, for the next frame's alpha.
+    if(m_adapt) {
+        const T disc = PI * m_radius * m_radius;
+
+        m_depth = (disc > 0 && m_area > disc) ? (m_area / disc) : 1.8;
     }
 
     glDisable(GL_FOG);
@@ -881,6 +897,9 @@ protected:
     /** Circles in the torus.  Only 2 makes a surface; see initialize(). */
     uint m_circles = 2;
 
+    /** Tori drawn through the Hopf foliation.  The n and b keys. */
+    uint m_shells = 1;
+
     matrix<T> rotate;
     matrix<T> back_rotate;
     bool waiting;
@@ -948,29 +967,61 @@ void HyperPlot<T,Plot>::initialize(uint n) {
         if(m < 3) m = 3;
         if(m > 64) m = 64;
 
-        torus<T> object(n, k, m);
-        this->add(object);
-
-        std::cout << "torus: " << k << " circles, " << m << " per circle, "
-                  << object.size() << " vertices, "
-                  << object.get_faces().size() << " faces" << std::endl;
-
-        // Hue from the position around the first circle, rather than one per
-        // vertex from the golden ratio.
+        // One torus, or a stack of them through the Hopf foliation.
         //
-        // Scattered hues are right when vertices are landmarks -- a
-        // hypercube has sixteen of them and each is somewhere in particular.
-        // A mesh vertex is just where the surface got sampled, so scattering
-        // hues across 1024 of them gives every face four unrelated corners to
-        // blend and the surface renders as coloured static.
+        // Radii (cos a, sin a) give a torus for every a in (0, pi/2): they are
+        // disjoint, they fill the sphere apart from the two circles they close
+        // down onto at the ends, and each threads through the last.  Spacing a
+        // evenly across the interval samples that family.  a = pi/4 is the
+        // Clifford torus, which is what a single shell gives.
         //
-        // The wrap is exact and free: position around a circle is cyclic and
-        // so is hue, so the last band meets the first with no seam.
+        // Only for k=2.  Above that the radii are a simplex rather than one
+        // angle, and there is no single family to walk.
+        const uint shells = (k == 2 ? m_shells : 1);
+
         hues.clear();
-        for(uint i = 0; i < object.size(); i++)
-            hues.push_back(static_cast<T>(i % object.M) / object.M);
 
-        surface = (object.K == 2);
+        for(uint shell = 0; shell < shells; shell++) {
+            std::vector<T> weight;
+
+            if(shells > 1) {
+                const T a = PI / 2 * (shell + 1) / (shells + 1);
+
+                weight.push_back(std::cos(a));
+                weight.push_back(std::sin(a));
+            }
+
+            torus<T> object(n, k, m, weight);
+            this->add(object);
+
+            // One hue per shell, so the nesting is legible.  Within a shell
+            // the shading is the surface's own; between them it is the colour
+            // that says which is which where they pass through each other.
+            const T hue = (shells > 1)
+                ? static_cast<T>(shell) / shells
+                : 0.0;
+
+            for(uint i = 0; i < object.size(); i++)
+                hues.push_back(shells > 1
+                               ? hue
+                               : static_cast<T>(i % object.M) / object.M);
+
+            if(shell == 0)
+                std::cout << "torus: " << k << " circles, " << m
+                          << " per circle, " << shells << " shell"
+                          << (shells > 1 ? "s, " : ", ")
+                          << shells * object.size() << " vertices, "
+                          << shells * object.get_faces().size() << " faces"
+                          << std::endl;
+        }
+
+        // A single torus is banded by position around its first circle:
+        // scattered hues are right when vertices are landmarks, but a mesh
+        // vertex is just where the surface got sampled, and scattering across
+        // 1024 of them gives every face four unrelated corners to blend and
+        // renders the surface as coloured static.  The wrap is exact and
+        // free, position around a circle being cyclic like hue itself.
+        surface = (k == 2);
         break;
     }
     }
@@ -1103,6 +1154,13 @@ void HyperPlot<T,Plot>::key_pressed(unsigned char key, int x, int y) {
             return;
 
         initialize(d);
+    } else if(key == 'n' || key == 'b') {
+        const uint want = (key == 'n' ? m_shells + 1 : m_shells - 1);
+
+        if(want >= 1 && want <= 8) {
+            m_shells = want;
+            if(m_shape == TORUS) initialize(this->D);
+        }
     } else if(key == 'h') {
         // Only from the sphere; a hypercube is not on one.
         if(m_shape == TORUS) {

--- a/jlib/math/matrix.hh
+++ b/jlib/math/matrix.hh
@@ -340,7 +340,8 @@ protected:
 template<typename T>
 class torus : public object<T> {
 public:
-    torus(uint n, uint k = 2, uint m = 32);
+    torus(uint n, uint k = 2, uint m = 32,
+          std::vector<T> weight = std::vector<T>());
 
     virtual std::shared_ptr< object<T> > clone() const;
 
@@ -349,6 +350,18 @@ public:
 
     /** Samples around each circle. */
     uint M;
+
+    /**
+     * Radius of each circle, normalized so the sum of squares is one.
+     *
+     * Equal radii give the Clifford torus.  Unequal ones give the rest of the
+     * family: with k=2 and radii (cos a, sin a), every a in (0, pi/2) is a
+     * torus, they are disjoint, and together they fill the sphere except for
+     * the two circles a=0 and a=pi/2 that they close down onto.  That is the
+     * Hopf foliation, and stereographic projection shows it as tori nested
+     * one inside the next, each threading through the last.
+     */
+    std::vector<T> R;
 
 protected:
     virtual void build_faces() const;
@@ -1344,7 +1357,7 @@ std::shared_ptr< object<T> > torus<T>::clone() const {
 
 template<typename T>
 inline
-torus<T>::torus(uint n, uint k, uint m)
+torus<T>::torus(uint n, uint k, uint m, std::vector<T> weight)
     : object<T>(n),
       K(k),
       M(m)
@@ -1360,8 +1373,19 @@ torus<T>::torus(uint n, uint k, uint m)
     uint count = 1;
     for(uint j = 0; j < K; j++) count *= M;
 
-    // On the unit sphere: k circles of radius 1/sqrt(k) give sum r^2 = 1.
-    const T r = 1.0 / std::sqrt(static_cast<T>(K));
+    // On the unit sphere, whatever the proportions: the radii are normalized
+    // so their squares sum to one.  Equal radii are the Clifford torus.
+    R.assign(K, 1.0 / std::sqrt(static_cast<T>(K)));
+
+    if(weight.size() == K) {
+        T sum = 0;
+        for(uint j = 0; j < K; j++) sum += weight[j] * weight[j];
+
+        if(sum > 0) {
+            sum = std::sqrt(sum);
+            for(uint j = 0; j < K; j++) R[j] = weight[j] / sum;
+        }
+    }
 
     for(uint i = 0; i < count; i++) {
         vertex<T> v(n);
@@ -1375,8 +1399,8 @@ torus<T>::torus(uint n, uint k, uint m)
 
             const T angle = 2 * M_PI * static_cast<T>(digit) / M;
 
-            v[2 * j]     = r * std::cos(angle);
-            v[2 * j + 1] = r * std::sin(angle);
+            v[2 * j]     = R[j] * std::cos(angle);
+            v[2 * j + 1] = R[j] * std::sin(angle);
         }
 
         this->v.push_back(v);

--- a/jlib/math/matrix.hh
+++ b/jlib/math/matrix.hh
@@ -309,6 +309,52 @@ protected:
 };
 
 
+/**
+ * A flat torus: k circles, one per pair of coordinate axes, in n dimensions.
+ *
+ * The Cartesian product of k circles, S^1 x ... x S^1, with circle j laid in
+ * the (2j, 2j+1) coordinate plane and every axis from 2k up left at zero:
+ *
+ *     x_2j     = r cos(theta_j)
+ *     x_(2j+1) = r sin(theta_j)
+ *
+ * At k=2, n=4 this is the Clifford torus, which is what XScreenSaver's
+ * hypertorus draws.  Every radius is 1/sqrt(k), so the whole thing sits on the
+ * unit sphere of R^2k.
+ *
+ * It is flat -- zero Gaussian curvature -- which is why no such surface exists
+ * in three dimensions and why its shadow is so strange.  Rotations that mix
+ * the unused axes into the used ones carry parts of it through the axis being
+ * projected away, and the perspective divide inflates and deflates them, so
+ * the surface passes through itself and comes back out.
+ *
+ * k is independent of n, so the mesh does not grow when n does: a 2-torus is
+ * the same m^2 vertices whether it turns in four dimensions or ten, and only
+ * the number of planes it can turn in changes.  n must be at least 2k.
+ *
+ * The topology is a cuboid's with cycles in place of edges.  A vertex is a
+ * tuple of k digits base m rather than a pattern of n bits, its neighbour
+ * along axis j steps that digit by one modulo m rather than flipping a bit,
+ * and a face still comes from choosing two axes and pinning the rest.
+ */
+template<typename T>
+class torus : public object<T> {
+public:
+    torus(uint n, uint k = 2, uint m = 32);
+
+    virtual std::shared_ptr< object<T> > clone() const;
+
+    /** Circles. */
+    uint K;
+
+    /** Samples around each circle. */
+    uint M;
+
+protected:
+    virtual void build_faces() const;
+};
+
+
 template<typename T>
 class pyramoid : public object<T> {
 public:
@@ -1281,6 +1327,115 @@ void cuboid<T>::build_faces() const {
                 f.push_back(base | bit_a);
                 f.push_back(base | bit_a | bit_b);
                 f.push_back(base | bit_b);
+
+                this->faces.push_back(f);
+            }
+        }
+    }
+}
+
+
+template<typename T>
+inline
+std::shared_ptr< object<T> > torus<T>::clone() const {
+    return std::make_shared< torus<T> >(*this);
+}
+
+
+template<typename T>
+inline
+torus<T>::torus(uint n, uint k, uint m)
+    : object<T>(n),
+      K(k),
+      M(m)
+{
+    // A cycle needs three vertices to be one: at two the step forward and the
+    // step back are the same neighbour, at one it is a self-loop.
+    if(M < 3) M = 3;
+    if(K < 1) K = 1;
+
+    // Each circle occupies a coordinate pair, so there has to be room.
+    if(2 * K > n) K = n / 2;
+
+    uint count = 1;
+    for(uint j = 0; j < K; j++) count *= M;
+
+    // On the unit sphere: k circles of radius 1/sqrt(k) give sum r^2 = 1.
+    const T r = 1.0 / std::sqrt(static_cast<T>(K));
+
+    for(uint i = 0; i < count; i++) {
+        vertex<T> v(n);
+        for(uint x = 0; x < n; x++) v[x] = 0;
+
+        // digit j of i, base M, is the position around circle j
+        uint rest = i;
+        for(uint j = 0; j < K; j++) {
+            const uint digit = rest % M;
+            rest /= M;
+
+            const T angle = 2 * M_PI * static_cast<T>(digit) / M;
+
+            v[2 * j]     = r * std::cos(angle);
+            v[2 * j + 1] = r * std::sin(angle);
+        }
+
+        this->v.push_back(v);
+        this->adj.push_back(std::vector<uint>());
+    }
+
+    // One edge per vertex per circle: the step forward.  Stepping back would
+    // reach the same edges from the other end.
+    uint stride = 1;
+    for(uint j = 0; j < K; j++) {
+        for(uint i = 0; i < count; i++) {
+            const uint digit = (i / stride) % M;
+            const uint next = i + stride * ((digit + 1) % M) - stride * digit;
+
+            this->connect(i, next);
+        }
+
+        stride *= M;
+    }
+}
+
+
+/**
+ * The 2-faces of a flat torus.
+ *
+ * One quad per vertex per pair of circles: step forward along both.  That is
+ * C(k,2)*m^k of them -- 1024 for a 2-torus at m=32, and equal to the vertex
+ * count, which is Euler characteristic zero as a torus requires.
+ *
+ * Emitted around the quad rather than across it, and consistently: unlike a
+ * hypercube's shadow, this is a real surface, so its faces have a side.
+ */
+template<typename T>
+inline
+void torus<T>::build_faces() const {
+    uint count = 1;
+    for(uint j = 0; j < K; j++) count *= M;
+
+    std::vector<uint> stride(K);
+    uint s = 1;
+    for(uint j = 0; j < K; j++) { stride[j] = s; s *= M; }
+
+    for(uint a = 0; a < K; a++) {
+        for(uint b = a + 1; b < K; b++) {
+            for(uint i = 0; i < count; i++) {
+                const uint da = (i / stride[a]) % M;
+                const uint db = (i / stride[b]) % M;
+
+                const uint ia = i + stride[a] * ((da + 1) % M) - stride[a] * da;
+                const uint ib = i + stride[b] * ((db + 1) % M) - stride[b] * db;
+
+                const uint dab = (ia / stride[b]) % M;
+                const uint iab = ia + stride[b] * ((dab + 1) % M) - stride[b] * dab;
+
+                typename object<T>::face_type f;
+                f.push_back(i);
+                f.push_back(ia);
+                f.push_back(iab);
+                f.push_back(ib);
 
                 this->faces.push_back(f);
             }

--- a/tests/math_object_test.cc
+++ b/tests/math_object_test.cc
@@ -13,6 +13,7 @@
  */
 #include <jlib/math/matrix.hh>
 
+#include <cmath>
 #include <iomanip>
 #include <iostream>
 #include <map>
@@ -124,6 +125,101 @@ int main() {
 
         std::cout << "\n";
     }
+
+    // The flat torus, checked against what a torus has to be.
+    //
+    // The alternating sum of cell counts is the real test: it only comes out
+    // right if the vertices, the cyclic adjacency and the face enumeration all
+    // agree, and a missing wrap-around at the seam would break it.
+    //
+    // A k-torus grid has C(k,j)*m^k cells of dimension j, so the full sum is
+    // m^k*(1-1)^k = 0.  object only holds cells up to dimension 2, so what is
+    // checkable here is the truncation, m^k*(1 - k + C(k,2)).  At k=2 nothing
+    // exists above dimension 2 and that truncation is the Euler characteristic
+    // itself, zero, as a torus requires; at k=3 it is m^3, with the 3-cells
+    // that would cancel it not represented.
+    for(uint k = 2; k <= 3; k++) {
+        for(uint m = 3; m <= 8; m += 5) {
+            const uint n = 2 * k;
+            torus<T> t(n, k, m);
+
+            long verts = 1;
+            for(uint j = 0; j < k; j++) verts *= m;
+
+            const long edges = static_cast<long>(k) * verts;
+            const long faces = (static_cast<long>(k) * (k - 1) / 2) * verts;
+
+            std::cout << k << "-torus in " << n << "D, " << m << " per circle:\n";
+            check("vertices", t.size(), verts);
+            check("edges (each once)", t.get_edges().size(), edges);
+            check("faces", t.get_faces().size(), faces);
+
+            // every vertex has two neighbours per circle
+            long degree_wrong = 0;
+            for(uint i = 0; i < t.size(); i++)
+                if(t.adjacent(i).size() != 2 * k) ++degree_wrong;
+            check("vertices with wrong degree", degree_wrong, 0);
+
+            const long alternating = verts * (1 - static_cast<long>(k)
+                                              + static_cast<long>(k) * (k - 1) / 2);
+            check(k == 2 ? "Euler characteristic V-E+F" : "V-E+F (2-skeleton)",
+                  static_cast<long>(t.size()) - edges + faces, alternating);
+
+            // on the unit sphere, by construction
+            long off_sphere = 0;
+            for(uint i = 0; i < t.size(); i++) {
+                T r2 = 0;
+                for(uint x = 0; x < t.D; x++) r2 += t[i][x] * t[i][x];
+                if(std::fabs(std::sqrt(r2) - 1.0) > 1e-9) ++off_sphere;
+            }
+            check("vertices off the unit sphere", off_sphere, 0);
+
+            // every side of every face is a real edge, and every edge is used
+            // by exactly the faces that should use it
+            std::map<std::pair<uint,uint>, long> sides;
+            long face_oob = 0, wrong_size = 0;
+            for(uint f = 0; f < t.get_faces().size(); f++) {
+                const std::vector<uint>& face = t.get_faces()[f];
+                if(face.size() != 4) ++wrong_size;
+                for(uint x = 0; x < face.size(); x++) {
+                    if(face[x] >= t.size()) ++face_oob;
+                    const uint p = face[x], q = face[(x + 1) % face.size()];
+                    sides[p < q ? std::make_pair(p, q) : std::make_pair(q, p)]++;
+                }
+            }
+            check("faces that are not quads", wrong_size, 0);
+            check("out-of-range face indices", face_oob, 0);
+
+            std::set<std::pair<uint,uint> > real;
+            for(uint e = 0; e < t.get_edges().size(); e++)
+                real.insert(t.get_edges()[e]);
+
+            long not_an_edge = 0;
+            for(std::map<std::pair<uint,uint>, long>::iterator u = sides.begin();
+                u != sides.end(); u++)
+                if(real.find(u->first) == real.end()) ++not_an_edge;
+            check("face sides that are not edges", not_an_edge, 0);
+            check("edges covered by faces", sides.size(), edges);
+
+            std::cout << "\n";
+        }
+    }
+
+    // A 2-torus in higher ambient dimensions is the same surface: the mesh
+    // must not grow, and the unused axes must stay flat.
+    for(uint n = 4; n <= 7; n++) {
+        torus<T> t(n, 2, 8);
+
+        std::cout << "2-torus in " << n << "D: ";
+        check("vertices", t.size(), 64);
+
+        long nonzero = 0;
+        for(uint i = 0; i < t.size(); i++)
+            for(uint x = 4; x < t.D; x++)
+                if(t[i][x] != 0) ++nonzero;
+        check("  nonzero unused axes", nonzero, 0);
+    }
+    std::cout << "\n";
 
     // the shape that used to be mangled: duplicates must survive as distinct
     spheroid<T> s(3);


### PR DESCRIPTION
The hypercube work built a pipeline -- index topology, faces, per-frame
normals, depth-sorted translucency -- and this is the shape it was worth
building for.  A hypercube is flat squares you can follow in wireframe; a
torus is curvature, which only reads through shading, and its projection
passes through itself, which only reads through depth ordering.

The starting point was XScreenSaver's hypertorus, which draws the Clifford
torus in four dimensions and is written for four dimensions specifically:
hardcoded 4-vectors, an explicit w, the six rotation planes of R^4 written out
one at a time.  jlib had already generalized every one of those.

    macOS  24 tests, 23 pass, 1 skip
    Linux  25 tests, 23 pass, 2 skip

the shape

    math::torus(n, k, m, weight) is the product of k circles in n dimensions,
    circle j in the (2j, 2j+1) coordinate plane:

        x_2j = r_j cos(theta_j),  x_(2j+1) = r_j sin(theta_j)

    with the radii normalized so the sum of squares is one, which puts it on
    the unit sphere.  Equal radii and k=2 is the Clifford torus, which is what
    hypertorus draws.

    k is independent of n.  A 2-torus is the same m^2 vertices whether it
    turns in four dimensions or ten; only the number of planes it can turn in
    changes, which is what makes D=5 and up affordable.

    The topology is a cuboid's with cycles in place of edges.  A vertex is k
    digits base m rather than n bits, its neighbour along axis j steps that
    digit by one modulo m rather than flipping a bit, and a face still comes
    from choosing two axes and pinning the rest.  build_faces() is nearly the
    same function #30 wrote.

    Tests check the alternating sum of cell counts.  A k-torus grid has
    C(k,j)*m^k cells of dimension j, so the full sum is m^k*(1-1)^k = 0;
    object holds cells up to dimension 2, so what is checkable is the
    truncation m^k*(1 - k + C(k,2)), which at k=2 is the Euler characteristic
    itself and zero, as a torus requires.  It only comes out right if the
    vertices, the cyclic adjacency and the face enumeration all agree, and a
    missing wrap-around at either seam would break it.

    I first asserted zero for every k.  The run reported exactly the m^3 that
    the truncation predicts at k=3, which is the test being wrong rather than
    the code.

shading a surface

    Faces meeting at a vertex are averaged into a vertex normal, since a
    surface's curvature is the thing being shown and flat faces hide it.
    Adjacent faces on the projected torus disagree by a median of about ten
    degrees, which is squarely in the range that reads as facets.

    Aligned before averaging.  A hypercube's faces meet at right angles and
    its shadow everts, so averaging there rounds off corners that are not
    round -- visible as the shading flashing as it turns, which is why it is
    off for the hypercube.  A torus has consistent winding, so its faces agree
    except along the fold curves where the projection reverses orientation;
    taking the first face at a vertex as the reference and flipping the rest
    to agree keeps the average meaningful across a fold, and the fold reads as
    a crease, which is what it is.

    Colour is banded by position around the first circle rather than scattered
    per vertex.  Scattered hues are right when vertices are landmarks -- a
    hypercube has sixteen and each is somewhere in particular -- but a mesh
    vertex is only where the surface got sampled, and scattering across 1024
    of them gives every face four unrelated corners to blend, which renders as
    coloured static.  The wrap costs nothing: position around a circle is
    cyclic and so is hue.

    The mesh is not drawn over its own surface.  A hypercube's edges are 2% of
    the projected area and they are the structure; a 32x32 torus puts 2048 of
    them over the same area, covering 21%, and what you see is the mesh.

    Alpha is measured rather than set, for the torus.  Solving 1-(1-a)^depth
    for a fixed total gives a = 1-(1-alpha)^(1.8/depth), which leaves a
    surface where it was and thins denser things in proportion.  Accumulated
    across every object, since nested tori lie along the same lines of sight:
    four surfaces 1.8 deep each stack 7 deep, and treating each as alone would
    take them to near opacity.  Off for the hypercube, whose look was settled.

stereographic projection

    x_i' = x_i / (1 - x_(d-1)), which needs the figure on the unit sphere.
    The torus is built there and rotation keeps it there.

    The reason to want it is that it sends circles to circles.  At D=4 the
    Clifford torus comes through as an ordinary donut ruled by Villarceau
    circles, which perspective projection does not show.  That is exact and
    tested: the unrotated Clifford torus satisfies (rho - sqrt2)^2 + z^2 = 1
    to a worst residual of 2.8e-15.

    The eye offset has to be zero for it, since any translation before the
    divide moves the figure off the sphere; the offset for whatever
    perspective steps remain is applied after it instead.

    Two things it breaks that had to be repaired.  The framing takes a
    percentile rather than a maximum, because a vertex approaching the pole
    runs off toward infinity and the framing only ever grows, so one of them
    would shrink the figure to a dot permanently.  And the stereographic image
    breathes -- how much it magnifies depends on how close the figure passes
    to the pole, measured between 1.0 and 4.8 at D=6 -- so it is normalized
    per frame before the perspective steps, which assume about unit radius.
    Without that, parts arrive within 0.36 of an eye whose near plane is at
    1.5 and are magnified an order of magnitude past the far side, and the
    figure appears to sweep forward and swallow the camera.  That last one
    looked like the frustum straddling the eye from #22; it is not, there are
    no sign flips at any rotation, it is only scale.

the foliation

    Radii (cos a, sin a) give a torus for every a in (0, pi/2).  They are
    disjoint, they fill the sphere apart from the two circles they close down
    onto at the ends, and each threads through the last.  a = pi/4 is the
    Clifford torus.  Spacing a evenly and drawing several samples that family,
    which under stereographic projection is the nested-tori picture.

    Checked rather than eyeballed: shell a projects onto
    (rho - 1/cos a)^2 + z^2 = tan(a)^2, worst residual 7e-14, and consecutive
    shells are disjoint because the gap between tube centres is always less
    than the difference of their radii -- strictly one inside the next.

    This is the first thing to put more than one object in a math::Plot.  The
    list and the vertex numbering that runs across objects both existed and
    had never been exercised.

keys

    t     hypercube or torus
    h     stereographic or perspective, torus only
    k j   circles, needs D >= 2k
    n b   shells through the foliation, k=2 only
    m     smooth or flat normals
    l     wireframe
    o     solid faces
    z x   zoom

not covered

    Higher k is in and works, but only k=2 is a surface.  Above that the faces
    are interior scaffold: measured, a 3-torus at the coarsest useful mesh
    stacks 18 deep against a 2-torus's 1.8, denser than a 10-cube with a tenth
    the faces.  It reads as a lattice or a cloud rather than an object.  Kept
    because it is cheap and the toggle is interesting, not because it is the
    point.

    Stereographic projection is exact at D=4, where it is the only step.
    Above that it is a stereographic step followed by perspective ones, and
    there is no canonical composition -- what is here is a defensible choice
    rather than a derivation.

    jglfwhyper and the other raster plots have no torus.  They reduce to two
    dimensions, so they would get wireframe only, and a wireframe torus does
    not show what any of this was for.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
