### PR TITLE
Replace the last throw() specifications

### DIFF
--- a/jlib/crypt/crypt.hh
+++ b/jlib/crypt/crypt.hh
@@ -39,8 +39,8 @@ namespace jlib {
             exception(const std::string& msg = "") {
                 m_msg = std::string("jlib::crypt exception")+( (msg=="")?"":": ")+msg;
             }
-            virtual ~exception() throw() {}
-            virtual const char* what() const throw() { return m_msg.c_str(); }
+            virtual ~exception() {}
+            virtual const char* what() const noexcept { return m_msg.c_str(); }
         protected:
             std::string m_msg;
         };
@@ -58,15 +58,15 @@ namespace jlib {
                 exception(const std::string& s) {
                     m_msg = ("jlib::crypt::gpg::exception: " + s);
                 }
-                virtual ~exception() throw() {}
-                virtual const char* what() const throw() { return m_msg.c_str(); }
+                virtual ~exception() {}
+                virtual const char* what() const noexcept { return m_msg.c_str(); }
             protected:
                 std::string m_msg;
             };
 
             class eof : public std::exception {
             public:
-                virtual const char* what() const throw() { return "jlib::crypt::gpg: EOF"; }
+                virtual const char* what() const noexcept { return "jlib::crypt::gpg: EOF"; }
             };
 
             class ctx;

--- a/jlib/media/AudioFile.hh
+++ b/jlib/media/AudioFile.hh
@@ -34,8 +34,8 @@ namespace jlib {
                 exception(const std::string& msg = "") {
                     m_msg = std::string("jlib::media::AudioBuffer::exception")+((msg!="")?": ":"")+msg;
                 }
-                virtual ~exception() throw() {}
-                virtual const char* what() const throw() { return m_msg.c_str(); }
+                virtual ~exception() {}
+                virtual const char* what() const noexcept { return m_msg.c_str(); }
             protected:
                 std::string m_msg;
             };
@@ -54,8 +54,8 @@ namespace jlib {
                 exception(const std::string& msg = "") {
                     m_msg = std::string("jlib::media::AudioFile::exception")+((msg!="")?": ":"")+msg;
                 }
-                virtual ~exception() throw() {}
-                virtual const char* what() const throw() { return m_msg.c_str(); }
+                virtual ~exception() {}
+                virtual const char* what() const noexcept { return m_msg.c_str(); }
             protected:
                 std::string m_msg;
             };

--- a/jlib/media/Dsp.hh
+++ b/jlib/media/Dsp.hh
@@ -41,8 +41,8 @@ namespace jlib {
                     m_msg = "jlib::media::Dsp exception"+
                         (msg != "" ? (": "+msg):"");
                 }
