### PR TITLE
Add a lock-free ring buffer

### DIFF
--- a/jlib/sys/Makefile.am
+++ b/jlib/sys/Makefile.am
@@ -8,5 +8,5 @@ libjsys_la_LIBADD = $(PTHREAD_LIBS)
 libjsysincludedir = $(includedir)/jlib-1.2/jlib/sys
 libjsysinclude_HEADERS = tfstream.hh socketstream.hh sslstream.hh proxystream.hh \
                          sslproxystream.hh serialstream.hh pstream.hh \
-                         sys.hh Directory.hh auto.hh sync.hh Servent.hh \
+                         sys.hh Directory.hh auto.hh sync.hh ringbuffer.hh Servent.hh \
                          ASServent.hh pipe.hh object.hh joystick.hh

--- a/jlib/sys/ringbuffer.hh
+++ b/jlib/sys/ringbuffer.hh
@@ -1,0 +1,175 @@
+/* -*- mode: C++ c-basic-offset: 4  -*-
+ *
+ * Copyright (c) 2000 Joe Yandle <jwy@divisionbyzero.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ *
+ */
+
+#ifndef JLIB_SYS_RINGBUFFER_HH
+#define JLIB_SYS_RINGBUFFER_HH
+
+#include <algorithm>
+#include <atomic>
+#include <cstddef>
+#include <vector>
+
+namespace jlib {
+namespace sys {
+
+/**
+ * A lock-free queue for one producer and one consumer.
+ *
+ * Written for the audio path, where the consumer is a device callback running
+ * under a realtime deadline: it may not allocate, take a lock, or block, so
+ * the usual mutex-and-condition queue is not available to it.  Nothing here
+ * allocates after construction and nothing waits.
+ *
+ * Exactly one thread may call write(), and exactly one other may call read().
+ * That restriction is what makes it lock-free without a compare-and-swap: each
+ * index is written by one thread only and read by both, so a plain load and
+ * store with the right ordering is enough.  Two producers would corrupt it.
+ *
+ * The indices are monotonic counts of items ever written and ever read, rather
+ * than positions in the array, and the position is the count modulo the
+ * capacity.  Counting rather than pointing removes the usual difficulty that a
+ * full buffer and an empty one look alike -- the difference of the counts is
+ * the fill, unambiguously, so the whole capacity is usable and there is no
+ * spare slot.  The counts wrap eventually; unsigned arithmetic means their
+ * difference stays right when they do.
+ */
+template<typename T>
+class ringbuffer {
+public:
+    typedef std::size_t size_type;
+
+    /**
+     * @param capacity items the buffer holds, all of them usable
+     */
+    explicit ringbuffer(size_type capacity)
+        : m_buf(capacity),
+          m_written(0),
+          m_read(0)
+    {
+    }
+
+    size_type capacity() const { return m_buf.size(); }
+
+    /**
+     * Items waiting to be read.
+     *
+     * Safe from either thread, and a lower bound from the producer's side:
+     * the consumer may have taken more by the time the answer is used, never
+     * fewer.  The reverse holds for writable().
+     */
+    size_type readable() const
+    {
+        return m_written.load(std::memory_order_acquire) -
+               m_read.load(std::memory_order_acquire);
+    }
+
+    /** Room for that many more items. */
+    size_type writable() const { return capacity() - readable(); }
+
+    bool empty() const { return readable() == 0; }
+    bool full() const { return writable() == 0; }
+
+    /**
+     * Copy in up to n items, and say how many went.
+     *
+     * A short write means the buffer filled; it is not an error, and the
+     * caller keeps the rest.  Producer thread only.
+     */
+    size_type write(const T* src, size_type n)
+    {
+        // The producer owns m_written, so it needs no synchronization to read
+        // its own value.  m_read is the consumer's, and acquire here pairs
+        // with its release in read() so the space it has freed is visible.
+        const size_type written = m_written.load(std::memory_order_relaxed);
+        const size_type read = m_read.load(std::memory_order_acquire);
+
+        const size_type count = std::min(n, capacity() - (written - read));
+        if(count == 0)
+            return 0;
+
+        // At most two runs, since the region can wrap the end of the array.
+        const size_type pos = written % capacity();
+        const size_type first = std::min(count, capacity() - pos);
+
+        std::copy(src, src + first, m_buf.begin() + pos);
+        if(count > first)
+            std::copy(src + first, src + count, m_buf.begin());
+
+        // Release, so a consumer that sees the new count also sees the items.
+        // Publishing the count before the data is exactly the bug this
+        // ordering exists to prevent.
+        m_written.store(written + count, std::memory_order_release);
+
+        return count;
+    }
+
+    /**
+     * Copy out up to n items, and say how many came.
+     *
+     * A short read means the buffer ran dry.  Consumer thread only.
+     */
+    size_type read(T* dst, size_type n)
+    {
+        const size_type read = m_read.load(std::memory_order_relaxed);
+        const size_type written = m_written.load(std::memory_order_acquire);
+
+        const size_type count = std::min(n, written - read);
+        if(count == 0)
+            return 0;
+
+        const size_type pos = read % capacity();
+        const size_type first = std::min(count, capacity() - pos);
+
+        std::copy(m_buf.begin() + pos, m_buf.begin() + pos + first, dst);
+        if(count > first)
+            std::copy(m_buf.begin(), m_buf.begin() + (count - first), dst + first);
+
+        m_read.store(read + count, std::memory_order_release);
+
+        return count;
+    }
+
+    /**
+     * Discard everything held.
+     *
+     * Not safe against a running consumer -- it moves the read index, which is
+     * the consumer's to move.  Call it only with the consumer stopped, which
+     * for the audio path means after the stream has been aborted.
+     */
+    void clear()
+    {
+        m_read.store(m_written.load(std::memory_order_acquire),
+                     std::memory_order_release);
+    }
+
+private:
+    std::vector<T> m_buf;
+
+    /** Items ever written.  Producer writes, both read. */
+    std::atomic<size_type> m_written;
+
+    /** Items ever read.  Consumer writes, both read. */
+    std::atomic<size_type> m_read;
+};
+
+}
+}
+
+#endif // JLIB_SYS_RINGBUFFER_HH

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -19,7 +19,8 @@ MEDIA_TESTS = media_datastream_test \
               media_notestream_test \
               media_player_test \
               media_wavfile_test \
