### PR TITLE
Fix two memory-safety bugs in media

### DIFF
--- a/jlib/media/PlayList.hh
+++ b/jlib/media/PlayList.hh
@@ -214,10 +214,25 @@ namespace jlib {
 
             const int n = (int)(((double)get_width() / (double)ticks_per_minute)*60*m_samples_per_sec);
 
-            Type::scaled samples[n];// = new Type::sample<N>::buf[n];
-            typename Type::sample<N>::buf samples_out[n];// = new Type::sample<N>::buf[n];
-            memset(samples,0,n*sizeof(Type::scaled));
-            memset(samples_out,0,n*sizeof(typename Type::sample<N>::buf));
+            // Nothing to render, and every path below would be worse than
+            // useless: the mixing loop takes a remainder modulo n, and a
+            // zero-length array is not something you can declare.
+            if(n <= 0)
+                return std::string();
+
+            // Heap, not stack.
+            //
+            // These were declared as arrays of length n, which is not C++ at
+            // all -- a GNU extension the compilers here happen to take -- and
+            // n comes from the playlist rather than from anything bounded.  At
+            // 4/4 and 120bpm the two of them together come to about 33K of
+            // stack per tick of width, so a few hundred ticks of playlist runs
+            // off the end of an 8M stack, and nothing checks.  The commented
+            // out new[] on the old lines says this was on the heap once.
+            //
+            // Value-initialized, which is what the two memsets were for.
+            std::vector<Type::scaled> samples(n);
+            std::vector<typename Type::sample<N>::buf> samples_out(n);
 
             std::string data;
             
@@ -276,7 +291,8 @@ namespace jlib {
             for(int z=0;z<n;z++)
                 samples_out[z] = Type::sample<N>::descale(samples[z]);
 
-            data.assign((char*)samples_out, n*sizeof(typename Type::sample<N>::buf));
+            data.assign((const char*)samples_out.data(),
+                        n*sizeof(typename Type::sample<N>::buf));
             
             if(getenv("JLIB_MEDIA_PLAYLIST_DEBUG"))
                 std::cerr << "void jlib::media::PlayList::render(): leave" << std::endl;

--- a/jlib/media/audiofilestream.hh
+++ b/jlib/media/audiofilestream.hh
@@ -139,9 +139,8 @@ namespace jlib {
         basic_audiofilestream<charT,traitT>::basic_audiofilestream() 
             : basic_datastream<charT,traitT>()
         {
-            if(this->m_buf) delete this->m_buf;
-            this->m_buf=new basic_audiofilebuf<charT,traitT>();
-            this->init(this->m_buf);
+            this->m_buf.reset(new basic_audiofilebuf<charT,traitT>());
+            this->init(this->m_buf.get());
         }
         
         template< typename charT, typename traitT >
@@ -149,8 +148,8 @@ namespace jlib {
         basic_audiofilestream<charT,traitT>::basic_audiofilestream(AudioFile* audiofile)
             : basic_datastream<charT,traitT>()
         {
-            this->m_buf=new basic_audiofilebuf<charT,traitT>(audiofile);
-            this->init(this->m_buf);
+            this->m_buf.reset(new basic_audiofilebuf<charT,traitT>(audiofile));
+            this->init(this->m_buf.get());
         }
         
         template< typename charT, typename traitT >
@@ -160,7 +159,7 @@ namespace jlib {
         {
             if(!this->m_buf)
                 throw basic_audiofilebuf<charT,traitT>::exception("m_buf == null");
-            basic_audiofilebuf<charT,traitT>* buf = dynamic_cast< basic_audiofilebuf<charT,traitT>* >(this->m_buf);
+            basic_audiofilebuf<charT,traitT>* buf = dynamic_cast< basic_audiofilebuf<charT,traitT>* >(this->m_buf.get());
             if(buf)
                 return buf->get_audiofile();
             else
@@ -174,7 +173,7 @@ namespace jlib {
         {
             if(!this->m_buf)
                 throw basic_audiofilebuf<charT,traitT>::exception("m_buf == null");
-            basic_audiofilebuf<charT,traitT>* buf = dynamic_cast< basic_audiofilebuf<charT,traitT>* >(this->m_buf);
+            basic_audiofilebuf<charT,traitT>* buf = dynamic_cast< basic_audiofilebuf<charT,traitT>* >(this->m_buf.get());
             if(buf)
                 buf->set_audiofile(audiofile);
             else

--- a/jlib/media/datastream.hh
+++ b/jlib/media/datastream.hh
@@ -289,8 +289,8 @@ namespace jlib {
         basic_datastream<charT,traitT>::basic_datastream() 
             : basic_stream<charT,traitT>()
         {
-            this->m_buf=new basic_databuf<charT,traitT>();
-            this->init(this->m_buf);
+            this->m_buf.reset(new basic_databuf<charT,traitT>());
+            this->init(this->m_buf.get());
         }
         
         template< typename charT, typename traitT >
@@ -298,8 +298,8 @@ namespace jlib {
         basic_datastream<charT,traitT>::basic_datastream(std::string data) 
             : basic_stream<charT,traitT>()
         {
-            this->m_buf=new basic_databuf<charT,traitT>(data);
-            this->init(this->m_buf);
+            this->m_buf.reset(new basic_databuf<charT,traitT>(data));
+            this->init(this->m_buf.get());
         }
         
         template< typename charT, typename traitT >
@@ -309,7 +309,7 @@ namespace jlib {
         {
             if(!this->m_buf)
                 throw basic_databuf<charT,traitT>::exception("this->m_buf == null");
-            basic_databuf<charT,traitT>* buf = dynamic_cast< basic_databuf<charT,traitT>* >(this->m_buf);
+            basic_databuf<charT,traitT>* buf = dynamic_cast< basic_databuf<charT,traitT>* >(this->m_buf.get());
             if(buf)
                 return buf->get_data();
             else
@@ -323,7 +323,7 @@ namespace jlib {
         {
             if(!this->m_buf)
                 throw basic_databuf<charT,traitT>::exception("this->m_buf == null");
-            basic_databuf<charT,traitT>* buf = dynamic_cast< basic_databuf<charT,traitT>* >(this->m_buf);
+            basic_databuf<charT,traitT>* buf = dynamic_cast< basic_databuf<charT,traitT>* >(this->m_buf.get());
             if(buf)
                 buf->set_data(data);
             else

--- a/jlib/media/notestream.hh
+++ b/jlib/media/notestream.hh
@@ -519,8 +519,8 @@ namespace jlib {
         basic_notestream<charT,traitT>::basic_notestream() 
             : basic_datastream<charT,traitT>()
         {
-            this->m_buf=new basic_notebuf<charT,traitT>();
-            this->init(this->m_buf);
+            this->m_buf.reset(new basic_notebuf<charT,traitT>());
+            this->init(this->m_buf.get());
         }
         
         template< typename charT, typename traitT >
@@ -528,8 +528,8 @@ namespace jlib {
         basic_notestream<charT,traitT>::basic_notestream(std::string note) 
             : basic_datastream<charT,traitT>()
         {
-            this->m_buf=new basic_notebuf<charT,traitT>(note);
-            this->init(this->m_buf);
+            this->m_buf.reset(new basic_notebuf<charT,traitT>(note));
+            this->init(this->m_buf.get());
         }
         
         template< typename charT, typename traitT >
@@ -537,8 +537,8 @@ namespace jlib {
         basic_notestream<charT,traitT>::basic_notestream(double freq) 
             : basic_datastream<charT,traitT>()
         {
-            this->m_buf=new basic_notebuf<charT,traitT>(freq);
-            this->init(this->m_buf);
+            this->m_buf.reset(new basic_notebuf<charT,traitT>(freq));
+            this->init(this->m_buf.get());
         }
 
         template< typename charT, typename traitT >
@@ -546,8 +546,8 @@ namespace jlib {
         basic_notestream<charT,traitT>::basic_notestream(int step, double base) 
             : basic_datastream<charT,traitT>()
         {
-            this->m_buf=new basic_notebuf<charT,traitT>(step, base);
-            this->init(this->m_buf);
+            this->m_buf.reset(new basic_notebuf<charT,traitT>(step, base));
+            this->init(this->m_buf.get());
         }
 
         template< typename charT, typename traitT >
@@ -557,7 +557,7 @@ namespace jlib {
         {
             if(!this->m_buf)
                 throw basic_notebuf<charT,traitT>::exception("this->m_buf == null");
-            basic_notebuf<charT,traitT>* buf = dynamic_cast< basic_notebuf<charT,traitT>* >(this->m_buf);
+            basic_notebuf<charT,traitT>* buf = dynamic_cast< basic_notebuf<charT,traitT>* >(this->m_buf.get());
             if(buf)
                 return buf->get_note();
             else
@@ -571,7 +571,7 @@ namespace jlib {
         {
             if(!this->m_buf)
                 throw basic_notebuf<charT,traitT>::exception("this->m_buf == null");
-            basic_notebuf<charT,traitT>* buf = dynamic_cast< basic_notebuf<charT,traitT>* >(this->m_buf);
+            basic_notebuf<charT,traitT>* buf = dynamic_cast< basic_notebuf<charT,traitT>* >(this->m_buf.get());
             if(buf)
                 buf->set_note(note);
             else
@@ -585,7 +585,7 @@ namespace jlib {
         {
             if(!this->m_buf)
                 throw basic_notebuf<charT,traitT>::exception("this->m_buf == null");
-            basic_notebuf<charT,traitT>* buf = dynamic_cast< basic_notebuf<charT,traitT>* >(this->m_buf);
+            basic_notebuf<charT,traitT>* buf = dynamic_cast< basic_notebuf<charT,traitT>* >(this->m_buf.get());
             if(buf)
                 buf->set_note(freq);
             else
@@ -599,7 +599,7 @@ namespace jlib {
         {
             if(!this->m_buf)
                 throw basic_notebuf<charT,traitT>::exception("this->m_buf == null");
-            basic_notebuf<charT,traitT>* buf = dynamic_cast< basic_notebuf<charT,traitT>* >(this->m_buf);
+            basic_notebuf<charT,traitT>* buf = dynamic_cast< basic_notebuf<charT,traitT>* >(this->m_buf.get());
             if(buf)
                 buf->set_note(step,base);
             else
@@ -613,7 +613,7 @@ namespace jlib {
         {
             if(!this->m_buf)
                 throw basic_notebuf<charT,traitT>::exception("this->m_buf == null");
-            basic_notebuf<charT,traitT>* buf = dynamic_cast< basic_notebuf<charT,traitT>* >(this->m_buf);
+            basic_notebuf<charT,traitT>* buf = dynamic_cast< basic_notebuf<charT,traitT>* >(this->m_buf.get());
             if(buf)
                 return buf->get_time();
             else
@@ -627,7 +627,7 @@ namespace jlib {
         {
             if(!this->m_buf)
                 throw typename basic_notebuf<charT,traitT>::exception("this->m_buf == null");
-            basic_notebuf<charT,traitT>* buf = dynamic_cast< basic_notebuf<charT,traitT>* >(this->m_buf);
+            basic_notebuf<charT,traitT>* buf = dynamic_cast< basic_notebuf<charT,traitT>* >(this->m_buf.get());
             if(buf)
                 buf->set_time(time);
             else
@@ -641,7 +641,7 @@ namespace jlib {
         {
             if(!this->m_buf)
                 throw typename basic_notebuf<charT,traitT>::exception("this->m_buf == null");
-            basic_notebuf<charT,traitT>* buf = dynamic_cast< basic_notebuf<charT,traitT>* >(this->m_buf);
+            basic_notebuf<charT,traitT>* buf = dynamic_cast< basic_notebuf<charT,traitT>* >(this->m_buf.get());
             if(buf)
                 buf->set_nearest_time(time);
             else

--- a/jlib/media/stream.hh
+++ b/jlib/media/stream.hh
@@ -29,6 +29,7 @@
 #include <iostream>
 #include <exception>
 #include <string>
+#include <memory>
 #include <vector>
 #include <list>
 
@@ -212,7 +213,16 @@ namespace jlib {
             }
 
         protected:
-            basic_streambuf<charT,traitT>* m_buf;
+            /**
+             * The buffer, owned.
+             *
+             * Each derived stream installs its own subclass here and the base
+             * destroys it.  It was a raw pointer new'd in every derived
+             * constructor and deleted in ~basic_stream, which is sound only
+             * because std::basic_iostream makes the whole hierarchy
+             * uncopyable -- the ownership was correct but stated nowhere.
+             */
+            std::unique_ptr< basic_streambuf<charT,traitT> > m_buf;
         };
         
         typedef basic_stream<char> stream;
@@ -372,14 +382,13 @@ namespace jlib {
         basic_stream<charT,traitT>::basic_stream() 
             : std::basic_iostream<charT,traitT>(NULL)
         {
-            m_buf = 0;
+
         }
         
         template< typename charT, typename traitT >
         inline
         basic_stream<charT,traitT>::~basic_stream() {
-            if(m_buf != 0)
-                delete m_buf;
+
         }
 
         template< typename charT, typename traitT >

--- a/jlib/media/stream.hh
+++ b/jlib/media/stream.hh
@@ -29,6 +29,7 @@
 #include <iostream>
 #include <exception>
 #include <string>
+#include <vector>
 #include <list>
 
 #include <cstdlib>
@@ -71,6 +72,24 @@ namespace jlib {
             
             basic_streambuf();
             virtual ~basic_streambuf();
+
+            /**
+             * Not copyable.
+             *
+             * std::basic_streambuf leaves its copy operations protected rather
+             * than deleted, so a derived class gets implicit ones -- and both
+             * compiled here and double-freed, since the two buffers were raw
+             * pointers deleted in the destructor.  The vectors below fix the
+             * ownership, but a copy would still be wrong: the base copies the
+             * get and put area pointers, so the copy's stream positions would
+             * address the original's storage.  A streambuf is not a value.
+             *
+             * basic_stream needs no such declaration -- std::basic_iostream
+             * deletes its copy operations, so the whole stream layer is
+             * already uncopyable by inheritance.
+             */
+            basic_streambuf(const basic_streambuf&) = delete;
+            basic_streambuf& operator=(const basic_streambuf&) = delete;
             
             //virtual int_type underflow();
             virtual int_type overflow(int_type c=traits_type::eof());
@@ -101,8 +120,12 @@ namespace jlib {
             pos_type m_length;
             pos_type m_pos;
             std::list<plugin*> m_plugins;
-            char_type* m_get_buf;
-            char_type* m_put_buf;
+            // Vectors rather than new[], so the buffer owns them and nothing
+            // has to remember to free them.  Sized once in the constructor and
+            // never resized, so the pointers handed to setg and setp stay
+            // valid for the life of the object.
+            std::vector<char_type> m_get_buf;
+            std::vector<char_type> m_put_buf;
         };
         
         template<typename charT, typename traitT=std::char_traits<charT> >
@@ -198,11 +221,11 @@ namespace jlib {
         template< typename charT, typename traitT >
         inline
         basic_streambuf<charT,traitT>::basic_streambuf() {
-            m_get_buf = new char_type[BUF_SIZE];
-            this->setg(m_get_buf,m_get_buf,m_get_buf);
+            m_get_buf.resize(BUF_SIZE);
+            this->setg(m_get_buf.data(),m_get_buf.data(),m_get_buf.data());
             
-            m_put_buf = new char_type[BUF_SIZE];
-            this->setp(m_put_buf,m_put_buf+BUF_SIZE);
+            m_put_buf.resize(BUF_SIZE);
+            this->setp(m_put_buf.data(),m_put_buf.data()+BUF_SIZE);
 
             m_eintr = false;
             m_length = pos_type(off_type(traits_type::eof()));
@@ -220,9 +243,6 @@ namespace jlib {
             if(std::getenv("JLIB_MEDIA_STREAM_DEBUG"))
                 std::cerr << "basic_streambuf<charT,traitT>::~basic_streambuf()"<<std::endl;
             close();
-            
-            delete [] m_get_buf;
-            delete [] m_put_buf;
         }
         
         template< typename charT, typename traitT >

--- a/jlib/media/wavstream.hh
+++ b/jlib/media/wavstream.hh
@@ -247,8 +247,8 @@ namespace jlib {
         basic_wavstream<charT,traitT>::basic_wavstream() 
             : basic_stream<charT,traitT>()
         {
-            m_buf=new basic_wavbuf<charT,traitT>();
-            this->init(m_buf);
+            this->m_buf.reset(new basic_wavbuf<charT,traitT>());
+            this->init(this->m_buf.get());
         }
         
         template< typename charT, typename traitT >
@@ -256,8 +256,8 @@ namespace jlib {
         basic_wavstream<charT,traitT>::basic_wavstream(std::string wav) 
             : basic_stream<charT,traitT>()
         {
-            m_buf=new basic_wavbuf<charT,traitT>(wav);
-            this->init(m_buf);
+            this->m_buf.reset(new basic_wavbuf<charT,traitT>(wav));
+            this->init(this->m_buf.get());
         }
         
         template< typename charT, typename traitT >
@@ -265,9 +265,9 @@ namespace jlib {
         std::string
         basic_wavstream<charT,traitT>::get_wav() const
         {
-            if(!m_buf)
+            if(!this->m_buf)
                 throw basic_wavbuf<charT,traitT>::exception("m_buf == null");
-            basic_wavbuf<charT,traitT>* buf = dynamic_cast< basic_wavbuf<charT,traitT>* >(m_buf);
+            basic_wavbuf<charT,traitT>* buf = dynamic_cast< basic_wavbuf<charT,traitT>* >(this->m_buf.get());
             if(buf)
                 return buf->get_wav();
             else
@@ -279,9 +279,9 @@ namespace jlib {
         void
         basic_wavstream<charT,traitT>::set_wav(std::string wav) 
         {
-            if(!m_buf)
+            if(!this->m_buf)
                 throw basic_wavbuf<charT,traitT>::exception("m_buf == null");
-            basic_wavbuf<charT,traitT>* buf = dynamic_cast< basic_wavbuf<charT,traitT>* >(m_buf);
+            basic_wavbuf<charT,traitT>* buf = dynamic_cast< basic_wavbuf<charT,traitT>* >(this->m_buf.get());
             if(buf)
                 buf->set_wav(wav);
             else


### PR DESCRIPTION
closes #14, closes #12

Both are latent -- nothing in the tree triggers either today -- but both are
reachable from ordinary use of the library rather than from the demos.

    macOS  24 tests, 23 pass, 1 skip
    Linux  25 tests, 23 pass, 2 skip
    notestream and datastream round-trip clean under ASan and UBSan

stack allocation sized from a playlist file

    PlayList::render() declared its two mixing buffers as arrays of length n:

        const int n = (int)(((double)get_width() / ticks_per_minute)*60*44100);
        Type::scaled samples[n];
        typename Type::sample<N>::buf samples_out[n];

    Variable length arrays are not C++.  They are a GNU extension that the
    compilers here happen to accept, so this was never going to build
    everywhere, but the portability is the smaller half.

    n comes from get_width(), which comes from the playlist.  At 4/4 and 120bpm
    the two arrays together are about 33K of stack per tick of width, so a few
    hundred ticks runs off the end of an 8M stack.  Nothing bounds it and
    nothing checks it: the size of a file decides how much stack to take.

    They are std::vector now, which is where the commented-out new[] on both
    lines says they used to be.  The vectors are value-initialized, which is
    what the two memsets were doing.

    Also an early return when n <= 0.  A zero or negative width gave a
    non-positive VLA, which is undefined on its own, but the mixing loop then
    indexes samples[(x + sample_begin) % n] -- so it was a division by zero as
    well.

double free in the streambuf

    The issue said copying a datastream double-frees.  That was wrong, and
    worth recording because the wrong layer is the interesting part.

    The stream layer is already safe.  std::basic_iostream deletes its copy
    operations, so basic_stream inherits the deletion: copy construction, copy
    assignment, move construction and move assignment are all rejected.
    Checked all four.

    std::basic_streambuf is different.  It leaves its copy operations
    protected rather than deleted, which is deliberate -- it lets a derived
    class implement copying if it wants to -- and the effect is that a derived
    class that says nothing gets implicit ones.  basic_streambuf said nothing,
    and held its get and put areas as raw char_type* allocated with new[] in
    the constructor and deleted in the destructor.  So both copy construction
    and copy assignment compiled, and both double-freed:

        ==ERROR: AddressSanitizer: attempting double-free
        SUMMARY: double-free stream.hh:224 in basic_streambuf::~basic_streambuf

    Fixed at the root rather than papered over.  The two areas are
    std::vector now, sized once in the constructor and never resized, so the
    pointers handed to setg and setp stay valid and nothing has to remember to
    free anything.  The destructor's two delete[] calls are gone.

    The copy operations are deleted as well, because the vectors alone would
    not be enough.  std::basic_streambuf's copy assignment copies the get and
    put area pointers, so a copy would own its own storage while its stream
    positions addressed the original's -- a different bug in place of the one
    removed.  A streambuf is not a value.

    Nothing in the tree copies one, which is why neither had fired.

the stream's buffer, while here

    basic_stream held its buffer as a raw owning pointer: new'd in every
    derived constructor, deleted in the base destructor, with one derived
    constructor deleting it first in case it was already set.  That was sound,
    because std::basic_iostream makes the hierarchy uncopyable, but the
    ownership was correct by accident of the base class rather than by
    statement, and the same reasoning had already been wrong once above.

    It is a unique_ptr now.  Installing a buffer is reset(), the two accessors
    that downcast take .get(), and the destructor does nothing.  The
    constructor's m_buf = 0 and the pre-emptive delete in audiofilestream both
    go away, since a unique_ptr starts null and reset() frees what it held.

    No behaviour change; notestream and datastream still round-trip identically
    under ASan and UBSan.

not covered

    #38 is adjacent and untouched: media/wavstream.hh is in the installed
    headers and does not compile.  It was converted along with the others so
    the four streams stay consistent, but it still has the same 20 errors it
    had before, against members that no longer exist.  It needs a decision
    about whether to fix it or stop shipping it.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
