### PR TITLE
Finish wavstream

### DIFF
--- a/jlib/media/AudioFile.cc
+++ b/jlib/media/AudioFile.cc
@@ -19,6 +19,8 @@
  */
 
 #include <jlib/media/AudioFile.hh>
+
+#include <utility>
 #include <jlib/media/Type.hh>
 
 #include <jlib/util/util.hh>
@@ -69,7 +71,7 @@ namespace jlib {
             return m_format;
         }
 
-        std::string AudioFile::get_pcm() const {
+        const std::string& AudioFile::get_pcm() const {
             return m_pcm;
         }
 
@@ -90,10 +92,10 @@ namespace jlib {
         }
 
         void AudioFile::set_pcm(std::string pcm) {
-            m_pcm = pcm;
+            m_pcm = std::move(pcm);
         }
 
-        void AudioFile::add_pcm(std::string pcm) {
+        void AudioFile::add_pcm(const std::string& pcm) {
             m_pcm.append(pcm);
         }
 

--- a/jlib/media/AudioFile.hh
+++ b/jlib/media/AudioFile.hh
@@ -67,7 +67,21 @@ namespace jlib {
             int get_channels() const; 
             int get_samples_per_sec() const; 
             int get_format() const; 
-            std::string get_pcm() const;
+            /**
+             * The samples, by reference.
+             *
+             * This returned by value, which was free when it was written:
+             * libstdc++'s std::string was copy-on-write then, so returning one
+             * was a refcount bump.  C++11 outlawed that and gcc dropped it in
+             * 5.0, which turned every call into a full copy of the audio --
+             * measured, 861K for a five second stereo sample, and four times
+             * that to get it as far as a datastream.
+             *
+             * The setters keep taking by value, but move rather than assign,
+             * so passing a temporary costs nothing and passing a variable
+             * costs one copy instead of two.
+             */
+            const std::string& get_pcm() const;
         
             int get_sample_count() const;
 
@@ -76,7 +90,7 @@ namespace jlib {
             void set_samples_per_sec(int s); 
             void set_format(int s); 
             void set_pcm(std::string pcm);
-            void add_pcm(std::string pcm);
+            void add_pcm(const std::string& pcm);
             void clear_pcm();
 
             virtual void load();

--- a/jlib/media/datastream.hh
+++ b/jlib/media/datastream.hh
@@ -24,6 +24,7 @@
 #include <iostream>
 #include <exception>
 #include <string>
+#include <utility>
 #include <vector>
 #include <cstring>
 
@@ -70,7 +71,7 @@ namespace jlib {
             virtual pos_type seekpos(pos_type, 
                                      std::ios_base::openmode = std::ios_base::in | std::ios_base::out);
 
-            std::string get_data() const; 
+            const std::string& get_data() const; 
             void set_data(std::string s);
 
         protected:
@@ -83,7 +84,7 @@ namespace jlib {
             basic_datastream();
             basic_datastream(std::string data);
             
-            std::string get_data() const; 
+            const std::string& get_data() const; 
             void set_data(std::string s);
 
             static basic_datastream<charT,traitT>* create_scaled(basic_stream<charT,traitT>* s);
@@ -107,7 +108,7 @@ namespace jlib {
         basic_databuf<charT,traitT>::basic_databuf(std::string data) 
             : basic_streambuf<charT,traitT>()
         {
-            set_data(data);
+            set_data(std::move(data));
         }
         
         /*
@@ -120,14 +121,14 @@ namespace jlib {
         
         template< typename charT, typename traitT >
         inline
-        std::string basic_databuf<charT,traitT>::get_data() const {
+        const std::string& basic_databuf<charT,traitT>::get_data() const {
             return m_data;
         }
 
         template< typename charT, typename traitT >
         inline
         void basic_databuf<charT,traitT>::set_data(std::string data) {
-            m_data = data;
+            m_data = std::move(data);
             this->set_length(m_data.length());
         }
 
@@ -298,13 +299,13 @@ namespace jlib {
         basic_datastream<charT,traitT>::basic_datastream(std::string data) 
             : basic_stream<charT,traitT>()
         {
-            this->m_buf.reset(new basic_databuf<charT,traitT>(data));
+            this->m_buf.reset(new basic_databuf<charT,traitT>(std::move(data)));
             this->init(this->m_buf.get());
         }
         
         template< typename charT, typename traitT >
         inline
-        std::string
+        const std::string&
         basic_datastream<charT,traitT>::get_data() const
         {
             if(!this->m_buf)
@@ -325,7 +326,7 @@ namespace jlib {
                 throw basic_databuf<charT,traitT>::exception("this->m_buf == null");
             basic_databuf<charT,traitT>* buf = dynamic_cast< basic_databuf<charT,traitT>* >(this->m_buf.get());
             if(buf)
-                buf->set_data(data);
+                buf->set_data(std::move(data));
             else
                 throw typename basic_databuf<charT,traitT>::exception("buf == null");
         }

--- a/jlib/media/wavstream.hh
+++ b/jlib/media/wavstream.hh
@@ -21,19 +21,38 @@
 #ifndef JLIB_MEDIA_WAVSTREAM_HH
 #define JLIB_MEDIA_WAVSTREAM_HH
 
-#include <iostream>
 #include <exception>
+#include <iostream>
 #include <string>
 #include <cstring>
 
-
-#include <errno.h>
-
+#include <jlib/media/WavFile.hh>
 #include <jlib/media/stream.hh>
 
 namespace jlib {
     namespace media {
-        
+
+        /**
+         * A read-only stream over a WAV file's samples.
+         *
+         * The point of it is to cut out the middle man.  Getting a WAV's audio
+         * into anything that takes a media::stream meant
+         *
+         *     WavFile in(path);
+         *     datastream data(in.get_pcm());
+         *     data.set<WavFile>(in);
+         *
+         * -- three objects, and the format had to be copied across by hand
+         * afterwards or the samples would be interpreted wrongly.  A wavstream
+         * is one object that holds the file, serves its samples, and takes its
+         * format from the header, so there is nothing to remember and nothing
+         * to get out of step.
+         *
+         * Read-only.  The class used to carry its own copies of WavFile's
+         * three chunk builders, which were never called by anything, and
+         * writing a WAV is what WavFile::save is for.  sync() reports failure
+         * rather than quietly discarding anything written.
+         */
         template< typename charT, typename traitT = std::char_traits<charT> >
         class basic_wavbuf : public basic_streambuf<charT,traitT> {
         public:
@@ -47,76 +66,107 @@ namespace jlib {
             protected:
                 std::string m_msg;
             };
-            
-            typedef charT 					            char_type;
-            typedef traitT 					            traits_type;
-            typedef typename traits_type::int_type 		int_type;
-            typedef typename traits_type::pos_type 		pos_type;
-            typedef typename traits_type::off_type 		off_type;
-            
+
+            typedef charT                               char_type;
+            typedef traitT                              traits_type;
+            typedef typename traits_type::int_type      int_type;
+            typedef typename traits_type::pos_type      pos_type;
+            typedef typename traits_type::off_type      off_type;
+
             static const unsigned int BUF_SIZE = 1024;
-            
+
             basic_wavbuf();
-            basic_wavbuf(std::string file);
-            
+            explicit basic_wavbuf(const std::string& file);
+            explicit basic_wavbuf(const WavFile& wav);
+
             virtual int_type underflow();
-            //virtual int_type overflow(int_type c=traits_type::eof());
             virtual int_type sync();
 
-            std::string get_file() const; 
-            void set_file(std::string s);
+            /** The file this was loaded from, empty if it was handed a WavFile. */
+            std::string get_file() const;
+
+            /** Load a WAV and rewind to the start of its samples. */
+            void set_file(const std::string& s);
+
+            const WavFile& get_wav() const;
+            void set_wav(const WavFile& w);
 
         protected:
+            /**
+             * Take the stream's format from the file's, and rewind.
+             *
+             * This is the part that made it worth finishing.  A datastream
+             * knows nothing about what it holds, so its format has to be set
+             * separately and can disagree with the samples; a wavstream reads
+             * both from the same header.
+             */
+            void adopt();
 
-            std::string create_riff_header();
-            std::string create_format_chunk();
-            std::string create_data_chunk();
-
+            WavFile m_wav;
             std::string m_file;
             std::string::size_type m_p;
         };
-        
+
         template<typename charT, typename traitT=std::char_traits<charT> >
         class basic_wavstream : public basic_stream<charT,traitT> {
         public:
             basic_wavstream();
-            basic_wavstream(std::string file);
-            
-            std::string get_file() const; 
-            void set_file(std::string s);
+            explicit basic_wavstream(const std::string& file);
+            explicit basic_wavstream(const WavFile& wav);
+
+            std::string get_file() const;
+            void set_file(const std::string& s);
+
+            const WavFile& get_wav() const;
+            void set_wav(const WavFile& w);
 
         protected:
+            basic_wavbuf<charT,traitT>* buf() const;
         };
-        
+
         typedef basic_wavstream<char> wavstream;
-        
-        
+
+
         template< typename charT, typename traitT >
         inline
-        basic_wavbuf<charT,traitT>::basic_wavbuf() 
-            : basic_streambuf<charT,traitT>()
+        basic_wavbuf<charT,traitT>::basic_wavbuf()
+            : basic_streambuf<charT,traitT>(),
+              m_p(0)
         {
-            m_p = 0;
-            set_file("");
+            adopt();
         }
-        
+
         template< typename charT, typename traitT >
         inline
-        basic_wavbuf<charT,traitT>::basic_wavbuf(std::string file) 
-            : basic_streambuf<charT,traitT>()
+        basic_wavbuf<charT,traitT>::basic_wavbuf(const std::string& file)
+            : basic_streambuf<charT,traitT>(),
+              m_p(0)
         {
-            m_p = 0;
             set_file(file);
         }
-        
-        /*
+
         template< typename charT, typename traitT >
         inline
-        basic_wavbuf<charT,traitT>::~basic_wavbuf() {
-            
+        basic_wavbuf<charT,traitT>::basic_wavbuf(const WavFile& wav)
+            : basic_streambuf<charT,traitT>(),
+              m_wav(wav),
+              m_p(0)
+        {
+            adopt();
         }
-        */
-        
+
+        template< typename charT, typename traitT >
+        inline
+        void basic_wavbuf<charT,traitT>::adopt() {
+            this->set_format(m_wav.get_format());
+            this->set_channels(m_wav.get_channels());
+            this->set_samples_per_sec(m_wav.get_samples_per_sec());
+            this->set_bits_per_sample(m_wav.get_bits_per_sample());
+            this->set_length(m_wav.get_pcm().length());
+
+            m_p = 0;
+        }
+
         template< typename charT, typename traitT >
         inline
         std::string basic_wavbuf<charT,traitT>::get_file() const {
@@ -125,171 +175,132 @@ namespace jlib {
 
         template< typename charT, typename traitT >
         inline
-        void basic_wavbuf<charT,traitT>::set_file(std::string file) {
+        void basic_wavbuf<charT,traitT>::set_file(const std::string& file) {
             m_file = file;
-            set_length(m_file.length());
+
+            if(!m_file.empty())
+                m_wav.load(m_file);
+
+            adopt();
         }
 
         template< typename charT, typename traitT >
         inline
-        typename basic_wavbuf<charT,traitT>::int_type 
+        const WavFile& basic_wavbuf<charT,traitT>::get_wav() const {
+            return m_wav;
+        }
+
+        template< typename charT, typename traitT >
+        inline
+        void basic_wavbuf<charT,traitT>::set_wav(const WavFile& wav) {
+            m_wav = wav;
+            m_file.clear();
+
+            adopt();
+        }
+
+        template< typename charT, typename traitT >
+        inline
+        typename basic_wavbuf<charT,traitT>::int_type
         basic_wavbuf<charT,traitT>::underflow() {
-            if(getenv("JLIB_MEDIA_STREAM_DEBUG"))
-                std::cerr << "enter jlib::media::basic_wavbuf<charT,traitT>::underflow()"<<std::endl;
-            
-            if(m_wav.length() == 0) {
-                if(getenv("JLIB_MEDIA_STREAM_DEBUG")) {
-                    std::cerr << "\tm_wav.length() == 0, returning eof"<<std::endl;
-                    std::cerr << "leave jlib::media::basic_wavbuf<charT,traitT>::underflow()"<<std::endl;
-                }
+            // By reference.  get_pcm() returned by value when this was written,
+            // which was free under the copy-on-write std::string of the time
+            // and is a copy of the whole file now.
+            const std::string& pcm = m_wav.get_pcm();
+
+            if(m_p >= pcm.length())
                 return traits_type::eof();
-            }
 
-            if(m_p == m_wav.length()) {
-                if(getenv("JLIB_MEDIA_STREAM_DEBUG")) {
-                    std::cerr << "\tm_p == m_wav.length(), returning eof"<<std::endl;
-                    std::cerr << "leave jlib::media::basic_wavbuf<charT,traitT>::underflow()"<<std::endl;
-                }
-                return traits_type::eof();
-            }
-            //m_p = 0;
+            const std::string::size_type left = pcm.length() - m_p;
+            const std::string::size_type count =
+                (left > BUF_SIZE) ? BUF_SIZE : left;
 
-            if(m_p > m_wav.length())
-                throw exception("m_p > m_wav.length() in underflow()");
+            std::memcpy(this->eback(), pcm.data() + m_p, count);
+            this->setg(this->eback(), this->eback(), this->eback() + count);
 
-            int count = (((m_p+BUF_SIZE) > m_wav.length()) ? (m_wav.length()-m_p) : (BUF_SIZE));
-            if(getenv("JLIB_MEDIA_STREAM_DEBUG")) {
-                std::cerr << "\tm_p = "<<m_p<<std::endl;
-                std::cerr << "\tcount = "<<count<<std::endl;
-                std::cerr << "\tm_wav.length() = "<<m_wav.length()<<std::endl;
-                std::cerr << "\ttraits_type::eof() = "<<traits_type::eof()<<std::endl;
-            }
-            memcpy(eback(),m_wav.wav()+m_p,count);
-
-            char_type* end = eback()+count;
-            setg(eback(), eback(), end);
-            
             m_p += count;
 
-            if(getenv("JLIB_MEDIA_STREAM_DEBUG"))
-                std::cerr << "leave jlib::media::basic_wavbuf<charT,traitT>::underflow(): return "
-                          <<(int)*gptr() << std::endl;
-            return traits_type::to_int_type(*gptr());
+            return traits_type::to_int_type(*this->gptr());
         }
 
         template< typename charT, typename traitT >
         inline
-        typename basic_wavbuf<charT,traitT>::int_type 
+        typename basic_wavbuf<charT,traitT>::int_type
         basic_wavbuf<charT,traitT>::sync() {
-            if(getenv("JLIB_MEDIA_STREAM_DEBUG"))
-                std::cerr << "basic_wavbuf<charT,traitT>::sync()"<<std::endl;
-
-            m_wav.append(pbase(),pptr() - pbase());
-            setp(pbase(), pbase()+BUF_SIZE);
-
-            return 0;                
+            // Read-only.  Anything written would have nowhere to go, so say so
+            // rather than swallow it; an empty put area syncs cleanly, which is
+            // what flushing on destruction does.
+            return (this->pptr() != this->pbase()) ? -1 : 0;
         }
-
-        template< typename charT, typename traitT >
-        inline
-        std::string basic_wavbuf<charT,traitT>::create_riff_header() {
-            std::string chunk(GROUP_ID_SIZE+RIFF_TYPE_SIZE, '\0');
-
-            chunk.replace(0,GROUP_ID_SIZE,"RIFF\0\0\0\0");
-            chunk.replace(RIFF_TYPE_OFFSET,RIFF_TYPE_SIZE,"WAVE");
-            
-            return chunk;
-        }
-
-        template< typename charT, typename traitT >
-        inline
-        std::string basic_wavbuf<charT,traitT>::create_format_chunk() {
-            std::string chunk(CHUNK_ID_SIZE+CHUNK_SIZE_SIZE+FMT_CHUNK_SIZE, '\0');
-            int base = CHUNK_ID_SIZE+CHUNK_SIZE_SIZE;
-
-            chunk.replace(0,CHUNK_ID_SIZE,CHUNK_ID_FORMAT);
-            util::set<int>(chunk,FMT_CHUNK_SIZE,CHUNK_SIZE_OFFSET);
-
-            util::set<short>(chunk,get_format_tag(),base+FORMAT_TAG_OFFSET);
-            util::set<u_short>(chunk,get_bits_per_sample(),base+BITS_PER_SAMPLE_OFFSET);
-            util::set<u_int32_t>(chunk,get_samples_per_sec(),base+SAMPLES_PER_SEC_OFFSET);
-            util::set<u_short>(chunk,get_channels(),base+CHANNELS_OFFSET);
-   
-            return chunk;
-        }
-
-        template< typename charT, typename traitT >
-        inline
-        std::string basic_wavbuf<charT,traitT>::create_data_chunk() {
-            std::string chunk(CHUNK_ID_SIZE+CHUNK_SIZE_SIZE, '\0');
-            
-            chunk.replace(0,CHUNK_ID_SIZE,CHUNK_ID_DATA);
-            util::set<u_int>(chunk,get_pcm().length(),CHUNK_SIZE_OFFSET);
-
-            chunk.append(get_pcm());
-
-            return chunk;
-        }
-
-
-
-
-
-
-
-
-
-
 
 
         template< typename charT, typename traitT >
         inline
-        basic_wavstream<charT,traitT>::basic_wavstream() 
+        basic_wavstream<charT,traitT>::basic_wavstream()
             : basic_stream<charT,traitT>()
         {
             this->m_buf.reset(new basic_wavbuf<charT,traitT>());
             this->init(this->m_buf.get());
         }
-        
+
         template< typename charT, typename traitT >
         inline
-        basic_wavstream<charT,traitT>::basic_wavstream(std::string wav) 
+        basic_wavstream<charT,traitT>::basic_wavstream(const std::string& file)
+            : basic_stream<charT,traitT>()
+        {
+            this->m_buf.reset(new basic_wavbuf<charT,traitT>(file));
+            this->init(this->m_buf.get());
+        }
+
+        template< typename charT, typename traitT >
+        inline
+        basic_wavstream<charT,traitT>::basic_wavstream(const WavFile& wav)
             : basic_stream<charT,traitT>()
         {
             this->m_buf.reset(new basic_wavbuf<charT,traitT>(wav));
             this->init(this->m_buf.get());
         }
-        
+
         template< typename charT, typename traitT >
         inline
-        std::string
-        basic_wavstream<charT,traitT>::get_wav() const
-        {
+        basic_wavbuf<charT,traitT>* basic_wavstream<charT,traitT>::buf() const {
             if(!this->m_buf)
-                throw basic_wavbuf<charT,traitT>::exception("m_buf == null");
-            basic_wavbuf<charT,traitT>* buf = dynamic_cast< basic_wavbuf<charT,traitT>* >(this->m_buf.get());
-            if(buf)
-                return buf->get_wav();
-            else
-                throw basic_wavbuf<charT,traitT>::exception("buf == null");
+                throw typename basic_wavbuf<charT,traitT>::exception("m_buf == null");
+
+            basic_wavbuf<charT,traitT>* b =
+                dynamic_cast< basic_wavbuf<charT,traitT>* >(this->m_buf.get());
+
+            if(!b)
+                throw typename basic_wavbuf<charT,traitT>::exception("buf == null");
+
+            return b;
         }
 
         template< typename charT, typename traitT >
         inline
-        void
-        basic_wavstream<charT,traitT>::set_wav(std::string wav) 
-        {
-            if(!this->m_buf)
-                throw basic_wavbuf<charT,traitT>::exception("m_buf == null");
-            basic_wavbuf<charT,traitT>* buf = dynamic_cast< basic_wavbuf<charT,traitT>* >(this->m_buf.get());
-            if(buf)
-                buf->set_wav(wav);
-            else
-                throw basic_wavbuf<charT,traitT>::exception("buf == null");
+        std::string basic_wavstream<charT,traitT>::get_file() const {
+            return buf()->get_file();
+        }
+
+        template< typename charT, typename traitT >
+        inline
+        void basic_wavstream<charT,traitT>::set_file(const std::string& file) {
+            buf()->set_file(file);
+        }
+
+        template< typename charT, typename traitT >
+        inline
+        const WavFile& basic_wavstream<charT,traitT>::get_wav() const {
+            return buf()->get_wav();
+        }
+
+        template< typename charT, typename traitT >
+        inline
+        void basic_wavstream<charT,traitT>::set_wav(const WavFile& wav) {
+            buf()->set_wav(wav);
         }
 
     }
 }
 
-
-#endif // JLIB_MEDIA_STREAM_HH
+#endif // JLIB_MEDIA_WAVSTREAM_HH

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -18,7 +18,8 @@ if HAVE_PORTAUDIO
 MEDIA_TESTS = media_datastream_test \
               media_notestream_test \
               media_player_test \
-              media_wavfile_test
+              media_wavfile_test \
+              media_wavstream_test
 endif
 
 if HAVE_SODIUM
@@ -67,6 +68,9 @@ media_player_test_SOURCES     = media_player_test.cc
 media_player_test_LDADD       = $(JMEDIA_LA) $(JSYS_LA)
 media_wavfile_test_SOURCES    = media_wavfile_test.cc
 media_wavfile_test_LDADD      = $(JMEDIA_LA) $(JSYS_LA)
+
+media_wavstream_test_SOURCES  = media_wavstream_test.cc
+media_wavstream_test_LDADD    = $(JMEDIA_LA) $(JSYS_LA)
 
 net_extract_address_test_SOURCES        = net_extract_address_test.cc
 net_extract_address_test_LDADD          = $(JNET_LA)

--- a/tests/media_wavstream_test.cc
+++ b/tests/media_wavstream_test.cc
@@ -1,0 +1,121 @@
+// Read a WAV back through wavstream.
+//
+// The point of the class is that it needs no help: it holds the file, serves
+// its samples, and takes its format from the same header the samples came
+// from.  So the test writes a known WAV and checks that streaming it back
+// gives identical bytes and a format nobody had to set by hand.
+#include <jlib/media/WavFile.hh>
+#include <jlib/media/notestream.hh>
+#include <jlib/media/wavstream.hh>
+
+#include <jlib/media/PortAudioSink.hh>
+
+#include "audio_test.hh"
+
+#include <cstdio>
+#include <iostream>
+#include <string>
+
+using namespace jlib::media;
+using namespace jlib::tests;
+
+static int failures = 0;
+
+static void check(const char* what, long got, long want) {
+    const bool ok = (got == want);
+    if(!ok) ++failures;
+    std::cout << (ok ? "  ok   " : "  FAIL ") << what
+              << ": got " << got << ", expected " << want << "\n";
+}
+
+int main(int argc, char** argv) {
+    const audio_mode mode = get_audio_mode(argc, argv);
+    const std::string path = "wavstream_test.wav";
+
+    try {
+        // a known signal, written through the path that already has a test
+        std::string pcm;
+        {
+            notestream note(440.0);
+            note.set_format(Type::PCM_S16_LE);
+            note.set_channels(1);
+
+            char buf[4096];
+            while(note.good()) {
+                note.read(buf, sizeof(buf));
+                pcm.append(buf, note.gcount());
+            }
+        }
+
+        if(pcm.empty()) {
+            std::cerr << "notestream produced no samples" << std::endl;
+            return 1;
+        }
+
+        {
+            WavFile out;
+            out.set_format(Type::PCM_S16_LE);
+            out.set_channels(1);
+            out.set_samples_per_sec(44100);
+            out.set_bits_per_sample(16);
+            out.set_pcm(pcm);
+            out.save(path);
+        }
+
+        // and back, with nothing set by hand
+        wavstream ws(path);
+
+        check("format",          ws.get_format(),          Type::PCM_S16_LE);
+        check("channels",        ws.get_channels(),        1);
+        check("samples per sec", ws.get_samples_per_sec(), 44100);
+        check("bits per sample", ws.get_bits_per_sample(), 16);
+
+        std::string back;
+        char buf[4096];
+        while(ws.good()) {
+            ws.read(buf, sizeof(buf));
+            back.append(buf, ws.gcount());
+        }
+
+        check("bytes streamed", back.size(), pcm.size());
+        check("bytes identical", back == pcm ? 1 : 0, 1);
+
+        // constructing from a WavFile already in hand must agree
+        {
+            WavFile in(path);
+            wavstream direct(in);
+
+            check("from WavFile: format", direct.get_format(), Type::PCM_S16_LE);
+
+            std::string other;
+            while(direct.good()) {
+                direct.read(buf, sizeof(buf));
+                other.append(buf, direct.gcount());
+            }
+            check("from WavFile: identical", other == pcm ? 1 : 0, 1);
+        }
+
+        // read-only: a write must fail rather than vanish
+        {
+            wavstream w(path);
+            w << "not audio";
+            w.flush();
+            check("writing sets a failbit", w.good() ? 0 : 1, 1);
+        }
+
+        if(failures == 0 && should_play(mode, Type::PCM_S16_LE)) {
+            wavstream play(path);
+            PortAudioSink dsp;
+            dsp.play(play);
+        }
+
+        std::remove(path.c_str());
+    }
+    catch(std::exception& e) {
+        std::cerr << "wavstream test: " << e.what() << std::endl;
+        std::remove(path.c_str());
+        return 1;
+    }
+
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
closes #38

wavstream was an unfinished experiment that shipped as a broken public header.
Finishing it turned up the reason it was worth having, which is the second half
of this: std::string stopped being copy-on-write fifteen years ago and a good
deal of this library was written assuming it still was.

    macOS  25 tests, 24 pass, 1 skip
    Linux  26 tests, 24 pass, 2 skip

std::string is not copy-on-write any more

    Most of this was written when libstdc++'s std::string was copy-on-write,
    so returning one by value was a refcount bump and there was nothing wrong
    with writing it that way.  C++11 outlawed COW -- the iterator invalidation
    rules make it impossible -- and gcc dropped it in 5.0.  Every one of those
    returns is a full deep copy now.  The code reads the same and does
    something else.

    Measured, with an 861K PCM buffer (five seconds, stereo, 44.1k, 16-bit):

        datastream data(af.get_pcm());     3447K copied

    Four times the data, to hand one file's samples to a stream.

    AudioFile::get_pcm() and basic_databuf::get_data() return const& now.  The
    bulk setters still take by value but move into place rather than assign,
    which costs nothing for a temporary and one copy instead of two for a
    variable, and needs no signature change.  The constructor chain moves
    through rather than copying at each hop.

    Same call now copies 863K -- once, into the buffer that has to hold it.

    #56 has the rest.  A survey of the headers finds 40 accessors returning
    std::string by value and 226 functions taking one by value.  Most are
    filenames and header field names where the copy is a few dozen bytes and
    not worth the churn; the group that matters is jlib/net, where
    Email::raw() and Email::data() return whole messages by value and
    jlib-mail pays for it per message held.

wavstream

    It was never finished and never used.  Referenced nowhere, half-way
    through a rename -- m_wav in the bodies, m_file in the declaration -- and
    carrying its own copies of WavFile's three chunk builders, which nothing
    called.  The stream wrapper called get_wav() and set_wav() on a buffer
    class that never declared them.  50 compile errors, in a header that
    make install copies into $(includedir).

    The idea behind it was the section above.  Getting a WAV's samples into
    anything that takes a media::stream meant

        WavFile in(path);
        datastream data(in.get_pcm());
        data.set<WavFile>(in);

    -- three objects, four copies of the audio, and a format that had to be
    carried across by hand afterwards or the samples would be read wrongly.

    basic_wavbuf holds a WavFile now, serves its samples by reference, and
    takes format, channels, rate and bit depth from the same header the
    samples came from.  One object, one copy, and no second place for the
    format to be set differently.

    Read-only.  The three chunk builders are gone: WavFile has them, and
    writing a WAV is WavFile::save.  sync() reports failure rather than
    quietly discarding, so writing to a wavstream sets a failbit instead of
    vanishing.

    Rewritten rather than patched.  The 50 errors were about equally the
    mechanical kind -- unqualified pbase, pptr, eback, gptr, which a template
    with a dependent base needs this-> for -- and references to a member that
    was never declared, and the class that would have come out of fixing only
    those was datastream under another name with dead WAV code attached.

tests

    media_wavstream_test, nine assertions: the round trip is byte-identical,
    the format arrives without anything setting it, constructing from a
    WavFile already in hand agrees with constructing from a path, and writing
    fails rather than silently doing nothing.

    The format assertions are the ones worth having.  They are what separates
    this from a datastream, and they are the failure a datastream cannot
    catch, since its format is set from somewhere else and nothing checks that
    the two agree.

not covered

    The write side.  A wavstream cannot produce a WAV and does not pretend to.

    Changing an accessor from by-value to const& is source-compatible for
    std::string s = x.get() and for auto, which strips the reference, but it
    lets const std::string& s = temp().get() dangle.  No such use exists here,
    and the pattern was already a hazard, but it is worth a grep on each file
    touched by the #56 sweep.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
