### PR TITLE
Cut the allocations in the reduction loop

### DIFF
--- a/jlib/apps/jhardhyper.cc
+++ b/jlib/apps/jhardhyper.cc
@@ -826,11 +826,22 @@ math::vertex<T> HPlot<T>::transform(const math::vertex<T>& vertex) const {
         d--;
     }
 
+    this->build_projections();
+
     for(; d > 3; d--) {
-        math::matrix<T> p = math::matrix<T>::project(d, math::Plot<T>::clip);
-        math::vertex<T> v(d);
-        v = ret;
-        ret = p * v();
+        // Reset the homogeneous coordinate, then project in place.
+        //
+        // This used to build a fresh vertex of the same dimensionality, copy
+        // ret into it and multiply that.  The copy was not the point: vertex(d)
+        // sets its own homogeneous coordinate to 1 and operator=(vertex) copies
+        // only the spatial elements, so what the temporary did was reset w
+        // before the multiply.  That matters in orthographic mode, where
+        // normalize() is skipped and w is not already 1, so it is kept -- but
+        // as one assignment rather than an allocation and a copy per step per
+        // vertex.  change() runs unconditionally here, so ret's dimensionality
+        // tracks the step and it can be projected in place.
+        ret[d] = 1;
+        ret = this->m_project[math::Plot<T>::D - d] * ret();
 
         const bool outermost = (d == static_cast<int>(math::Plot<T>::D));
         if(m == mode::perspective || (m == mode::mixed && outermost)) {

--- a/jlib/math/Plot.hh
+++ b/jlib/math/Plot.hh
@@ -90,7 +90,7 @@ public:
     void multiply(const math::matrix<T>& m);
     Plot& operator*(const math::matrix<T>& m);
 
-    void setClip(std::vector< std::pair<T,T> > c);
+    void setClip(const std::vector< std::pair<T,T> >& c);
 
     projection_mode get_projection_mode() const;
     void set_projection_mode(projection_mode m);
@@ -137,6 +137,22 @@ protected:
      * transform() is const.
      */
     mutable T m_radius;
+
+    /**
+     * One projection matrix per reduction step, built once and kept.
+     *
+     * project() depends only on the step's dimension and the clip volume,
+     * neither of which changes within a frame, but it was being rebuilt for
+     * every vertex: at D=10 that is seven matrices per vertex and 1024
+     * vertices, so seven thousand matrices a frame where four are needed.
+     *
+     * Discarded whenever D or the clip changes, which is the only way either
+     * can move.  mutable because transform() is const.
+     */
+    mutable std::vector< math::matrix<T> > m_project;
+
+    /** Build m_project if it is empty. */
+    void build_projections() const;
 
     std::vector< std::pair<T,T> > clip;
     // Held by pointer so a shape keeps its type.  These used to be stored by
@@ -291,11 +307,16 @@ math::vertex<T> Plot<T>::transform(const math::vertex<T>& vertex) const {
     // match the step, that index still holds the 1 left by the previous step --
     // so the divide silently became a no-op.  That is what made every step
     // after the first orthographic by accident, which is now MIXED.
+    build_projections();
+
     for(int d = (D - 1); d > 2; d--) {
-        math::matrix<T> p = math::matrix<T>::project(d, clip);
+        // The temporary stays here, unlike in jhardhyper's copy of this loop.
+        // change() below is conditional, so outside perspective mode ret keeps
+        // its dimensionality while the steps shrink, and v is what truncates
+        // ret to the step -- not merely a copy of it.
         math::vertex<T> v(d);
         v = ret;
-        ret = p * v();
+        ret = m_project[D - d] * v();
 
         if(m_projection == projection_mode::perspective) {
             ret.normalize();
@@ -354,8 +375,24 @@ void Plot<T>::set(STACK s) {
 
 template<typename T>
 inline
-void Plot<T>::setClip(std::vector< std::pair<T,T> > c) {
+void Plot<T>::setClip(const std::vector< std::pair<T,T> >& c) {
     clip = c;
+    m_project.clear();
+}
+
+
+template<typename T>
+inline
+void Plot<T>::build_projections() const {
+    if(!m_project.empty())
+        return;
+
+    // Every step any reduction might take, indexed by D - d.  This one starts
+    // at D-1, since its outermost step uses the projection stack rather than
+    // project(); jhardhyper's starts at D.  Building the union is two extra
+    // matrices a frame and keeps one index convention.
+    for(int d = D; d > 2; d--)
+        m_project.push_back(math::matrix<T>::project(d, clip));
 }
 
 template<typename T>
@@ -413,6 +450,7 @@ inline
 void Plot<T>::change(uint n) {
     D = n;
     m_radius = 0;
+    m_project.clear();
     while(modelview.size()) {
         modelview.pop();
     }

--- a/jlib/math/matrix.hh
+++ b/jlib/math/matrix.hh
@@ -98,7 +98,7 @@ public:
     static matrix<T> diagonal(uint n, T x);
     static matrix<T> diagonalv(uint n, ...);
     
-    static matrix<T> project(uint n, std::vector< std::pair<T,T> > clip);
+    static matrix<T> project(uint n, const std::vector< std::pair<T,T> >& clip);
     static matrix<T> translate(uint n, const vertex<T>& v);
     static matrix<T> rotate(uint n, plane p, double rad);
     static matrix<T> rotate(uint n, PLANE p, double rad);
@@ -882,7 +882,7 @@ std::map<std::string, matrix<T> > matrix<T>::factor(factorization f) const {
 
 template<typename T>
 inline
-matrix<T> matrix<T>::project(uint n, std::vector< std::pair<T,T> > clip) {
+matrix<T> matrix<T>::project(uint n, const std::vector< std::pair<T,T> >& clip) {
     uint z = (n - 1);
     uint w = (n);
     matrix<T> ret(n+1, n+1);


### PR DESCRIPTION
#47, partly.  jhardhyper was slowing down noticeably above D=10, and the
reduction loop was allocating about ninety times per vertex per frame.  It now
allocates about half that, and the cuboid and both hyper plots are visibly
smoother above D=10.

    macOS  24 tests, 23 pass, 1 skip
    Linux  25 tests, 23 pass, 2 skip

measured, cuboid at D=10, per frame

                    before                   after
    jhardhyper      92160 allocs, 7.1 MB     49152 allocs, 2.0 MB   -47% -73%
    raster Plot     95232 allocs, 6.2 MB     76800 allocs, 3.8 MB   -19% -38%

    Max coordinate difference exactly 0.0, checked against the previous loop in
    all three projection modes at D=4 through 8, before any of it was applied.

what changed

    matrix::project() took its clip volume by value.  That is a std::vector
    copy on every call and it is called D-3 times per vertex.  Now const&.

    The projection matrices are cached.  They depend only on the step's
    dimension and the clip volume, and neither moves within a frame, but they
    were rebuilt for every vertex: at D=10 that is seven thousand matrices a
    frame where eight are wanted.  Discarded by change() and setClip(), which
    are the only things that can move either.

    jhardhyper's per-step temporary vertex is gone.

the temporary was not a copy

    Deleting it as redundant would have been a silent bug, and this is the
    reason the equivalence check came first.

        vertex<T> v(d);
        v = ret;
        ret = p * v();

    vertex(d) sets its own homogeneous coordinate to 1, and operator=(vertex)
    copies only the spatial elements, so it never overwrites that 1.  What the
    step actually did was reset w before the multiply.  In perspective mode
    normalize() has already made w 1 and it makes no difference; in
    orthographic mode normalize() is skipped, w is whatever the last step left,
    and dropping the reset changes the result.

    So the reset is kept, as one assignment rather than an allocation and a
    copy per step per vertex.

    The raster path keeps the temporary, which is why it improved less.
    Plot::transform calls change() conditionally, so outside perspective mode
    the vertex's dimensionality and the step's diverge, and there the temporary
    really is truncating rather than only resetting w.  The two loops look
    alike and do not mean the same thing.

what is left

    About 48 allocations per vertex, roughly half each in two places.

    vertex::change() builds a fresh vertex and deep-copies on every step.  It
    could be nearly free when shrinking -- buffer::resize already reuses
    storage in that direction -- but change() is currently the point where a
    vertex detaches from any storage it shares, which is load-bearing for the
    design reviewed in #48.  Doing it in place needs an ownership check, so it
    is left for its own change.

    The matrix multiply allocates its result.  Avoiding that needs a multiply
    that writes into a matrix the caller supplies.

    #47 stays open for both.

corrected along the way

    The issue originally blamed the per-face corner vectors.  They were never
    the problem: measured, six allocations for a whole frame, because the
    vector is reused across faces and a vertex copy allocates nothing at all --
    buffer holds a shared_ptr to its array, so copying one is a refcount bump.
    Withdrawn on the issue before this work started.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