-                virtual ~exception() throw() {}
-                virtual const char* what() const throw() { return m_msg.c_str(); }
+                virtual ~exception() {}
+                virtual const char* what() const noexcept { return m_msg.c_str(); }
                 
                 static void throw_errno(const std::string& msg) {
                     std::ostringstream o;

--- a/jlib/media/audiofilestream.hh
+++ b/jlib/media/audiofilestream.hh
@@ -49,8 +49,8 @@ namespace jlib {
                 exception(const std::string& msg = "") {
                     m_msg = std::string("jlib::media::basic_audiofilebuf::exception")+(msg==""?"":": ")+msg;
                 }
-                virtual ~exception() throw() {}
-                virtual const char* what() const throw() { return m_msg.c_str(); }
+                virtual ~exception() {}
+                virtual const char* what() const noexcept { return m_msg.c_str(); }
             protected:
                 std::string m_msg;
             };

--- a/jlib/media/datastream.hh
+++ b/jlib/media/datastream.hh
@@ -44,8 +44,8 @@ namespace jlib {
                 exception(const std::string& msg = "") {
                     m_msg = std::string("jlib::media::basic_databuf::exception")+(msg==""?"":": ")+msg;
                 }
-                virtual ~exception() throw() {}
-                virtual const char* what() const throw() { return m_msg.c_str(); }
+                virtual ~exception() {}
+                virtual const char* what() const noexcept { return m_msg.c_str(); }
             protected:
                 std::string m_msg;
             };

--- a/jlib/media/notestream.hh
+++ b/jlib/media/notestream.hh
@@ -58,8 +58,8 @@ namespace jlib {
                 exception(const std::string& msg = "") {
                     m_msg = std::string("jlib::media::basic_notebuf::exception")+(msg==""?"":": ")+msg;
                 }
-                virtual ~exception() throw() {}
-                virtual const char* what() const throw() { return m_msg.c_str(); }
+                virtual ~exception() {}
+                virtual const char* what() const noexcept { return m_msg.c_str(); }
             protected:
                 std::string m_msg;
             };

--- a/jlib/media/stream.hh
+++ b/jlib/media/stream.hh
@@ -49,8 +49,8 @@ namespace jlib {
                 exception(const std::string& msg = "") {
                     m_msg = std::string("jlib::media::basic_streambuf::exception")+(msg==""?"":": ")+msg;
                 }
-                virtual ~exception() throw() {}
-                virtual const char* what() const throw() { return m_msg.c_str(); }
+                virtual ~exception() {}
+                virtual const char* what() const noexcept { return m_msg.c_str(); }
             protected:
                 std::string m_msg;
             };

--- a/jlib/media/wavstream.hh
+++ b/jlib/media/wavstream.hh
@@ -61,8 +61,8 @@ namespace jlib {
                 exception(const std::string& msg = "") {
                     m_msg = std::string("jlib::media::basic_wavbuf::exception")+(msg==""?"":": ")+msg;
                 }
-                virtual ~exception() throw() {}
-                virtual const char* what() const throw() { return m_msg.c_str(); }
+                virtual ~exception() {}
+                virtual const char* what() const noexcept { return m_msg.c_str(); }
             protected:
                 std::string m_msg;
             };

--- a/jlib/net/ASMailBox.hh
+++ b/jlib/net/ASMailBox.hh
@@ -213,8 +213,8 @@ namespace jlib {
                 exception(const std::string& msg = "") {
                     m_msg = std::string("jlib::net::ASMailBox exception")+( (msg=="")?"":": ")+msg;
                 }
-                virtual ~exception() throw() {}
-                virtual const char* what() const throw() { return m_msg.c_str(); }
+                virtual ~exception() {}
+                virtual const char* what() const noexcept { return m_msg.c_str(); }
             protected:
                 std::string m_msg;
             };

--- a/jlib/net/Email.hh
+++ b/jlib/net/Email.hh
@@ -42,8 +42,8 @@ namespace jlib {
                 exception(const std::string& msg = "") {
                     m_msg = "jlib::net::email exception: "+msg;
                 }
-                virtual ~exception() throw() {}
-                virtual const char* what() const throw() { return m_msg.c_str(); }
+                virtual ~exception() {}
+                virtual const char* what() const noexcept { return m_msg.c_str(); }
             protected:
                 std::string m_msg;
             };

--- a/jlib/net/Imap4.hh
+++ b/jlib/net/Imap4.hh
@@ -64,8 +64,8 @@ namespace jlib {
                 exception(const std::string& msg = "") {
                     m_msg = "imap4 exception: "+msg;
                 }
-                virtual ~exception() throw() {}
-                virtual const char* what() const throw() { return m_msg.c_str(); }
+                virtual ~exception() {}
+                virtual const char* what() const noexcept { return m_msg.c_str(); }
             protected:
                 std::string m_msg;
             };

--- a/jlib/net/MBox.hh
+++ b/jlib/net/MBox.hh
@@ -41,8 +41,8 @@ namespace jlib {
                 exception(const std::string& msg = "") {
                     m_msg = std::string("jlib::net::MBoxBuf exception")+( (msg=="")?"":": ")+msg;
                 }
-                virtual ~exception() throw() {}
-                virtual const char* what() const throw() { return m_msg.c_str(); }
+                virtual ~exception() {}
+                virtual const char* what() const noexcept { return m_msg.c_str(); }
             protected:
                 std::string m_msg;
             };

--- a/jlib/net/MailBox.hh
+++ b/jlib/net/MailBox.hh
@@ -183,8 +183,8 @@ namespace jlib {
                 exception(const std::string& msg = "") {
                     m_msg = std::string("jlib::net::MailBox exception")+( (msg=="")?"":": ")+msg;
                 }
-                virtual ~exception() throw() {}
-                virtual const char* what() const throw() { return m_msg.c_str(); }
+                virtual ~exception() {}
+                virtual const char* what() const noexcept { return m_msg.c_str(); }
             protected:
                 std::string m_msg;
             };

--- a/jlib/net/MailFetch.hh
+++ b/jlib/net/MailFetch.hh
@@ -43,8 +43,8 @@ namespace jlib {
                 exception(const std::string& msg = "") {
                     m_msg = "jlib::net::MailFetch exception: "+msg;
                 }
-                virtual ~exception() throw() {}
-                virtual const char* what() const throw() { return m_msg.c_str(); }
+                virtual ~exception() {}
+                virtual const char* what() const noexcept { return m_msg.c_str(); }
             protected:
                 std::string m_msg;
             };

--- a/jlib/net/Pop3.hh
+++ b/jlib/net/Pop3.hh
@@ -44,8 +44,8 @@ namespace jlib {
                 exception(const std::string& msg = "") {
                     m_msg = "jlib::net::Pop3::exception: "+msg;
                 }
-                virtual ~exception() throw() {}
-                virtual const char* what() const throw() { return m_msg.c_str(); }
+                virtual ~exception() {}
+                virtual const char* what() const noexcept { return m_msg.c_str(); }
             protected:
                 std::string m_msg;
             };

--- a/jlib/net/net.hh
+++ b/jlib/net/net.hh
@@ -44,8 +44,8 @@ namespace jlib {
             exception(const std::string& msg = "") {
                 m_msg = (msg != "" ? ("jlib::net::exception: "+msg) : "jlib::net::exception");
             }
-            virtual ~exception() throw() {}
-            virtual const char* what() const throw() { return m_msg.c_str(); }
+            virtual ~exception() {}
+            virtual const char* what() const noexcept { return m_msg.c_str(); }
         protected:
             std::string m_msg;
         };

--- a/jlib/sys/ASServent.hh
+++ b/jlib/sys/ASServent.hh
@@ -56,8 +56,8 @@ public:
             m_msg = "jlib::sys::ASServent<Request,Response> exception"+
                 (msg != "" ? (": "+msg):"");
         }