-              media_wavstream_test
+              media_wavstream_test \
+              sys_ringbuffer_test
 endif
 
 if HAVE_SODIUM
@@ -71,6 +72,9 @@ media_wavfile_test_LDADD      = $(JMEDIA_LA) $(JSYS_LA)
 
 media_wavstream_test_SOURCES  = media_wavstream_test.cc
 media_wavstream_test_LDADD    = $(JMEDIA_LA) $(JSYS_LA)
+
+sys_ringbuffer_test_SOURCES   = sys_ringbuffer_test.cc
+sys_ringbuffer_test_LDADD     = $(JSYS_LA)
 
 net_extract_address_test_SOURCES        = net_extract_address_test.cc
 net_extract_address_test_LDADD          = $(JNET_LA)

--- a/tests/sys_ringbuffer_test.cc
+++ b/tests/sys_ringbuffer_test.cc
@@ -1,0 +1,173 @@
+// The lock-free ring buffer.
+//
+// Two halves.  The single-threaded part pins down the arithmetic -- fill,
+// space, wrap-around, short reads and writes -- where a mistake is a wrong
+// number and easy to see.  The threaded part runs a producer against a
+// consumer and checks that every item arrives exactly once, in order, and
+// whole.
+//
+// What that second part does not do is verify the memory ordering, and it is
+// worth saying so rather than leaving the impression it does.  ThreadSanitizer
+// does not help either: it finds races on ordinary accesses, but once the
+// synchronization is atomic it takes the atomics at their word and will not
+// tell you an ordering is too weak.  Checked -- replacing every acquire and
+// release in ringbuffer.hh with relaxed leaves both this test and TSan
+// perfectly happy, on hardware where it could genuinely tear.
+//
+// So the ordering rests on the argument in ringbuffer.hh, not on this test.
+// Each item does carry fields derived from its value, so one published before
+// its contents were written would show up as inconsistent rather than merely
+// late -- but that did not catch the all-relaxed version either, over several
+// runs.  The window is too narrow to hit: a chunk is a kilobyte of stores, and
+// the counter is stored after them, so by the time a consumer looks the data
+// has drained regardless of what the ordering permits.
+//
+// The point of saying this is that a green result here is evidence the
+// arithmetic and the handoff work, and is not evidence the ordering is
+// sufficient.  Confirming that needs a tool that models the memory model --
+// relacy, CDSChecker, GenMC -- rather than a stress test.
+#include <jlib/sys/ringbuffer.hh>
+
+#include <iostream>
+#include <thread>
+#include <vector>
+
+using jlib::sys::ringbuffer;
+
+static int failures = 0;
+
+static void check(const char* what, long got, long want) {
+    const bool ok = (got == want);
+    if(!ok) ++failures;
+    std::cout << (ok ? "  ok   " : "  FAIL ") << what
+              << ": got " << got << ", expected " << want << "\n";
+}
+
+static void single_threaded() {
+    std::cout << "single threaded:\n";
+
+    ringbuffer<int> r(8);
+
+    check("capacity", r.capacity(), 8);
+    check("starts empty", r.readable(), 0);
+    check("starts writable", r.writable(), 8);
+
+    int in[8] = { 0, 1, 2, 3, 4, 5, 6, 7 };
+    check("write 5", r.write(in, 5), 5);
+    check("readable after 5", r.readable(), 5);
+    check("writable after 5", r.writable(), 3);
+
+    // the whole capacity is usable: no slot is given up to tell full from empty
+    check("write 5 more, room for 3", r.write(in, 5), 3);
+    check("full", r.writable(), 0);
+    check("write when full", r.write(in, 1), 0);
+
+    int out[16] = { 0 };
+    check("read 4", r.read(out, 4), 4);
+    check("first four values", out[0] + out[1]*10 + out[2]*100 + out[3]*1000, 0 + 10 + 200 + 3000);
+
+    // and now the interesting case: writing past the end of the array
+    check("write 4 across the wrap", r.write(in, 4), 4);
+    check("readable", r.readable(), 8);
+
+    // drain and confirm the order survived the wrap
+    int all[8] = { 0 };
+    check("read 8", r.read(all, 8), 8);
+    check("read when empty", r.read(out, 1), 0);
+
+    const int want[8] = { 4, 0, 1, 2, 0, 1, 2, 3 };
+    long wrong = 0;
+    for(int i = 0; i < 8; i++)
+        if(all[i] != want[i]) ++wrong;
+    check("values in order across the wrap", wrong, 0);
+
+    // short read gives what there is
+    check("write 3", r.write(in, 3), 3);
+    check("asked 10, got 3", r.read(out, 10), 3);
+
+    check("write 6 then clear", r.write(in, 6), 6);
+    r.clear();
+    check("empty after clear", r.readable(), 0);
+    check("all space back", r.writable(), 8);
+}
+
+/**
+ * An item that can be checked for having arrived whole.
+ *
+ * Several words, and the tail derived from the head, so a consumer that sees
+ * the item before the producer finished writing it sees a mismatch rather than
+ * a plausible value.  Wider than an int on purpose: a single word could be
+ * published atomically by accident on some hardware and hide the problem.
+ */
+struct item {
+    int seq;
+    int pad[6];
+    int derived;
+
+    void fill(int n) {
+        seq = n;
+        for(int i = 0; i < 6; i++) pad[i] = n + i + 1;
+        derived = n * 3 + 7;
+    }
+
+    bool whole() const {
+        if(derived != seq * 3 + 7) return false;
+        for(int i = 0; i < 6; i++)
+            if(pad[i] != seq + i + 1) return false;
+        return true;
+    }
+};
+
+static void threaded() {
+    std::cout << "\nproducer against consumer:\n";
+
+    // deliberately small relative to the traffic, so both sides really do run
+    // out and have to cope with short transfers
+    ringbuffer<item> r(64);
+
+    const int total = 2000000;
+
+    long received = 0, torn = 0, out_of_order = 0;
+
+    std::thread producer([&r, total]() {
+        int next = 0;
+        item chunk[32];
+        while(next < total) {
+            int n = 0;
+            while(n < 32 && next + n < total) { chunk[n].fill(next + n); n++; }
+
+            std::size_t sent = 0;
+            while(sent < static_cast<std::size_t>(n))
+                sent += r.write(chunk + sent, n - sent);
+
+            next += n;
+        }
+    });
+
+    std::thread consumer([&r, total, &received, &torn, &out_of_order]() {
+        item chunk[32];
+        while(received < total) {
+            const std::size_t n = r.read(chunk, 32);
+            for(std::size_t i = 0; i < n; i++) {
+                if(!chunk[i].whole()) ++torn;
+                if(chunk[i].seq != static_cast<int>(received)) ++out_of_order;
+                ++received;
+            }
+        }
+    });
+
+    producer.join();
+    consumer.join();
+
+    check("items received", received, total);
+    check("items published before they were written", torn, 0);
+    check("items out of order", out_of_order, 0);
+    check("empty at the end", r.readable(), 0);
+}
+
+int main() {
+    single_threaded();
+    threaded();
+
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
First step of #60, on its own so it can be tested in isolation.

    macOS  26 tests, 25 pass, 1 skip
    Linux  27 tests, 25 pass, 2 skip

why

    PortAudio's callback runs on a realtime thread and may not allocate, take a
    lock, or block, so the queue between it and whatever feeds it cannot be the
    usual mutex and condition variable.  #60 has the rest of the design; this
    is the part it stands on, and the part where a mistake is quietest.

what it is

    jlib/sys/ringbuffer.hh, header-only, one producer and one consumer.  That
    restriction is what makes it lock-free without a compare-and-swap: each
    index is written by one thread only and read by both, so a plain load and
    store with the right ordering suffices.  Two producers would corrupt it,
    and the header says so.

    The indices count items ever written and ever read rather than pointing
    into the array, with the position being the count modulo the capacity.
    Counting removes the usual problem that a full buffer and an empty one look
    alike, so the whole capacity is usable with no slot given up to tell them
    apart.  The counts wrap eventually and unsigned arithmetic keeps their
    difference right when they do.

    Copies go in at most two runs, since a region can span the end of the
    array.  Nothing allocates after construction and nothing waits.

what the tests establish, and what they do not

    The single-threaded half pins down the arithmetic: fill, space, short reads
    and writes, the whole capacity being usable, order surviving a wrap, clear.

    The threaded half runs a producer against a consumer through a 64-slot
    buffer, two million items, and checks that each arrives exactly once, in
    order, and internally consistent -- the items carry fields derived from
    their sequence number, so one published before it was written would read as
    inconsistent rather than merely late.

    That is worth stating precisely, because it is easy to assume more.  It
    does not verify the memory ordering.  ThreadSanitizer does not either: it
    finds races on ordinary accesses, but where the synchronization is atomic it
    takes the atomics at their word and will not say an ordering is too weak.

    Checked rather than assumed.  Replacing every acquire and release in the
    header with relaxed leaves TSan silent and the test green, including the
    consistency check, over repeated runs -- on arm64, which is weakly ordered
    enough to permit the tear.  The window is too narrow to hit: a chunk is
    about a kilobyte of stores and the count is stored after them, so by the
    time a consumer looks the data has drained whatever the ordering allowed.

    So the ordering rests on the release/acquire pairing being argued in the
    header, and a green run here is evidence the arithmetic and the handoff
    work rather than evidence the ordering is sufficient.  Confirming that
    wants a tool that models the memory model -- relacy, CDSChecker, GenMC --
    and none is set up here.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
