### PR TITLE
Stop copying, and start moving

### DIFF
--- a/jlib/apps/jcublas.cc
+++ b/jlib/apps/jcublas.cc
@@ -31,7 +31,7 @@ using namespace jlib::util;
 
 typedef float T;
 
-math::matrix<T> load(std::string path, uint r, uint c, bool greyscale = true);
+math::matrix<T> load(const std::string& path, uint r, uint c, bool greyscale = true);
 char convert(int n);
 int convert(char c);
 char capitalize(char c);
@@ -365,7 +365,7 @@ int main(int argc, char** argv) {
     return 0;
 }
 
-math::matrix<T> load(std::string path, uint r, uint c, bool greyscale) {
+math::matrix<T> load(const std::string& path, uint r, uint c, bool greyscale) {
     using MagickCore::Quantum;
     const uint QMAX = QuantumRange;
     Magick::Image image(path);

--- a/jlib/apps/jglfwhyper.cc
+++ b/jlib/apps/jglfwhyper.cc
@@ -40,7 +40,7 @@ public:
     }
 
     // GLFW reports typed text, as X does; HyperPlot wants a single char.
-    void key_pressed(std::string key, int x, int y) {
+    void key_pressed(const std::string& key, int x, int y) {
         if(key.empty())
             return;
 

--- a/jlib/apps/jgltorus.cc
+++ b/jlib/apps/jgltorus.cc
@@ -77,7 +77,7 @@ bool paused = false;
 
 jlib::glfw::Window* g_window = 0;
 
-void on_keyboard(std::string key, int x, int y);
+void on_keyboard(const std::string& key, int x, int y);
 void on_mouse(int button, int x, int y);
 void on_idle();
 void on_display();
@@ -167,7 +167,7 @@ void on_mouse(int button, int x, int y) {
     
 }
 
-void on_keyboard(std::string k, int x, int y) {
+void on_keyboard(const std::string& k, int x, int y) {
     if(k.empty())
         return;
 

--- a/jlib/apps/jglxbox.cc
+++ b/jlib/apps/jglxbox.cc
@@ -74,7 +74,7 @@ const GLdouble H = 2.3;
 
 bool paused = false;
 
-void on_keyboard(std::string key, int x, int y);
+void on_keyboard(const std::string& key, int x, int y);
 void on_mouse(int button, int x, int y);
 void on_idle(glx::Window& window);
 void increment(GLdouble& rad, const GLdouble& inc);
@@ -155,7 +155,7 @@ void on_mouse(int button, int x, int y) {
     
 }
 
-void on_keyboard(std::string key,int x,int y) {
+void on_keyboard(const std::string& key,int x,int y) {
     if(key == "q") {
         std::exit(0);
     } else if(key == " ") {

--- a/jlib/apps/jglxhyper.cc
+++ b/jlib/apps/jglxhyper.cc
@@ -48,7 +48,7 @@ public:
         glMaterialfv(GL_FRONT_AND_BACK, GL_AMBIENT_AND_DIFFUSE, fcolors);
     }
 
-    void key_pressed(std::string key, int x, int y) {
+    void key_pressed(const std::string& key, int x, int y) {
         HyperPlot<T, PlotType>::key_pressed(key[0], x, y);
     }
 

--- a/jlib/apps/jhardhyper.cc
+++ b/jlib/apps/jhardhyper.cc
@@ -1344,7 +1344,7 @@ public:
     }
 
     // GLFW reports typed text, as X does; HyperPlot wants a single char.
-    void key_pressed(std::string key, int x, int y) {
+    void key_pressed(const std::string& key, int x, int y) {
         if(key.empty())
             return;
 

--- a/jlib/apps/jhyper.cc
+++ b/jlib/apps/jhyper.cc
@@ -64,7 +64,7 @@ public:
         set_foreground(255*color.r, 255*color.g, 255*color.b);
     }
     
-    void key_pressed(std::string key, int x, int y) {
+    void key_pressed(const std::string& key, int x, int y) {
         HyperPlot<T, PlotType>::key_pressed(key[0], x, y);
 
         if(key == "y" || key == "h") {

--- a/jlib/apps/jlib-mail.cc
+++ b/jlib/apps/jlib-mail.cc
@@ -44,7 +44,7 @@ namespace jlib {
         
         class ConsoleMain : public sys::Object {
         public:
-            void push(std::string cmd, std::function<void(std::string)> slot) {
+            void push(const std::string& cmd, std::function<void(std::string)> slot) {
                 m_handlers.insert(std::make_pair(cmd,slot));
             }
 
@@ -86,7 +86,7 @@ namespace jlib {
 
         class MailClient : public ConsoleMain {
         public:
-            MailClient(std::string url="") {
+            MailClient(const std::string& url="") {
                 init();
                 if(url != "") {
                     open(url);
@@ -141,7 +141,7 @@ namespace jlib {
             }
 
 
-            void open(std::string s) {
+            void open(const std::string& s) {
                 jlib::util::URL url(s);
                 if(m_folder != 0) {
                     delete m_folder;
@@ -160,7 +160,7 @@ namespace jlib {
 
             }
    
-            void read(std::string s) {
+            void read(const std::string& s) {
                 if(m_folder == 0) {
                     std::cout << "ERROR: no valid mailfolder"<<std::endl;
                     return;
@@ -181,12 +181,11 @@ namespace jlib {
 
          
         protected:
-            std::ostream& printw(std::ostream& out, std::string in, unsigned int w) {
-                if(in.length() >= w) {
-                    in = in.substr(0,w);
-                }
-                //out << std::setw(w) << std::setfill(' ') << std::left <<in;
-                out << in;
+            std::ostream& printw(std::ostream& out, const std::string& in, unsigned int w) {
+                // On a local; this truncated its own parameter.
+                const std::string text = (in.length() >= w) ? in.substr(0, w) : in;
+                //out << std::setw(w) << std::setfill(' ') << std::left << text;
+                out << text;
                 return out;
             }
 

--- a/jlib/apps/jneural-alpha.cc
+++ b/jlib/apps/jneural-alpha.cc
@@ -28,7 +28,7 @@ using namespace jlib::util;
 
 typedef double T;
 
-math::matrix<T> load(std::string path, uint r, uint c, bool greyscale = true);
+math::matrix<T> load(const std::string& path, uint r, uint c, bool greyscale = true);
 char convert(int n);
 int convert(char c);
 char capitalize(char c);
@@ -361,7 +361,7 @@ int main(int argc, char** argv) {
     return 0;
 }
 
-math::matrix<T> load(std::string path, uint r, uint c, bool greyscale) {
+math::matrix<T> load(const std::string& path, uint r, uint c, bool greyscale) {
     using MagickCore::Quantum;
     const uint QMAX = QuantumRange;
     Magick::Image image(path);

--- a/jlib/apps/jneural-search.cc
+++ b/jlib/apps/jneural-search.cc
@@ -28,8 +28,8 @@ using namespace jlib::util;
 
 typedef double T;
 
-math::matrix<T> load(std::string path, uint r, uint c, bool greyscale = true);
-std::vector<std::tuple<int,math::matrix<T>>> load_mnist(std::string path);
+math::matrix<T> load(const std::string& path, uint r, uint c, bool greyscale = true);
+std::vector<std::tuple<int,math::matrix<T>>> load_mnist(const std::string& path);
 
 char convert(int n);
 int convert(char c);
@@ -295,7 +295,7 @@ int main(int argc, char** argv) {
     return 0;
 }
 
-std::vector<std::tuple<int,math::matrix<T>>> load_mnist(std::string path) {
+std::vector<std::tuple<int,math::matrix<T>>> load_mnist(const std::string& path) {
     std::cout << "Loading mnist data from " << path << std::endl;
     std::vector<std::tuple<int,math::matrix<T>>> inputs;
     std::ifstream ifs(path);
@@ -324,7 +324,7 @@ std::vector<std::tuple<int,math::matrix<T>>> load_mnist(std::string path) {
 
 
 
-math::matrix<T> load(std::string path, uint r, uint c, bool greyscale) {
+math::matrix<T> load(const std::string& path, uint r, uint c, bool greyscale) {
     using MagickCore::Quantum;
     const uint QMAX = QuantumRange;
     Magick::Image image(path);

--- a/jlib/apps/jnote.cc
+++ b/jlib/apps/jnote.cc
@@ -11,7 +11,7 @@
 const long double 	PI = 3.14159265358979323846264338;
 
 void play(double freq, int format, int channels, double t);
-void play(std::string note, int format, int channels, double t);
+void play(const std::string& note, int format, int channels, double t);
 void play(jlib::media::notestream& ns, int format, int channels, double t);
 
 int main(int argc, char** argv) {
@@ -56,7 +56,7 @@ int main(int argc, char** argv) {
 }
 
 // note denotes the frequency
-void play(std::string note, int format, int channels, double t) {
+void play(const std::string& note, int format, int channels, double t) {
     jlib::media::notestream ns(note);
     play(ns, format, channels, t);
 }

--- a/jlib/apps/jpoisoned.cc
+++ b/jlib/apps/jpoisoned.cc
@@ -60,7 +60,7 @@ public:
 	}
     };
 
-    Download(std::string file) 
+    Download(const std::string& file) 
 	: state(get_incoming() + file)
     {
 	load();
@@ -183,7 +183,7 @@ private:
 
 class Show {
 public:
-    void on_key_press(std::string key, int x, int y) {
+    void on_key_press(const std::string& key, int x, int y) {
 	if (key == "q" || key == "Q") {
 	    std::exit(0);
 	} else {

--- a/jlib/crypt/crypt.cc
+++ b/jlib/crypt/crypt.cc
@@ -69,7 +69,7 @@ namespace jlib {
                 gpgme_set_progress_cb(m_ctx, cb, hook);
             }
 
-            void ctx::op_keylist_start(std::string ptrn, bool secret_only) {
+            void ctx::op_keylist_start(const std::string& ptrn, bool secret_only) {
                 const char* pttrn = (ptrn != "" ? ptrn.c_str() : NULL);
                 gpgme_error_t err = gpgme_op_keylist_start(m_ctx, pttrn, static_cast<int>(secret_only));
 
@@ -211,11 +211,11 @@ namespace jlib {
                 return data::ptr(new data(d, n, copy));
             }
 
-            data::ptr data::create(std::string d) {
+            data::ptr data::create(const std::string& d) {
                 return data::ptr(new data(d));
             }
 
-            data::ptr data::create(std::string file, bool copy) {
+            data::ptr data::create(const std::string& file, bool copy) {
                 return data::ptr(new data(file, copy));
             }
 
@@ -230,14 +230,14 @@ namespace jlib {
                 } 
             }
 
-            data::data(std::string data) {
+            data::data(const std::string& data) {
                 gpgme_error_t err = gpgme_data_new_from_mem(&m_data, data.data(), data.length(), 1);
                 if(gpgme_err_code(err) != GPG_ERR_NO_ERROR) {
                     throw exception(err);
                 } 
             }
 
-            data::data(std::string file, bool copy) {
+            data::data(const std::string& file, bool copy) {
                 gpgme_error_t err = gpgme_data_new_from_file(&m_data, file.c_str(), static_cast<int>(copy));
                 if(gpgme_err_code(err) != GPG_ERR_NO_ERROR) {
                     throw exception(err);
@@ -309,7 +309,7 @@ namespace jlib {
                 return ret;
             }
 
-            void data::write(std::string data) {
+            void data::write(const std::string& data) {
                 std::size_t n = gpgme_data_write(m_data, data.data(), data.length());
                 if(n != data.size()) {
                     std::ostringstream os;
@@ -341,7 +341,7 @@ namespace jlib {
             }
             */
 
-            key::list list_keys(std::string id, bool secret_only) {
+            key::list list_keys(const std::string& id, bool secret_only) {
                 key::list keys;
                 ctx ctx;
                 
@@ -359,31 +359,31 @@ namespace jlib {
                 return keys;
             }
 
-            std::string verify(std::string sig) {
+            std::string verify(const std::string& sig) {
                 return "";
             }
 
-            std::string verify(std::string sig,std::list<std::string> data) {
+            std::string verify(const std::string& sig,std::list<std::string> data) {
                 return "";
             }
 
-            std::string decrypt(std::string text, std::string pass) {
+            std::string decrypt(const std::string& text, const std::string& pass) {
                 return "";
             }
 
-            std::string decrypt(std::string text, std::string pass, std::string& out) {
+            std::string decrypt(const std::string& text, const std::string& pass, std::string& out) {
                 return "";
             }
 
-            std::string sign(std::string from, std::string data, std::string pass) {
+            std::string sign(const std::string& from, const std::string& data, const std::string& pass) {
                 return "";
             }
 
-            std::string encrypt(std::string to, std::string data) {
+            std::string encrypt(const std::string& to, const std::string& data) {
                 return "";
             }
 
-            std::string sign_encrypt(std::string from, std::string to, std::string data, std::string pass) {
+            std::string sign_encrypt(const std::string& from, const std::string& to, const std::string& data, const std::string& pass) {
                 return "";
             }
 

--- a/jlib/crypt/crypt.hh
+++ b/jlib/crypt/crypt.hh
@@ -36,7 +36,7 @@ namespace jlib {
 
         class exception : public std::exception {
         public:
-            exception(std::string msg = "") {
+            exception(const std::string& msg = "") {
                 m_msg = std::string("jlib::crypt exception")+( (msg=="")?"":": ")+msg;
             }
             virtual ~exception() throw() {}
@@ -55,7 +55,7 @@ namespace jlib {
                         std::string(gpg_strsource(err)) + ":" +
                         std::string(gpg_strerror(err));
                 }
-                exception(std::string s) {
+                exception(const std::string& s) {
                     m_msg = ("jlib::crypt::gpg::exception: " + s);
                 }
                 virtual ~exception() throw() {}
@@ -76,14 +76,14 @@ namespace jlib {
                 typedef std::shared_ptr<data> ptr;
 
                 static ptr create(const char* data, size_t n, bool copy = true);
-                static ptr create(std::string data);
-                static ptr create(std::string file, bool copy);
+                static ptr create(const std::string& data);
+                static ptr create(const std::string& file, bool copy);
                 static ptr create();
 
             protected:
                 data(const char* data, size_t n, bool copy = true);
-                data(std::string data);
-                data(std::string file, bool copy);
+                data(const std::string& data);
+                data(const std::string& file, bool copy);
                 data();
 
             public:
@@ -100,7 +100,7 @@ namespace jlib {
                 gpgme_data_encoding_t get_encoding();
 
                 std::string read(int n = -1);
-                void write(std::string data);
+                void write(const std::string& data);
 
                 off_t seek(off_t offset, int whence);
                 void rewind();
@@ -143,7 +143,7 @@ namespace jlib {
                 void set_passphrase_cb(gpgme_passphrase_cb_t cb, void* hook = 0);
                 void set_progress_cb(gpgme_progress_cb_t cb, void* hook = 0);
 
-                void op_keylist_start(std::string ptrn = "", bool secret_only = false);
+                void op_keylist_start(const std::string& ptrn = "", bool secret_only = false);
                 key::ptr op_keylist_next();
                 void op_keylist_end();
 
@@ -168,17 +168,17 @@ namespace jlib {
             void init(gpgme_protocol_t proto = GPGME_PROTOCOL_OpenPGP);
             //GpgmeIdleFunc register_idle(GpgmeIdleFunc idle);
             
-            key::list list_keys(std::string id, bool secret_only = false);
+            key::list list_keys(const std::string& id, bool secret_only = false);
 
-            std::string verify(std::string sig);
-            std::string verify(std::string sig,std::list<std::string> data);
+            std::string verify(const std::string& sig);
+            std::string verify(const std::string& sig,std::list<std::string> data);
 
-            std::string decrypt(std::string text, std::string pass);
-            std::string decrypt(std::string text, std::string pass, std::string& out);
+            std::string decrypt(const std::string& text, const std::string& pass);
+            std::string decrypt(const std::string& text, const std::string& pass, std::string& out);
 
-            std::string sign(std::string from, std::string data, std::string pass);
-            std::string encrypt(std::string to, std::string data);
-            std::string sign_encrypt(std::string from, std::string to, std::string data, std::string pass);
+            std::string sign(const std::string& from, const std::string& data, const std::string& pass);
+            std::string encrypt(const std::string& to, const std::string& data);
+            std::string sign_encrypt(const std::string& from, const std::string& to, const std::string& data, const std::string& pass);
         }
     }
 }

--- a/jlib/glfw/Plot.hh
+++ b/jlib/glfw/Plot.hh
@@ -51,7 +51,7 @@ template<typename T>
 class Plot : public math::Plot<T>, public Window {
 public:
     Plot(uint n, std::vector< std::pair<T,T> > c, uint w = 400, uint h = 400,
-         std::string title = "jlib::glfw::Plot");
+         const std::string& title = "jlib::glfw::Plot");
 
     virtual void draw();
     virtual void draw_point(std::pair<uint,uint> p, uint index);
@@ -72,7 +72,7 @@ protected:
 
 template<typename T>
 inline
-Plot<T>::Plot(uint n, std::vector< std::pair<T,T> > c, uint w, uint h, std::string title)
+Plot<T>::Plot(uint n, std::vector< std::pair<T,T> > c, uint w, uint h, const std::string& title)
     : math::Plot<T>(n, c, w, h),
       Window(title, w, h, true)
 {

--- a/jlib/glfw/Window.cc
+++ b/jlib/glfw/Window.cc
@@ -61,7 +61,7 @@ void require_glfw() {
 
 }
 
-Window::Window(std::string title, int width, int height, bool depth)
+Window::Window(const std::string& title, int width, int height, bool depth)
     : m_window(0),
       m_title(title),
       m_timeout(10000),
@@ -119,7 +119,7 @@ int Window::get_height() const {
     return h;
 }
 
-void Window::set_title(std::string title) {
+void Window::set_title(const std::string& title) {
     m_title = title;
     glfwSetWindowTitle(m_window, title.c_str());
 }

--- a/jlib/glfw/Window.hh
+++ b/jlib/glfw/Window.hh
@@ -63,7 +63,7 @@ class Window {
 public:
     class exception : public std::exception {
     public:
-        exception(std::string msg = "") {
+        exception(const std::string& msg = "") {
             m_msg = "jlib::glfw::Window exception" + (msg != "" ? (": " + msg) : "");
         }
         virtual ~exception() noexcept {}
@@ -73,7 +73,7 @@ public:
         std::string m_msg;
     };
 
-    Window(std::string title, int width, int height, bool depth = true);
+    Window(const std::string& title, int width, int height, bool depth = true);
     virtual ~Window();
 
     /**
@@ -86,7 +86,7 @@ public:
     int get_width() const;
     int get_height() const;
 
-    void set_title(std::string title);
+    void set_title(const std::string& title);
     void center();
 
     void clear();

--- a/jlib/glu/textures.cc
+++ b/jlib/glu/textures.cc
@@ -29,7 +29,7 @@ namespace jlib {
 namespace glu {
 namespace textures {
         
-void init(std::string data) {
+void init(const std::string& data) {
     GLuint texture;
 
     glGenTextures(1, &texture);

--- a/jlib/glu/textures.hh
+++ b/jlib/glu/textures.hh
@@ -27,7 +27,7 @@ namespace jlib {
 namespace glu {
 namespace textures {
 
-void init(std::string texture);
+void init(const std::string& texture);
 std::string make_checker2d();
 
 }

--- a/jlib/glx/Window.cc
+++ b/jlib/glx/Window.cc
@@ -34,7 +34,7 @@ static int double_buffer[] = { GLX_RGBA,
                                GLX_DEPTH_SIZE, 16,
                                None };
 
-Window::Window(std::string title, int w, int h, bool depth) 
+Window::Window(const std::string& title, int w, int h, bool depth) 
     : x::Window(),
       m_depth(depth)
 {	  

--- a/jlib/glx/Window.hh
+++ b/jlib/glx/Window.hh
@@ -29,14 +29,14 @@ namespace glx {
         
 class Window : public x::Window {
 public:
-    Window(std::string title="jlib::glx::Window", int w=400, int h=400, bool depth = true);
+    Window(const std::string& title="jlib::glx::Window", int w=400, int h=400, bool depth = true);
     virtual ~Window();
     
     virtual void clear();
     virtual void flush();
     virtual void iterate();
     
-    //Window& operator<<(std::string msg);
+    //Window& operator<<(const std::string& msg);
     //Window& operator<<(int value);
 
     void on_configure(int w, int h);

--- a/jlib/media/AudioFile.cc
+++ b/jlib/media/AudioFile.cc
@@ -41,7 +41,7 @@ const std::string DSP = "/dev/dsp";
 
 namespace jlib {
     namespace media {
-        AudioFile::AudioFile(std::string filename)
+        AudioFile::AudioFile(const std::string& filename)
             : m_bits_per_sample(16),
               m_channels(1),
               m_samples_per_sec(44100),
@@ -91,7 +91,7 @@ namespace jlib {
             m_format = s;
         }
 
-        void AudioFile::set_pcm(std::string pcm) {
+        void AudioFile::set_pcm(const std::string& pcm) {
             m_pcm = std::move(pcm);
         }
 
@@ -111,11 +111,11 @@ namespace jlib {
             save(m_filename);
         }
 
-        void AudioFile::load(std::string filename) {
+        void AudioFile::load(const std::string& filename) {
             m_filename = std::move(filename);
         }
 
-        void AudioFile::save(std::string filename) {
+        void AudioFile::save(const std::string& filename) {
             m_filename = filename;
             std::ofstream ofs(filename.c_str());
             ofs << m_pcm;

--- a/jlib/media/AudioFile.cc
+++ b/jlib/media/AudioFile.cc
@@ -112,7 +112,7 @@ namespace jlib {
         }
 
         void AudioFile::load(std::string filename) {
-            m_filename = filename;
+            m_filename = std::move(filename);
         }
 
         void AudioFile::save(std::string filename) {

--- a/jlib/media/AudioFile.hh
+++ b/jlib/media/AudioFile.hh
@@ -31,7 +31,7 @@ namespace jlib {
         public:
             class exception : public std::exception {
             public:
-                exception(std::string msg = "") {
+                exception(const std::string& msg = "") {
                     m_msg = std::string("jlib::media::AudioBuffer::exception")+((msg!="")?": ":"")+msg;
                 }
                 virtual ~exception() throw() {}
@@ -51,7 +51,7 @@ namespace jlib {
             
             class exception : public std::exception {
             public:
-                exception(std::string msg = "") {
+                exception(const std::string& msg = "") {
                     m_msg = std::string("jlib::media::AudioFile::exception")+((msg!="")?": ":"")+msg;
                 }
                 virtual ~exception() throw() {}
@@ -60,7 +60,7 @@ namespace jlib {
                 std::string m_msg;
             };
 
-            AudioFile(std::string filename="");
+            AudioFile(const std::string& filename="");
             ~AudioFile();
             
             int get_bits_per_sample() const; 
@@ -89,14 +89,14 @@ namespace jlib {
             void set_channels(int s); 
             void set_samples_per_sec(int s); 
             void set_format(int s); 
-            void set_pcm(std::string pcm);
+            void set_pcm(const std::string& pcm);
             void add_pcm(const std::string& pcm);
             void clear_pcm();
 
             virtual void load();
             virtual void save();
-            virtual void load(std::string filename);
-            virtual void save(std::string filename);
+            virtual void load(const std::string& filename);
+            virtual void save(const std::string& filename);
 
             /**
              * get the p'th sample from the pcm data

--- a/jlib/media/AudioSink.hh
+++ b/jlib/media/AudioSink.hh
@@ -49,7 +49,7 @@ class AudioSink {
 public:
     class exception : public std::exception {
     public:
-        exception(std::string msg = "") {
+        exception(const std::string& msg = "") {
             m_msg = "jlib::media::AudioSink exception" + (msg != "" ? (": " + msg) : "");
         }
         virtual ~exception() noexcept {}

--- a/jlib/media/Dsp.cc
+++ b/jlib/media/Dsp.cc
@@ -37,7 +37,7 @@ const int JLIB_MEDIA_DSP_FRAGSIZE = 2048;
 namespace jlib {
     namespace media {
         
-        Dsp::Dsp(std::string node,bool open)
+        Dsp::Dsp(const std::string& node,bool open)
             : m_bits_per_sample(-1),
               m_samples_per_sec(-1),
               m_channels(-1),
@@ -56,7 +56,7 @@ namespace jlib {
             close();
         }
         
-        void Dsp::open(std::string node) {
+        void Dsp::open(const std::string& node) {
             if(node != "")
                 m_node = node;
             
@@ -212,7 +212,7 @@ namespace jlib {
             if(m_dsp != -1) ::close(m_dsp);
         }
         
-        void Dsp::write(std::string data) {
+        void Dsp::write(const std::string& data) {
             if(m_dsp != -1 && data.length() > 0) {
                 int e = ::write(m_dsp,data.data(),data.length());
                 if(e == -1)

--- a/jlib/media/Dsp.hh
+++ b/jlib/media/Dsp.hh
@@ -37,14 +37,14 @@ namespace jlib {
         public:
             class exception : public std::exception {
             public:
-                exception(std::string msg = "") {
+                exception(const std::string& msg = "") {
                     m_msg = "jlib::media::Dsp exception"+
                         (msg != "" ? (": "+msg):"");
                 }
                 virtual ~exception() throw() {}
                 virtual const char* what() const throw() { return m_msg.c_str(); }
                 
-                static void throw_errno(std::string msg) {
+                static void throw_errno(const std::string& msg) {
                     std::ostringstream o;
                     o << ((msg!="")?(msg+": "):"") << strerror(errno);
                     throw exception(o.str());
@@ -54,10 +54,10 @@ namespace jlib {
                 std::string m_msg;
             };
 
-            Dsp(std::string node="/dev/dsp",bool open=true);
+            Dsp(const std::string& node="/dev/dsp",bool open=true);
             virtual ~Dsp();
 
-            void open(std::string node="");
+            void open(const std::string& node="");
 
             void config(stream& s);
             void config(int bits_per_sample, int samples_per_sec, int channels, int format);
@@ -78,7 +78,7 @@ namespace jlib {
 
             void close();
         protected:
-            void write(std::string data);
+            void write(const std::string& data);
 
             int m_bits_per_sample, m_samples_per_sec, m_channels, m_format;
             int m_fragsize;

--- a/jlib/media/PlayList.cc
+++ b/jlib/media/PlayList.cc
@@ -22,6 +22,7 @@
 
 #include <jlib/media/PlayList.hh>
 
+#include <utility>
 #include <iostream>
 
 
@@ -52,10 +53,10 @@ namespace jlib {
         void Roll::set_id(int id) { m_id = id; }
         
         std::string Roll::get_sample() const { return m_sample; }
-        void Roll::set_sample(std::string sample) { m_sample = sample; }
+        void Roll::set_sample(std::string sample) { m_sample = std::move(sample); }
         
         std::string Roll::get_name() const { return m_name; }
-        void Roll::set_name(std::string name) { m_name = name; }
+        void Roll::set_name(std::string name) { m_name = std::move(name); }
         
         Roll::reference Roll::operator[](int i) {
             return m_pattern[i];
@@ -92,7 +93,7 @@ namespace jlib {
         void Pattern::set_id(int id) { m_id = id; }
         
         std::string Pattern::get_name() const { return m_name; }
-        void Pattern::set_name(std::string name) { m_name = name; }
+        void Pattern::set_name(std::string name) { m_name = std::move(name); }
         
         Pattern::reference Pattern::operator[](int i) {
             return m_rolls[i];
@@ -126,7 +127,7 @@ namespace jlib {
         void PlayList::set_id(int id) { m_id = id; }
         
         std::string PlayList::get_name() const { return m_name; }
-        void PlayList::set_name(std::string name) { m_name = name; }
+        void PlayList::set_name(std::string name) { m_name = std::move(name); }
 
         int PlayList::get_bpm() const { return m_bpm; }
         void PlayList::set_bpm(int bpm) { m_bpm = bpm; }

--- a/jlib/media/PlayList.cc
+++ b/jlib/media/PlayList.cc
@@ -29,7 +29,7 @@
 namespace jlib {
     namespace media {
         
-        Roll::Roll(int id, stream* s, std::string name, std::string sample, std::string data) 
+        Roll::Roll(int id, stream* s, const std::string& name, const std::string& sample, const std::string& data) 
             : m_pattern(data.length())
         {
             set_id(id);
@@ -53,10 +53,10 @@ namespace jlib {
         void Roll::set_id(int id) { m_id = id; }
         
         std::string Roll::get_sample() const { return m_sample; }
-        void Roll::set_sample(std::string sample) { m_sample = std::move(sample); }
+        void Roll::set_sample(const std::string& sample) { m_sample = std::move(sample); }
         
         std::string Roll::get_name() const { return m_name; }
-        void Roll::set_name(std::string name) { m_name = std::move(name); }
+        void Roll::set_name(const std::string& name) { m_name = std::move(name); }
         
         Roll::reference Roll::operator[](int i) {
             return m_pattern[i];
@@ -79,7 +79,7 @@ namespace jlib {
         }
         
         
-        Pattern::Pattern(int id, std::string name) {
+        Pattern::Pattern(int id, const std::string& name) {
             m_id = id;
             m_name = name;
             m_roll_id_max = 0;
@@ -93,7 +93,7 @@ namespace jlib {
         void Pattern::set_id(int id) { m_id = id; }
         
         std::string Pattern::get_name() const { return m_name; }
-        void Pattern::set_name(std::string name) { m_name = std::move(name); }
+        void Pattern::set_name(const std::string& name) { m_name = std::move(name); }
         
         Pattern::reference Pattern::operator[](int i) {
             return m_rolls[i];
@@ -115,7 +115,7 @@ namespace jlib {
 
         PlayList::PlayList() { m_pattern_id_max = 0; }
 
-        PlayList::PlayList(int id, std::string name) { 
+        PlayList::PlayList(int id, const std::string& name) { 
             set_id(id);
             set_name(name);
             m_pattern_id_max = 0; 
@@ -127,7 +127,7 @@ namespace jlib {
         void PlayList::set_id(int id) { m_id = id; }
         
         std::string PlayList::get_name() const { return m_name; }
-        void PlayList::set_name(std::string name) { m_name = std::move(name); }
+        void PlayList::set_name(const std::string& name) { m_name = std::move(name); }
 
         int PlayList::get_bpm() const { return m_bpm; }
         void PlayList::set_bpm(int bpm) { m_bpm = bpm; }

--- a/jlib/media/PlayList.hh
+++ b/jlib/media/PlayList.hh
@@ -49,17 +49,17 @@ namespace jlib {
             typedef rep_type::difference_type difference_type;
             typedef rep_type::allocator_type allocator_type;            
             
-            Roll(int id, stream* s, std::string name, std::string sample, std::string data);
+            Roll(int id, stream* s, const std::string& name, const std::string& sample, const std::string& data);
             Roll();
             
             int get_id() const;
             void set_id(int id);
             
             std::string get_name() const;
-            void set_name(std::string name);
+            void set_name(const std::string& name);
             
             std::string get_sample() const;
-            void set_sample(std::string sample);
+            void set_sample(const std::string& sample);
             
             reference operator[](int i);
             const_reference operator[](int i) const;
@@ -96,14 +96,14 @@ namespace jlib {
             typedef rep_type::difference_type difference_type;
             typedef rep_type::allocator_type allocator_type;            
             
-            Pattern(int id, std::string name);
+            Pattern(int id, const std::string& name);
             virtual ~Pattern();
             
             int get_id() const;
             void set_id(int id);
             
             std::string get_name() const;
-            void set_name(std::string id);
+            void set_name(const std::string& id);
             
             int get_next_roll_id();
             
@@ -148,14 +148,14 @@ namespace jlib {
             typedef rep_type::allocator_type allocator_type;            
 
             PlayList();
-            PlayList(int id, std::string name);
+            PlayList(int id, const std::string& name);
             virtual ~PlayList();
 
             int get_id() const;
             void set_id(int id);
             
             std::string get_name() const;
-            void set_name(std::string id);
+            void set_name(const std::string& id);
 
             int get_bpm() const;
             void set_bpm(int bpm);

--- a/jlib/media/PortAudioSink.cc
+++ b/jlib/media/PortAudioSink.cc
@@ -81,7 +81,7 @@ PortAudioSink::~PortAudioSink() {
     }
 }
 
-void PortAudioSink::throw_pa(std::string ctx, PaError err) const {
+void PortAudioSink::throw_pa(const std::string& ctx, PaError err) const {
     std::ostringstream o;
     o << ctx << " failed: " << Pa_GetErrorText(err);
 

--- a/jlib/media/PortAudioSink.hh
+++ b/jlib/media/PortAudioSink.hh
@@ -88,7 +88,7 @@ protected:
     const std::string& convert(const std::string& pcm, std::string& scratch) const;
 
     void start();
-    [[noreturn]] void throw_pa(std::string ctx, PaError err) const;
+    [[noreturn]] void throw_pa(const std::string& ctx, PaError err) const;
 
     PaStream* m_stream;
     PaSampleFormat m_pa_format;

--- a/jlib/media/WavFile.cc
+++ b/jlib/media/WavFile.cc
@@ -71,7 +71,7 @@ namespace jlib {
             set_format_tag(WAV_FMT_PCM);
         }
 
-        WavFile::WavFile(std::string filename, bool load_data) {
+        WavFile::WavFile(const std::string& filename, bool load_data) {
             set_format_tag(WAV_FMT_PCM);
             m_filename = filename;
             parse_chunks();
@@ -235,7 +235,7 @@ namespace jlib {
             m_format_tag = s;
         }
 
-        void WavFile::load(std::string filename) {
+        void WavFile::load(const std::string& filename) {
             m_filename = filename;
             parse_chunks();
             parse_fmt();
@@ -243,7 +243,7 @@ namespace jlib {
             load_data_chunks();
         }
 
-        void WavFile::save(std::string filename) {
+        void WavFile::save(const std::string& filename) {
             m_filename = filename;
             std::ofstream ofs(filename.c_str());
             ofs << create_riff_header() << create_format_chunk() << create_data_chunk();

--- a/jlib/media/WavFile.hh
+++ b/jlib/media/WavFile.hh
@@ -31,15 +31,15 @@ namespace jlib {
         class WavFile : public AudioFile {
         public:
             WavFile();
-            WavFile(std::string filename, bool load_data=true);
+            WavFile(const std::string& filename, bool load_data=true);
             virtual ~WavFile();
 
             int get_format_tag() const;
             
             void set_format_tag(int s);
 
-            virtual void load(std::string filename);
-            virtual void save(std::string filename);
+            virtual void load(const std::string& filename);
+            virtual void save(const std::string& filename);
 
             void load_data_chunks();
 

--- a/jlib/media/audiofilestream.hh
+++ b/jlib/media/audiofilestream.hh
@@ -46,7 +46,7 @@ namespace jlib {
         public:
             class exception : public std::exception {
             public:
-                exception(std::string msg = "") {
+                exception(const std::string& msg = "") {
                     m_msg = std::string("jlib::media::basic_audiofilebuf::exception")+(msg==""?"":": ")+msg;
                 }
                 virtual ~exception() throw() {}

--- a/jlib/media/datastream.hh
+++ b/jlib/media/datastream.hh
@@ -41,7 +41,7 @@ namespace jlib {
         public:
             class exception : public std::exception {
             public:
-                exception(std::string msg = "") {
+                exception(const std::string& msg = "") {
                     m_msg = std::string("jlib::media::basic_databuf::exception")+(msg==""?"":": ")+msg;
                 }
                 virtual ~exception() throw() {}
@@ -59,7 +59,7 @@ namespace jlib {
             static const unsigned int BUF_SIZE = 1024;
             
             basic_databuf();
-            basic_databuf(std::string data);
+            basic_databuf(const std::string& data);
             
             virtual int_type underflow();
             //virtual int_type overflow(int_type c=traits_type::eof());
@@ -72,7 +72,7 @@ namespace jlib {
                                      std::ios_base::openmode = std::ios_base::in | std::ios_base::out);
 
             const std::string& get_data() const; 
-            void set_data(std::string s);
+            void set_data(const std::string& s);
 
         protected:
             std::string m_data;
@@ -82,10 +82,10 @@ namespace jlib {
         class basic_datastream : public basic_stream<charT,traitT> {
         public:
             basic_datastream();
-            basic_datastream(std::string data);
+            basic_datastream(const std::string& data);
             
             const std::string& get_data() const; 
-            void set_data(std::string s);
+            void set_data(const std::string& s);
 
             static basic_datastream<charT,traitT>* create_scaled(basic_stream<charT,traitT>* s);
 
@@ -105,7 +105,7 @@ namespace jlib {
         
         template< typename charT, typename traitT >
         inline
-        basic_databuf<charT,traitT>::basic_databuf(std::string data) 
+        basic_databuf<charT,traitT>::basic_databuf(const std::string& data) 
             : basic_streambuf<charT,traitT>()
         {
             set_data(std::move(data));
@@ -127,7 +127,7 @@ namespace jlib {
 
         template< typename charT, typename traitT >
         inline
-        void basic_databuf<charT,traitT>::set_data(std::string data) {
+        void basic_databuf<charT,traitT>::set_data(const std::string& data) {
             m_data = std::move(data);
             this->set_length(m_data.length());
         }
@@ -296,7 +296,7 @@ namespace jlib {
         
         template< typename charT, typename traitT >
         inline
-        basic_datastream<charT,traitT>::basic_datastream(std::string data) 
+        basic_datastream<charT,traitT>::basic_datastream(const std::string& data) 
             : basic_stream<charT,traitT>()
         {
             this->m_buf.reset(new basic_databuf<charT,traitT>(std::move(data)));
@@ -320,7 +320,7 @@ namespace jlib {
         template< typename charT, typename traitT >
         inline
         void
-        basic_datastream<charT,traitT>::set_data(std::string data) 
+        basic_datastream<charT,traitT>::set_data(const std::string& data) 
         {
             if(!this->m_buf)
                 throw basic_databuf<charT,traitT>::exception("this->m_buf == null");

--- a/jlib/media/notestream.hh
+++ b/jlib/media/notestream.hh
@@ -55,7 +55,7 @@ namespace jlib {
         public:
             class exception : public std::exception {
             public:
-                exception(std::string msg = "") {
+                exception(const std::string& msg = "") {
                     m_msg = std::string("jlib::media::basic_notebuf::exception")+(msg==""?"":": ")+msg;
                 }
                 virtual ~exception() throw() {}

--- a/jlib/media/stream.hh
+++ b/jlib/media/stream.hh
@@ -46,7 +46,7 @@ namespace jlib {
         public:
             class exception : public std::exception {
             public:
-                exception(std::string msg = "") {
+                exception(const std::string& msg = "") {
                     m_msg = std::string("jlib::media::basic_streambuf::exception")+(msg==""?"":": ")+msg;
                 }
                 virtual ~exception() throw() {}

--- a/jlib/media/wavstream.hh
+++ b/jlib/media/wavstream.hh
@@ -58,7 +58,7 @@ namespace jlib {
         public:
             class exception : public std::exception {
             public:
-                exception(std::string msg = "") {
+                exception(const std::string& msg = "") {
                     m_msg = std::string("jlib::media::basic_wavbuf::exception")+(msg==""?"":": ")+msg;
                 }
                 virtual ~exception() throw() {}

--- a/jlib/net/ASImapBox.cc
+++ b/jlib/net/ASImapBox.cc
@@ -64,7 +64,7 @@ namespace jlib {
             }
         }
 
-        void ASImapBox::on_set_password(std::string password) {
+        void ASImapBox::on_set_password(const std::string& password) {
             m_url.set_pass(password);
             m_pass = password;
         }

--- a/jlib/net/ASImapBox.hh
+++ b/jlib/net/ASImapBox.hh
@@ -38,7 +38,7 @@ namespace jlib {
 
             virtual void on_init();
 
-            virtual void on_set_password(std::string password);
+            virtual void on_set_password(const std::string& password);
 
             virtual void on_list_folders();
 

--- a/jlib/net/ASMBox.cc
+++ b/jlib/net/ASMBox.cc
@@ -67,7 +67,7 @@ namespace jlib {
             push(MailBoxResponse(MailBoxResponse::STATUS, "Initialized"));
         }
 
-        void ASMBox::on_set_password(std::string password) {
+        void ASMBox::on_set_password(const std::string& password) {
 
         }
 

--- a/jlib/net/ASMBox.hh
+++ b/jlib/net/ASMBox.hh
@@ -38,7 +38,7 @@ namespace jlib {
 
             virtual void on_init();
 
-            virtual void on_set_password(std::string password);
+            virtual void on_set_password(const std::string& password);
 
             virtual void on_list_folders();
 

--- a/jlib/net/ASMailBox.cc
+++ b/jlib/net/ASMailBox.cc
@@ -66,7 +66,7 @@ namespace jlib {
 
         MailBoxRequest::MailBoxRequest(request_type t, 
                                        folder_info_type s, 
-                                       Email e, 
+                                       const Email& e, 
                                        folder_indx_type i)
             : type(t),
               src(s),
@@ -116,7 +116,7 @@ namespace jlib {
 
         MailBoxResponse::MailBoxResponse(response_type t, 
                                        folder_info_type s, 
-                                       Email e, 
+                                       const Email& e, 
                                        folder_indx_type i) 
             : type(t),
               src(s),
@@ -316,19 +316,19 @@ namespace jlib {
         }
 
         
-        void ASMailBox::append_message(folder_info_type folder, Email email) {
+        void ASMailBox::append_message(folder_info_type folder, const Email& email) {
             push(MailBoxRequest(MailBoxRequest::APPEND_MESSAGE, folder, email));
         }
 
         void ASMailBox::set_message_flags(folder_info_type folder, 
                                           folder_indx_type indx, 
-                                          Email email) {
+                                          const Email& email) {
             push(MailBoxRequest(MailBoxRequest::SET_MESSAGE_FLAGS, folder, email, indx));
         }
         
         void ASMailBox::unset_message_flags(folder_info_type folder, 
                                             folder_indx_type indx, 
-                                            Email email) {
+                                            const Email& email) {
             push(MailBoxRequest(MailBoxRequest::UNSET_MESSAGE_FLAGS, folder, email, indx));
         }
 

--- a/jlib/net/ASMailBox.cc
+++ b/jlib/net/ASMailBox.cc
@@ -32,7 +32,7 @@ namespace jlib {
             id = master.ref()++;;
         }
 
-        MailBoxRequest::MailBoxRequest(request_type t, std::string p)
+        MailBoxRequest::MailBoxRequest(request_type t, const std::string& p)
             : type(t),
               password(p)
         {
@@ -84,7 +84,7 @@ namespace jlib {
             priority = static_cast<int>(t);
         }
 
-        MailBoxResponse::MailBoxResponse(response_type t, std::string p, float pct)
+        MailBoxResponse::MailBoxResponse(response_type t, const std::string& p, float pct)
             : type(t),
               text(p),
               pct(pct)
@@ -273,7 +273,7 @@ namespace jlib {
             push(MailBoxRequest(MailBoxRequest::INITIALIZE));
         }
 
-        void ASMailBox::set_password(std::string password) {
+        void ASMailBox::set_password(const std::string& password) {
             push(MailBoxRequest(MailBoxRequest::SET_PASSWORD, password));
         }
 

--- a/jlib/net/ASMailBox.hh
+++ b/jlib/net/ASMailBox.hh
@@ -105,7 +105,7 @@ namespace jlib {
 
             MailBoxRequest(request_type t);
 
-            MailBoxRequest(request_type t, std::string p);
+            MailBoxRequest(request_type t, const std::string& p);
 
             MailBoxRequest(request_type t, folder_info_type src, 
                            folder_indx_type indx=folder_indx_type());
@@ -175,7 +175,7 @@ namespace jlib {
 
             MailBoxResponse(response_type t);
 
-            MailBoxResponse(response_type t, std::string text, float p=0);
+            MailBoxResponse(response_type t, const std::string& text, float p=0);
 
             MailBoxResponse(response_type t, folder_info_type src, 
                             folder_indx_type indx=folder_indx_type());
@@ -210,7 +210,7 @@ namespace jlib {
         public:
             class exception : public std::exception {
             public:
-                exception(std::string msg = "") {
+                exception(const std::string& msg = "") {
                     m_msg = std::string("jlib::net::ASMailBox exception")+( (msg=="")?"":": ")+msg;
                 }
                 virtual ~exception() throw() {}
@@ -229,7 +229,7 @@ namespace jlib {
 
             void init();
             void reinit();
-            void set_password(std::string password);
+            void set_password(const std::string& password);
             void list_folders();
 
             void create_folder(folder_info_type folder);
@@ -253,7 +253,7 @@ namespace jlib {
 
 
             virtual void on_init() = 0;
-            virtual void on_set_password(std::string password) = 0;
+            virtual void on_set_password(const std::string& password) = 0;
 
             virtual void on_list_folders() = 0;
 

--- a/jlib/net/ASMailBox.hh
+++ b/jlib/net/ASMailBox.hh
@@ -113,7 +113,7 @@ namespace jlib {
             MailBoxRequest(request_type t, folder_info_type src, folder_info_type dst, 
                            folder_indx_type indx=folder_indx_type());
 
-            MailBoxRequest(request_type t, folder_info_type src, Email email, 
+            MailBoxRequest(request_type t, folder_info_type src, const Email& email, 
                            folder_indx_type indx=folder_indx_type());
 
             request_type type;
@@ -183,7 +183,7 @@ namespace jlib {
             MailBoxResponse(response_type t, folder_info_type src, folder_info_type dst, 
                            folder_indx_type indx=folder_indx_type());
 
-            MailBoxResponse(response_type t, folder_info_type src, Email email, 
+            MailBoxResponse(response_type t, folder_info_type src, const Email& email, 
                            folder_indx_type indx=folder_indx_type());
 
 
@@ -244,12 +244,12 @@ namespace jlib {
             void copy_messages(folder_info_type src, folder_info_type dst, 
                                folder_indx_type indx);
             
-            void append_message(folder_info_type folder, Email email);
+            void append_message(folder_info_type folder, const Email& email);
             
             void set_message_flags(folder_info_type folder, 
-                                   folder_indx_type indx, Email email);
+                                   folder_indx_type indx, const Email& email);
             void unset_message_flags(folder_info_type folder, 
-                                     folder_indx_type indx, Email email);
+                                     folder_indx_type indx, const Email& email);
 
 
             virtual void on_init() = 0;
@@ -269,12 +269,12 @@ namespace jlib {
             virtual void on_copy_messages(folder_info_type src, folder_info_type dst, 
                                           folder_indx_type indx) = 0;
 
-            virtual void on_append_message(folder_info_type folder, Email email) = 0;
+            virtual void on_append_message(folder_info_type folder, const Email& email) = 0;
 
             virtual void on_set_message_flags(folder_info_type folder, 
-                                              folder_indx_type indx, Email email) = 0;
+                                              folder_indx_type indx, const Email& email) = 0;
             virtual void on_unset_message_flags(folder_info_type folder, 
-                                                folder_indx_type indx, Email email) = 0;
+                                                folder_indx_type indx, const Email& email) = 0;
 
 
 

--- a/jlib/net/Email.cc
+++ b/jlib/net/Email.cc
@@ -44,7 +44,7 @@ namespace jlib {
             : m_is_loaded(false),
               m_indx(-1)
         {
-            create(is);
+            create(std::move(is));
         }
 
         void Email::create(std::string is) {
@@ -62,7 +62,8 @@ namespace jlib {
                 }
                 std::cerr << ">, \"" << m_raw << "\") " << std::endl;
             }
-            m_raw = is;// = parse_end(is, m_bounds);
+            // Moved: is is not read again below, and it is the whole message.
+            m_raw = std::move(is);// = parse_end(is, m_bounds);
             if(getenv("JLIB_NET_EMAIL_DEBUG")) {
                 std::cerr <<"jlib::net::Email::create(): after parse_end(),"
                           <<"m_raw => \n" << m_raw << std::endl;

--- a/jlib/net/Email.cc
+++ b/jlib/net/Email.cc
@@ -40,14 +40,14 @@ namespace jlib {
             m_sort = "DATE"; 
         }
 
-        Email::Email(std::string is) 
+        Email::Email(const std::string& is) 
             : m_is_loaded(false),
               m_indx(-1)
         {
             create(std::move(is));
         }
 
-        void Email::create(std::string is) {
+        void Email::create(const std::string& is) {
             if(getenv("JLIB_NET_EMAIL_DEBUG")) {
                 std::cerr <<"jlib::net::Email::create(): entering"<<std::endl;
             }
@@ -224,7 +224,7 @@ namespace jlib {
             return (s1 < s2);
         }
         
-        void Email::sort(std::string field) {
+        void Email::sort(const std::string& field) {
             m_sort = std::move(field);
         }
         
@@ -246,16 +246,16 @@ namespace jlib {
             build_mime(m_raw, *this);
         }
 
-        std::string Email::operator[](std::string key) const {
+        std::string Email::operator[](const std::string& key) const {
             return m_headers[key];
         }
 
-        void Email::set(std::string key,std::string val) {
+        void Email::set(const std::string& key,std::string val) {
             //std::multimap<std::string,std::string>::const_iterator i = m_headers.lower_bound(key);
             m_headers.set(key,val);
         }
 
-        void Email::add(std::string key,std::string val) {
+        void Email::add(const std::string& key,std::string val) {
             m_headers.add(key,val);
         }
 
@@ -376,7 +376,7 @@ namespace jlib {
             return ret;
         }
 
-        bool Email::is(std::string type) const {
+        bool Email::is(const std::string& type) const {
             std::string ctype = jlib::util::lower(find("CONTENT-TYPE"));
             return (ctype.find(type) != std::string::npos);
         }
@@ -453,7 +453,7 @@ namespace jlib {
             return m_indx;
         }
 
-        Email::reference Email::grep(std::string s, bool recursive) {
+        Email::reference Email::grep(const std::string& s, bool recursive) {
             std::string::size_type i;
             if((i = m_data.find(s)) != std::string::npos) {
                 return *this;

--- a/jlib/net/Email.cc
+++ b/jlib/net/Email.cc
@@ -207,10 +207,6 @@ namespace jlib {
             }
         }
         
-        Email::~Email() {
-            
-        }
-        
         bool operator<(const Email& j1, const Email& j2) {
             std::string s1 = j1[j1.m_sort];
             std::string s2 = j2[j2.m_sort];
@@ -229,7 +225,7 @@ namespace jlib {
         }
         
         void Email::sort(std::string field) {
-            m_sort = field;
+            m_sort = std::move(field);
         }
         
         std::vector<Email>& Email::attach() {

--- a/jlib/net/Email.hh
+++ b/jlib/net/Email.hh
@@ -87,7 +87,14 @@ namespace jlib {
             /**
              * Destructor.
              */
-            ~Email();
+            /**
+             * No destructor.
+             *
+             * There was an empty one, and a user-declared destructor -- even
+             * an empty one -- suppresses the implicit move constructor and
+             * move assignment.  Every std::move of one of these was silently
+             * doing a copy; measured, moving a 2M Email copied 4M.
+             */
             
             void set(std::string key,std::string val);
             void add(std::string key,std::string val);

--- a/jlib/net/Email.hh
+++ b/jlib/net/Email.hh
@@ -104,7 +104,17 @@ namespace jlib {
              *
              * @return raw text
              */
-            std::string raw() const { return m_raw; }
+            /**
+             * The raw message, by reference.
+             *
+             * This returned by value, which was free when it was written:
+             * libstdc++'s std::string was copy-on-write then, so returning
+             * one was a refcount bump.  C++11 outlawed COW and gcc dropped it
+             * in 5.0, which turned every call into a full copy of the
+             * message.  Measured, building an Email from a 2M message copied
+             * 12M, and each raw() or data() after that copied 2M more.
+             */
+            const std::string& raw() const { return m_raw; }
 
             /**
              * Get vector of Email attachments
@@ -147,12 +157,12 @@ namespace jlib {
             /**
              * set the binary data to what is passed
              */
-            void data(std::string data) { m_data = data; }
+            void data(std::string data) { m_data = std::move(data); }
             
             /**
              * get the binary data
              */
-            std::string data() const { return m_data; }
+            const std::string& data() const { return m_data; }
 
             /**
              * build the text of the email based on the data and attachments

--- a/jlib/net/Email.hh
+++ b/jlib/net/Email.hh
@@ -39,7 +39,7 @@ namespace jlib {
         public:
             class exception : public std::exception {
             public:
-                exception(std::string msg = "") {
+                exception(const std::string& msg = "") {
                     m_msg = "jlib::net::email exception: "+msg;
                 }
                 virtual ~exception() throw() {}
@@ -80,9 +80,9 @@ namespace jlib {
             /**
              * create email from passed data string
              */
-            Email(std::string is);
+            Email(const std::string& is);
             
-            void create(std::string is);
+            void create(const std::string& is);
 
             /**
              * Destructor.
@@ -96,11 +96,11 @@ namespace jlib {
              * doing a copy; measured, moving a 2M Email copied 4M.
              */
             
-            void set(std::string key,std::string val);
-            void add(std::string key,std::string val);
+            void set(const std::string& key,std::string val);
+            void add(const std::string& key,std::string val);
 
-            std::string find(std::string key) const { return operator[](key); }
-            std::string operator[](std::string key) const;
+            std::string find(const std::string& key) const { return operator[](key); }
+            std::string operator[](const std::string& key) const;
             Email& operator[](unsigned int i) { return m_attach[i]; }
 
             void push_front(const Email& e) { m_attach.insert(m_attach.begin(),e); }
@@ -152,7 +152,7 @@ namespace jlib {
              * @param field field to sort by
              *
              */
-            void sort(std::string field);
+            void sort(const std::string& field);
             
             /**
              * Get the headers for this email.
@@ -164,7 +164,7 @@ namespace jlib {
             /**
              * set the binary data to what is passed
              */
-            void data(std::string data) { m_data = std::move(data); }
+            void data(const std::string& data) { m_data = std::move(data); }
             
             /**
              * get the binary data
@@ -218,7 +218,7 @@ namespace jlib {
             std::string get_name() const;
             std::string get_filename() const;
 
-            bool is(std::string type) const;
+            bool is(const std::string& type) const;
 
             void parse_received();
 
@@ -230,11 +230,11 @@ namespace jlib {
             void set_indx(int indx);
             int get_indx() const;
 
-            reference grep(std::string s, bool recursive = true);
+            reference grep(const std::string& s, bool recursive = true);
 
         protected:
             std::string get_text(bool html, bool render, bool globbed, bool recurse) const;
-            bool check(std::string buf);
+            bool check(const std::string& buf);
             
             std::string m_sort;
             std::string m_raw;

--- a/jlib/net/Imap4.cc
+++ b/jlib/net/Imap4.cc
@@ -45,7 +45,7 @@ namespace jlib {
 
 
         ListItem::ListItem() {}
-        ListItem::ListItem(std::string line) {
+        ListItem::ListItem(const std::string& line) {
             unsigned int i,j;
             i = line.find("(");
             j = line.find(")",i+1);
@@ -301,7 +301,7 @@ namespace jlib {
         }
 
         std::string Imap4::retrieve_headers(unsigned int which, 
-                                       std::string mailbox,
+                                       const std::string& mailbox,
                                        unsigned int& size)
         {
             sys::socketstream* sock;
@@ -319,7 +319,7 @@ namespace jlib {
         }
         std::string Imap4::retrieve_headers(sys::socketstream& sock, 
                                        unsigned int which, 
-                                       std::string mailbox,
+                                       const std::string& mailbox,
                                        unsigned int& size) {
 
             std::string buf;
@@ -364,7 +364,7 @@ namespace jlib {
             return ret;            
         }
 
-        std::string Imap4::retrieve(int which, std::string mailbox) {
+        std::string Imap4::retrieve(int which, const std::string& mailbox) {
             sys::socketstream* sock;
             sock = connect();
             login(*sock);
@@ -379,7 +379,7 @@ namespace jlib {
             return ret;
         }
 
-        std::string Imap4::retrieve(sys::socketstream& sock, int which, std::string mailbox) 
+        std::string Imap4::retrieve(sys::socketstream& sock, int which, const std::string& mailbox) 
         {
             std::string buf;
             //std::vector<std::string> info;
@@ -492,7 +492,7 @@ namespace jlib {
             m_state = UnConnected;
         }
         
-        void Imap4::remove(int which, std::string mailbox) {
+        void Imap4::remove(int which, const std::string& mailbox) {
             sys::socketstream* sock;
             sock = connect();
             login(*sock);
@@ -508,7 +508,7 @@ namespace jlib {
         }
         
         /*
-        bool Imap4::internal(std::string data) {
+        bool Imap4::internal(const std::string& data) {
             return util::contains(data, INTERNAL);
         }
         */
@@ -523,7 +523,7 @@ namespace jlib {
             return true;
         }
 
-        std::vector<std::string> Imap4::handshake(sys::socketstream& sock, std::string data) {
+        std::vector<std::string> Imap4::handshake(sys::socketstream& sock, const std::string& data) {
             std::string buf;
             std::string com = tag(1)+" "+data;
             std::vector<std::string> ret;
@@ -676,10 +676,10 @@ namespace jlib {
             handshake(sock,"LOGOUT");
             m_state = UnConnected;
         }
-        void Imap4::authenticate(sys::socketstream& sock,std::string name) {
+        void Imap4::authenticate(sys::socketstream& sock, const std::string& name) {
             handshake(sock,"AUTHENTICATE "+name);
         }
-        void Imap4::login(sys::socketstream& sock, std::string user, std::string pass) {
+        void Imap4::login(sys::socketstream& sock, const std::string& user, const std::string& pass) {
             if(user!="" && pass != "") {
                 handshake(sock,"LOGIN "+user+" "+pass);
             }
@@ -689,37 +689,37 @@ namespace jlib {
             m_state = Authenticated;
         }
 
-        std::vector<std::string> Imap4::select(sys::socketstream& sock, std::string path) {
+        std::vector<std::string> Imap4::select(sys::socketstream& sock, const std::string& path) {
             std::vector<std::string> config = handshake(sock,"SELECT \""+path+"\"");
             parse(config);
             m_state = Selected;
             return config;
         }
         
-        std::vector<std::string> Imap4::examine(sys::socketstream& sock, std::string path) {
+        std::vector<std::string> Imap4::examine(sys::socketstream& sock, const std::string& path) {
             std::vector<std::string> ret = handshake(sock,"EXAMINE \""+path+"\"");
             parse(ret);
             m_state = Selected;
             return ret;
         }
 
-        void Imap4::create(sys::socketstream& sock, std::string path) {
+        void Imap4::create(sys::socketstream& sock, const std::string& path) {
             handshake(sock,"CREATE \""+path+"\"");
         }
-        void Imap4::remove(sys::socketstream& sock, std::string path) {
+        void Imap4::remove(sys::socketstream& sock, const std::string& path) {
             handshake(sock,"DELETE \""+path+"\"");
         }
-        void Imap4::rename(sys::socketstream& sock, std::string old_name, std::string new_name) {
+        void Imap4::rename(sys::socketstream& sock, const std::string& old_name, const std::string& new_name) {
             handshake(sock,"RENAME \""+old_name+"\" \""+new_name+"\"");
         }
-        void Imap4::subscribe(sys::socketstream& sock, std::string path) {
+        void Imap4::subscribe(sys::socketstream& sock, const std::string& path) {
             handshake(sock,"SUBSCRIBE \""+path+"\"");
         }
-        void Imap4::unsubscribe(sys::socketstream& sock, std::string path) {
+        void Imap4::unsubscribe(sys::socketstream& sock, const std::string& path) {
             handshake(sock,"UNSUBSCRIBE \""+path+"\"");
         }
 
-        std::vector<ListItem> Imap4::list(sys::socketstream& sock, std::string ref, std::string path) {
+        std::vector<ListItem> Imap4::list(sys::socketstream& sock, const std::string& ref, const std::string& path) {
             std::vector<ListItem> ret;
             std::vector<std::string> ls = handshake(sock,"LIST \""+ref+"\" \""+path+"\"");
             for(unsigned int i=0;i<ls.size()-1;i++) {
@@ -728,7 +728,7 @@ namespace jlib {
             return ret;
         }
 
-        std::vector<ListItem> Imap4::lsub(sys::socketstream& sock, std::string ref, std::string path) {
+        std::vector<ListItem> Imap4::lsub(sys::socketstream& sock, const std::string& ref, const std::string& path) {
             std::vector<ListItem> ret;
             std::vector<std::string> ls = handshake(sock,"LIST \""+ref+"\" \""+path+"\"");
             for(unsigned int i=0;i<ls.size()-1;i++) {
@@ -737,9 +737,12 @@ namespace jlib {
             return ret;
         }
 
-        void Imap4::append(sys::socketstream& sock, std::string path, std::string data, std::string flag, std::string date) {
+        void Imap4::append(sys::socketstream& sock, const std::string& path, const std::string& data, const std::string& flag, const std::string& date) {
             std::string buf;
-            path = (path == "INBOX" ? path : (m_url.get_path_no_slash() + path));
+
+            // On a local; this overwrote its own parameter.
+            const std::string box =
+                (path == "INBOX" ? path : (m_url.get_path_no_slash() + path));
             tag(1);
             if(getenv("JLIB_NET_IMAP4_DEBUG")) {
                 std::cout << tag() << " APPEND \""<<path<<"\" ("<<flag<<") {"<<data.length()<<"}"<<std::endl;
@@ -791,7 +794,7 @@ namespace jlib {
             handshake(sock,"EXPUNGE");
         }
 
-        std::vector<std::string> Imap4::search(sys::socketstream& sock, std::string criteria, std::string spec) {
+        std::vector<std::string> Imap4::search(sys::socketstream& sock, const std::string& criteria, const std::string& spec) {
             std::vector<std::string> ret = handshake(sock,"");
             return ret;
         }
@@ -815,7 +818,7 @@ namespace jlib {
             return ret;            
         }
 
-        std::vector<std::string> Imap4::store(sys::socketstream& sock, std::pair<unsigned int,unsigned int> set, std::string key, std::vector<std::string> val) {
+        std::vector<std::string> Imap4::store(sys::socketstream& sock, std::pair<unsigned int,unsigned int> set, const std::string& key, std::vector<std::string> val) {
             std::ostringstream cmd;
             cmd << "STORE "<<set.first<<":"<<set.second<<" "<<key<<" (";
             for(unsigned int i=0;i<val.size();i++) {
@@ -830,14 +833,14 @@ namespace jlib {
             return ret;
         }
 
-        void Imap4::copy(sys::socketstream& sock, std::pair<unsigned int,unsigned int> set, std::string box) {
+        void Imap4::copy(sys::socketstream& sock, std::pair<unsigned int,unsigned int> set, const std::string& box) {
             std::string path = (box == "INBOX" ? box : (m_url.get_path_no_slash() + box));
             std::ostringstream cmd;
             cmd << "COPY " << set.first << ":" << set.second << " \"" << path << "\"";
             std::vector<std::string> ret = handshake(sock,cmd.str());
         }
         
-        std::vector<std::string> Imap4::uid(sys::socketstream& sock, std::string cmd, std::vector<std::string> arg) {
+        std::vector<std::string> Imap4::uid(sys::socketstream& sock, const std::string& cmd, std::vector<std::string> arg) {
             std::vector<std::string> ret = handshake(sock,"");
             return ret;
         }

--- a/jlib/net/Imap4.hh
+++ b/jlib/net/Imap4.hh
@@ -36,7 +36,7 @@ namespace jlib {
         class ListItem {
         public:
             ListItem();
-            ListItem(std::string line);
+            ListItem(const std::string& line);
             
             std::vector<std::string> get_attributes();
             std::string get_delim();
@@ -61,7 +61,7 @@ namespace jlib {
         public:
             class exception : public std::exception {
             public:
-                exception(std::string msg = "") {
+                exception(const std::string& msg = "") {
                     m_msg = "imap4 exception: "+msg;
                 }
                 virtual ~exception() throw() {}
@@ -141,7 +141,7 @@ namespace jlib {
              *
              * @param name authentication mechanism name
              */ 
-            void authenticate(jlib::sys::socketstream& sock, std::string name);
+            void authenticate(jlib::sys::socketstream& sock, const std::string& name);
 
             /**
              * The LOGIN command identifies the user to the server and carries
@@ -152,7 +152,7 @@ namespace jlib {
              *
              * @throw imap4_exception if an exception occurs while doing i/o
              */
-            void login(jlib::sys::socketstream& sock, std::string user="", std::string pass="");
+            void login(jlib::sys::socketstream& sock, const std::string& user="", const std::string& pass="");
             
 
             // 6.3.    Client Commands - Authenticated State
@@ -179,7 +179,7 @@ namespace jlib {
              *
              * @return vector containing server response
              */
-            std::vector<std::string> select(jlib::sys::socketstream& sock, std::string path);
+            std::vector<std::string> select(jlib::sys::socketstream& sock, const std::string& path);
 
             /**
              * The EXAMINE command is identical to SELECT and returns the same
@@ -191,7 +191,7 @@ namespace jlib {
              *
              * @return vector containing server response
              */
-            std::vector<std::string> examine(jlib::sys::socketstream& sock, std::string path);
+            std::vector<std::string> examine(jlib::sys::socketstream& sock, const std::string& path);
 
             /**
              * The CREATE command creates a mailbox with the given name.  An OK
@@ -202,7 +202,7 @@ namespace jlib {
              * 
              * @param path mailbox name
              */
-            void create(jlib::sys::socketstream& sock, std::string path);
+            void create(jlib::sys::socketstream& sock, const std::string& path);
 
             /**
              * The DELETE command permanently removes the mailbox with the given
@@ -213,7 +213,7 @@ namespace jlib {
              *
              * @param path mailbox name
              */
-            void remove(jlib::sys::socketstream& sock, std::string path);
+            void remove(jlib::sys::socketstream& sock, const std::string& path);
             
             /**
              * The RENAME command changes the name of a mailbox.  A tagged OK
@@ -225,7 +225,7 @@ namespace jlib {
              * @param old_name old mailbox name
              * @param new_name new mailbox name
              */
-            void rename(jlib::sys::socketstream& sock, std::string old_name, std::string new_name);
+            void rename(jlib::sys::socketstream& sock, const std::string& old_name, const std::string& new_name);
             
             /**
              * The SUBSCRIBE command adds the specified mailbox name to the
@@ -235,7 +235,7 @@ namespace jlib {
              *
              * @param path mailbox
              */
-            void subscribe(jlib::sys::socketstream& sock, std::string path);
+            void subscribe(jlib::sys::socketstream& sock, const std::string& path);
 
             /**
              * The UNSUBSCRIBE command removes the specified mailbox name from
@@ -245,7 +245,7 @@ namespace jlib {
              * 
              * @param path mailbox
              */
-            void unsubscribe(jlib::sys::socketstream& sock, std::string path);
+            void unsubscribe(jlib::sys::socketstream& sock, const std::string& path);
 
             /**
              * The LIST command returns a subset of names from the complete set
@@ -279,7 +279,7 @@ namespace jlib {
              * @param ref reference name
              * @param path mailbox name
              */
-            std::vector<ListItem> list(jlib::sys::socketstream& sock, std::string ref, std::string path);
+            std::vector<ListItem> list(jlib::sys::socketstream& sock, const std::string& ref, const std::string& path);
 
             /**
              * The LSUB command returns a subset of names from the set of names
@@ -290,7 +290,7 @@ namespace jlib {
              * @param ref reference name
              * @param path mailbox name
              */
-            std::vector<ListItem> lsub(jlib::sys::socketstream& sock, std::string ref, std::string path);
+            std::vector<ListItem> lsub(jlib::sys::socketstream& sock, const std::string& ref, const std::string& path);
 
             /**
              * The APPEND command appends the literal argument as a new message
@@ -305,7 +305,7 @@ namespace jlib {
              * @param flag optional flag parenthesized list
              * @param date optional date/time string
              */
-            void append(jlib::sys::socketstream& sock, std::string path, std::string data, std::string flag="", std::string date="");
+            void append(jlib::sys::socketstream& sock, const std::string& path, const std::string& data, const std::string& flag="", const std::string& date="");
 
 
             //6.4.    Client Commands - Selected State
@@ -352,7 +352,7 @@ namespace jlib {
              *
              * @return vector with server response
              */
-            std::vector<std::string> search(jlib::sys::socketstream& sock, std::string criteria, std::string spec="");
+            std::vector<std::string> search(jlib::sys::socketstream& sock, const std::string& criteria, const std::string& spec="");
             
             /**
              * The FETCH command retrieves data associated with a message in the
@@ -399,7 +399,7 @@ namespace jlib {
              * 
              * @return vector containing sever response
              */
-            std::vector<std::string> store(jlib::sys::socketstream& sock, std::pair<unsigned int,unsigned int> set, std::string key, std::vector<std::string> val);
+            std::vector<std::string> store(jlib::sys::socketstream& sock, std::pair<unsigned int,unsigned int> set, const std::string& key, std::vector<std::string> val);
             
             /**
              * The COPY command copies the specified message(s) to the specified
@@ -409,7 +409,7 @@ namespace jlib {
              * @param set message set
              * @param box mailbox
              */
-            void copy(jlib::sys::socketstream& sock, std::pair<unsigned int,unsigned int> set, std::string box);
+            void copy(jlib::sys::socketstream& sock, std::pair<unsigned int,unsigned int> set, const std::string& box);
 
             /**
              * The UID command has two forms.  In the first form, it takes as its
@@ -470,7 +470,7 @@ namespace jlib {
              * 
              * @return result of cmd
              */
-            std::vector<std::string> uid(jlib::sys::socketstream& sock, std::string cmd, std::vector<std::string> arg);
+            std::vector<std::string> uid(jlib::sys::socketstream& sock, const std::string& cmd, std::vector<std::string> arg);
 
             /**
              * Any command prefixed with an X is an experimental command.
@@ -478,7 +478,7 @@ namespace jlib {
              * or standards-track revision of this specification, MUST use the X
              * prefix.
              */
-            //void x(std::string cmd);
+            //void x(const std::string& cmd);
             
             /**
              * Get the the specified email with flags
@@ -494,8 +494,8 @@ namespace jlib {
              * @param which which email we're retrieving
              * @throw imap4_exception if an exception occurs while doing i/o
              */
-            std::string retrieve(int which, std::string mailbox="INBOX");
-            std::string retrieve(jlib::sys::socketstream& sock, int which, std::string mailbox="INBOX");
+            std::string retrieve(int which, const std::string& mailbox="INBOX");
+            std::string retrieve(jlib::sys::socketstream& sock, int which, const std::string& mailbox="INBOX");
             
             /**
              * Retrieve the text of specified email
@@ -503,8 +503,8 @@ namespace jlib {
              * @param which which email we're retrieving
              * @throw std::exception if an exception occurs while doing i/o
              */
-            std::string retrieve_headers(unsigned int which, std::string mailbox,unsigned int& size);
-            std::string retrieve_headers(jlib::sys::socketstream& sock, unsigned int which, std::string mailbox,unsigned int& size);
+            std::string retrieve_headers(unsigned int which, const std::string& mailbox,unsigned int& size);
+            std::string retrieve_headers(jlib::sys::socketstream& sock, unsigned int which, const std::string& mailbox,unsigned int& size);
             
             /**
              * Remove this email from it's server
@@ -512,9 +512,9 @@ namespace jlib {
              * @param which which email we're removing
              * @throw std::exception if an exception occurs while doing i/o
              */
-            void remove(int which, std::string mailbox="INBOX");
+            void remove(int which, const std::string& mailbox="INBOX");
             
-            std::vector<std::string> handshake(jlib::sys::socketstream& sock, std::string data);
+            std::vector<std::string> handshake(jlib::sys::socketstream& sock, const std::string& data);
             
             bool unseen(jlib::sys::socketstream& sock,int i);
 

--- a/jlib/net/Imap4Folder.hh
+++ b/jlib/net/Imap4Folder.hh
@@ -54,8 +54,8 @@ namespace jlib {
             Imap4Folder(jlib::util::URL url)
                 : MailFolder(NULL)
             {
-                m_rep = new Imap4FolderBuffer(url);
-                init(m_rep);
+                // Straight to init, which owns it; see MFolder.
+                init(new Imap4FolderBuffer(url));
             }
         };
 

--- a/jlib/net/MBox.hh
+++ b/jlib/net/MBox.hh
@@ -38,7 +38,7 @@ namespace jlib {
         public:
             class exception : public std::exception {
             public:
-                exception(std::string msg = "") {
+                exception(const std::string& msg = "") {
                     m_msg = std::string("jlib::net::MBoxBuf exception")+( (msg=="")?"":": ")+msg;
                 }
                 virtual ~exception() throw() {}

--- a/jlib/net/MFolder.cc
+++ b/jlib/net/MFolder.cc
@@ -21,6 +21,8 @@
 #include <jlib/net/net.hh>
 #include <jlib/net/MFolder.hh>
 
+#include <utility>
+
 #include <jlib/sys/sys.hh>
 
 #include <jlib/util/util.hh>
@@ -113,7 +115,8 @@ namespace jlib {
                         jlib::sys::getstring( ifs, buf, (m_divide[j+1]-m_divide[j]) );
                     }
                     //std::istringstream is(buf);
-                    m_rep[j].create(buf);
+                    // buf is not read again; it is the whole message.
+                    m_rep[j].create(std::move(buf));
                     m_filled[j] = true;
                 }
             }
@@ -198,7 +201,11 @@ namespace jlib {
                               <<"constructing Email object and pushing onto m_rep" << std::endl;
                 }
                 
-                m_rep.push_back(Email(buf));
+                // Moved twice over: the buffer into the Email, and the Email
+                // into the vector.  This built the message, copied it into a
+                // temporary Email, then copied that Email -- raw and body both
+                // -- into m_rep.
+                m_rep.push_back(Email(std::move(buf)));
                 m_rep.back().set_data_size(size);
                 m_filled.push_back(false);
             }

--- a/jlib/net/MFolder.cc
+++ b/jlib/net/MFolder.cc
@@ -42,7 +42,7 @@ namespace jlib {
     namespace net {
 
 
-        MFolderBuffer::MFolderBuffer(std::string path) {
+        MFolderBuffer::MFolderBuffer(const std::string& path) {
             m_scan_begin = 0;
             m_path = path;
             std::ofstream ofs(m_path.c_str(),std::ios_base::out | std::ios_base::app);

--- a/jlib/net/MFolder.hh
+++ b/jlib/net/MFolder.hh
@@ -28,7 +28,7 @@ namespace jlib {
         
         class MFolderBuffer : public FolderBuffer {
         public:
-            MFolderBuffer(std::string path);
+            MFolderBuffer(const std::string& path);
 
             virtual ~MFolderBuffer();
             
@@ -65,7 +65,7 @@ namespace jlib {
         
         class MFolder : public MailFolder {
         public:
-            MFolder(std::string path)
+            MFolder(const std::string& path)
                 : MailFolder(NULL)
             {
                 // Straight to init, which owns it.  This assigned the base's

--- a/jlib/net/MFolder.hh
+++ b/jlib/net/MFolder.hh
@@ -68,8 +68,10 @@ namespace jlib {
             MFolder(std::string path)
                 : MailFolder(NULL)
             {
-                m_rep = new MFolderBuffer(path);
-                init(m_rep);
+                // Straight to init, which owns it.  This assigned the base's
+                // m_rep and then passed the same pointer to init, which
+                // assigned it again.
+                init(new MFolderBuffer(path));
             }
                 
         };

--- a/jlib/net/MailBox.cc
+++ b/jlib/net/MailBox.cc
@@ -23,7 +23,7 @@
 namespace jlib {
 	namespace net {
 
-        MailNode::MailNode(std::string name, bool folder, bool parent) {
+        MailNode::MailNode(const std::string& name, bool folder, bool parent) {
             m_path.push_back(name);
             m_is_folder=folder;
             m_is_parent=parent;
@@ -83,7 +83,7 @@ namespace jlib {
             }
         }
 
-        void MailNode::set_name(std::string n) { 
+        void MailNode::set_name(const std::string& n) { 
             if(m_path.size() > 0) {
                 m_path.back() = n;
             }
@@ -96,7 +96,7 @@ namespace jlib {
             return m_delim; 
         }
 
-        void MailNode::set_delim(std::string n) { 
+        void MailNode::set_delim(const std::string& n) { 
             m_delim=n; 
         }
         
@@ -108,7 +108,7 @@ namespace jlib {
         
 
         std::string MailNode::pathstr(std::list<std::string> path, 
-                                      std::string delim, 
+                                      const std::string& delim, 
                                       bool begin_delim,
                                       bool end_delim,
                                       bool only_delim) {
@@ -149,7 +149,7 @@ namespace jlib {
             m_buf  = buf;
         }
 
-        MailBox::MailBox(std::string name, BoxBuf* buf) {
+        MailBox::MailBox(const std::string& name, BoxBuf* buf) {
             m_name = name;
             m_buf  = buf;
         }

--- a/jlib/net/MailBox.hh
+++ b/jlib/net/MailBox.hh
@@ -59,7 +59,7 @@ namespace jlib {
             typedef rep_type::allocator_type allocator_type;            
 
 
-            MailNode(std::string name="INBOX", bool folder=true, bool parent=false);
+            MailNode(const std::string& name="INBOX", bool folder=true, bool parent=false);
             MailNode(std::list<std::string> path, bool folder, bool parent);
 
             MailNode& operator[](unsigned int i);
@@ -76,10 +76,10 @@ namespace jlib {
             bool is_filled() const { return (m_folder != 0); }
             
             std::string get_name() const;
-            void set_name(std::string n);
+            void set_name(const std::string& n);
 
             std::string get_delim() const;
-            void set_delim(std::string n);
+            void set_delim(const std::string& n);
 
             std::list<std::string> get_path() const;
             void set_path(const std::list<std::string>& n);
@@ -106,7 +106,7 @@ namespace jlib {
             void clear() { m_children.clear(); }
 
             static std::string pathstr(std::list<std::string> path, 
-                                       std::string delim="/", 
+                                       const std::string& delim="/", 
                                        bool begin_delim = true, 
                                        bool end_delim = false,
                                        bool only_delim = false);
@@ -180,7 +180,7 @@ namespace jlib {
         public:
             class exception : public std::exception {
             public:
-                exception(std::string msg = "") {
+                exception(const std::string& msg = "") {
                     m_msg = std::string("jlib::net::MailBox exception")+( (msg=="")?"":": ")+msg;
                 }
                 virtual ~exception() throw() {}
@@ -191,7 +191,7 @@ namespace jlib {
 
 
             MailBox(BoxBuf* buf);
-            MailBox(std::string name, BoxBuf* buf);
+            MailBox(const std::string& name, BoxBuf* buf);
             virtual ~MailBox();
 
             void init();
@@ -217,7 +217,7 @@ namespace jlib {
 
             MailFolder* get_folder(std::list<std::string> path);
 
-            void set_name(std::string n) { m_name = std::move(n); }
+            void set_name(const std::string& n) { m_name = std::move(n); }
             std::string get_name() { return m_name; }
             
         protected:

--- a/jlib/net/MailBox.hh
+++ b/jlib/net/MailBox.hh
@@ -21,6 +21,7 @@
 #ifndef JLIB_NET_MAILBOX_HH
 #define JLIB_NET_MAILBOX_HH
 
+#include <utility>
 #include <string>
 #include <iostream>
 #include <map>
@@ -216,7 +217,7 @@ namespace jlib {
 
             MailFolder* get_folder(std::list<std::string> path);
 
-            void set_name(std::string n) { m_name = n; }
+            void set_name(std::string n) { m_name = std::move(n); }
             std::string get_name() { return m_name; }
             
         protected:

--- a/jlib/net/MailFetch.hh
+++ b/jlib/net/MailFetch.hh
@@ -40,7 +40,7 @@ namespace jlib {
         public:
             class exception : public std::exception {
             public:
-                exception(std::string msg = "") {
+                exception(const std::string& msg = "") {
                     m_msg = "jlib::net::MailFetch exception: "+msg;
                 }
                 virtual ~exception() throw() {}

--- a/jlib/net/MailFolder.cc
+++ b/jlib/net/MailFolder.cc
@@ -26,11 +26,10 @@ namespace jlib {
     namespace net {
         
         MailFolder::MailFolder(FolderBuffer* buffer) {
-            m_rep = buffer;
+            m_rep.reset(buffer);
         }
         
         MailFolder::~MailFolder() {
-            delete m_rep;
         }
         
         jlib::util::Headers MailFolder::get_headers(unsigned int i) {

--- a/jlib/net/MailFolder.hh
+++ b/jlib/net/MailFolder.hh
@@ -24,6 +24,8 @@
 #include <jlib/net/Email.hh>
 
 
+#include <memory>
+#include <utility>
 #include <string>
 #include <iostream>
 #include <map>
@@ -98,8 +100,27 @@ namespace jlib {
             typedef rep_type::difference_type difference_type;
             typedef rep_type::allocator_type allocator_type;
 
+            /** Takes ownership of the buffer. */
             MailFolder(FolderBuffer* buffer);
             virtual ~MailFolder();
+
+            /**
+             * Not copyable, movable.
+             *
+             * This owned its buffer through a raw pointer and deleted it,
+             * with no copy control declared, so copying one copied the
+             * pointer and both destructors freed it -- the same shape as the
+             * Date and streambuf double frees.  Nothing in the tree copies a
+             * MailFolder, and it is a polymorphic base, so a copy would slice
+             * as well as double free.  Deleted rather than fixed.
+             *
+             * Moving is fine and now works: the destructor was suppressing
+             * the implicit move operations, so std::move was a copy.
+             */
+            MailFolder(const MailFolder&) = delete;
+            MailFolder& operator=(const MailFolder&) = delete;
+            MailFolder(MailFolder&&) = default;
+            MailFolder& operator=(MailFolder&&) = default;
 
 
             virtual Email& get(unsigned int i);
@@ -129,11 +150,11 @@ namespace jlib {
             unsigned int get_size(unsigned int i);
             std::set<Email::flag_type> get_flags(unsigned int i);
 
-            void init(FolderBuffer* buffer) { m_rep = buffer; }
+            void init(FolderBuffer* buffer) { m_rep.reset(buffer); }
 
             Email copy(unsigned int i) { return get(i); }
 
-            void sort_field(std::string field) { m_sort_field = field; }
+            void sort_field(std::string field) { m_sort_field = std::move(field); }
             std::string sort_field() { return m_sort_field; }
 
             void filter_rules(std::multimap<std::string,std::string>& rules) { m_filter_rules = rules; }
@@ -154,7 +175,9 @@ namespace jlib {
             size_type size() const { return m_rep->size(); }
 
         protected:
-            FolderBuffer* m_rep;
+            // Owned.  A unique_ptr so the ownership is stated rather than
+            // implied by a delete in the destructor.
+            std::unique_ptr<FolderBuffer> m_rep;
 
             /**
              * field to sort by

--- a/jlib/net/MailFolder.hh
+++ b/jlib/net/MailFolder.hh
@@ -154,7 +154,7 @@ namespace jlib {
 
             Email copy(unsigned int i) { return get(i); }
 
-            void sort_field(std::string field) { m_sort_field = std::move(field); }
+            void sort_field(const std::string& field) { m_sort_field = std::move(field); }
             std::string sort_field() { return m_sort_field; }
 
             void filter_rules(std::multimap<std::string,std::string>& rules) { m_filter_rules = rules; }

--- a/jlib/net/Pop3.cc
+++ b/jlib/net/Pop3.cc
@@ -102,7 +102,7 @@ namespace jlib {
             handshake(sock,"DELE "+jlib::util::string_value(which), OK);
         }
         
-        std::string Pop3::handshake(jlib::sys::socketstream& sock, std::string data, std::string ok) {
+        std::string Pop3::handshake(jlib::sys::socketstream& sock, const std::string& data, const std::string& ok) {
             if(getenv("JLIB_NET_POP3_DEBUG")) std::cout << data << std::endl;
             sock << data << "\r\n" << std::flush;
             std::string buf;

--- a/jlib/net/Pop3.hh
+++ b/jlib/net/Pop3.hh
@@ -41,7 +41,7 @@ namespace jlib {
         public:
             class exception : public std::exception {
             public:
-                exception(std::string msg = "") {
+                exception(const std::string& msg = "") {
                     m_msg = "jlib::net::Pop3::exception: "+msg;
                 }
                 virtual ~exception() throw() {}
@@ -73,7 +73,7 @@ namespace jlib {
              */
             void disconnect(jlib::sys::socketstream& sock);
             
-            std::string handshake(jlib::sys::socketstream& sock, std::string data, std::string ok);
+            std::string handshake(jlib::sys::socketstream& sock, const std::string& data, const std::string& ok);
             
             jlib::util::URL m_url;
             bool m_remove;

--- a/jlib/net/net.cc
+++ b/jlib/net/net.cc
@@ -111,7 +111,7 @@ namespace jlib {
             }
         }
 
-        std::vector<std::string> parse_header(std::istream& stream, std::string header) {
+        std::vector<std::string> parse_header(std::istream& stream, const std::string& header) {
             std::vector<std::string> ret;
             std::string buf, key, val;
             std::vector<std::string>::iterator current = ret.end();
@@ -174,7 +174,7 @@ namespace jlib {
             return ret;
         }
         
-        void parse_divide(std::istream& is, std::vector<long>& divide, std::string div) {
+        void parse_divide(std::istream& is, std::vector<long>& divide, const std::string& div) {
             if(getenv("JLIB_NET_DEBUG")) {
                 std::cerr <<"net::parse_divide(is,divide,\""<<div<<"\"): entering"<<std::endl;
             }
@@ -215,7 +215,7 @@ namespace jlib {
         // Returns size_type rather than long so that npos survives the round
         // trip.  Callers used to store the result in a u_int, which truncates
         // npos (SIZE_MAX) to 0xFFFFFFFF and so never compares equal to it.
-        std::string::size_type find_end(std::string s, const std::vector<std::string>& e) {
+        std::string::size_type find_end(const std::string& s, const std::vector<std::string>& e) {
             std::string::size_type ret = s.npos;
             std::string::size_type p;
             for(std::string::size_type i=0;i<e.size();i++) {
@@ -232,7 +232,7 @@ namespace jlib {
             return ret;
         }
 
-        std::string parse_end(std::string s, const std::vector<std::string>& ends) {
+        std::string parse_end(const std::string& s, const std::vector<std::string>& ends) {
             if(ends.size() == 0) {
                 return s;
             }
@@ -276,7 +276,7 @@ namespace jlib {
             raw = tmp;
         }
 
-        bool same_address(std::string p_addr1, std::string p_addr2) {
+        bool same_address(const std::string& p_addr1, const std::string& p_addr2) {
             std::string addr1, addr2;
             
             try {
@@ -290,7 +290,7 @@ namespace jlib {
             return (addr1 == addr2);
         }
         
-        std::string extract_address(std::string p_addr) {
+        std::string extract_address(const std::string& p_addr) {
             // p was a u_int, which truncates npos to 0xFFFFFFFF, so the
             // "no @ present" guard below never fired: the function fell into
             // the else branch, where p+1 wrapped to 0, and returned a chunk of
@@ -319,7 +319,7 @@ namespace jlib {
             }
         }
 
-        std::list<std::string> extract_addresses(std::string s) {
+        std::list<std::string> extract_addresses(const std::string& s) {
             std::list<std::string> tokens = util::tokenize_list(s, ",");
             std::list<std::string> ret;
 
@@ -333,7 +333,7 @@ namespace jlib {
             return ret;
         }
 
-        std::list<std::string> split_addresses(std::string s) {
+        std::list<std::string> split_addresses(const std::string& s) {
             std::list<std::string> ret;
             std::string token;
             u_int x = 0, y;
@@ -457,7 +457,7 @@ namespace jlib {
             }    
         }
 
-        bool is_addr(std::string s) {
+        bool is_addr(const std::string& s) {
             for(std::string::size_type i=0;i<s.length();i++) {
                 if(!isdigit(s[i]) && s[i] != '.')
                     return false;
@@ -465,7 +465,7 @@ namespace jlib {
             return true;
         }
 
-        std::pair< std::string, std::vector<std::string> > get_host(std::string s) {
+        std::pair< std::string, std::vector<std::string> > get_host(const std::string& s) {
             struct hostent *h;
             std::pair< std::string, std::vector<std::string> > ret;
 
@@ -513,11 +513,11 @@ namespace jlib {
             return inet_ntoa(a);
         }
 
-        long get_ip_val(std::string addr) {
+        long get_ip_val(const std::string& addr) {
             return inet_addr(addr.c_str());
         }
 
-        bool is_reserved(std::string ip) {
+        bool is_reserved(const std::string& ip) {
             long twf_ip   = htonl(0x0a000000);
             long twf_mask = htonl(0xff000000);
             long twy_ip   = htonl(0xac100000);
@@ -538,7 +538,7 @@ namespace jlib {
 
 
         std::string pathstr(std::list<std::string> path, 
-                            std::string delim, 
+                            const std::string& delim, 
                             bool begin_delim,
                             bool end_delim,
                             bool only_delim) {
@@ -571,7 +571,7 @@ namespace jlib {
         }
 
         namespace mbox {
-            std::string make_path(std::string maildir, std::list<std::string> path) {
+            std::string make_path(const std::string& maildir, std::list<std::string> path) {
                 if(path.size() == 1 && path.front() == "INBOX") {
                     return (std::string(SYS_MAIL_DIR) + "/" + getenv("USER"));
                 } else {
@@ -580,20 +580,20 @@ namespace jlib {
 
             }
 
-            void create(std::string maildir, std::list<std::string> path) {
+            void create(const std::string& maildir, std::list<std::string> path) {
                 create(make_path(maildir, path));
             }
 
-            void create(std::string path) {
+            void create(const std::string& path) {
                 std::fstream box(path.c_str(), (std::ios_base::out|std::ios_base::app));
                 box.close();
             }
 
-            void deleet(std::string maildir, std::list<std::string> path) {
+            void deleet(const std::string& maildir, std::list<std::string> path) {
                 deleet(make_path(maildir, path));
             }
 
-            void deleet(std::string path) {
+            void deleet(const std::string& path) {
                 int e = unlink(path.c_str());
                 if(e == -1) {
                     std::ostringstream o;
@@ -602,11 +602,11 @@ namespace jlib {
                 }
             }
 
-            void rename(std::string maildir, std::list<std::string> src, std::list<std::string> dst) {
+            void rename(const std::string& maildir, std::list<std::string> src, std::list<std::string> dst) {
                 rename(make_path(maildir, src), make_path(maildir, dst));
             }
 
-            void rename(std::string src, std::string dst) {
+            void rename(const std::string& src, const std::string& dst) {
                 int e = ::rename(src.c_str(), dst.c_str());
                 if(e == -1) {
                     std::ostringstream o;
@@ -615,11 +615,11 @@ namespace jlib {
                 }
             }
 
-            void remove(std::string maildir, std::list<std::string> path, std::list<int> which, std::vector<long> divide) {
+            void remove(const std::string& maildir, std::list<std::string> path, std::list<int> which, std::vector<long> divide) {
                 remove(make_path(maildir, path), which, divide);
             }
 
-            void remove(std::string path, std::list<int> which, std::vector<long> divide) {
+            void remove(const std::string& path, std::list<int> which, std::vector<long> divide) {
                 std::vector<int> phys;
                 std::vector<int>::iterator pi;
                 for(std::list<int>::iterator i = which.begin(); i != which.end(); i++) {
@@ -652,11 +652,11 @@ namespace jlib {
                 
             }
             
-            Email get(std::string maildir, std::list<std::string> path, int i, std::vector<long> divide, bool oheader) {
+            Email get(const std::string& maildir, std::list<std::string> path, int i, std::vector<long> divide, bool oheader) {
                 return get(make_path(maildir, path), i, divide, oheader);
             }
 
-            Email get(std::string path, int i, std::vector<long> divide, bool oheader) {
+            Email get(const std::string& path, int i, std::vector<long> divide, bool oheader) {
                 std::ifstream ifs(path.c_str(), std::ios_base::in);
                 return get(ifs, i, divide, oheader);
             }
@@ -707,11 +707,11 @@ namespace jlib {
              }
 
 
-            void append(std::string maildir, std::list<std::string> path, Email e) {
+            void append(const std::string& maildir, std::list<std::string> path, Email e) {
                 append(make_path(maildir, path), e);
             }
 
-            void append(std::string path, Email e) {
+            void append(const std::string& path, Email e) {
                 std::ofstream ofs(path.c_str(), std::ios_base::out | std::ios_base::app);
                 std::ifstream ifs(path.c_str());
                 ifs.seekg(-1,std::ios_base::end);
@@ -732,7 +732,7 @@ namespace jlib {
 
         namespace smtp {
 
-            std::vector<std::string> parse(std::string field) {
+            std::vector<std::string> parse(const std::string& field) {
                 std::vector<std::string> ret;
                 std::string tmp = field;
                 tmp = util::excise(tmp, "\"", "\"");
@@ -747,7 +747,7 @@ namespace jlib {
             }
 
 
-            void handshake(sys::socketstream& stream, std::string data, std::string ok) {
+            void handshake(sys::socketstream& stream, const std::string& data, const std::string& ok) {
                 if(getenv("JLIB_NET_DEBUG"))
                     std::cerr << "SMTP << "<<data<<std::endl;
                 stream << data << "\r\n" << std::flush;
@@ -763,9 +763,10 @@ namespace jlib {
                 }
             }
             
-            //void send(std::string mail, std::string rcpt, std::string data, 
+            //void send(const std::string& mail, const std::string& rcpt, const std::string& data, 
             //std::string host, const unsigned int port) {
 
+            /** By value deliberately: data is modified in place and returned. */
             std::string convert_to_crlf(std::string data) {
                 std::string::size_type p = 0, i;
                 while( (i=data.find("\n",p)) != std::string::npos ) {
@@ -778,20 +779,20 @@ namespace jlib {
                 return data;
             }
 
-            void send(std::string mail, std::string rcpt, std::string data, sys::socketstream& stream);
-            void finish(std::string mail, std::string rcpt, std::string data, sys::socketstream& stream);
+            void send(const std::string& mail, const std::string& rcpt, const std::string& data, sys::socketstream& stream);
+            void finish(const std::string& mail, const std::string& rcpt, const std::string& data, sys::socketstream& stream);
 
-            void send(std::string mail, std::string rcpt, std::string data, std::string host, unsigned int port) {
+            void send(const std::string& mail, const std::string& rcpt, const std::string& data, const std::string& host, unsigned int port) {
                 sys::socketstream stream(host, port);
                 send(mail, rcpt, data, stream);
             }
 
-            void send_ssl(std::string mail, std::string rcpt, std::string data, std::string host, unsigned int port) {
+            void send_ssl(const std::string& mail, const std::string& rcpt, const std::string& data, const std::string& host, unsigned int port) {
                 sys::sslstream stream(host, port);
                 send(mail, rcpt, data, stream);
             }
 
-            std::list<std::string> eshake(sys::socketstream& sock, std::string data, std::string ok) {
+            std::list<std::string> eshake(sys::socketstream& sock, const std::string& data, const std::string& ok) {
                 std::list<std::string> ret;
                 std::string buf;
                 
@@ -809,7 +810,7 @@ namespace jlib {
                 return ret;
             }
 
-            void send_tls(std::string mail, std::string rcpt, std::string data, std::string host, unsigned int port) {
+            void send_tls(const std::string& mail, const std::string& rcpt, const std::string& data, const std::string& host, unsigned int port) {
                 sys::tlsstream stream(host, port, true);
                 std::list<std::string> r;
 
@@ -825,7 +826,7 @@ namespace jlib {
                 finish(mail, rcpt, data, stream);
             }
                 
-            void send_tls_auth(std::string mail, std::string rcpt, std::string data, std::string host, unsigned int port, std::string user, std::string pass) {
+            void send_tls_auth(const std::string& mail, const std::string& rcpt, const std::string& data, const std::string& host, unsigned int port, const std::string& user, const std::string& pass) {
                 sys::tlsstream stream(host, port, true);
                 std::list<std::string> r;
 
@@ -858,7 +859,7 @@ namespace jlib {
                 finish(mail, rcpt, data, stream);
             }
                 
-            void send_ssl_auth(std::string mail, std::string rcpt, std::string data, std::string host, unsigned int port, std::string user, std::string pass) {
+            void send_ssl_auth(const std::string& mail, const std::string& rcpt, const std::string& data, const std::string& host, unsigned int port, const std::string& user, const std::string& pass) {
                 sys::sslstream stream(host, port);
                 std::list<std::string> r;
 
@@ -884,7 +885,7 @@ namespace jlib {
                 finish(mail, rcpt, data, stream);
             }
                 
-            void send(std::string mail, std::string rcpt, std::string data, sys::socketstream& stream) {
+            void send(const std::string& mail, const std::string& rcpt, const std::string& data, sys::socketstream& stream) {
                 std::string helo = "localhost";
                 std::string greet;
 
@@ -898,7 +899,7 @@ namespace jlib {
                 finish(mail, rcpt, data, stream);
             }
 
-            void finish(std::string mail, std::string rcpt, std::string data, sys::socketstream& stream) {
+            void finish(const std::string& mail, const std::string& rcpt, const std::string& data, sys::socketstream& stream) {
                 handshake(stream, "MAIL FROM: <"+extract_address(mail)+">", "250");
                 
                 std::vector<std::string> rcptVec = parse(rcpt);
@@ -906,24 +907,27 @@ namespace jlib {
                     handshake(stream, "RCPT TO: <"+(*i)+">", "250");
                 }
                
-                data = convert_to_crlf(data);
+                // On a local: this rewrote its own parameter, first to
+                // canonical line endings and then to escape any end-of-message
+                // sequence in the body.
+                std::string body = convert_to_crlf(data);
                 std::string eom = "\r\n.\r\n";
                 std::string neom = "\r\n. \r\n";
-                while(data.find(eom) != data.npos) {
-                    data.replace(data.find(eom), eom.length(), neom);
+                while(body.find(eom) != body.npos) {
+                    body.replace(body.find(eom), eom.length(), neom);
                 }
                 
                 handshake(stream, "DATA", "354");
-                handshake(stream, data+eom, "250");
+                handshake(stream, body+eom, "250");
                 
                 stream.close();
             }
 
             /*
-            void send(std::string mail, std::string rcpt, std::string data, std::string host) {
+            void send(const std::string& mail, const std::string& rcpt, const std::string& data, const std::string& host) {
                 send(mail,rcpt,data,host,25);
             }
-            void send(std::string mail, std::string rcpt, std::string data) {
+            void send(const std::string& mail, const std::string& rcpt, const std::string& data) {
                 send(mail,rcpt,data,"localhost",25);
             }
             */
@@ -984,7 +988,7 @@ namespace jlib {
         }
 
         namespace html {
-            std::string render(std::string s) {
+            std::string render(const std::string& s) {
                 sys::tfstream buf;
                 std::string cmd,out,err;
 

--- a/jlib/net/net.hh
+++ b/jlib/net/net.hh
@@ -41,7 +41,7 @@ namespace jlib {
 	namespace net {
         class exception : public std::exception {
         public:
-            exception(std::string msg = "") {
+            exception(const std::string& msg = "") {
                 m_msg = (msg != "" ? ("jlib::net::exception: "+msg) : "jlib::net::exception");
             }
             virtual ~exception() throw() {}
@@ -56,15 +56,15 @@ namespace jlib {
         /**
          * get a vector of the headers whose key is header
          */
-        std::vector<std::string> parse_header(std::istream& stream, std::string header);
+        std::vector<std::string> parse_header(std::istream& stream, const std::string& header);
 
-        void parse_divide(std::istream& is, std::vector<long>& divide, std::string div);
+        void parse_divide(std::istream& is, std::vector<long>& divide, const std::string& div);
 
         /**
          * parse through s, looking for the first occurance of something in ends
          * when it's found, return the std::string up to that point
          */
-        std::string parse_end(std::string s, const std::vector<std::string>& ends);
+        std::string parse_end(const std::string& s, const std::vector<std::string>& ends);
 
         /**
          * parse through is, looking for the first occurance of something in ends
@@ -80,7 +80,7 @@ namespace jlib {
          * @param p_addr1 second address
          * @return true if same addr, ow false
          */
-        bool same_address(std::string p_addr1, std::string p_addr2);
+        bool same_address(const std::string& p_addr1, const std::string& p_addr2);
             
         /**
          * Extract the actual email address from the given string
@@ -89,7 +89,7 @@ namespace jlib {
          * @return extracted email addr
          * @throw email_exception if we can't parse a valid address from the string
          */
-        std::string extract_address(std::string p_addr);
+        std::string extract_address(const std::string& p_addr);
 
         /**
          * Extract the actual email addresses from a comma delimited string
@@ -98,7 +98,7 @@ namespace jlib {
          * @return list of extracted email addrs
          * @throw email_exception if we can't parse a valid address from the string
          */
-        std::list<std::string> extract_addresses(std::string s);
+        std::list<std::string> extract_addresses(const std::string& s);
 
         /**
          * Split the full addresses from a comma delimited string
@@ -107,7 +107,7 @@ namespace jlib {
          * @return list of split email addrs
          * @throw email_exception if we can't parse a valid address from the string
          */
-        std::list<std::string> split_addresses(std::string s);
+        std::list<std::string> split_addresses(const std::string& s);
 
         /**
          * recurse through email, building text for mime and placing it
@@ -119,53 +119,53 @@ namespace jlib {
         /**
          * Do a lookup on the passed name/addr
          */
-        std::pair< std::string, std::vector<std::string> > get_host(std::string s);
+        std::pair< std::string, std::vector<std::string> > get_host(const std::string& s);
 
-        bool is_addr(std::string s);
+        bool is_addr(const std::string& s);
 
         std::string get_ip_string(long addr);
-        long get_ip_val(std::string addr);
+        long get_ip_val(const std::string& addr);
 
-        bool is_reserved(std::string ip);
+        bool is_reserved(const std::string& ip);
 
         std::string pathstr(std::list<std::string> path, 
-                            std::string delim="/", 
+                            const std::string& delim="/", 
                             bool begin_delim = true, 
                             bool end_delim = false,
                             bool only_delim = false);
 
 
         namespace mbox {
-            std::string make_path(std::string maildir, std::list<std::string> path);
+            std::string make_path(const std::string& maildir, std::list<std::string> path);
 
-            void create(std::string maildir, std::list<std::string> path);
-            void create(std::string path);
+            void create(const std::string& maildir, std::list<std::string> path);
+            void create(const std::string& path);
 
-            void deleet(std::string maildir, std::list<std::string> path);
-            void deleet(std::string path);
+            void deleet(const std::string& maildir, std::list<std::string> path);
+            void deleet(const std::string& path);
 
-            void rename(std::string maildir, std::list<std::string> src, std::list<std::string> dst);
-            void rename(std::string src, std::string dst);
+            void rename(const std::string& maildir, std::list<std::string> src, std::list<std::string> dst);
+            void rename(const std::string& src, const std::string& dst);
 
-            void remove(std::string maildir, std::list<std::string> path, std::list<int> which, std::vector<long> divide);
-            void remove(std::string path, std::list<int> which, std::vector<long> divide);
+            void remove(const std::string& maildir, std::list<std::string> path, std::list<int> which, std::vector<long> divide);
+            void remove(const std::string& path, std::list<int> which, std::vector<long> divide);
 
-            Email get(std::string maildir, std::list<std::string> path, int i, std::vector<long> divide, bool oheader=false);
-            Email get(std::string path, int i, std::vector<long> divide, bool oheader=false);
+            Email get(const std::string& maildir, std::list<std::string> path, int i, std::vector<long> divide, bool oheader=false);
+            Email get(const std::string& path, int i, std::vector<long> divide, bool oheader=false);
             Email get(std::istream& is, int i, std::vector<long> divide, bool oheader=false);
 
-            void append(std::string maildir, std::list<std::string> path, Email e);
-            void append(std::string path, Email e);
+            void append(const std::string& maildir, std::list<std::string> path, Email e);
+            void append(const std::string& path, Email e);
         }
 
         namespace smtp {
-            void send(std::string mail, std::string rcpt, std::string data, std::string host, unsigned int port);
+            void send(const std::string& mail, const std::string& rcpt, const std::string& data, const std::string& host, unsigned int port);
 
-            void send_ssl(std::string mail, std::string rcpt, std::string data, std::string host, unsigned int port);
+            void send_ssl(const std::string& mail, const std::string& rcpt, const std::string& data, const std::string& host, unsigned int port);
 
-            void send_tls(std::string mail, std::string rcpt, std::string data, std::string host,unsigned int port);
-            void send_tls_auth(std::string mail, std::string rcpt, std::string data, std::string host,unsigned int port, std::string user, std::string pass);
-            void send_ssl_auth(std::string mail, std::string rcpt, std::string data, std::string host,unsigned int port, std::string user, std::string pass);
+            void send_tls(const std::string& mail, const std::string& rcpt, const std::string& data, const std::string& host,unsigned int port);
+            void send_tls_auth(const std::string& mail, const std::string& rcpt, const std::string& data, const std::string& host,unsigned int port, const std::string& user, const std::string& pass);
+            void send_ssl_auth(const std::string& mail, const std::string& rcpt, const std::string& data, const std::string& host,unsigned int port, const std::string& user, const std::string& pass);
         }
 
         namespace http {
@@ -202,7 +202,7 @@ namespace jlib {
         }
 
         namespace html {
-            std::string render(std::string s);
+            std::string render(const std::string& s);
         }
 
     }

--- a/jlib/sys/ASServent.hh
+++ b/jlib/sys/ASServent.hh
@@ -52,14 +52,14 @@ class ASServent {
 public:
     class exception : public std::exception {
     public:
-        exception(std::string msg = "") {
+        exception(const std::string& msg = "") {
             m_msg = "jlib::sys::ASServent<Request,Response> exception"+
                 (msg != "" ? (": "+msg):"");
         }
         virtual ~exception() throw() {}
         virtual const char* what() const throw() { return m_msg.c_str(); }
         
-        static void throw_errno(std::string msg) {
+        static void throw_errno(const std::string& msg) {
             std::ostringstream o;
             o << ((msg!="")?(msg+": "):"") << strerror(errno);
             throw exception(o.str());

--- a/jlib/sys/Directory.cc
+++ b/jlib/sys/Directory.cc
@@ -27,7 +27,7 @@
 
 namespace jlib {
     namespace sys {
-        Directory::Directory(std::string p_path) {
+        Directory::Directory(const std::string& p_path) {
             m_path = p_path;
             if(m_path != "/" && m_path[m_path.length()-1] == '/') {
                 m_path = m_path.substr(0,m_path.length()-1);
@@ -152,7 +152,7 @@ namespace jlib {
             return ret;
         }
         
-        bool Directory::is(std::string p_file, file_type p_type) const {
+        bool Directory::is(const std::string& p_file, file_type p_type) const {
             std::string file_path = m_path+"/"+p_file;
             struct stat mystat;
             if(stat(file_path.c_str(), &mystat) == -1) {
@@ -181,7 +181,7 @@ namespace jlib {
             }
         }
         
-        Directory Directory::sub(std::string file) const {
+        Directory Directory::sub(const std::string& file) const {
             return Directory(m_path+"/"+file);
         }
         

--- a/jlib/sys/Directory.hh
+++ b/jlib/sys/Directory.hh
@@ -32,7 +32,7 @@ namespace jlib {
         public:
             class exception : public std::exception {
             public:
-                exception(std::string msg = "") {
+                exception(const std::string& msg = "") {
                     m_msg = "jlib::sys::Directory exception: "+msg;
                 }
                 virtual ~exception() throw() {}
@@ -41,7 +41,7 @@ namespace jlib {
                 std::string m_msg;
             };
 
-            Directory(std::string p_path = "/");
+            Directory(const std::string& p_path = "/");
             Directory(const Directory& p_copy);
             virtual ~Directory() {}
             
@@ -50,13 +50,13 @@ namespace jlib {
             
             std::string get_path() const;
             std::string get_name() const;
-            Directory sub(std::string file) const;
+            Directory sub(const std::string& file) const;
             
             std::vector<std::string> list_files(bool p_full_path = false) const;
             std::vector<std::string> list_dirs(bool p_full_path = false) const;
             std::vector<Directory> list_subdirs() const;
             
-            bool is(std::string p_file, file_type p_type) const;
+            bool is(const std::string& p_file, file_type p_type) const;
             
             std::vector<std::string> list(file_type p_type = ALL, bool p_full_path=false, bool p_show_dots = false) const;
             

--- a/jlib/sys/Servent.hh
+++ b/jlib/sys/Servent.hh
@@ -46,14 +46,14 @@ namespace jlib {
         public:
             class exception : public std::exception {
             public:
-                exception(std::string msg = "") {
+                exception(const std::string& msg = "") {
                     m_msg = "jlib::sys::Servent exception"+
                         (msg != "" ? (": "+msg):"");
                 }
                 virtual ~exception() noexcept {}
                 virtual const char* what() const noexcept { return m_msg.c_str(); }
                 
-                static void throw_errno(std::string msg) {
+                static void throw_errno(const std::string& msg) {
                     std::ostringstream o;
                     o << ((msg!="")?(msg+": "):"") << strerror(errno);
                     throw exception(o.str());

--- a/jlib/sys/joystick.hh
+++ b/jlib/sys/joystick.hh
@@ -46,10 +46,10 @@ namespace jlib {
         public:
             class exception : public std::exception {
             public:
-                exception(std::string msg = "") {
+                exception(const std::string& msg = "") {
                     m_msg = "sys::joystick exception: " + msg;
                 }
-                exception(std::string msg, int e) {
+                exception(const std::string& msg, int e) {
                     m_msg = "sys::joystick exception: " + msg + std::strerror(e);
                 }
                 virtual ~exception() throw() {}
@@ -69,7 +69,7 @@ namespace jlib {
                 js_event jse;
             };
 
-            joystick(std::string device, bool open = true, bool write = false) 
+            joystick(const std::string& device, bool open = true, bool write = false) 
                 : m_device(device),
                   m_fd(-1)
             {
@@ -137,7 +137,7 @@ namespace jlib {
                 return data;
             }
             
-            std::string set_axes_map(std::string amap) {
+            std::string set_axes_map(const std::string& amap) {
                 std::string data(ABS_MAX + 1, 0);
 
                 if (ioctl(m_fd, JSIOCSAXMAP, amap.data()) < 0)
@@ -159,7 +159,7 @@ namespace jlib {
                 return data;
             }
             
-            std::string set_button_map(std::string amap) {
+            std::string set_button_map(const std::string& amap) {
                 std::string data(KEY_MAX - BTN_MISC + 1, 0);
 
                 if (ioctl(m_fd, JSIOCSBTNMAP, amap.data()) < 0)

--- a/jlib/sys/pipe.hh
+++ b/jlib/sys/pipe.hh
@@ -39,14 +39,14 @@ namespace jlib {
         public:
             class exception : public std::exception {
             public:
-                exception(std::string msg = "") {
+                exception(const std::string& msg = "") {
                     m_msg = "jlib::sys::pipe exception"+
                         (msg != "" ? (": "+msg):"");
                 }
                 virtual ~exception() throw() {}
                 virtual const char* what() const throw() { return m_msg.c_str(); }
                 
-                [[noreturn]] static void throw_errno(std::string msg) {
+                [[noreturn]] static void throw_errno(const std::string& msg) {
                     std::ostringstream o;
                     o << ((msg!="")?(msg+": "):"") << strerror(errno);
                     throw exception(o.str());

--- a/jlib/sys/proxystream.hh
+++ b/jlib/sys/proxystream.hh
@@ -42,8 +42,8 @@ public:
     
     static const unsigned int BUF_SIZE = 1024;
     
-    basic_proxybuf(std::string host, u_int port,
-                   std::string phost, u_int pport) 
+    basic_proxybuf(const std::string& host, u_int port,
+                   const std::string& phost, u_int pport) 
         : basic_socketbuf<charT,traitT>(phost,pport),
         m_proxy_host(host),
         m_proxy_port(port)
@@ -135,16 +135,16 @@ public:
         : basic_socketstream<charT,traitT>()
     {}
     
-    basic_proxystream(std::string host, unsigned int port,
-                      std::string phost, u_int pport) 
+    basic_proxystream(const std::string& host, unsigned int port,
+                      const std::string& phost, u_int pport) 
         : basic_socketstream<charT,traitT>()
     {
         this->m_buf=new basic_proxybuf<charT,traitT>(host,port,phost,pport);
         this->init(this->m_buf);
     }
             
-    void open(std::string host, unsigned int port,
-              std::string phost, u_int pport) 
+    void open(const std::string& host, unsigned int port,
+              const std::string& phost, u_int pport) 
     {
         this->m_buf=new basic_proxybuf<charT,traitT>(host,port,phost,pport);
         this->init(this->m_buf);

--- a/jlib/sys/pstream.hh
+++ b/jlib/sys/pstream.hh
@@ -49,7 +49,7 @@ namespace jlib {
             
             static const unsigned int BUF_SIZE = 1024;
 
-            basic_procbuf(std::string cmd, std::ios_base::openmode mode) {
+            basic_procbuf(const std::string& cmd, std::ios_base::openmode mode) {
                 char_type* tmp;
                 
                 tmp = new char_type[BUF_SIZE];
@@ -161,7 +161,7 @@ namespace jlib {
             int exitval() { return m_exitval; }
 
         protected:
-            void open_process(std::string cmd, std::ios_base::openmode mode) {
+            void open_process(const std::string& cmd, std::ios_base::openmode mode) {
                 m_cmd = cmd;
                 m_mode = mode;
                 m_filep = 0;
@@ -195,7 +195,7 @@ namespace jlib {
                 m_buf = 0;
             }
 
-            basic_pstream(std::string cmd, std::ios_base::openmode mode)
+            basic_pstream(const std::string& cmd, std::ios_base::openmode mode)
                 : std::basic_iostream<charT,traitT>(NULL)
             {
                 m_buf = 0;
@@ -208,7 +208,7 @@ namespace jlib {
                     delete m_buf;
             }
             
-            void open(std::string cmd, std::ios_base::openmode mode) {
+            void open(const std::string& cmd, std::ios_base::openmode mode) {
                 if(m_buf != 0)
                     delete m_buf;
                 m_buf=new basic_procbuf<charT,traitT>(cmd,mode);

--- a/jlib/sys/serialstream.hh
+++ b/jlib/sys/serialstream.hh
@@ -34,7 +34,7 @@ namespace jlib {
         public:
             class exception : public std::exception {
             public:
-                exception(std::string msg = "") {
+                exception(const std::string& msg = "") {
                     m_msg = "serial exception: "+msg;
                 }
                 virtual ~exception() throw() {}
@@ -51,7 +51,7 @@ namespace jlib {
             
             static const unsigned int BUF_SIZE = 1024;
 
-            basic_serialbuf(std::string dev, std::ios_base::openmode mode);
+            basic_serialbuf(const std::string& dev, std::ios_base::openmode mode);
             virtual ~basic_serialbuf();
 
             virtual int_type underflow();
@@ -61,7 +61,7 @@ namespace jlib {
             void close();
 
         protected:
-            void open_serial(std::string dev, std::ios_base::openmode mode);
+            void open_serial(const std::string& dev, std::ios_base::openmode mode);
 
             std::string m_dev;
             unsigned int m_port;
@@ -72,9 +72,9 @@ namespace jlib {
         class basic_serialstream : public std::basic_iostream<charT> {
         public:
             basic_serialstream();
-            basic_serialstream(std::string dev, std::ios_base::openmode mode);
+            basic_serialstream(const std::string& dev, std::ios_base::openmode mode);
 
-            void open(std::string dev, std::ios_base::openmode mode);
+            void open(const std::string& dev, std::ios_base::openmode mode);
             void close();
         private:
             basic_serialbuf<charT,traitT>* m_buf;

--- a/jlib/sys/socketstream.hh
+++ b/jlib/sys/socketstream.hh
@@ -46,7 +46,7 @@ namespace jlib {
         public:
             class exception : public std::exception {
             public:
-                exception(std::string msg = "") {
+                exception(const std::string& msg = "") {
                     m_msg = "socket exception: "+msg;
                 }
                 virtual ~exception() throw() {}
@@ -63,7 +63,7 @@ namespace jlib {
             
             static const unsigned int BUF_SIZE = 1024;
 
-            basic_socketbuf(std::string host, unsigned int port) {
+            basic_socketbuf(const std::string& host, unsigned int port) {
                 char_type* tmp;
                 
                 tmp = new char_type[BUF_SIZE];
@@ -174,7 +174,7 @@ namespace jlib {
             int get_socket() { return m_sock; }
             
         protected:
-            void open_socket(std::string host, unsigned int port) {
+            void open_socket(const std::string& host, unsigned int port) {
                 m_host = host;
                 m_port = port;
 
@@ -239,7 +239,7 @@ namespace jlib {
                 //exceptions(std::ios_base::badbit);
             }
 
-            basic_socketstream(std::string host, unsigned int port)
+            basic_socketstream(const std::string& host, unsigned int port)
                 : std::basic_iostream<charT,traitT>(NULL)
             {
                 m_buf = 0;
@@ -253,7 +253,7 @@ namespace jlib {
                     delete m_buf;
             }
             
-            void open(std::string host, unsigned int port) {
+            void open(const std::string& host, unsigned int port) {
                 if(m_buf != 0)
                     delete m_buf;
                 m_buf=new basic_socketbuf<charT,traitT>(host,port);

--- a/jlib/sys/sslproxystream.hh
+++ b/jlib/sys/sslproxystream.hh
@@ -41,8 +41,8 @@ namespace jlib {
             
             static const unsigned int BUF_SIZE = 1024;
 
-            basic_sslproxybuf(std::string host, unsigned int port, 
-                              std::string phost, u_int pport)
+            basic_sslproxybuf(const std::string& host, unsigned int port, 
+                              const std::string& phost, u_int pport)
                 : basic_proxybuf<charT,traitT>(host,port,phost,pport)
             {
                 open_ssl();
@@ -173,16 +173,16 @@ namespace jlib {
                 : basic_proxystream<charT,traitT>()
             {}
 
-            basic_sslproxystream(std::string host, unsigned int port,
-                                 std::string phost, u_int pport) 
+            basic_sslproxystream(const std::string& host, unsigned int port,
+                                 const std::string& phost, u_int pport) 
                 : basic_proxystream<charT,traitT>()
             {
                 this->m_buf=new basic_sslproxybuf<charT,traitT>(host,port,phost,pport);
                 this->init(this->m_buf);
             }
             
-            void open(std::string host, unsigned int port,
-                      std::string phost, u_int pport) 
+            void open(const std::string& host, unsigned int port,
+                      const std::string& phost, u_int pport) 
             {
                 this->m_buf=new basic_sslproxybuf<charT,traitT>(host,port,phost,pport);
                 this->init(this->m_buf);

--- a/jlib/sys/sslstream.hh
+++ b/jlib/sys/sslstream.hh
@@ -43,7 +43,7 @@ namespace jlib {
             
             static const unsigned int BUF_SIZE = 1024;
 
-            basic_sslbuf(std::string host, unsigned int port, const SSL_METHOD* method, bool delay = false)
+            basic_sslbuf(const std::string& host, unsigned int port, const SSL_METHOD* method, bool delay = false)
                 : basic_socketbuf<charT,traitT>(host,port),
                   m_ctx(0),
                   m_ssl(0),
@@ -146,7 +146,7 @@ namespace jlib {
 
         protected:
 
-            std::string print(std::string ctx, int err) {
+            std::string print(const std::string& ctx, int err) {
                 std::ostringstream o;
                 o << ctx << " failed: ";
                 
@@ -190,7 +190,7 @@ namespace jlib {
                 return o.str();
             }
 
-            void throw_if(std::string ctx, int err) {
+            void throw_if(const std::string& ctx, int err) {
                 if(err <= 0) 
                     throw typename basic_socketbuf<charT, traitT>::exception(this->print(ctx, err));
             }
@@ -261,14 +261,14 @@ namespace jlib {
                 : basic_socketstream<charT,traitT>()
             {}
 
-            basic_sslstream(std::string host, unsigned int port) 
+            basic_sslstream(const std::string& host, unsigned int port) 
                 : basic_socketstream<charT,traitT>()
             {
                 this->m_buf=new basic_sslbuf<charT,traitT>(host, port, TLS_client_method());
                 this->init(this->m_buf);
             }
             
-            void open(std::string host, unsigned int port) {
+            void open(const std::string& host, unsigned int port) {
                 this->m_buf=new basic_sslbuf<charT,traitT>(host, port, TLS_client_method());
                 this->init(this->m_buf);
             }
@@ -282,7 +282,7 @@ namespace jlib {
                 : basic_socketstream<charT,traitT>()
             {}
 
-            basic_tlsstream(std::string host, unsigned int port, bool delay = false) 
+            basic_tlsstream(const std::string& host, unsigned int port, bool delay = false) 
                 : basic_socketstream<charT,traitT>()
             {
                 if(getenv("JLIB_SYS_SOCKET_DEBUG"))
@@ -291,7 +291,7 @@ namespace jlib {
                 this->init(this->m_buf);
             }
             
-            void open(std::string host, unsigned int port, bool delay = false) {
+            void open(const std::string& host, unsigned int port, bool delay = false) {
                 this->m_buf=new basic_sslbuf<charT,traitT>(host,port, TLS_client_method(), delay);
                 this->init(this->m_buf);
             }

--- a/jlib/sys/sync.hh
+++ b/jlib/sys/sync.hh
@@ -36,7 +36,7 @@ namespace sys {
 
 class sync_exception : public std::exception {
 public:
-    sync_exception(std::string msg = "") {
+    sync_exception(const std::string& msg = "") {
         m_msg = "sys exception: "+msg;
     }
     virtual ~sync_exception() throw() {}

--- a/jlib/sys/sys.cc
+++ b/jlib/sys/sys.cc
@@ -115,7 +115,7 @@ namespace jlib {
         // to void*(*)(void*) and call through it, which is undefined behaviour,
         // and hand-managed the slot with new/delete.  std::thread does both
         // correctly and needs neither.
-        void thread(const std::function<void()>& slt, std::string s) {
+        void thread(const std::function<void()>& slt, const std::string& s) {
             if(std::getenv("JLIB_SYS_DEBUG"))
                 std::cout << "entering jlib::sys::thread()"<<std::endl;
 
@@ -156,7 +156,7 @@ namespace jlib {
                 std::cout << "leaving jlib::sys::thread()"<<std::endl;
         }
         
-        void lock(std::string s) {
+        void lock(const std::string& s) {
             if(std::getenv("JLIB_SYS_DEBUG"))
                 std::cout << "entering jlib::sys::lock(\""<<s<<"\")"<<std::endl;
             named_mutex(s).lock();
@@ -164,7 +164,7 @@ namespace jlib {
                 std::cout << "leaving jlib::sys::lock(\""<<s<<"\")"<<std::endl;
         }
         
-        void unlock(std::string s) {
+        void unlock(const std::string& s) {
             if(std::getenv("JLIB_SYS_DEBUG"))
                 std::cout << "entering jlib::sys::unlock(\""<<s<<"\")"<<std::endl;
             // As before, unlocking a name that was never locked is a no-op
@@ -178,7 +178,7 @@ namespace jlib {
                 std::cout << "leaving jlib::sys::unlock(\""<<s<<"\")"<<std::endl;
         }
 
-        bool locked(std::string s) {
+        bool locked(const std::string& s) {
             std::mutex& m = named_mutex(s);
             if(m.try_lock()) {
                 m.unlock();
@@ -187,23 +187,23 @@ namespace jlib {
             return true;
         }
 
-        void shell(std::string cmd) {
+        void shell(const std::string& cmd) {
             tfstream stderrstr;
             std::string err;
-            cmd = cmd + " 2>"+stderrstr.get_path();
-            int ret = system(cmd.c_str());
+            const std::string line = cmd + " 2>"+stderrstr.get_path();
+            int ret = system(line.c_str());
             stderrstr.seekg(0,std::ios_base::beg);
             getstring(stderrstr,err);
 
             if(ret != 0) {
-                throw sys_exception("error running shell command '"+cmd+"': '"+err+"'");
+                throw sys_exception("error running shell command '"+line+"': '"+err+"'");
             }
         }
 
-        void shell(std::string cmd, std::string& out, std::string& err) {
+        void shell(const std::string& cmd, std::string& out, std::string& err) {
             tfstream stdoutstr, stderrstr;
-            cmd = cmd + " >"+stdoutstr.get_path()+" 2>"+stderrstr.get_path();
-            int ret = system(cmd.c_str());
+            const std::string line = cmd + " >"+stdoutstr.get_path()+" 2>"+stderrstr.get_path();
+            int ret = system(line.c_str());
 
             stdoutstr.seekg(0,std::ios_base::beg);
             stderrstr.seekg(0,std::ios_base::beg);
@@ -212,22 +212,24 @@ namespace jlib {
             getstring(stderrstr,err);
 
             if(ret != 0) {
-                throw sys_exception("error running shell command '"+cmd+"': '"+err+"'");
+                throw sys_exception("error running shell command '"+line+"': '"+err+"'");
             }
         }
 
-        void shell(std::string cmd, std::string in, std::string& out, std::string& err, bool in_file) {
+        void shell(const std::string& cmd, const std::string& in, std::string& out, std::string& err, bool in_file) {
             tfstream stdinstr, stdoutstr, stderrstr;
+            std::string line;
+
             if(in_file) {
                 stdinstr.close();
-                cmd = cmd+" <"+in+" >"+stdoutstr.get_path()+" 2>"+stderrstr.get_path();
+                line = cmd + " <"+in+" >"+stdoutstr.get_path()+" 2>"+stderrstr.get_path();
             }
             else {
                 stdinstr << in;
                 stdinstr.close();
-                cmd = cmd+" <"+stdinstr.get_path()+" >"+stdoutstr.get_path()+" 2>"+stderrstr.get_path();
+                line = cmd + " <"+stdinstr.get_path()+" >"+stdoutstr.get_path()+" 2>"+stderrstr.get_path();
             }
-            int ret = system(cmd.c_str());
+            int ret = system(line.c_str());
             stdoutstr.seekg(0,std::ios_base::beg);
             stderrstr.seekg(0,std::ios_base::beg);
             
@@ -235,14 +237,14 @@ namespace jlib {
             getstring(stderrstr,err);
 
             if(ret != 0) {
-                throw sys_exception("error running shell command '"+cmd+"': '"+err+"'");
+                throw sys_exception("error running shell command '"+line+"': '"+err+"'");
             }
         }
 
-        void secure_shell(std::string cmd, std::string& out, std::string& err) {
+        void secure_shell(const std::string& cmd, std::string& out, std::string& err) {
             stfstream stdoutstr, stderrstr;
-            cmd = cmd + " >"+stdoutstr.get_path()+" 2>"+stderrstr.get_path();
-            int ret = system(cmd.c_str());
+            const std::string line = cmd + " >"+stdoutstr.get_path()+" 2>"+stderrstr.get_path();
+            int ret = system(line.c_str());
             stdoutstr.seekg(0,std::ios_base::beg);
             stderrstr.seekg(0,std::ios_base::beg);
             
@@ -250,22 +252,24 @@ namespace jlib {
             getstring(stderrstr,err);
 
             if(ret != 0) {
-                throw sys_exception("error running shell command '"+cmd+"': '"+err+"'");
+                throw sys_exception("error running shell command '"+line+"': '"+err+"'");
             }
         }
 
-        void secure_shell(std::string cmd, std::string in, std::string& out, std::string& err, bool in_file) {
+        void secure_shell(const std::string& cmd, const std::string& in, std::string& out, std::string& err, bool in_file) {
             stfstream stdinstr, stdoutstr, stderrstr;
+            std::string line;
+
             if(in_file) {
                 stdinstr.close();
-                cmd = cmd+" <"+in+" >"+stdoutstr.get_path()+" 2>"+stderrstr.get_path();
+                line = cmd + " <"+in+" >"+stdoutstr.get_path()+" 2>"+stderrstr.get_path();
             }
             else {
                 stdinstr << in;
                 stdinstr.close();
-                cmd = cmd+" <"+stdinstr.get_path()+" >"+stdoutstr.get_path()+" 2>"+stderrstr.get_path();
+                line = cmd + " <"+stdinstr.get_path()+" >"+stdoutstr.get_path()+" 2>"+stderrstr.get_path();
             }
-            int ret = system(cmd.c_str());
+            int ret = system(line.c_str());
             stdoutstr.seekg(0,std::ios_base::beg);
             stderrstr.seekg(0,std::ios_base::beg);
             
@@ -273,7 +277,7 @@ namespace jlib {
             getstring(stderrstr,err);
 
             if(ret != 0) {
-                throw sys_exception("error running shell command '"+cmd+"': '"+err+"'");
+                throw sys_exception("error running shell command '"+line+"': '"+err+"'");
             }
         }
 

--- a/jlib/sys/sys.hh
+++ b/jlib/sys/sys.hh
@@ -32,7 +32,7 @@ namespace jlib {
 
         class io_exception : public std::exception {
         public:
-            io_exception(std::string msg = "") {
+            io_exception(const std::string& msg = "") {
                 m_msg = "io exception: "+msg;
             }
             virtual ~io_exception() throw() {}
@@ -43,7 +43,7 @@ namespace jlib {
         
         class sys_exception : public std::exception {
         public:
-            sys_exception(std::string msg = "") {
+            sys_exception(const std::string& msg = "") {
                 m_msg = "sys exception: "+msg;
             }
             virtual ~sys_exception() throw() {}
@@ -74,36 +74,36 @@ namespace jlib {
          * before and unlock after
          *
          */
-        void thread(const std::function<void()>& slot, std::string s="");
+        void thread(const std::function<void()>& slot, const std::string& s="");
 
         /**
          * lock a global mutex referred to by s
          */
-        void lock(std::string s);
+        void lock(const std::string& s);
 
         /**
          * lock a global mutex referred to by s
          */
-        void unlock(std::string s);
+        void unlock(const std::string& s);
 
         /**
          * is the mutex locked?
          */
-        bool locked(std::string s);
+        bool locked(const std::string& s);
 
         /**
          * run the std::string as a shell command, and throw an exception
          * if the command fails
          * 
          */
-        void shell(std::string cmd);
+        void shell(const std::string& cmd);
 
         /**
          * run the std::string as a shell command, and throw an exception
          * if the command fails.  return stdout and stderr in the passed
          * strings.
          */
-        void shell(std::string cmd, std::string& out, std::string& err);
+        void shell(const std::string& cmd, std::string& out, std::string& err);
 
         /**
          * run the std::string as a shell command, and throw an exception
@@ -114,7 +114,7 @@ namespace jlib {
          * the shell command using stdin.  The flag input_file tells whether
          * the parameter 'in' is a file path or a plain string.
          */
-        void shell(std::string cmd, std::string in, std::string& out, std::string& err, bool in_file=true);
+        void shell(const std::string& cmd, const std::string& in, std::string& out, std::string& err, bool in_file=true);
 
         /**
          * run the std::string as a shell command, and throw an exception
@@ -124,7 +124,7 @@ namespace jlib {
          * to keep anyone from recovering the contents.
          *
          */
-        void secure_shell(std::string cmd, std::string& out, std::string& err);
+        void secure_shell(const std::string& cmd, std::string& out, std::string& err);
 
         /**
          * run the std::string as a shell command, and throw an exception
@@ -137,7 +137,7 @@ namespace jlib {
          * the shell command using stdin.  The flag input_file tells whether
          * the parameter 'in' is a file path or a plain string.
          */
-        void secure_shell(std::string cmd, std::string in, std::string& out, std::string& err, bool in_file=false);
+        void secure_shell(const std::string& cmd, const std::string& in, std::string& out, std::string& err, bool in_file=false);
 
 
     }

--- a/jlib/sys/tfstream.hh
+++ b/jlib/sys/tfstream.hh
@@ -32,7 +32,7 @@ namespace jlib {
         public:
             class exception : public std::exception {
             public:
-                exception(std::string msg = "") {
+                exception(const std::string& msg = "") {
                     m_msg = "jlib::sys::tfstream exception: "+msg;
                 }
                 virtual ~exception() throw() {}

--- a/jlib/util/Date.cc
+++ b/jlib/util/Date.cc
@@ -102,7 +102,7 @@ namespace jlib {
             m_time.tm_isdst = t->tm_isdst;
         }
         
-        int Date::find_month(std::string s, name_format f) const {
+        int Date::find_month(const std::string& s, name_format f) const {
             switch(f) {
             case SHORT:
                 for(int i=0; i<MONTH_MAX; i++) {
@@ -123,7 +123,7 @@ namespace jlib {
             }
         }
         
-        int Date::find_weekday(std::string s, name_format f) const {
+        int Date::find_weekday(const std::string& s, name_format f) const {
             switch(f) {
             case SHORT:
                 for(int i=0; i<WEEK_MAX; i++) {
@@ -152,7 +152,7 @@ namespace jlib {
 
             return mktime(&t);
         }
-        std::string Date::build_date(std::string fmt) const {
+        std::string Date::build_date(const std::string& fmt) const {
             std::ostringstream os;
             std::string::size_type i = fmt.find("%");
             
@@ -289,7 +289,7 @@ namespace jlib {
         }
         
         
-        void Date::build_date(std::istream& is, std::string fmt) {
+        void Date::build_date(std::istream& is, const std::string& fmt) {
             std::string::size_type i = fmt.find("%");
             
             int ibuf;
@@ -524,11 +524,11 @@ namespace jlib {
             build_date(is2,fmt);
         }
         
-        std::string Date::get(std::string fmt) const {
+        std::string Date::get(const std::string& fmt) const {
             return build_date(fmt);
         }
         
-        void Date::set(std::string s, std::string fmt) {
+        void Date::set(const std::string& s, const std::string& fmt) {
             //std::cout << "setting "<<s<<" to format "<<fmt<<std::endl;
             std::memset(&m_time, 0, sizeof(struct tm));
             m_current_tz = "";
@@ -553,7 +553,7 @@ namespace jlib {
             }
         }
         
-        std::string Date::sanitize(std::string s) const {
+        std::string Date::sanitize(const std::string& s) const {
             std::string ret = s;
             std::string bad = "();,\"\'[]";
             std::string::size_type i;
@@ -563,7 +563,7 @@ namespace jlib {
             return ret;
         }
         
-        bool Date::is_alpha(std::string s) const {
+        bool Date::is_alpha(const std::string& s) const {
             for(std::string::size_type i=0; i<s.length(); i++) {
                 if(!isalpha(s[i]))
                     return false;
@@ -571,7 +571,7 @@ namespace jlib {
             return true;
         }
         
-        bool Date::is_digit(std::string s) const {
+        bool Date::is_digit(const std::string& s) const {
             for(std::string::size_type i=0; i<s.length(); i++) {
                 if(!isdigit(s[i]))
                     return false;
@@ -579,7 +579,7 @@ namespace jlib {
             return true;
         }
         
-        std::string Date::first_upper(std::string s) const {
+        std::string Date::first_upper(const std::string& s) const {
             std::string ret = s;
             if(s.length()) {
                 ret[0] = toupper(s[0]);
@@ -590,7 +590,7 @@ namespace jlib {
             return ret;
         }
         
-        bool Date::is_time(std::string s) const {
+        bool Date::is_time(const std::string& s) const {
             return (
                     s.length() == 8 &&
                     isdigit(s[0]) &&
@@ -604,7 +604,7 @@ namespace jlib {
                     );
         }
         
-        bool Date::is_timezone(std::string s) const {
+        bool Date::is_timezone(const std::string& s) const {
             /*
               bool nzone = ( (s.length() == 5) && (s[0] == '-' || s[0] == '+') && (is_digit(s.substr(1,4))) );
               
@@ -624,11 +624,11 @@ namespace jlib {
         }
         
         
-        bool Date::is_date(std::string s) const {
+        bool Date::is_date(const std::string& s) const {
             return true;
         }
         
-        std::string Date::which_date(std::string s) const {
+        std::string Date::which_date(const std::string& s) const {
             return s;
         }
         

--- a/jlib/util/Date.cc
+++ b/jlib/util/Date.cc
@@ -44,55 +44,62 @@ const int WEEK_MAX=8;
 namespace jlib {
     namespace util {
         Date::Date() {
-            m_time = new struct tm;
             m_tz_name = create_tz_names();
             m_tz_val = create_tz_vals();
             set();
         }
         
         Date::Date(time_t secs) {
-            m_time = new struct tm;
             set(secs);
         }
         
         Date::Date(struct tm* t) {
-            m_time = new struct tm;
             set(t);
         }
         
         Date::~Date() {
-            delete m_time;
         }
-        
+
         void Date::set() {
             time_t now = ::time(0);
-            set(localtime(&now));
-            if(m_time == 0)
+
+            // Checked here rather than after the fact.  This tested m_time for
+            // null once m_time was the thing being written, which said nothing
+            // about whether localtime had failed.
+            struct tm* t = localtime(&now);
+            if(t == 0)
                 throw exception("error calling localtime(time_t*) in xdbc::Date::set()");
+
+            set(t);
         }
         
         /**
          * set from the seconds value passed
          */
         void Date::set(time_t secs) {
-            set(localtime(&secs));
-            if(m_time == 0)
+            struct tm* t = localtime(&secs);
+            if(t == 0)
                 throw exception("error calling localtime(time_t*) in xdbc::Date::set(time_t)");
+
+            set(t);
         }
         
         /**
          * set from the timeval* passed
          */
         void Date::set(struct tm* t) {
-            m_time->tm_sec = t->tm_sec;
-            m_time->tm_min = t->tm_min;
-            m_time->tm_hour = t->tm_hour;
-            m_time->tm_mday = t->tm_mday;
-            m_time->tm_mon = t->tm_mon;
-            m_time->tm_year = t->tm_year;
-            m_time->tm_wday = t->tm_wday;
-            m_time->tm_yday = t->tm_yday;
-            m_time->tm_isdst = t->tm_isdst;
+            if(t == 0)
+                throw exception("set(struct tm*): null");
+
+            m_time.tm_sec = t->tm_sec;
+            m_time.tm_min = t->tm_min;
+            m_time.tm_hour = t->tm_hour;
+            m_time.tm_mday = t->tm_mday;
+            m_time.tm_mon = t->tm_mon;
+            m_time.tm_year = t->tm_year;
+            m_time.tm_wday = t->tm_wday;
+            m_time.tm_yday = t->tm_yday;
+            m_time.tm_isdst = t->tm_isdst;
         }
         
         int Date::find_month(std::string s, name_format f) const {
@@ -137,7 +144,13 @@ namespace jlib {
             }
         }
         time_t Date::time() const {
-            return mktime(m_time);
+            // On a copy.  mktime normalizes the struct it is handed, so this
+            // was writing to the object from a const method -- which compiled
+            // only because m_time was a pointer, and pointing at non-const
+            // data through a const member is not a const member.
+            struct tm t = m_time;
+
+            return mktime(&t);
         }
         std::string Date::build_date(std::string fmt) const {
             std::ostringstream os;
@@ -160,38 +173,38 @@ namespace jlib {
             sfmt.append(fmt[i],1);
             switch(fmt[i]) {
             case 'H':
-                os << std::setw(2) << std::setfill('0') << m_time->tm_hour ;
+                os << std::setw(2) << std::setfill('0') << m_time.tm_hour ;
                 break;
             case 'I':
-                if(m_time->tm_hour == 0) {
+                if(m_time.tm_hour == 0) {
                     os << std::setw(2) << std::setfill('0') << 12 ;
                 }
-                else if(m_time->tm_hour <= 12) {
-                    os << std::setw(2) << std::setfill('0') << m_time->tm_hour ;
+                else if(m_time.tm_hour <= 12) {
+                    os << std::setw(2) << std::setfill('0') << m_time.tm_hour ;
                 }
                 else {
-                    os << std::setw(2) << std::setfill('0') << (m_time->tm_hour - 12) ;
+                    os << std::setw(2) << std::setfill('0') << (m_time.tm_hour - 12) ;
                 }
                 break;
             case 'k':
-                os << std::setw(2) << std::setfill(' ') << m_time->tm_hour ;
+                os << std::setw(2) << std::setfill(' ') << m_time.tm_hour ;
                 break;
             case 'l':
-                if(m_time->tm_hour == 0) {
+                if(m_time.tm_hour == 0) {
                     os << std::setw(2) << std::setfill(' ') << 12 ;
                 }
-                else if(m_time->tm_hour <= 12) {
-                    os << std::setw(2) << std::setfill(' ') << m_time->tm_hour ;
+                else if(m_time.tm_hour <= 12) {
+                    os << std::setw(2) << std::setfill(' ') << m_time.tm_hour ;
                 }
                 else {
-                    os << std::setw(2) << std::setfill(' ') << (m_time->tm_hour - 12) ;
+                    os << std::setw(2) << std::setfill(' ') << (m_time.tm_hour - 12) ;
                 }
                 break;
             case 'M':
-                os << std::setw(2) << std::setfill('0') << m_time->tm_min ;
+                os << std::setw(2) << std::setfill('0') << m_time.tm_min ;
                 break;
             case 'p':
-                if(m_time->tm_hour >= 12) {
+                if(m_time.tm_hour >= 12) {
                     os << "PM" ;
                 }
                 else {
@@ -202,10 +215,13 @@ namespace jlib {
                 os << build_date("%I:%M:%S %p") ;
                 break;
             case 's':
-                os << mktime(m_time) ;
+                {
+                    struct tm t = m_time;
+                    os << mktime(&t);
+                }
                 break;
             case 'S':
-                os << std::setw(2) << std::setfill('0') << m_time->tm_sec ;
+                os << std::setw(2) << std::setfill('0') << m_time.tm_sec ;
                 break;
             case 'T':
                 os << build_date("%H:%M:%S");
@@ -220,39 +236,39 @@ namespace jlib {
                 os << tzname[0] ;
                 break;
             case 'a':
-                os << short_weekdays[m_time->tm_wday] ;
+                os << short_weekdays[m_time.tm_wday] ;
                 break;
             case 'A':
-                os << long_weekdays[m_time->tm_wday] ;
+                os << long_weekdays[m_time.tm_wday] ;
                 break;
             case 'b':
-                os << short_months[m_time->tm_mon] ;
+                os << short_months[m_time.tm_mon] ;
                 break;
             case 'B':
-                os << long_months[m_time->tm_mon] ;
+                os << long_months[m_time.tm_mon] ;
                 break;
             case 'c':
                 os << build_date("%a %b %d %X %Z %Y") ;
                 break;
             case 'd':
-                os <<std::setw(2) <<std::setfill('0') << m_time->tm_mday;
+                os <<std::setw(2) <<std::setfill('0') << m_time.tm_mday;
                 break;
             case 'D':
                 os << build_date("%m/%d/%y") ;
                 break;
             case 'h':
-                os << short_months[m_time->tm_wday] ;
+                os << short_months[m_time.tm_wday] ;
                 break;
             case 'j':
-                os <<std::setw(3) <<std::setfill('0') << m_time->tm_yday;
+                os <<std::setw(3) <<std::setfill('0') << m_time.tm_yday;
                 break;
             case 'm':
-                os <<std::setw(2) <<std::setfill('0') << (m_time->tm_mon+1);
+                os <<std::setw(2) <<std::setfill('0') << (m_time.tm_mon+1);
                 break;
             case 'U':
                 break;
             case 'w':
-                os <<std::setw(2) <<std::setfill('0') << m_time->tm_wday;
+                os <<std::setw(2) <<std::setfill('0') << m_time.tm_wday;
                 break;
             case 'W':
                 break;
@@ -260,10 +276,10 @@ namespace jlib {
                 os << build_date("%D") ;
                 break;
             case 'y':
-                os << std::setw(2) << std::setfill('0') << (m_time->tm_year % 100) ;
+                os << std::setw(2) << std::setfill('0') << (m_time.tm_year % 100) ;
                 break;
             case 'Y':
-                os << (m_time->tm_year + 1900) ;
+                os << (m_time.tm_year + 1900) ;
                 break;
             default:
                 throw exception("bad format std::string '"+fmt+"': the directive that failed was "+sfmt);
@@ -300,11 +316,11 @@ namespace jlib {
             case 'H':
             case 'k':
                 is >> ibuf;
-                m_time->tm_hour = ibuf;
+                m_time.tm_hour = ibuf;
                 break;
             case 'M':
                 is >> ibuf;
-                m_time->tm_min = ibuf;
+                m_time.tm_min = ibuf;
                 break;
             case 'p':
                 is >> sbuf;
@@ -319,7 +335,7 @@ namespace jlib {
                 if(sbuf == "AM") {
                 }
                 else if(sbuf == "PM") {
-                    m_time->tm_hour += 12;
+                    m_time.tm_hour += 12;
                 }
                 else {
                     throw exception("bad AM/PM specifier '"+sbuf+"' in format '"+fmt+"'");
@@ -331,7 +347,7 @@ namespace jlib {
                 break;
             case 'S':
                 is >> ibuf;
-                m_time->tm_sec = ibuf;
+                m_time.tm_sec = ibuf;
                 break;
             case 'T':
                 build_date(is, "%H:%M:%S");
@@ -343,7 +359,7 @@ namespace jlib {
                 is >> sbuf;
                 /*
                   if(m_tz_name[sbuf] != "") {
-                  m_time->tm_hour += m_tz_val[sbuf];
+                  m_time.tm_hour += m_tz_val[sbuf];
                   }
                 */
                 break;
@@ -355,29 +371,29 @@ namespace jlib {
                 break;
             case 'b':
                 is >> sbuf;
-                m_time->tm_mon = find_month(sbuf, SHORT);
+                m_time.tm_mon = find_month(sbuf, SHORT);
                 break;
             case 'B':
                 is >> sbuf;
-                m_time->tm_mon = find_month(sbuf, LONG);
+                m_time.tm_mon = find_month(sbuf, LONG);
                 break;
             case 'c':
                 build_date(is, "%a %b %d %X %Z %Y");
                 break;
             case 'd':
                 is >> ibuf;
-                m_time->tm_mday = ibuf;
+                m_time.tm_mday = ibuf;
                 break;
             case 'D':
                 build_date(is, "%m/%d/%y");
                 break;
             case 'h':
                 is >> sbuf;
-                m_time->tm_mon = find_month(sbuf, SHORT);
+                m_time.tm_mon = find_month(sbuf, SHORT);
                 break;
             case 'm':
                 is >> ibuf;
-                m_time->tm_mon = ibuf-1;
+                m_time.tm_mon = ibuf-1;
                 break;
             case 'x':
                 build_date(is, "%D");
@@ -385,16 +401,16 @@ namespace jlib {
             case 'y':
                 is >> ibuf;
                 if(ibuf < 70) {
-                    m_time->tm_year = 100+ibuf;
+                    m_time.tm_year = 100+ibuf;
                 }
                 else {
-                    m_time->tm_year = ibuf;
+                    m_time.tm_year = ibuf;
                 }
                 
                 break;
             case 'Y':
                 is >> ibuf;
-                m_time->tm_year  = ibuf-1900;
+                m_time.tm_year  = ibuf-1900;
                 break;
             default:
                 throw exception("bad format std::string '"+fmt+"': the directive that failed was "+sfmt);
@@ -514,7 +530,7 @@ namespace jlib {
         
         void Date::set(std::string s, std::string fmt) {
             //std::cout << "setting "<<s<<" to format "<<fmt<<std::endl;
-            std::memset(m_time, 0, sizeof(struct tm));
+            std::memset(&m_time, 0, sizeof(struct tm));
             m_current_tz = "";
             std::istringstream is(s);
             build_date(is,fmt);
@@ -523,16 +539,16 @@ namespace jlib {
             //debug_print();
         }
         void Date::reinit() {
-            int isdst = m_time->tm_isdst;
-            time_t newtime = mktime(m_time);
+            int isdst = m_time.tm_isdst;
+            time_t newtime = mktime(&m_time);
             /*
               if(m_current_tz != "") {
               newtime += (3600*m_tz_val[m_current_tz]);
               }
             */
             set(localtime(&newtime));
-            if(isdst == 0 && m_time->tm_isdst == 1) {
-                m_time->tm_hour--;
+            if(isdst == 0 && m_time.tm_isdst == 1) {
+                m_time.tm_hour--;
                 reinit();
             }
         }
@@ -617,15 +633,15 @@ namespace jlib {
         }
         
         void Date::debug_print() const {
-            std::cout << "m_time->tm_sec = " << m_time->tm_sec << std::endl;
-            std::cout << "m_time->tm_min = " << m_time->tm_min << std::endl;
-            std::cout << "m_time->tm_hour = " << m_time->tm_hour << std::endl;
-            std::cout << "m_time->tm_mday = " << m_time->tm_mday << std::endl;
-            std::cout << "m_time->tm_mon = " << m_time->tm_mon << std::endl;
-            std::cout << "m_time->tm_year = " << m_time->tm_year << std::endl;
-            std::cout << "m_time->tm_wday = " << m_time->tm_wday << std::endl;
-            std::cout << "m_time->tm_yday = " << m_time->tm_yday << std::endl;
-            std::cout << "m_time->tm_isdst = " << m_time->tm_isdst << std::endl;
+            std::cout << "m_time.tm_sec = " << m_time.tm_sec << std::endl;
+            std::cout << "m_time.tm_min = " << m_time.tm_min << std::endl;
+            std::cout << "m_time.tm_hour = " << m_time.tm_hour << std::endl;
+            std::cout << "m_time.tm_mday = " << m_time.tm_mday << std::endl;
+            std::cout << "m_time.tm_mon = " << m_time.tm_mon << std::endl;
+            std::cout << "m_time.tm_year = " << m_time.tm_year << std::endl;
+            std::cout << "m_time.tm_wday = " << m_time.tm_wday << std::endl;
+            std::cout << "m_time.tm_yday = " << m_time.tm_yday << std::endl;
+            std::cout << "m_time.tm_isdst = " << m_time.tm_isdst << std::endl;
             
         }
         
@@ -660,7 +676,7 @@ namespace jlib {
         }
         
         struct tm* Date::stm() {
-            return m_time;
+            return &m_time;
         }
         
         

--- a/jlib/util/Date.hh
+++ b/jlib/util/Date.hh
@@ -132,6 +132,20 @@ namespace jlib {
             Date(time_t secs);
             Date(struct tm* t);
             virtual ~Date();
+
+            /**
+             * The rest of the five, explicitly.
+             *
+             * A user-declared destructor -- which a polymorphic class needs,
+             * and which also anchors the vtable -- suppresses the implicit
+             * move constructor and move assignment, so every std::move of a
+             * Date was quietly doing a copy.  Defaulting them says what was
+             * meant and costs nothing now that m_time is a value.
+             */
+            Date(const Date&) = default;
+            Date& operator=(const Date&) = default;
+            Date(Date&&) = default;
+            Date& operator=(Date&&) = default;
             
             /**
              * set from the current time
@@ -156,12 +170,12 @@ namespace jlib {
              */
             time_t time() const;
             
-            int year() const { return m_time->tm_year; }
-            int mon() const { return m_time->tm_mon; }
-            int mday() const { return m_time->tm_mday; }
-            int hour() const { return m_time->tm_hour; }
-            int min() const { return m_time->tm_min; }
-            int sec() const { return m_time->tm_sec; }
+            int year() const { return m_time.tm_year; }
+            int mon() const { return m_time.tm_mon; }
+            int mday() const { return m_time.tm_mday; }
+            int hour() const { return m_time.tm_hour; }
+            int min() const { return m_time.tm_min; }
+            int sec() const { return m_time.tm_sec; }
             
             friend std::istream& operator>>(std::istream& in, Date& d);
             friend std::ostream& operator<<(std::ostream& out, const Date& d);
@@ -255,7 +269,20 @@ namespace jlib {
             struct tm* stm();
             
         private:
-            struct tm* m_time;
+            /**
+             * The broken-down time, by value.
+             *
+             * This was a struct tm* allocated with new in every constructor
+             * and deleted in the destructor -- for a POD of nine ints, which
+             * needs no allocation at all.  Worse, no copy constructor was
+             * declared, so copying a Date copied the pointer and both
+             * destructors freed it: ASan reported the double free at
+             * Date.cc:63.
+             *
+             * As a value the copy is correct and free, and with the
+             * destructor gone the implicit move comes back.
+             */
+            struct tm m_time;
             std::map<std::string,std::string> m_tz_name;
             std::map<std::string,int> m_tz_val;
             

--- a/jlib/util/Date.hh
+++ b/jlib/util/Date.hh
@@ -120,7 +120,7 @@ namespace jlib {
 
             class exception : public std::exception {
             public:
-                exception(std::string msg = "date exception") : m_msg(msg) {}
+                exception(const std::string& msg = "date exception") : m_msg(msg) {}
                 virtual ~exception() throw() {}
                 virtual const char* what() const throw() { return m_msg.c_str(); }
             protected:
@@ -162,8 +162,8 @@ namespace jlib {
              */
             virtual void set(struct tm* t);
             
-            virtual std::string get(std::string fmt="%a, %d %b %Y %H:%M:%S %z") const;
-            virtual void set(std::string s, std::string fmt="%O");
+            virtual std::string get(const std::string& fmt="%a, %d %b %Y %H:%M:%S %z") const;
+            virtual void set(const std::string& s, const std::string& fmt="%O");
             
             /**
              * return the current date as a time_t
@@ -183,14 +183,14 @@ namespace jlib {
             /**
              * given a month as string, return it's integer rep
              */
-            int find_month(std::string s, name_format f) const;
-            int find_weekday(std::string s, name_format f) const;
+            int find_month(const std::string& s, name_format f) const;
+            int find_weekday(const std::string& s, name_format f) const;
             
             /**
              * recursively build date std::string from current tm and passed
              * fmt string
              */
-            std::string build_date(std::string fmt) const;
+            std::string build_date(const std::string& fmt) const;
             
             /**
              * recursively build tm from passed date s and format fmt
@@ -199,7 +199,7 @@ namespace jlib {
              * the clustered directives are ignored, as are the day of week
              * and day of year
              */
-            void build_date(std::istream& is, std::string fmt);
+            void build_date(std::istream& is, const std::string& fmt);
             
             /**
              * automagically parse the date string, building a best
@@ -218,35 +218,35 @@ namespace jlib {
              * get rid of punctuation 
              *
              */
-            std::string sanitize(std::string s) const;
+            std::string sanitize(const std::string& s) const;
             
             /**
              * is the entire std::string alpha
              *
              */
-            bool is_alpha(std::string s) const;
+            bool is_alpha(const std::string& s) const;
             
             /**
              * is the entire std::string digit
              *
              */
-            bool is_digit(std::string s) const;
+            bool is_digit(const std::string& s) const;
             
-            bool is_time(std::string s) const;
-            bool is_timezone(std::string s) const;
-            bool is_date(std::string s) const;
+            bool is_time(const std::string& s) const;
+            bool is_timezone(const std::string& s) const;
+            bool is_date(const std::string& s) const;
             
             /**
              * return the format std::string for the passed date
              *
              */
-            std::string which_date(std::string s) const;
+            std::string which_date(const std::string& s) const;
             
             /**
              * convert the std::string to first letter uppercase, ow lower
              *
              */
-            std::string first_upper(std::string s) const;
+            std::string first_upper(const std::string& s) const;
             
             /**
              * print the contents of each member of the struct tm*

--- a/jlib/util/Headers.cc
+++ b/jlib/util/Headers.cc
@@ -36,16 +36,17 @@ namespace jlib {
             
         }
 
-        Headers::Headers(std::string s) 
+        Headers::Headers(const std::string& s) 
             : m_length(0)
         {
             parse(s);
         }
 
         
-        std::string Headers::operator[](std::string key) const {
-            key = upper(key);
-            return get(key);
+        std::string Headers::operator[](const std::string& key) const {
+            // On a local; this overwrote its own parameter.
+            const std::string k = upper(key);
+            return get(k);
         }
 
         Headers::operator std::string() const {
@@ -75,14 +76,15 @@ namespace jlib {
             return o.str();
         }
         
-        std::string Headers::get(std::string key) const {
+        std::string Headers::get(const std::string& key) const {
             std::string charset;
             return get(key, charset);
         }
 
-        std::string Headers::get(std::string key, std::string& charset) const {
-            key = upper(key);
-            map_type::const_iterator i = m_charset_map.find(key);
+        std::string Headers::get(const std::string& key, std::string& charset) const {
+            // On a local; this overwrote its own parameter.
+            const std::string k = upper(key);
+            map_type::const_iterator i = m_charset_map.find(k);
             if(i != m_charset_map.end()) {
                 charset = i->second.front();
             }
@@ -95,16 +97,17 @@ namespace jlib {
             }
         }
 
-        void Headers::set(std::string key, std::string val) {
-            key = upper(key);
+        void Headers::set(const std::string& key, const std::string& val) {
+            // On a local; this overwrote its own parameter.
+            const std::string k = upper(key);
 
-            list_type& l = m_map[key];
+            list_type& l = m_map[k];
             l.clear();
             l.push_back(val);
 
-            list_type::iterator i = std::find(m_keys.begin(),m_keys.end(),key);
+            list_type::iterator i = std::find(m_keys.begin(),m_keys.end(),k);
             if(i == m_keys.end()) {
-                m_keys.push_back(key);
+                m_keys.push_back(k);
             }
             else {
                 i++;
@@ -112,18 +115,20 @@ namespace jlib {
             }
         }
 
-        void Headers::add(std::string key, std::string val) {
-            key = upper(key);
-            m_map[key].push_back(val);
-            m_keys.push_back(key);
+        void Headers::add(const std::string& key, const std::string& val) {
+            // On a local; this overwrote its own parameter.
+            const std::string k = upper(key);
+            m_map[k].push_back(val);
+            m_keys.push_back(k);
         }
 
         
-        void Headers::append(std::string key, std::string val) {
-            key = upper(key);
-            list_type& list = m_map[key];
+        void Headers::append(const std::string& key, const std::string& val) {
+            // On a local; this overwrote its own parameter.
+            const std::string k = upper(key);
+            list_type& list = m_map[k];
             if(list.size() == 0) {
-                add(key,val);
+                add(k,val);
             }
             else {
                 list.front() += val;
@@ -135,10 +140,11 @@ namespace jlib {
             return m_keys;
         }
 
-        Headers::list_type Headers::vals(std::string key) const {
-            key = upper(key);
+        Headers::list_type Headers::vals(const std::string& key) const {
+            // On a local; this overwrote its own parameter.
+            const std::string k = upper(key);
             
-            const_iterator i = find(key);
+            const_iterator i = find(k);
             if(i != end()) {
                 return i->second;
             }
@@ -148,7 +154,7 @@ namespace jlib {
         }
 
         
-        void Headers::parse(std::string s, bool uppercase) {
+        void Headers::parse(const std::string& s, bool uppercase) {
             // Moved into the stream rather than copied.  This took the whole
             // message by value and then copied it again into the istringstream,
             // so parsing a 2M message cost 4M before it read a byte.  Taking by
@@ -337,6 +343,10 @@ namespace jlib {
 
                 */
 
+        /**
+         * By value deliberately: val is the working buffer, decoded in place
+         * and returned.
+         */
         std::string Headers::decode(std::string val, std::string& charset) {
             //static jlib::util::Regex reg("(.*)=\\?(.+)\\?([QqBb])\\?(.+)\\?=(.*)");
             static const std::string BEGIN = "=?", END = "?=";
@@ -398,7 +408,7 @@ namespace jlib {
             return val;
         }
 
-        std::string Headers::encode(std::string val, std::string charset) {
+        std::string Headers::encode(const std::string& val, const std::string& charset) {
             bool high = false;
             std::string::size_type i = 0, p, x;
             std::string ret;
@@ -421,7 +431,7 @@ namespace jlib {
             return ret;
         }
 
-        std::string::size_type Headers::find_high(std::string val, std::string::size_type p) {
+        std::string::size_type Headers::find_high(const std::string& val, std::string::size_type p) {
             for(; p < val.length(); p++) {
                 if(static_cast<u_char>(val[p]) > 127) {
                     return p;
@@ -436,8 +446,8 @@ namespace jlib {
             return m_length;
         }
 
-            Headers::iterator Headers::find(std::string key) { return m_map.find(upper(key)); }
-            Headers::const_iterator Headers::find(std::string key) const { return m_map.find(upper(key)); }
+            Headers::iterator Headers::find(const std::string& key) { return m_map.find(upper(key)); }
+            Headers::const_iterator Headers::find(const std::string& key) const { return m_map.find(upper(key)); }
 
             Headers::iterator Headers::begin() { return m_map.begin(); }
             Headers::const_iterator Headers::begin() const { return m_map.begin(); }
@@ -452,19 +462,19 @@ namespace jlib {
 
             void Headers::clear() { m_map.clear(); }
 
-            Headers::list_type::iterator Headers::begin(std::string key) { return m_map.find(upper(key))->second.begin(); }
-            Headers::list_type::const_iterator Headers::begin(std::string key) const { return m_map.find(upper(key))->second.begin(); }
-            Headers::list_type::iterator Headers::end(std::string key) { return m_map.find(upper(key))->second.end(); }
-            Headers::list_type::const_iterator Headers::end(std::string key) const { return m_map.find(upper(key))->second.end(); }
-            Headers::list_type::reverse_iterator Headers::rbegin(std::string key) { return m_map.find(upper(key))->second.rbegin(); }
-            Headers::list_type::const_reverse_iterator Headers::rbegin(std::string key) const { return m_map.find(upper(key))->second.rbegin(); }
-            Headers::list_type::reverse_iterator Headers::rend(std::string key) { return m_map.find(upper(key))->second.rend(); }
-            Headers::list_type::const_reverse_iterator Headers::rend(std::string key) const { return m_map.find(upper(key))->second.rend(); }
-            bool Headers::empty(std::string key) const { return (m_map.find(upper(key)) == m_map.end() ||
+            Headers::list_type::iterator Headers::begin(const std::string& key) { return m_map.find(upper(key))->second.begin(); }
+            Headers::list_type::const_iterator Headers::begin(const std::string& key) const { return m_map.find(upper(key))->second.begin(); }
+            Headers::list_type::iterator Headers::end(const std::string& key) { return m_map.find(upper(key))->second.end(); }
+            Headers::list_type::const_iterator Headers::end(const std::string& key) const { return m_map.find(upper(key))->second.end(); }
+            Headers::list_type::reverse_iterator Headers::rbegin(const std::string& key) { return m_map.find(upper(key))->second.rbegin(); }
+            Headers::list_type::const_reverse_iterator Headers::rbegin(const std::string& key) const { return m_map.find(upper(key))->second.rbegin(); }
+            Headers::list_type::reverse_iterator Headers::rend(const std::string& key) { return m_map.find(upper(key))->second.rend(); }
+            Headers::list_type::const_reverse_iterator Headers::rend(const std::string& key) const { return m_map.find(upper(key))->second.rend(); }
+            bool Headers::empty(const std::string& key) const { return (m_map.find(upper(key)) == m_map.end() ||
                                                         m_map.find(upper(key))->second.empty()); }
-            Headers::size_type Headers::size(std::string key) const { return m_map.find(upper(key))->second.size(); }
+            Headers::size_type Headers::size(const std::string& key) const { return m_map.find(upper(key))->second.size(); }
 
-            void Headers::clear(std::string key) { if(!empty(upper(key))) m_map.find(upper(key))->second.clear(); }
+            void Headers::clear(const std::string& key) { if(!empty(upper(key))) m_map.find(upper(key))->second.clear(); }
 
             std::string Headers::get_charset() { 
                 return m_charset;

--- a/jlib/util/Headers.cc
+++ b/jlib/util/Headers.cc
@@ -23,6 +23,8 @@
 #include <jlib/util/util.hh>
 #include <jlib/util/Headers.hh>
 
+#include <utility>
+
 #include <sstream>
 #include <algorithm>
 
@@ -151,7 +153,12 @@ namespace jlib {
 
         
         void Headers::parse(std::string s, bool uppercase) {
-            std::istringstream stream(s);
+            // Moved into the stream rather than copied.  This took the whole
+            // message by value and then copied it again into the istringstream,
+            // so parsing a 2M message cost 4M before it read a byte.  Taking by
+            // value and moving costs one copy for a variable and none for a
+            // temporary, and does not change the signature.
+            std::istringstream stream(std::move(s));
             if(getenv("JLIB_UTIL_HEADERS_DEBUG")) {
                 std::cerr <<"enter jlib::util::Headers::parse()"<<std::endl;
             }

--- a/jlib/util/Headers.cc
+++ b/jlib/util/Headers.cc
@@ -42,10 +42,6 @@ namespace jlib {
             parse(s);
         }
 
-        Headers::~Headers() {
-            
-        }
-
         
         std::string Headers::operator[](std::string key) const {
             key = upper(key);

--- a/jlib/util/Headers.hh
+++ b/jlib/util/Headers.hh
@@ -61,8 +61,14 @@ namespace jlib {
 
             Headers();
             Headers(std::string s);
-
-            virtual ~Headers();
+            /**
+             * No destructor.
+             *
+             * There was an empty one, and a user-declared destructor -- even
+             * an empty one -- suppresses the implicit move constructor and
+             * move assignment.  Every std::move of one of these was silently
+             * doing a copy; measured, moving a 2M Email copied 4M.
+             */
 
             std::string operator[](std::string key) const;
             operator std::string() const;

--- a/jlib/util/Headers.hh
+++ b/jlib/util/Headers.hh
@@ -33,7 +33,7 @@ namespace jlib {
         public:
             class exception : public std::exception {
             public:
-                exception(std::string p_msg = "") {
+                exception(const std::string& p_msg = "") {
                     m_msg = "jlib::util::Headers::exception: "+p_msg;
                 }
                 virtual ~exception() throw() {}
@@ -60,7 +60,7 @@ namespace jlib {
             typedef map_type::allocator_type allocator_type;            
 
             Headers();
-            Headers(std::string s);
+            Headers(const std::string& s);
             /**
              * No destructor.
              *
@@ -70,24 +70,24 @@ namespace jlib {
              * doing a copy; measured, moving a 2M Email copied 4M.
              */
 
-            std::string operator[](std::string key) const;
+            std::string operator[](const std::string& key) const;
             operator std::string() const;
 
-            std::string get(std::string key) const;
-            std::string get(std::string key, std::string& charset) const;
-            void set(std::string key, std::string val);
-            void add(std::string key, std::string val);
-            void append(std::string key, std::string val);
+            std::string get(const std::string& key) const;
+            std::string get(const std::string& key, std::string& charset) const;
+            void set(const std::string& key, const std::string& val);
+            void add(const std::string& key, const std::string& val);
+            void append(const std::string& key, const std::string& val);
 
             list_type keys() const;
-            list_type vals(std::string key) const;
+            list_type vals(const std::string& key) const;
 
-            void parse(std::string s,bool uppercase=true);
+            void parse(const std::string& s,bool uppercase=true);
 
             unsigned int get_length() const;
 
-            iterator find(std::string key);
-            const_iterator find(std::string key) const;
+            iterator find(const std::string& key);
+            const_iterator find(const std::string& key) const;
 
             iterator begin();
             const_iterator begin() const;
@@ -102,22 +102,22 @@ namespace jlib {
 
             void clear();
 
-            list_type::iterator begin(std::string key);
-            list_type::const_iterator begin(std::string key) const;
-            list_type::iterator end(std::string key);
-            list_type::const_iterator end(std::string key) const;
-            list_type::reverse_iterator rbegin(std::string key);
-            list_type::const_reverse_iterator rbegin(std::string key) const;
-            list_type::reverse_iterator rend(std::string key);
-            list_type::const_reverse_iterator rend(std::string key) const;
-            bool empty(std::string key) const;
-            size_type size(std::string key) const;
+            list_type::iterator begin(const std::string& key);
+            list_type::const_iterator begin(const std::string& key) const;
+            list_type::iterator end(const std::string& key);
+            list_type::const_iterator end(const std::string& key) const;
+            list_type::reverse_iterator rbegin(const std::string& key);
+            list_type::const_reverse_iterator rbegin(const std::string& key) const;
+            list_type::reverse_iterator rend(const std::string& key);
+            list_type::const_reverse_iterator rend(const std::string& key) const;
+            bool empty(const std::string& key) const;
+            size_type size(const std::string& key) const;
 
-            void clear(std::string key);
+            void clear(const std::string& key);
 
             static std::string decode(std::string val, std::string& charset);
-            static std::string encode(std::string val, std::string charset);
-            static std::string::size_type find_high(std::string val, std::string::size_type p);
+            static std::string encode(const std::string& val, const std::string& charset);
+            static std::string::size_type find_high(const std::string& val, std::string::size_type p);
 
             /**
              * this is from the 'content-type' header

--- a/jlib/util/MimeType.cc
+++ b/jlib/util/MimeType.cc
@@ -30,7 +30,7 @@ namespace jlib {
     namespace util {
         
         
-        std::string MimeType::get_type_from_file(std::string path) {
+        std::string MimeType::get_type_from_file(const std::string& path) {
             //return gnome_mime_type_of_file(path.c_str());
             std::string out, err;
             sys::shell("file "+path, out, err);
@@ -38,7 +38,7 @@ namespace jlib {
             return parse_file_output(out);
         }
 
-        std::string MimeType::get_type_from_data(std::string data) {
+        std::string MimeType::get_type_from_data(const std::string& data) {
             std::string ret;
             std::string out, err;
             jlib::sys::tfstream in;
@@ -49,10 +49,11 @@ namespace jlib {
             return parse_file_output(out);
         }
 
-        std::string MimeType::parse_file_output(std::string data) {
-            if(data.find(":") != std::string::npos) {
-                data = data.substr(data.find(":"));
-            }
+        std::string MimeType::parse_file_output(const std::string& data) {
+            // On a local: this overwrote its own parameter.
+            const std::string body = (data.find(":") != std::string::npos)
+                ? data.substr(data.find(":"))
+                : data;
             std::string ret;
 
             if(icontains(data, "image")) {

--- a/jlib/util/MimeType.hh
+++ b/jlib/util/MimeType.hh
@@ -37,7 +37,7 @@ namespace jlib {
             
             class exception : public std::exception {
             public:
-                exception(std::string p_msg = "") {
+                exception(const std::string& p_msg = "") {
                     m_msg = "jlib::util::MimeType exception: "+p_msg;
                 }
                 virtual ~exception() throw() {}
@@ -53,7 +53,7 @@ namespace jlib {
              *
              * @return std::string description of data's MIME type
              */
-            static std::string get_type_from_file(std::string path);
+            static std::string get_type_from_file(const std::string& path);
 
             /**
              * Get the Mime-Type from the given filename
@@ -62,12 +62,12 @@ namespace jlib {
              *
              * @return std::string description of data's MIME type
              */
-            static std::string get_type_from_data(std::string data);
+            static std::string get_type_from_data(const std::string& data);
           
             /**
              * parse the text output of the UNIX file command into a mime-type
              */
-            static std::string parse_file_output(std::string data);
+            static std::string parse_file_output(const std::string& data);
         };
         
     }

--- a/jlib/util/Regex.cc
+++ b/jlib/util/Regex.cc
@@ -109,7 +109,7 @@ namespace jlib {
         }
 
 
-        Regex::Regex(std::string pattern, int flags) {
+        Regex::Regex(const std::string& pattern, int flags) {
             init(pattern, flags);
         }
         
@@ -121,7 +121,7 @@ namespace jlib {
             regfree(&m_regex);
         }
          
-        void Regex::init(std::string pattern, int flags) {
+        void Regex::init(const std::string& pattern, int flags) {
             m_pattern = pattern;
             m_flags = flags;
             m_size = (1+std::count(pattern.begin(),pattern.end(),'('));
@@ -133,7 +133,7 @@ namespace jlib {
             }
         }
        
-        Regex::Match Regex::match(std::string p_str) {
+        Regex::Match Regex::match(const std::string& p_str) {
             regmatch_t* match = new regmatch_t[m_size];
             unsigned int len = p_str.length()+1;
             char* text = new char[len];
@@ -157,7 +157,7 @@ namespace jlib {
             return tmp;
         }
         
-        Regex::Match Regex::operator()(std::string str) {
+        Regex::Match Regex::operator()(const std::string& str) {
             return match(str);
         }
 

--- a/jlib/util/Regex.hh
+++ b/jlib/util/Regex.hh
@@ -32,7 +32,7 @@ namespace jlib {
         public:
             class exception : public std::exception {
             public:
-                exception(std::string p_msg = "") {
+                exception(const std::string& p_msg = "") {
                     m_msg = "jlib::util::Regex::exception: "+p_msg;
                 }
                 virtual ~exception() throw() {}
@@ -63,19 +63,19 @@ namespace jlib {
                 char* m_text;
             };
 
-            Regex(std::string pattern="", int flags=REG_EXTENDED);
+            Regex(const std::string& pattern="", int flags=REG_EXTENDED);
             Regex(const Regex& r);
             ~Regex();
 
-            Match match(std::string str);
-            Match operator()(std::string str);
+            Match match(const std::string& str);
+            Match operator()(const std::string& str);
 
             Regex& operator=(const Regex& r);
 
             std::string operator[](unsigned int i);
 
         protected:
-            void init(std::string pattern, int flags);
+            void init(const std::string& pattern, int flags);
             void copy(const Regex& r);
 
             regex_t m_regex;

--- a/jlib/util/Timer.hh
+++ b/jlib/util/Timer.hh
@@ -19,7 +19,7 @@ namespace jlib {
         public:
             class exception : public std::exception {
             public:
-                exception(std::string msg = "") {
+                exception(const std::string& msg = "") {
                     m_msg = "jlib::util::Timer::exception: "+msg;
                 }
                 virtual ~exception() throw() {}

--- a/jlib/util/URL.cc
+++ b/jlib/util/URL.cc
@@ -61,10 +61,6 @@ namespace jlib {
             set_qs(qs);
         }
         
-        URL::~URL() {
-            
-        }
-        
         void URL::parse(std::string url) {
             if(std::getenv("JLIB_UTIL_URL_DEBUG"))
                 std::cerr << "jlib::util::URL::parse(\""<<url<<"\")"<<std::endl;
@@ -223,31 +219,31 @@ namespace jlib {
         }
         
         void URL::set_protocol(std::string protocol) {
-            m_protocol = protocol;
+            m_protocol = std::move(protocol);
         }
 
         void URL::set_user(std::string user) {
-            m_user = user;
+            m_user = std::move(user);
         }
 
         void URL::set_pass(std::string pass) {
-            m_pass = pass;
+            m_pass = std::move(pass);
         }
 
         void URL::set_host(std::string host) {
-            m_host = host;
+            m_host = std::move(host);
         }
 
         void URL::set_port(std::string port) {
-            m_port = port;
+            m_port = std::move(port);
         }
 
         void URL::set_path(std::string path) {
-            m_path = path;
+            m_path = std::move(path);
         }
 
         void URL::set_delim(std::string delim) {
-            m_delim = delim;
+            m_delim = std::move(delim);
         }
 
         void URL::set_qs(std::string qs) {

--- a/jlib/util/URL.cc
+++ b/jlib/util/URL.cc
@@ -40,18 +40,18 @@ namespace jlib {
             
         }
 
-        URL::URL(std::string url) {
+        URL::URL(const std::string& url) {
             parse(url);
         }
 
-        URL::URL(std::string protocol, std::string host, std::string path) {
+        URL::URL(const std::string& protocol, const std::string& host, const std::string& path) {
             set_protocol(protocol);
             set_host(host);
             set_path(path); 
        }
 
-        URL::URL(std::string protocol, std::string user, std::string pass, 
-                 std::string host, std::string port, std::string path, std::string qs) {
+        URL::URL(const std::string& protocol, const std::string& user, const std::string& pass, 
+                 const std::string& host, const std::string& port, const std::string& path, const std::string& qs) {
             set_protocol(protocol);
             set_user(user);
             set_pass(pass);
@@ -61,11 +61,12 @@ namespace jlib {
             set_qs(qs);
         }
         
-        void URL::parse(std::string url) {
+        void URL::parse(const std::string& url) {
             if(std::getenv("JLIB_UTIL_URL_DEBUG"))
                 std::cerr << "jlib::util::URL::parse(\""<<url<<"\")"<<std::endl;
             
-            url = jlib::util::trim(url);
+            // On a local: this overwrote its own parameter.
+            const std::string text = jlib::util::trim(url);
             jlib::util::Regex full_url(FULL_URL);
             
             if(full_url(url)) {
@@ -140,7 +141,7 @@ namespace jlib {
             
         }
 
-        std::map<std::string,std::string> URL::parse_qs(std::string qs) {
+        std::map<std::string,std::string> URL::parse_qs(const std::string& qs) {
             std::map<std::string,std::string> ret;
 
             std::vector<std::string> tokens = tokenize(qs,"&");
@@ -218,35 +219,35 @@ namespace jlib {
             return int_value(get_port());
         }
         
-        void URL::set_protocol(std::string protocol) {
+        void URL::set_protocol(const std::string& protocol) {
             m_protocol = std::move(protocol);
         }
 
-        void URL::set_user(std::string user) {
+        void URL::set_user(const std::string& user) {
             m_user = std::move(user);
         }
 
-        void URL::set_pass(std::string pass) {
+        void URL::set_pass(const std::string& pass) {
             m_pass = std::move(pass);
         }
 
-        void URL::set_host(std::string host) {
+        void URL::set_host(const std::string& host) {
             m_host = std::move(host);
         }
 
-        void URL::set_port(std::string port) {
+        void URL::set_port(const std::string& port) {
             m_port = std::move(port);
         }
 
-        void URL::set_path(std::string path) {
+        void URL::set_path(const std::string& path) {
             m_path = std::move(path);
         }
 
-        void URL::set_delim(std::string delim) {
+        void URL::set_delim(const std::string& delim) {
             m_delim = std::move(delim);
         }
 
-        void URL::set_qs(std::string qs) {
+        void URL::set_qs(const std::string& qs) {
             m_qs = qs;
             m_qs_hash = parse_qs(qs);
         }
@@ -256,7 +257,7 @@ namespace jlib {
             m_qs = parse_qs(qs);
         }
         
-        std::string URL::operator[](std::string key) const {
+        std::string URL::operator[](const std::string& key) const {
             const_iterator i = m_qs_hash.find(key);
             if(i != end()) return i->second;
             else return std::string();

--- a/jlib/util/URL.hh
+++ b/jlib/util/URL.hh
@@ -60,8 +60,14 @@ namespace jlib {
             URL(std::string protocol, std::string host, std::string path);
             URL(std::string protocol, std::string user, std::string pass, 
                 std::string host, std::string port, std::string path, std::string qs);
-
-            virtual ~URL();
+            /**
+             * No destructor.
+             *
+             * There was an empty one, and a user-declared destructor -- even
+             * an empty one -- suppresses the implicit move constructor and
+             * move assignment.  Every std::move of one of these was silently
+             * doing a copy; measured, moving a 2M Email copied 4M.
+             */
 
             void parse(std::string url);
             static std::map<std::string,std::string> parse_qs(std::string qs);

--- a/jlib/util/URL.hh
+++ b/jlib/util/URL.hh
@@ -32,7 +32,7 @@ namespace jlib {
         public:
             class exception : public std::exception {
             public:
-                exception(std::string p_msg = "") {
+                exception(const std::string& p_msg = "") {
                     m_msg = "jlib::util::URL::exception: "+p_msg;
                 }
                 virtual ~exception() throw() {}
@@ -56,10 +56,10 @@ namespace jlib {
             typedef rep_type::allocator_type allocator_type;            
 
             URL();
-            URL(std::string url);
-            URL(std::string protocol, std::string host, std::string path);
-            URL(std::string protocol, std::string user, std::string pass, 
-                std::string host, std::string port, std::string path, std::string qs);
+            URL(const std::string& url);
+            URL(const std::string& protocol, const std::string& host, const std::string& path);
+            URL(const std::string& protocol, const std::string& user, const std::string& pass, 
+                const std::string& host, const std::string& port, const std::string& path, const std::string& qs);
             /**
              * No destructor.
              *
@@ -69,8 +69,8 @@ namespace jlib {
              * doing a copy; measured, moving a 2M Email copied 4M.
              */
 
-            void parse(std::string url);
-            static std::map<std::string,std::string> parse_qs(std::string qs);
+            void parse(const std::string& url);
+            static std::map<std::string,std::string> parse_qs(const std::string& qs);
             static std::string parse_qs(std::map<std::string,std::string> qs);
 
             std::string get_protocol() const;
@@ -88,19 +88,19 @@ namespace jlib {
 
             unsigned int get_port_val() const;
 
-            std::string operator[](std::string key) const;
+            std::string operator[](const std::string& key) const;
             std::string operator()() const;
             operator std::string() const;
             std::vector<std::string> keys() const;
 
-            void set_protocol(std::string protocol);
-            void set_user(std::string user);
-            void set_pass(std::string pass);
-            void set_host(std::string host);
-            void set_port(std::string port);
-            void set_path(std::string path);
-            void set_delim(std::string delim);
-            void set_qs(std::string qs);
+            void set_protocol(const std::string& protocol);
+            void set_user(const std::string& user);
+            void set_pass(const std::string& pass);
+            void set_host(const std::string& host);
+            void set_port(const std::string& port);
+            void set_path(const std::string& path);
+            void set_delim(const std::string& delim);
+            void set_qs(const std::string& qs);
             void set_qs(std::map<std::string,std::string> qs);
            
             std::string coagulate() const;

--- a/jlib/util/json.cc
+++ b/jlib/util/json.cc
@@ -83,7 +83,7 @@ object::ptr object::create() {
     return ptr(new object());
 }
     
-object::ptr object::create(std::string data) { 
+object::ptr object::create(const std::string& data) { 
     return ptr(new object(data));
 }
     
@@ -92,7 +92,7 @@ object::object()
       m_put(true)
 {}
     
-object::object(std::string data)
+object::object(const std::string& data)
     : m_obj(json_tokener_parse(data.data())),
       m_put(true)
 {
@@ -113,7 +113,7 @@ object::~object() {
 	json_object_put(m_obj); 
 }
     
-proxy object::get(std::string key) const {
+proxy object::get(const std::string& key) const {
     return proxy(json_object_object_get(m_obj, key.data()));
 }
     
@@ -121,32 +121,32 @@ proxy object::get(std::size_t idx) const {
     return proxy(json_object_array_get_idx(m_obj, idx));
 }
     
-void object::add(std::string key, std::string val) {
+void object::add(const std::string& key, const std::string& val) {
     json_object_object_add(m_obj, key.data(), json_object_new_string(const_cast<char*>(val.data())));
 }
     
-void object::add(std::string key, int val) {
+void object::add(const std::string& key, int val) {
     json_object_object_add(m_obj, key.data(), json_object_new_int(val));
 }
     
-void object::add(std::string key, unsigned int val) {
+void object::add(const std::string& key, unsigned int val) {
     add(key, static_cast<int>(val));
 }
     
-void object::add(std::string key, double val) {
+void object::add(const std::string& key, double val) {
     json_object_object_add(m_obj, key.data(), json_object_new_double(val));
 }
     
-void object::add(std::string key, long double val) {
+void object::add(const std::string& key, long double val) {
     add(key, static_cast<double>(val));
 }
     
-void object::add(std::string key, object::ptr val) {
+void object::add(const std::string& key, object::ptr val) {
     json_object_object_add(m_obj, key.data(), val->obj());
     val->m_put = false;
 }
     
-void object::add(std::string key, object::arrayptr val) {
+void object::add(const std::string& key, object::arrayptr val) {
     json_object_object_add(m_obj, key.data(), val->obj());
     val->m_put = false;
 }
@@ -161,7 +161,7 @@ json_object* object::obj() {
     return m_obj;
 }
     
-object::ptr object::obj(std::string key) {
+object::ptr object::obj(const std::string& key) {
     json_object* o = json_object_object_get(m_obj, key.data());
     return ptr(new object(o, false));
 }
@@ -183,7 +183,7 @@ array::ptr array::create() {
     return ptr(new array());
 }
     
-array::ptr array::create(std::string data) { 
+array::ptr array::create(const std::string& data) { 
     return ptr(new array(data));
 }
     
@@ -192,7 +192,7 @@ array::array()
       m_put(true)
 {}
     
-array::array(std::string data)
+array::array(const std::string& data)
     : m_obj(json_tokener_parse(data.data())),
       m_put(true)
 {
@@ -212,7 +212,7 @@ array::~array() {
         json_object_put(m_obj); 
 }
     
-void array::add(std::string val) {
+void array::add(const std::string& val) {
     json_object_array_add(m_obj, json_object_new_string(const_cast<char*>(val.data())));
 }
     

--- a/jlib/util/json.hh
+++ b/jlib/util/json.hh
@@ -48,22 +48,22 @@ public:
     typedef std::shared_ptr<array> arrayptr;
     
     static ptr create();
-    static ptr create(std::string data);
+    static ptr create(const std::string& data);
     
     virtual ~object();
     
-    void add(std::string key, std::string val);
-    void add(std::string key, int val);
-    void add(std::string key, unsigned int val);
-    void add(std::string key, double val);
-    void add(std::string key, long double val);
-    void add(std::string key, ptr val);
-    void add(std::string key, arrayptr val);
+    void add(const std::string& key, const std::string& val);
+    void add(const std::string& key, int val);
+    void add(const std::string& key, unsigned int val);
+    void add(const std::string& key, double val);
+    void add(const std::string& key, long double val);
+    void add(const std::string& key, ptr val);
+    void add(const std::string& key, arrayptr val);
     
-    proxy get(std::string key) const;
+    proxy get(const std::string& key) const;
     proxy get(std::size_t idx) const;
     
-    ptr obj(std::string key);
+    ptr obj(const std::string& key);
     ptr obj(unsigned int x);
 
     bool is(type t) const;
@@ -79,7 +79,7 @@ public:
 private:
     object();
     object(json_object* obj, bool put);
-    object(std::string data);
+    object(const std::string& data);
     object(const object&);
     
     json_object* m_obj;
@@ -91,11 +91,11 @@ public:
     typedef std::shared_ptr<array> ptr;
     
     static ptr create();
-    static ptr create(std::string data);
+    static ptr create(const std::string& data);
     
     virtual ~array();
     
-    void add(std::string val);
+    void add(const std::string& val);
     void add(int val);
     void add(unsigned int val);
     void add(double val);
@@ -117,7 +117,7 @@ public:
     
 private:
     array();
-    array(std::string data);
+    array(const std::string& data);
     array(json_object* obj);
     
     json_object* m_obj;

--- a/jlib/util/util.cc
+++ b/jlib/util/util.cc
@@ -36,7 +36,7 @@ const int SZ = 64;
 namespace jlib {
 	namespace util {
 
-        std::string studly_caps(std::string s) {
+        std::string studly_caps(const std::string& s) {
             std::string ret = lower(s);
             if(s.length() > 0) {
                 ret[0] = toupper(ret[0]);
@@ -54,7 +54,7 @@ namespace jlib {
         }
 
 
-        std::vector<std::string> tokenize(std::string s, std::string d, bool split_delim) {
+        std::vector<std::string> tokenize(const std::string& s, const std::string& d, bool split_delim) {
             std::vector<std::string> ret;
             
             std::string::size_type i=0, j;
@@ -76,7 +76,7 @@ namespace jlib {
             return ret;
         }
 
-        std::list<std::string> tokenize_list(std::string s, std::string d, bool split_delim) {
+        std::list<std::string> tokenize_list(const std::string& s, const std::string& d, bool split_delim) {
             std::list<std::string> ret;
             
             std::string::size_type i=0, j;
@@ -97,7 +97,7 @@ namespace jlib {
             return ret;
         }
 
-        std::string excise(std::string s, std::string d1, std::string d2) {
+        std::string excise(const std::string& s, const std::string& d1, const std::string& d2) {
             std::string ret = s;
             int i,j=0;
             
@@ -110,7 +110,7 @@ namespace jlib {
             return ret;
         }
         
-        std::string slice(std::string s, std::string d1, std::string d2) {
+        std::string slice(const std::string& s, const std::string& d1, const std::string& d2) {
             std::string::size_type i, j;
             
             if( (i=s.find(d1)) != s.npos && (j=s.find(d2,i+1)) != s.npos ) {
@@ -121,7 +121,7 @@ namespace jlib {
             }
         }
         
-        std::string chip(std::string s) {
+        std::string chip(const std::string& s) {
             std::string::size_type i = s.find_first_not_of(WHITESPACE);
             if(i != s.npos) {
                 return s.substr(i);
@@ -131,7 +131,7 @@ namespace jlib {
             }
         }
         
-        std::string chop(std::string s) {
+        std::string chop(const std::string& s) {
             std::string::size_type i = s.find_last_not_of(WHITESPACE);
             if(i != s.npos) {
                 return s.substr(0,i+1);
@@ -141,7 +141,7 @@ namespace jlib {
             }
         }
         
-        std::string trim(std::string s) {
+        std::string trim(const std::string& s) {
             return chip(chop(s));
         }
         
@@ -168,11 +168,11 @@ namespace jlib {
             }
         }
 
-        bool imaps(const std::map<std::string,std::string>& m, std::string key, std::string val) {
+        bool imaps(const std::map<std::string,std::string>& m, const std::string& key, const std::string& val) {
             return (upper(const_cast< std::map<std::string,std::string>& >(m)[key]) == upper(val));
         }
         
-        std::string upper(std::string s) {
+        std::string upper(const std::string& s) {
             std::string ret = s;
             for(std::string::size_type i=0; i<ret.size(); i++) {
                 ret[i] = toupper(ret[i]);
@@ -180,7 +180,7 @@ namespace jlib {
             return ret;
         }
         
-        std::string lower(std::string s) {
+        std::string lower(const std::string& s) {
             std::string ret = s;
             for(std::string::size_type i=0; i<ret.size(); i++) {
                 ret[i] = tolower(ret[i]);
@@ -281,13 +281,13 @@ namespace jlib {
         }
         */
         
-        int int_value(std::string s, int base) { return intValue(s,base); }
-        int intValue(std::string s, int base) {
+        int int_value(const std::string& s, int base) { return intValue(s,base); }
+        int intValue(const std::string& s, int base) {
             return strtol(s.c_str(), NULL, base);
         }
         
-        double double_value(std::string s) { return doubleValue(s); }
-        double doubleValue(std::string s) {
+        double double_value(const std::string& s) { return doubleValue(s); }
+        double doubleValue(const std::string& s) {
             return strtod(s.c_str(), NULL);
         }
         
@@ -314,7 +314,7 @@ namespace jlib {
 
         }
 
-        std::string hex_value(std::string s, bool upper) {
+        std::string hex_value(const std::string& s, bool upper) {
             std::string ret;
             for(std::string::size_type i=0;i<s.length();i++) {
                 ret += hex_value(static_cast<unsigned char>(s[i]));
@@ -334,31 +334,31 @@ namespace jlib {
             return ret;
         }
 
-        bool contains(std::string s, std::string t) {
+        bool contains(const std::string& s, const std::string& t) {
             return (s.size() >= t.size() && (int)s.find(t) != -1);
         }
         
-        bool begins(std::string s, std::string t) {
+        bool begins(const std::string& s, const std::string& t) {
             return (s.size() >= t.size() && s.find(t) == 0);
         }
         
-        bool ends(std::string s, std::string t) {
+        bool ends(const std::string& s, const std::string& t) {
             return ( s.size() >= t.size() && s.rfind(t) == (s.size()-t.size()) );
         }
         
-        bool icontains(std::string s, std::string t) {
+        bool icontains(const std::string& s, const std::string& t) {
             return (s.size() >= t.size() && (int)upper(s).find(upper(t)) != -1);
         }
         
-        bool ibegins(std::string s, std::string t) {
+        bool ibegins(const std::string& s, const std::string& t) {
             return (s.size() >= t.size() && upper(s).find(upper(t)) == 0);
         }
         
-        bool iends(std::string s, std::string t) {
+        bool iends(const std::string& s, const std::string& t) {
             return ( s.size() >= t.size() && upper(s).rfind(upper(t)) == (s.size()-t.size()) );
         }
         
-        bool iequals(std::string s, std::string t) {
+        bool iequals(const std::string& s, const std::string& t) {
             return ( upper(s) == upper(t) );
         }        
 
@@ -601,7 +601,7 @@ namespace jlib {
                 return recode(s,decref);
             }
 
-            std::string recode(std::string s, const std::map<std::string,std::string>& codec) {
+            std::string recode(const std::string& s, const std::map<std::string,std::string>& codec) {
                 std::string ret = s;
                 /*
                 if(ret.length() > 1) {
@@ -629,22 +629,22 @@ namespace jlib {
         
         namespace file {
 
-            struct stat getstat(std::string path) {
+            struct stat getstat(const std::string& path) {
                 struct stat mystat;
                 if(::stat(path.c_str(), &mystat) == -1)
                     throw util_exception("error running stat(2) on "+path);
                 return mystat;
             }
 
-            long size(std::string path) {
+            long size(const std::string& path) {
                 return getstat(path).st_size;
             }
             
-            long mtime(std::string path) {
+            long mtime(const std::string& path) {
                 return getstat(path).st_mtime;
             }
             
-            void kill(std::string path, std::vector<long>& pts) {
+            void kill(const std::string& path, std::vector<long>& pts) {
                 if(pts.size() == 0) return;
                 std::sort(pts.begin(), pts.end());
                 
@@ -695,7 +695,7 @@ namespace jlib {
                 system(cmd.c_str());
             }
 
-            void keep(std::string path, std::vector<long>& pts) {
+            void keep(const std::string& path, std::vector<long>& pts) {
                 if(pts.size() == 0) return;
                 std::sort(pts.begin(), pts.end());
                 

--- a/jlib/util/util.cc
+++ b/jlib/util/util.cc
@@ -385,7 +385,7 @@ namespace jlib {
             }
             
 
-            std::string decode(std::string s) {
+            std::string decode(const std::string& s) {
                 char* out = new char[s.length()];
                 const char* in = s.data();
                 
@@ -434,7 +434,7 @@ namespace jlib {
                 }
             }
             
-            std::string encode(std::string s) {
+            std::string encode(const std::string& s) {
                 char* outbuf = new char[2*s.length()];
                 int sz = 0;
                 u_int j = 0;
@@ -482,7 +482,7 @@ namespace jlib {
         
         namespace qp {
             
-            std::string decode(std::string s) {
+            std::string decode(const std::string& s) {
                 std::string ret;
                 
                 int i=0;
@@ -507,7 +507,7 @@ namespace jlib {
                 return ret;
             }
 
-            std::string encode(std::string s) {
+            std::string encode(const std::string& s) {
                 std::string ret;
                 
                 //TODO: write qp::encode()
@@ -543,7 +543,7 @@ namespace jlib {
 	    }
 
 
-            std::string encode(std::string s) {
+            std::string encode(const std::string& s) {
                 std::string::size_type i, j=0;
                 std::string ret = s;
                 while( (i=ret.find_first_of(reserved,j)) != std::string::npos ) {
@@ -554,7 +554,7 @@ namespace jlib {
                 return ret;
             }
 
-            std::string decode(std::string s) {
+            std::string decode(const std::string& s) {
                 std::string ret = s;
                 std::string::size_type i;
                 while( (i=ret.find("%")) != ret.npos ) {
@@ -570,7 +570,7 @@ namespace jlib {
 
         namespace xml {
 
-            std::string encode(std::string s) {
+            std::string encode(const std::string& s) {
                 //static jlib::sys::sync< std::map< std::string, std::string> > encmap;
                 static jlib::sys::sync< std::map< std::string, std::string> > encmap;
 
@@ -586,7 +586,7 @@ namespace jlib {
                 return recode(s,encref);
             }
 
-            std::string decode(std::string s) {
+            std::string decode(const std::string& s) {
                 static jlib::sys::sync< std::map< std::string, std::string> > decmap;
 
                 decmap.lock();

--- a/jlib/util/util.hh
+++ b/jlib/util/util.hh
@@ -300,7 +300,7 @@ namespace jlib {
              * @param s std::string to parse data from
              * @return decoded data
              */
-            std::string decode(std::string s);
+            std::string decode(const std::string& s);
             
             /**
              * Encode the blob into a string.
@@ -308,7 +308,7 @@ namespace jlib {
              * @param s std::string to parse data from
              * @return encoded data
              */
-            std::string encode(std::string s);
+            std::string encode(const std::string& s);
 
         }
         
@@ -320,7 +320,7 @@ namespace jlib {
              * @param s std::string to parse data from
              * @return decoded data
              */
-            std::string decode(std::string s);
+            std::string decode(const std::string& s);
             
             /**
              * Encode the blob into a string.
@@ -328,20 +328,20 @@ namespace jlib {
              * @param s std::string to parse data from
              * @return encoded data
              */
-            std::string encode(std::string s);
+            std::string encode(const std::string& s);
 
         }
 
 
         namespace uri {
-            std::string encode(std::string s);
-            std::string decode(std::string s);
+            std::string encode(const std::string& s);
+            std::string decode(const std::string& s);
         }
        
         
         namespace xml {
-            std::string encode(std::string s);
-            std::string decode(std::string s);
+            std::string encode(const std::string& s);
+            std::string decode(const std::string& s);
             std::string recode(std::string s, const std::map<std::string,std::string>& codec);
         }
        

--- a/jlib/util/util.hh
+++ b/jlib/util/util.hh
@@ -48,7 +48,7 @@ namespace jlib {
         
         class util_exception : public std::exception {
         public:
-            util_exception(std::string p_msg = "") {
+            util_exception(const std::string& p_msg = "") {
                 m_msg = "util exception: "+p_msg;
             }
             virtual ~util_exception() throw() {}
@@ -63,12 +63,12 @@ namespace jlib {
          * @param s std::string to convert
          * @return s with all characters in upper case
          */
-        std::string upper(std::string s);
+        std::string upper(const std::string& s);
 
         /**
          * make the first character and every char following a '-' caps
          */
-        std::string studly_caps(std::string s);
+        std::string studly_caps(const std::string& s);
         
         /**
          * Convert to lower case.
@@ -76,7 +76,7 @@ namespace jlib {
          * @param s std::string to convert
          * @return s with all characters in upper case
          */
-        std::string lower(std::string s);
+        std::string lower(const std::string& s);
         
         /**
          * Tokenize this std::string with the given delimiter.
@@ -86,9 +86,9 @@ namespace jlib {
          * @return vector of strings
          */
 
-        std::vector<std::string> tokenize(std::string s, std::string d = " ", bool split_delim = true);
+        std::vector<std::string> tokenize(const std::string& s, const std::string& d = " ", bool split_delim = true);
 
-        std::list<std::string> tokenize_list(std::string s, std::string d = "/", bool split_delim = false);
+        std::list<std::string> tokenize_list(const std::string& s, const std::string& d = "/", bool split_delim = false);
         
         /**
          * Get a std::string from an int.
@@ -127,8 +127,8 @@ namespace jlib {
          * @param base radix to use on conversion
          * @return s converted to int
          */
-        int intValue(std::string s, int base = 10);
-        int int_value(std::string s, int base = 10);
+        int intValue(const std::string& s, int base = 10);
+        int int_value(const std::string& s, int base = 10);
         
         /**
          * Get a double from a string.
@@ -136,11 +136,11 @@ namespace jlib {
          * @param s std::string to convert to double
          * @return s converted to double
          */
-        double doubleValue(std::string s);
-        double double_value(std::string s);
+        double doubleValue(const std::string& s);
+        double double_value(const std::string& s);
 
         std::string hex_value(unsigned char c, bool upper=false);
-        std::string hex_value(std::string s, bool upper=false);
+        std::string hex_value(const std::string& s, bool upper=false);
         std::string hex_value(const unsigned char* data, std::size_t size, bool upper=false, bool space=false);
         
         /**
@@ -149,7 +149,7 @@ namespace jlib {
          * @param s std::string to chip
          * @return s without leading whitespace
          */
-        std::string chip(std::string s);
+        std::string chip(const std::string& s);
         
         /**
          * Remove whitespace from end of passed string.
@@ -157,7 +157,7 @@ namespace jlib {
          * @param s std::string to chop
          * @return s without trailing whitespace
          */
-        std::string chop(std::string s);
+        std::string chop(const std::string& s);
         
         /**
          * Remove whitespace from beginning and end of passed string.
@@ -165,7 +165,7 @@ namespace jlib {
          * @param s std::string to trim
          * @return s without leading or trailing whitespace
          */
-        std::string trim(std::string s);
+        std::string trim(const std::string& s);
         
         /**
          * Remove characters between passed delimiters
@@ -175,7 +175,7 @@ namespace jlib {
          * @param d2 ending delimiter
          * @return s without d1, d2, or anything between
          */
-        std::string excise(std::string s, std::string d1, std::string d2);
+        std::string excise(const std::string& s, const std::string& d1, const std::string& d2);
         
         /**
          * Remove characters except between passed delimiters
@@ -185,7 +185,7 @@ namespace jlib {
          * @param d2 ending delimiter
          * @return s between d1 and d2, or unchanged if s doesn't contain d1 and d2
          */
-        std::string slice(std::string s, std::string d1, std::string d2);
+        std::string slice(const std::string& s, const std::string& d1, const std::string& d2);
         
         /**
          * Tell if t is a substd::string of s
@@ -194,7 +194,7 @@ namespace jlib {
          * @param t needle
          * @return true if s contains t, ow false
          */
-        bool contains(std::string s, std::string t);
+        bool contains(const std::string& s, const std::string& t);
         
         /**
          * Tell if s begins with t.
@@ -203,7 +203,7 @@ namespace jlib {
          * @param t needle
          * @return true if s begins with t, ow false
          */
-        bool begins(std::string s, std::string t);
+        bool begins(const std::string& s, const std::string& t);
         
         /**
          * Tell if s ends with t.
@@ -212,7 +212,7 @@ namespace jlib {
          * @param t needle
          * @return true if s ends with t, ow false
          */
-        bool ends(std::string s, std::string t);
+        bool ends(const std::string& s, const std::string& t);
         
         /**
          * Tell if t is a substd::string of s
@@ -221,7 +221,7 @@ namespace jlib {
          * @param t needle
          * @return true if s contains t, ow false
          */
-        bool icontains(std::string s, std::string t);
+        bool icontains(const std::string& s, const std::string& t);
         
         /**
          * Tell if s begins with t.
@@ -230,7 +230,7 @@ namespace jlib {
          * @param t needle
          * @return true if s begins with t, ow false
          */
-        bool ibegins(std::string s, std::string t);
+        bool ibegins(const std::string& s, const std::string& t);
         
         /**
          * Tell if s ends with t.
@@ -239,7 +239,7 @@ namespace jlib {
          * @param t needle
          * @return true if s ends with t, ow false
          */
-        bool iends(std::string s, std::string t);
+        bool iends(const std::string& s, const std::string& t);
         
         /**
          * Tell if s equals t, case insensitive.
@@ -248,9 +248,9 @@ namespace jlib {
          * @param t str2
          * @return true if s equals t, ow false
          */
-        bool iequals(std::string s, std::string t);
+        bool iequals(const std::string& s, const std::string& t);
 
-        bool imaps(const std::map<std::string,std::string>& m, std::string key, std::string val);
+        bool imaps(const std::map<std::string,std::string>& m, const std::string& key, const std::string& val);
         
         // These read a T out of a byte buffer at an arbitrary offset, so the
         // address is not generally aligned for T.  Doing that by casting the
@@ -258,7 +258,7 @@ namespace jlib {
         // strict aliasing -- and -fsanitize=alignment traps it.  memcpy
         // expresses the same thing legally and compiles to the same load.
         template<class T>
-        T get(std::string s, unsigned int offset=0) {
+        T get(const std::string& s, unsigned int offset=0) {
             T t;
             std::memcpy(&t, s.data() + offset, sizeof(T));
             return t;
@@ -342,14 +342,14 @@ namespace jlib {
         namespace xml {
             std::string encode(const std::string& s);
             std::string decode(const std::string& s);
-            std::string recode(std::string s, const std::map<std::string,std::string>& codec);
+            std::string recode(const std::string& s, const std::map<std::string,std::string>& codec);
         }
        
         namespace file {
 
-            struct stat getstat(std::string path);
-            long size(std::string path);
-            long mtime(std::string path);
+            struct stat getstat(const std::string& path);
+            long size(const std::string& path);
+            long mtime(const std::string& path);
             
             /**
              * slice out from the file at path the regions marked in pts
@@ -359,7 +359,7 @@ namespace jlib {
              *
              * the idea here is to kget rid of these regions, and keep the rest
              */
-            void kill(std::string path, std::vector<long>& pts);
+            void kill(const std::string& path, std::vector<long>& pts);
 
             /**
              * slice out from the file at path the regions marked in pts
@@ -369,7 +369,7 @@ namespace jlib {
              *
              * the idea here is to keep these regions, and get rid of the rest
              */
-            void keep(std::string path, std::vector<long>& pts);
+            void keep(const std::string& path, std::vector<long>& pts);
 
         }
     }

--- a/jlib/util/xml.cc
+++ b/jlib/util/xml.cc
@@ -73,13 +73,13 @@ namespace jlib {
             
             // node methods
             
-            node::node(std::string name) 
+            node::node(const std::string& name) 
             { 
                 set_type(node::internal);
                 set_name(name);
             }
 
-            node::ptr node::create(std::string name) {
+            node::ptr node::create(const std::string& name) {
                 return node::ptr(new node(name));
             }
 
@@ -184,7 +184,7 @@ namespace jlib {
                 return true;
             }
             
-            std::string node::get_attribute(std::string key) const {
+            std::string node::get_attribute(const std::string& key) const {
                 attributes::const_iterator i=m_attributes.find(key);
                 if(i != m_attributes.end())
                     return i->second;
@@ -192,7 +192,7 @@ namespace jlib {
                     return std::string();
             }
 
-            void node::set_attribute(std::string key, std::string val) {
+            void node::set_attribute(const std::string& key, const std::string& val) {
                 attributes::iterator i=m_attributes.find(key);
                 if(i != m_attributes.end())
                     i->second = val;

--- a/jlib/util/xml.hh
+++ b/jlib/util/xml.hh
@@ -24,6 +24,7 @@
 #define JLIB_UTIL_XML_HH
 
 // needed includes
+#include <utility>
 #include <string>
 #include <list>
 #include <map>
@@ -126,7 +127,7 @@ namespace jlib {
 
                 //! returns the node name, if nodetype != nt_cdata
                 std::string get_name() const { return m_name; }
-                void set_name(std::string n) { m_name = n; }
+                void set_name(std::string n) { m_name = std::move(n); }
 
                 //! returns subnode list
                 list& get_list(){ return m_list; };
@@ -142,7 +143,7 @@ namespace jlib {
                 //! returns cdata string
                 std::string& get_cdata(){ return m_cdata; };
                 const std::string& get_cdata() const { return m_cdata; };
-                void set_cdata(std::string n) { m_cdata = n; }
+                void set_cdata(std::string n) { m_cdata = std::move(n); }
                 
                 //! loads  node from input stream
                 bool load( std::istream &instream );

--- a/jlib/util/xml.hh
+++ b/jlib/util/xml.hh
@@ -115,9 +115,9 @@ namespace jlib {
 
                 //! ctor
             protected:
-                node(std::string name="");
+                node(const std::string& name="");
             public:
-                static node::ptr create(std::string name="");
+                static node::ptr create(const std::string& name="");
                 //! dtor
                 virtual ~node();
                 
@@ -127,7 +127,7 @@ namespace jlib {
 
                 //! returns the node name, if nodetype != nt_cdata
                 std::string get_name() const { return m_name; }
-                void set_name(std::string n) { m_name = std::move(n); }
+                void set_name(const std::string& n) { m_name = std::move(n); }
 
                 //! returns subnode list
                 list& get_list(){ return m_list; };
@@ -137,13 +137,13 @@ namespace jlib {
                 attributes &get_attributes(){ return m_attributes; };
                 const attributes& get_attributes() const { return m_attributes; };
                 
-                std::string get_attribute(std::string key) const;
-                void set_attribute(std::string key, std::string val);
+                std::string get_attribute(const std::string& key) const;
+                void set_attribute(const std::string& key, const std::string& val);
 
                 //! returns cdata string
                 std::string& get_cdata(){ return m_cdata; };
                 const std::string& get_cdata() const { return m_cdata; };
-                void set_cdata(std::string n) { m_cdata = std::move(n); }
+                void set_cdata(const std::string& n) { m_cdata = std::move(n); }
                 
                 //! loads  node from input stream
                 bool load( std::istream &instream );
@@ -177,10 +177,10 @@ namespace jlib {
             class cdata : public node {
             protected:
                 cdata() { set_name("cdata"); set_type(node::cdata); }
-                cdata(std::string data) { set_name("cdata"); set_type(node::cdata); set_cdata(data); }
+                cdata(const std::string& data) { set_name("cdata"); set_type(node::cdata); set_cdata(data); }
             public:
                 static node::ptr create() { return node::ptr(new cdata()); }
-                static node::ptr create(std::string data) { return node::ptr(new cdata(data)); }
+                static node::ptr create(const std::string& data) { return node::ptr(new cdata(data)); }
 
                 virtual ~cdata() {}
             };

--- a/jlib/util/xmlparser.cc
+++ b/jlib/util/xmlparser.cc
@@ -232,7 +232,7 @@ namespace jlib {
             }
 
 
-            std::string parser::clean(std::string s) {
+            std::string parser::clean(const std::string& s) {
                 std::string ret = s;
                 if(ret.length() > 1) {
                     if( (ret[0] == '"' && ret[ret.length()-1] == '"') ||

--- a/jlib/util/xmlparser.hh
+++ b/jlib/util/xmlparser.hh
@@ -57,7 +57,7 @@ namespace jlib {
                  * get rid of enclosing quotes, and translate 
                  * &amp; etc
                  */
-                static std::string clean(std::string s);
+                static std::string clean(const std::string& s);
 
             protected:
                 std::istream &instream;

--- a/jlib/util/xmltokenizer.hh
+++ b/jlib/util/xmltokenizer.hh
@@ -53,9 +53,9 @@ namespace jlib {
                 //! compare operator for literals
                 bool operator !=(char ch){ return bgen?true:ch!=literal; };
                 //! compare operator for a generic string
-                bool operator ==(std::string str){ return bgen?str==generic:false; };
+                bool operator ==(const std::string& str){ return bgen?str==generic:false; };
                 //! compare operator for a generic string
-                bool operator !=(std::string str){ return bgen?str!=generic:true; };
+                bool operator !=(const std::string& str){ return bgen?str!=generic:true; };
                 //! compare operator for an xmltoken
                 bool operator ==(token tok)
                 {

--- a/jlib/x/Display.cc
+++ b/jlib/x/Display.cc
@@ -40,7 +40,7 @@ void Display::send_event(XEvent e) {
     //std::cout << "Display::send_event: status = " << s << std::endl;
 }
 
-KeySym Display::sym(std::string s) const {
+KeySym Display::sym(const std::string& s) const {
     return XStringToKeysym(s.data());
 }
 
@@ -48,7 +48,7 @@ KeyCode Display::code(KeySym sym) const {
     return XKeysymToKeycode(m_dpy, sym);
 }
 
-KeyCode Display::code(std::string s) const {
+KeyCode Display::code(const std::string& s) const {
     return XKeysymToKeycode(m_dpy, sym(s));
 }
 	

--- a/jlib/x/Display.hh
+++ b/jlib/x/Display.hh
@@ -33,10 +33,10 @@ public:
     
     void send_event(XEvent e);
 
-    KeySym sym(std::string s) const;
+    KeySym sym(const std::string& s) const;
 
     KeyCode code(KeySym sym) const;
-    KeyCode code(std::string s) const;
+    KeyCode code(const std::string& s) const;
     
 protected:
     ::Display* m_dpy;

--- a/jlib/x/Window.cc
+++ b/jlib/x/Window.cc
@@ -34,7 +34,7 @@ Window::Window()
 {
 }
 
-Window::Window(std::string title, int w, int h) 
+Window::Window(const std::string& title, int w, int h) 
 {
     m_timeout = 1000;
 
@@ -184,12 +184,12 @@ void Window::draw_string(std::pair<int,int> p, int s) {
     draw_string(s);
 }
 	
-void Window::draw_string(std::pair<int,int> p, std::string s) {
+void Window::draw_string(std::pair<int,int> p, const std::string& s) {
     move(p);
     draw_string(s);
 }
 	
-void Window::draw_string(std::string s) {
+void Window::draw_string(const std::string& s) {
     XDrawString(m_dpy, m_win, m_gc, m_p.first, m_p.second, s.data(), s.length());
     int w = XTextWidth(m_font, s.data(), s.length());
     move(m_p.first+w,m_p.second);
@@ -204,7 +204,7 @@ void Window::draw_string(int s) {
     draw_string(o.str());
 }
 	
-Window& Window::operator<<(std::string msg) {
+Window& Window::operator<<(const std::string& msg) {
     draw_string(msg);
     return *this;
 }
@@ -416,7 +416,7 @@ void Window::select_input(long event_mask) {
     XSelectInput(m_dpy, m_win, m_event_mask);
 }
 	
-void Window::set_font(std::string font) {
+void Window::set_font(const std::string& font) {
     m_font=XLoadQueryFont(m_dpy,font.c_str());
 	
     XSetFont(m_dpy,m_gc_draw,m_font->fid);
@@ -425,7 +425,7 @@ void Window::set_font(std::string font) {
     XSetFont(m_dpy,m_gc_overlay,m_font->fid);
 }
     
-void Window::set_title(std::string title) {
+void Window::set_title(const std::string& title) {
     m_title=title;
     XSetStandardProperties(m_dpy, m_win, title.c_str(), title.c_str(), 
                            None, NULL,0, NULL);

--- a/jlib/x/Window.hh
+++ b/jlib/x/Window.hh
@@ -32,7 +32,7 @@ class Window {
 public:
     typedef enum { DRAW, ERASE, OVERLAY, INVERT } mode_type;
     
-    Window(std::string title, int w, int h);
+    Window(const std::string& title, int w, int h);
     virtual ~Window();
     
     void set_mode(mode_type mode);
@@ -66,9 +66,9 @@ public:
     void draw_point(std::pair<int,int> p);
     
     void draw_string(int s);
-    void draw_string(std::string s);
+    void draw_string(const std::string& s);
     void draw_string(std::pair<int,int> p, int s);
-    void draw_string(std::pair<int,int> p, std::string s);
+    void draw_string(std::pair<int,int> p, const std::string& s);
     
     void draw_line(int x, int y);
     void draw_line(std::pair<int,int> p);
@@ -106,8 +106,8 @@ public:
     void set_line_size(int pixels);
     
     void select_input(long event_mask);
-    void set_font(std::string font);
-    void set_title(std::string title);
+    void set_font(const std::string& font);
+    void set_title(const std::string& title);
 
     void set_timeout(long micro);
     
@@ -117,7 +117,7 @@ public:
     void run();
     virtual void iterate();
     
-    Window& operator<<(std::string msg);
+    Window& operator<<(const std::string& msg);
     Window& operator<<(int value);
     
     sys::signal<void(std::string,int,int)> key_press;


### PR DESCRIPTION
closes #56

Three passes over one problem.  The first stops copies that were written
deliberately, back when they were free.  The second stops copies nobody wrote,
because std::move on most of these types was silently doing a copy.  The third
is the sweep: every string parameter that is only read now says so.

    macOS  25 tests, 24 pass, 1 skip
    Linux  26 tests, 24 pass, 2 skip
    the mail path is clean under ASan and UBSan

why the code looks the way it does

    Most of this was written when libstdc++'s std::string was copy-on-write.
    Returning one by value was a refcount bump and passing one by value was
    the same, so the code was written that way throughout and was right to be.
    C++11 outlawed COW -- the iterator invalidation rules make it impossible --
    and gcc dropped it in 5.0.  Every one of those is a deep copy now.  Nothing
    about the code changed; what it costs did.

measured, on a 2M message

        before   after
        12290K    6145K    Email e(msg)
         2048K       0     e.raw()
         2048K       0     e.data()
                    4097K  Email e(std::move(msg))
         4096K       0     Email moved = std::move(e)

    Building an Email copied the message six times over.  Moving one copied it
    outright.

1. the copies that were written

    Email::raw() and Email::data() return const&.  They return members
    directly, so the copy was never doing anything except being free.

    Email's constructor and create() move the message into m_raw -- the
    argument is not read again -- so a caller with no further use for the text
    can hand it over for nothing.

    Headers::parse took the whole message by value and then copied it again
    into an istringstream, so parsing a 2M message cost 4M before reading a
    byte.  It moves into the stream now, which needs C++20's move constructor
    for basic_istringstream; checked on both toolchains before relying on it.

    MFolderBuffer built each message, copied it into a temporary Email, then
    copied that Email -- raw and body both -- into the vector.  Both moves.

    ASMailBox passed Email by value through eight signatures, including the
    async request and response types, so a message was copied at every hop of
    the queue.  const& now; the request still stores its own copy, which it
    needs, since it outlives the caller.

    base64 and quoted-printable encode and decode took their input by value
    and never wrote to it.  Those carry attachment payloads.

2. the copies nobody wrote

    A user-declared destructor -- even an empty one -- suppresses the implicit
    move constructor and move assignment.  Email, Headers and URL each had one
    that did nothing, left from when a destructor was something you wrote by
    habit, and the effect was that every move of them fell back to copy.

    Nothing warns about this, and is_move_constructible is no help: it answers
    true when the move resolves to the copy constructor.  The tell is
    is_nothrow_move_constructible, false for all of them and true for
    std::string.  The three empty destructors are gone and there is now a
    static_assert rather than a reading of the code.

    two more double frees, the same shape as #12

    Date held a struct tm* -- allocated with new in all three constructors,
    deleted in the destructor -- for a POD of nine ints that needs no
    allocation at all.  No copy constructor was declared, so copying a Date
    copied the pointer and both destructors freed it.  ASan: double-free at
    Date.cc:63.  It is a value member now, which makes the copy correct and
    free.

    The pointer had also been hiding a const violation.  Date::time() const
    called mktime(m_time), and mktime normalizes the struct it is handed, so a
    const method was writing to the object -- which compiled only because
    pointing at non-const data through a const member is not a const member.
    It works on a copy now.  Two null checks moved with it: they tested m_time
    after the fact, which said nothing about whether localtime had failed, so
    they test localtime's result instead.

    MailFolder owned a FolderBuffer* the same way.  Nothing copies one and it
    is a polymorphic base, so a copy would slice as well as double free: copy
    deleted, move defaulted, buffer a unique_ptr.  Two derived classes were
    assigning the base's pointer and then passing the same pointer to init(),
    which assigned it again; they call init() once now.

    Date keeps its virtual destructor.  Removing it broke the link -- it was
    the class's key function and the vtable had nowhere to be emitted -- and a
    polymorphic class wants one regardless, so the other four of the five are
    defaulted explicitly instead.  Where the destructor could go entirely, it
    went, which is the better answer: no special members at all.

3. the sweep

    Roughly 660 string parameters across 98 files now take const&.  The reason
    is not the copies -- with small-string optimization a short string by value
    is a stack copy and a reference adds an indirection -- it is that
    void f(std::string s) where s is only read reads as pre-C++11 code, and
    this is not pre-C++11 code any more.

    Done by converting everything and letting the compiler find what could not
    be const, rather than by deciding in advance.  Nine survived, in three
    kinds:

    Working buffers.  Headers::decode, net::convert_to_crlf and the note
    parser take a string, modify it in place, and return or consume it.  By
    value is the correct idiom there, and they are commented as deliberate so
    the next sweep leaves them alone.

    Parameters that should have been locals.  sys::shell in five variants
    built its redirected command by overwriting cmd; MimeType::parse_file_output,
    URL::parse, Imap4::append, Headers::operator[] and five siblings,
    net::finish, and jlib-mail's printw each overwrote their own argument.
    They use named locals now, which reads better regardless:
    const std::string line = cmd + " 2>" + ... says what it is, where
    cmd = cmd + ... did not.

    The std::move sinks from the second pass, which the compiler rejected
    because you cannot move out of a const reference.  That is the useful
    property of doing it this way: the two idioms are mutually exclusive, so
    the distinction is enforced rather than remembered.

    std::string_view would be the more modern answer for the read-only cases,
    and is deliberately not used: a good number of these hand the string
    to a C API that wants null termination, and the change would be far
    riskier for no measured gain.

the hazard, checked

    Changing an accessor from by-value to const& is source-compatible for
    std::string s = x.raw() and for auto, which strips the reference.  What it
    does allow is const std::string& s = f().raw() binding to a member of a
    temporary and dangling.

    Grepped for it across the tree.  The only const-reference binding to any
    of these accessors is in wavstream, where the object is a member and
    outlives the reference.  Nothing else stores one.

what was left alone

    Regex owns a regex_t and declares a copy constructor that recompiles the
    pattern, which is correct.  A move would have to leave the source in a
    state regfree can be called on, and its payload is a compiled pattern
    rather than a message, so it keeps copy semantics.

    Email::get_primary_text() and that family return by value and stay so:
    they build their result rather than returning a member, so the return is
    already elided or moved.  MailFolder::copy() likewise -- it is named for
    what it does.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