-        virtual ~exception() throw() {}
-        virtual const char* what() const throw() { return m_msg.c_str(); }
+        virtual ~exception() {}
+        virtual const char* what() const noexcept { return m_msg.c_str(); }
         
         static void throw_errno(const std::string& msg) {
             std::ostringstream o;

--- a/jlib/sys/Directory.hh
+++ b/jlib/sys/Directory.hh
@@ -35,8 +35,8 @@ namespace jlib {
                 exception(const std::string& msg = "") {
                     m_msg = "jlib::sys::Directory exception: "+msg;
                 }
-                virtual ~exception() throw() {}
-                virtual const char* what() const throw() { return m_msg.c_str(); }
+                virtual ~exception() {}
+                virtual const char* what() const noexcept { return m_msg.c_str(); }
             protected:
                 std::string m_msg;
             };

--- a/jlib/sys/joystick.hh
+++ b/jlib/sys/joystick.hh
@@ -52,8 +52,8 @@ namespace jlib {
                 exception(const std::string& msg, int e) {
                     m_msg = "sys::joystick exception: " + msg + std::strerror(e);
                 }
-                virtual ~exception() throw() {}
-                virtual const char* what() const throw() { return m_msg.c_str(); }
+                virtual ~exception() {}
+                virtual const char* what() const noexcept { return m_msg.c_str(); }
             protected:
                 std::string m_msg;
             };

--- a/jlib/sys/pipe.hh
+++ b/jlib/sys/pipe.hh
@@ -43,8 +43,8 @@ namespace jlib {
                     m_msg = "jlib::sys::pipe exception"+
                         (msg != "" ? (": "+msg):"");
                 }
-                virtual ~exception() throw() {}
-                virtual const char* what() const throw() { return m_msg.c_str(); }
+                virtual ~exception() {}
+                virtual const char* what() const noexcept { return m_msg.c_str(); }
                 
                 [[noreturn]] static void throw_errno(const std::string& msg) {
                     std::ostringstream o;
@@ -58,7 +58,7 @@ namespace jlib {
 
             class would_block : public std::exception {
             public:
-                virtual const char* what() const throw() { 
+                virtual const char* what() const noexcept { 
                     return "jlib::sys::pipe: i/o would block";
                 }
             };

--- a/jlib/sys/serialstream.hh
+++ b/jlib/sys/serialstream.hh
@@ -37,8 +37,8 @@ namespace jlib {
                 exception(const std::string& msg = "") {
                     m_msg = "serial exception: "+msg;
                 }
-                virtual ~exception() throw() {}
-                virtual const char* what() const throw() { return m_msg.c_str(); }
+                virtual ~exception() {}
+                virtual const char* what() const noexcept { return m_msg.c_str(); }
             protected:
                 std::string m_msg;
             };

--- a/jlib/sys/socketstream.hh
+++ b/jlib/sys/socketstream.hh
@@ -49,8 +49,8 @@ namespace jlib {
                 exception(const std::string& msg = "") {
                     m_msg = "socket exception: "+msg;
                 }
-                virtual ~exception() throw() {}
-                virtual const char* what() const throw() { return m_msg.c_str(); }
+                virtual ~exception() {}
+                virtual const char* what() const noexcept { return m_msg.c_str(); }
             protected:
                 std::string m_msg;
             };

--- a/jlib/sys/sync.hh
+++ b/jlib/sys/sync.hh
@@ -39,8 +39,8 @@ public:
     sync_exception(const std::string& msg = "") {
         m_msg = "sys exception: "+msg;
     }
-    virtual ~sync_exception() throw() {}
-    virtual const char* what() const throw() { return m_msg.c_str(); }
+    virtual ~sync_exception() {}
+    virtual const char* what() const noexcept { return m_msg.c_str(); }
 protected:
     std::string m_msg;
 };

--- a/jlib/sys/sys.hh
+++ b/jlib/sys/sys.hh
@@ -35,8 +35,8 @@ namespace jlib {
             io_exception(const std::string& msg = "") {
                 m_msg = "io exception: "+msg;
             }
-            virtual ~io_exception() throw() {}
-            virtual const char* what() const throw() { return m_msg.c_str(); }
+            virtual ~io_exception() {}
+            virtual const char* what() const noexcept { return m_msg.c_str(); }
         protected:
             std::string m_msg;
         };
@@ -46,8 +46,8 @@ namespace jlib {
             sys_exception(const std::string& msg = "") {
                 m_msg = "sys exception: "+msg;
             }
-            virtual ~sys_exception() throw() {}
-            virtual const char* what() const throw() { return m_msg.c_str(); }
+            virtual ~sys_exception() {}
+            virtual const char* what() const noexcept { return m_msg.c_str(); }
         protected:
             std::string m_msg;
         };

--- a/jlib/sys/tfstream.hh
+++ b/jlib/sys/tfstream.hh
@@ -35,8 +35,8 @@ namespace jlib {
                 exception(const std::string& msg = "") {
                     m_msg = "jlib::sys::tfstream exception: "+msg;
                 }
-                virtual ~exception() throw() {}
-                virtual const char* what() const throw() { return m_msg.c_str(); }
+                virtual ~exception() {}
+                virtual const char* what() const noexcept { return m_msg.c_str(); }
             protected:
                 std::string m_msg;
             };

--- a/jlib/util/Date.hh
+++ b/jlib/util/Date.hh
@@ -121,8 +121,8 @@ namespace jlib {
             class exception : public std::exception {
             public:
                 exception(const std::string& msg = "date exception") : m_msg(msg) {}
-                virtual ~exception() throw() {}
-                virtual const char* what() const throw() { return m_msg.c_str(); }
+                virtual ~exception() {}
+                virtual const char* what() const noexcept { return m_msg.c_str(); }
             protected:
                 std::string m_msg;
             };

--- a/jlib/util/Headers.hh
+++ b/jlib/util/Headers.hh
@@ -36,8 +36,8 @@ namespace jlib {
                 exception(const std::string& p_msg = "") {
                     m_msg = "jlib::util::Headers::exception: "+p_msg;
                 }
-                virtual ~exception() throw() {}
-                virtual const char* what() const throw() { return m_msg.c_str(); }
+                virtual ~exception() {}
+                virtual const char* what() const noexcept { return m_msg.c_str(); }
             protected:
                 std::string m_msg;
             };

--- a/jlib/util/MimeType.hh
+++ b/jlib/util/MimeType.hh
@@ -40,8 +40,8 @@ namespace jlib {
                 exception(const std::string& p_msg = "") {
                     m_msg = "jlib::util::MimeType exception: "+p_msg;
                 }
-                virtual ~exception() throw() {}
-                virtual const char* what() const throw() { return m_msg.c_str(); }
+                virtual ~exception() {}
+                virtual const char* what() const noexcept { return m_msg.c_str(); }
             protected:
                 std::string m_msg;
             };

--- a/jlib/util/Regex.hh
+++ b/jlib/util/Regex.hh
@@ -35,8 +35,8 @@ namespace jlib {
                 exception(const std::string& p_msg = "") {
                     m_msg = "jlib::util::Regex::exception: "+p_msg;
                 }
-                virtual ~exception() throw() {}
-                virtual const char* what() const throw() { return m_msg.c_str(); }
+                virtual ~exception() {}
+                virtual const char* what() const noexcept { return m_msg.c_str(); }
             protected:
                 std::string m_msg;
             };

--- a/jlib/util/Timer.hh
+++ b/jlib/util/Timer.hh
@@ -22,8 +22,8 @@ namespace jlib {
                 exception(const std::string& msg = "") {
                     m_msg = "jlib::util::Timer::exception: "+msg;
                 }
-                virtual ~exception() throw() {}
-                virtual const char* what() const throw() { return m_msg.c_str(); }
+                virtual ~exception() {}
+                virtual const char* what() const noexcept { return m_msg.c_str(); }
             protected:
                 std::string m_msg;
             };

--- a/jlib/util/URL.hh
+++ b/jlib/util/URL.hh
@@ -35,8 +35,8 @@ namespace jlib {
                 exception(const std::string& p_msg = "") {
                     m_msg = "jlib::util::URL::exception: "+p_msg;
                 }
-                virtual ~exception() throw() {}
-                virtual const char* what() const throw() { return m_msg.c_str(); }
+                virtual ~exception() {}
+                virtual const char* what() const noexcept { return m_msg.c_str(); }
             protected:
                 std::string m_msg;
             };

--- a/jlib/util/util.hh
+++ b/jlib/util/util.hh
@@ -51,8 +51,8 @@ namespace jlib {
             util_exception(const std::string& p_msg = "") {
                 m_msg = "util exception: "+p_msg;
             }
-            virtual ~util_exception() throw() {}
-            virtual const char* what() const throw() { return m_msg.c_str(); }
+            virtual ~util_exception() {}
+            virtual const char* what() const noexcept { return m_msg.c_str(); }
         protected:
             std::string m_msg;
         };

--- a/jlib/util/xml.hh
+++ b/jlib/util/xml.hh
@@ -83,12 +83,12 @@ namespace jlib {
             public:
                 //! constructor
                 error( errorcode code ){ m_code = code; };
-                virtual ~error() throw() {}
+                virtual ~error() {}
                 //! returns the error code
                 errorcode get_error(){ return m_code; };
                 //! returns the std::string representation of the error code
                 std::string get_strerror();
-                virtual const char* what() const throw();
+                virtual const char* what() const noexcept;
             protected:
                 errorcode m_code;
             };


### PR DESCRIPTION
closes #13

The last of the phase-2 language cleanup.  74 of them, and the tree has none
left.

    macOS  25 tests, 24 pass, 1 skip
    Linux  26 tests, 24 pass, 2 skip

    Dynamic exception specifications were deprecated in C++11 and removed
    outright in C++17.  throw() survives only as a deprecated spelling of
    noexcept(true), and neither clang nor gcc says a word about it even with
    -pedantic, so nothing was going to force this.  It is here because 74
    throw() in the headers is the most dated-looking thing left in them.

    They came in exactly two shapes, which is what made it safe to do
    mechanically.

what() const throw()

    38 of them, every one an override of std::exception::what(), which the
    standard declares noexcept.  These say noexcept now.

~exception() throw()

    36 of them, all destructors of the per-class exception types.  These lost
    the specification rather than gaining a noexcept: destructors have been
    implicitly noexcept since C++11, so writing it adds nothing.

    Dropping it is only safe if the implicit specification really is noexcept,
    which it is unless a base or member has a potentially-throwing destructor.
    That is asserted rather than assumed -- is_nothrow_destructible on a
    sample across sys, net and util.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
