### PR TITLE
Drive PortAudio from its callback

### DIFF
--- a/jlib/media/PortAudioSink.cc
+++ b/jlib/media/PortAudioSink.cc
@@ -64,7 +64,10 @@ PortAudioSink::PortAudioSink()
     : m_stream(0),
       m_pa_format(paInt16),
       m_swap(false),
-      m_rebias(false)
+      m_rebias(false),
+      m_frame(0),
+      m_ticks(0),
+      m_underran(false)
 {
     require_portaudio();
 }
@@ -140,6 +143,18 @@ void PortAudioSink::config(int samples_per_sec, int channels, int format) {
     m_format = format;
     m_configured = true;
 
+    m_frame = get_frame_size();
+
+    // Eight periods of slack between write() and the device.
+    //
+    // The ring is the whole of the tolerance for the feeding thread being late:
+    // however long it is, that is how long the writer may be delayed before
+    // the device runs dry and the callback has to pad with silence.  Eight
+    // periods at the device's low-latency default is tens of milliseconds,
+    // which absorbs a scheduling hiccup or a slow read without adding latency
+    // anyone notices, since audio only sits in it when the writer is ahead.
+    m_ring.reset(new jlib::sys::ringbuffer<char>(8 * m_period * m_frame));
+
     start();
 }
 
@@ -160,22 +175,24 @@ void PortAudioSink::start() {
     out.suggestedLatency = info->defaultLowOutputLatency;
     out.hostApiSpecificStreamInfo = 0;
 
-    // A null callback selects the blocking interface, which is what lets
-    // write() keep the same shape Dsp had.
+    // A callback rather than a null one, which is what makes the device drive
+    // the transfer instead of a blocking write; see the note on the class.
     PaError err = Pa_OpenStream(&m_stream, 0, &out,
                                 static_cast<double>(m_samples_per_sec),
-                                m_period, paClipOff, 0, 0);
+                                m_period, paClipOff, &PortAudioSink::trampoline,
+                                this);
     if(err != paNoError) {
         m_stream = 0;
         throw_pa("Pa_OpenStream", err);
     }
 
-    err = Pa_StartStream(m_stream);
-    if(err != paNoError) {
-        Pa_CloseStream(m_stream);
-        m_stream = 0;
-        throw_pa("Pa_StartStream", err);
-    }
+    // Deliberately not started here.
+    //
+    // The device would begin asking for samples with the ring still empty, so
+    // the first callbacks would pad with silence -- a real underrun on every
+    // single playback, which is both a small gap at the start and enough to
+    // make underran() useless as a signal.  write() starts it once there is
+    // something to play; see resume().
 
     if(std::getenv("JLIB_MEDIA_SINK_DEBUG")) {
         std::cerr << "PortAudioSink: " << info->name
@@ -183,6 +200,47 @@ void PortAudioSink::start() {
                   << " " << m_channels << "ch"
                   << " period " << m_period << " frames" << std::endl;
     }
+}
+
+int PortAudioSink::trampoline(const void*, void* out, unsigned long frames,
+                              const PaStreamCallbackTimeInfo*,
+                              PaStreamCallbackFlags, void* user) {
+    return static_cast<PortAudioSink*>(user)->process(out, frames);
+}
+
+int PortAudioSink::process(void* out, unsigned long frames) noexcept {
+    char* dst = static_cast<char*>(out);
+    const std::size_t want = static_cast<std::size_t>(frames) * m_frame;
+
+    // Everything here has to be safe under a realtime deadline: no allocation,
+    // no lock, nothing that can block, and no exception.  A ring read is a
+    // couple of atomic loads and a memcpy, and memset cannot fail.
+    const std::size_t got = m_ring ? m_ring->read(dst, want) : 0;
+
+    if(got < want) {
+        // Silence for the rest.  The ring ran dry while the device wanted
+        // samples, so there is a gap either way; filling it with zeroes is the
+        // only choice that does not also play whatever was in the buffer.
+        std::memset(dst + got, 0, want - got);
+        m_underran.store(true, std::memory_order_relaxed);
+    }
+
+    // Wake anyone waiting for room.  Nearly free when nobody is -- the wait is
+    // registered in the atomic, so notify checks and returns.
+    m_ticks.fetch_add(1, std::memory_order_release);
+    m_ticks.notify_one();
+
+    return paContinue;
+}
+
+void PortAudioSink::wait_for_callback() const {
+    // Read the counter before deciding to wait, so a callback that runs in
+    // between cannot be missed: wait() returns at once when the value has
+    // already moved on.
+    const unsigned seen = m_ticks.load(std::memory_order_acquire);
+
+    if(m_ring->writable() == 0)
+        m_ticks.wait(seen, std::memory_order_acquire);
 }
 
 const std::string& PortAudioSink::convert(const std::string& pcm, std::string& scratch) const {
@@ -212,6 +270,20 @@ const std::string& PortAudioSink::convert(const std::string& pcm, std::string& s
     return scratch;
 }
 
+void PortAudioSink::resume() {
+    if(m_stream == 0)
+        return;
+
+    // Idempotent: this runs on every write, and only the first one after a
+    // stop or an abort has anything to do.
+    if(Pa_IsStreamActive(m_stream) == 1)
+        return;
+
+    PaError err = Pa_StartStream(m_stream);
+    if(err != paNoError && err != paStreamIsNotStopped)
+        throw_pa("Pa_StartStream", err);
+}
+
 void PortAudioSink::write(const std::string& pcm) {
     if(!m_configured)
         throw exception("write() before config()");
@@ -221,49 +293,39 @@ void PortAudioSink::write(const std::string& pcm) {
     std::string scratch;
     const std::string& out = convert(pcm, scratch);
 
-    const int frame = get_frame_size();
-    const unsigned long frames = out.size() / frame;
+    // Whole frames only, so the ring never holds a fraction of one and the
+    // callback can never hand the device a torn frame.
+    const std::size_t n = (out.size() / m_frame) * m_frame;
 
-    if(frames == 0)
-        return;
+    std::size_t sent = 0;
+    while(sent < n) {
+        sent += m_ring->write(out.data() + sent, n - sent);
 
-    PaError err = Pa_WriteStream(m_stream, out.data(), frames);
+        // Start the device once it has something to play, and before waiting on
+        // it -- waiting first would wait for a callback that is not running.
+        resume();
 
-    // An underrun means we were late with the next period; the audio already
-    // played with a gap.  Reporting it as an error would abort playback for
-    // something that has already happened and is recoverable.
-    if(err == paOutputUnderflowed) {
-        if(std::getenv("JLIB_MEDIA_SINK_DEBUG"))
-            std::cerr << "PortAudioSink: output underflowed" << std::endl;
-        return;
+        if(sent < n)
+            wait_for_callback();
     }
-
-    if(err != paNoError)
-        throw_pa("Pa_WriteStream", err);
 }
 
 int PortAudioSink::available() const {
-    if(m_stream == 0)
+    if(!m_ring)
         return 0;
 
-    signed long n = Pa_GetStreamWriteAvailable(m_stream);
-    if(n < 0)
-        throw_pa("Pa_GetStreamWriteAvailable", static_cast<PaError>(n));
-
-    return static_cast<int>(n);
+    return static_cast<int>(m_ring->writable() / m_frame);
 }
 
 int PortAudioSink::queued() const {
-    if(m_stream == 0)
+    if(!m_ring)
         return 0;
 
-    // PortAudio reports free space, not fill.  The device's total buffering
-    // is not directly exposed, so derive the queue depth from how much of the
-    // window we are holding: anything not free is waiting to be played.
-    const int window = m_period * 2;
-    const int free = available();
+    return static_cast<int>(m_ring->readable() / m_frame);
+}
 
-    return (free >= window) ? 0 : (window - free);
+bool PortAudioSink::underran() {
+    return m_underran.exchange(false, std::memory_order_relaxed);
 }
 
 void PortAudioSink::reset() {
@@ -276,29 +338,62 @@ void PortAudioSink::reset() {
     if(err != paNoError && err != paStreamIsStopped)
         throw_pa("Pa_AbortStream", err);
 
-    err = Pa_StartStream(m_stream);
-    if(err != paNoError)
-        throw_pa("Pa_StartStream", err);
+    // Only now.  ringbuffer::clear() moves the read index, which belongs to
+    // the consumer, and the consumer is the callback -- so it is safe here and
+    // nowhere else, because the abort above has stopped it running.
+    m_ring->clear();
+    m_underran.store(false, std::memory_order_relaxed);
+
+    // Left stopped.  Restarting on an empty ring is the startup underrun all
+    // over again; the next write() resumes it.
 }
 
 void PortAudioSink::drain() {
     if(m_stream == 0)
         return;
 
-    // Pa_StopStream waits for queued audio to finish, which is what
-    // SNDCTL_DSP_SYNC did.
+    // Two things hold audio now, and both have to finish.
+    //
+    // First the ring: wait for the callback to take the rest of it, on the same
+    // event write() waits on.  Guarded by the stream being active, or a stopped
+    // or aborted stream would leave this waiting for a callback that is never
+    // going to run.
+    while(Pa_IsStreamActive(m_stream) == 1 && !m_ring->empty()) {
+        const unsigned seen = m_ticks.load(std::memory_order_acquire);
+
+        if(!m_ring->empty())
+            m_ticks.wait(seen, std::memory_order_acquire);
+    }
+
+    // Then the device's own buffer, which is what Pa_StopStream waits for.
     PaError err = Pa_StopStream(m_stream);
     if(err != paNoError && err != paStreamIsStopped)
         throw_pa("Pa_StopStream", err);
 
-    err = Pa_StartStream(m_stream);
-    if(err != paNoError)
-        throw_pa("Pa_StartStream", err);
+    // Left stopped, as in reset(): the next write() resumes it.
 }
 
 void PortAudioSink::close() {
     if(m_stream == 0)
         return;
+
+    // Let the ring finish before stopping.
+    //
+    // Pa_StopStream waits for the device but knows nothing about the ring, so
+    // stopping with samples still in it would cut the tail off -- which is the
+    // last note of a melody, since AudioSink::play() leaves the drain to
+    // close() precisely so there is no gap between notes.
+    try {
+        while(Pa_IsStreamActive(m_stream) == 1 && !m_ring->empty()) {
+            const unsigned seen = m_ticks.load(std::memory_order_acquire);
+
+            if(!m_ring->empty())
+                m_ticks.wait(seen, std::memory_order_acquire);
+        }
+    }
+    catch(...) {
+        // Closing has to happen regardless.
+    }
 
     PaStream* s = m_stream;
     m_stream = 0;   // clear first, so a throw below cannot leave a stale handle

--- a/jlib/media/PortAudioSink.hh
+++ b/jlib/media/PortAudioSink.hh
@@ -22,6 +22,10 @@
 #define JLIB_MEDIA_PORTAUDIOSINK_HH
 
 #include <jlib/media/AudioSink.hh>
+#include <jlib/sys/ringbuffer.hh>
+
+#include <atomic>
+#include <memory>
 
 #include <portaudio.h>
 
@@ -31,16 +35,31 @@ namespace jlib {
 namespace media {
 
 /**
- * An AudioSink over PortAudio's blocking API.
+ * An AudioSink over PortAudio's callback API.
  *
  * This replaces Dsp, which drove OSS through /dev/dsp -- an interface that no
- * longer exists on modern Linux and never existed on macOS.  PortAudio's
- * blocking mode maps almost one-to-one onto what Dsp did:
+ * longer exists on modern Linux and never existed on macOS.
  *
- *      Dsp::write()            ->  Pa_WriteStream()
- *      Dsp::get_frags_used()   ->  queued(), from Pa_GetStreamWriteAvailable()
- *      Dsp::reset()            ->  Pa_AbortStream() + restart
- *      SNDCTL_DSP_SYNC         ->  drain(), via Pa_StopStream()
+ *      write()   ->  a ring buffer
+ *      the ring  ->  a callback the device runs when it wants samples
+ *
+ * It used the blocking interface first, which mapped more directly onto what
+ * Dsp did, and was abandoned for a reason worth recording: that interface
+ * exposes nothing waitable.  Pa_WriteStream blocks until the device has taken
+ * everything, Pa_GetStreamWriteAvailable says what could be written without
+ * blocking, and there is no way to wait until that becomes true -- no
+ * descriptor, no event.  So the only wait on offer was the write itself, which
+ * meant either blocking whichever thread called it, or not blocking and
+ * needing a timer to replace the pacing that was lost.  See #60.
+ *
+ * The callback inverts it.  The device asks when it needs audio, write() fills
+ * a ring buffer ahead of it, and when the ring is full write() waits on a
+ * counter the callback bumps -- an event the device itself generates, so there
+ * is no polling and no sleeping anywhere in the path.
+ *
+ * The callback runs under a realtime deadline and may not allocate, take a
+ * lock, or block.  It does exactly three things: read from the ring, pad with
+ * silence if the ring came up short, and bump the counter.
  *
  * PortAudio has no unsigned 16-bit format and no big-endian formats, so the
  * PCM_U16_* and PCM_*_BE variants are converted on the way through; see
@@ -58,8 +77,26 @@ public:
 
     virtual void write(const std::string& pcm);
 
+    /**
+     * Frames waiting in the ring, and room for more, both exact.
+     *
+     * queued() used to guess.  PortAudio reports free space rather than fill
+     * and does not expose the device's total buffering, so it assumed a total
+     * and subtracted -- see #37.  The ring is ours, so its fill is a fact.
+     *
+     * The device holds a little beyond the ring, bounded by the latency it was
+     * opened with, which is not included here and cannot be.
+     */
     virtual int queued() const;
     virtual int available() const;
+
+    /**
+     * Whether the callback has had to emit silence since this was last asked.
+     *
+     * An underrun means the ring ran dry while the device wanted samples, so
+     * there is a gap in what was played.  Reading it clears it.
+     */
+    bool underran();
 
     virtual void reset();
     virtual void drain();
@@ -87,13 +124,55 @@ protected:
      */
     const std::string& convert(const std::string& pcm, std::string& scratch) const;
 
+    /** Open the device.  Does not start it; see resume(). */
     void start();
+
+    /** Start the device if it is not already running.  Idempotent. */
+    void resume();
     [[noreturn]] void throw_pa(const std::string& ctx, PaError err) const;
+
+    /** What PortAudio calls; forwards to process(). */
+    static int trampoline(const void* in, void* out, unsigned long frames,
+                          const PaStreamCallbackTimeInfo* time,
+                          PaStreamCallbackFlags status, void* user);
+
+    /**
+     * Fill one buffer for the device.  Realtime: no allocation, no locks, no
+     * blocking, and it cannot throw.
+     */
+    int process(void* out, unsigned long frames) noexcept;
+
+    /** Block until the callback has taken something, or the ring is empty. */
+    void wait_for_callback() const;
 
     PaStream* m_stream;
     PaSampleFormat m_pa_format;
     bool m_swap;    // incoming endianness differs from the host
     bool m_rebias;  // incoming is unsigned 16, PortAudio wants signed
+
+    /**
+     * Bytes per frame, cached.
+     *
+     * get_frame_size() computes it from the format, and the callback needs it
+     * on every buffer -- cheap, but the callback's budget is the one place
+     * worth not spending anything avoidable.
+     */
+    int m_frame;
+
+    /** Between write() and the callback. */
+    std::unique_ptr< jlib::sys::ringbuffer<char> > m_ring;
+
+    /**
+     * Bumped by the callback every time it runs.
+     *
+     * This is what write() and drain() wait on, using C++20's atomic wait,
+     * which parks in the kernel rather than spinning or sleeping.  Notifying
+     * costs almost nothing when nobody is waiting, which is the common case.
+     */
+    mutable std::atomic<unsigned> m_ticks;
+
+    /** Set by the callback when it padded with silence. */
+    std::atomic<bool> m_underran;
 };
 
 }


### PR DESCRIPTION
Second step of #60.  The device now asks for audio instead of being told, and
nothing in the path sleeps or spins.

    macOS  26 tests, 25 pass, 1 skip
    Linux  27 tests, 25 pass, 2 skip
    jnote and jmelody verified by ear

    Not covered by the suite, and worth saying plainly: the media tests only
    open a device under --play, so a silent run never executes a single
    callback.  Building and passing says nothing about whether this works.

what it looks like now

    write() -> ring buffer -> callback -> device

    write() fills the ring, and when the ring is full it waits on a counter the
    callback bumps -- C++20's atomic wait, which parks in the kernel.  No timer,
    no polling, and notifying costs almost nothing when nobody is waiting,
    which is the usual case.

    The callback does three things: read the ring, pad with silence if the ring
    came up short, bump the counter.  It runs under a realtime deadline, so it
    may not allocate, take a lock, block, or throw -- a ring read is two atomic
    loads and a memcpy, and memset cannot fail.

why the blocking interface could not do this

    Recorded because it is not obvious and I got it wrong once.  Pa_WriteStream
    blocks until the device has taken everything, and Pa_GetStreamWriteAvailable
    says what could be written without blocking -- but there is no way to wait
    until that becomes true.  No descriptor, no event; checked portaudio.h.

    So the only wait the blocking API offers is the write itself, and the two
    ways out both fail.  Blocking on the caller's thread is #36.  Not blocking
    removes the pacing that the block was providing: AudioSink::play() is
    while(s) play_frag(s), and measured against a sink that frees a period at a
    time, that polled 562 times per period written.  Replacing the pacing means
    a sleep, which is a timer standing in for an event.

    The callback supplies the event that was missing.

queued() is exact now

    It used to assume the device's total buffering was two periods and subtract
    the free space, because PortAudio reports free space and not fill -- #37.
    The ring is ours, so its fill is a fact.  Documented as excluding the
    device's own buffer, which is bounded by the latency the stream was opened
    with and genuinely cannot be known.

three orderings that matter

    reset() aborts before clearing the ring.  ringbuffer::clear() moves the
    read index, which belongs to the consumer, and the consumer is the
    callback: it is safe there and nowhere else, because the abort has stopped
    it running.

    close() drains the ring before stopping.  Pa_StopStream waits for the
    device but knows nothing about the ring, so stopping with samples still in
    it cuts off the tail -- which is the last note of a melody, since
    AudioSink::play() leaves the drain to close() so there is no gap between
    notes.

    The device starts on the first write, not at config().  Starting it with
    the ring empty meant the callback ran immediately and padded with silence:
    a real underrun on every playback, a gap at the start, and underran() stuck
    true and therefore useless.  reset() and drain() leave the stream stopped
    for the same reason and let the next write resume it.

still to come

    #36 is not closed by this.  write() still blocks when the ring is full, and
    Player still calls it from the thread that reads its commands -- the wait is
    better but it is in the same place.  The feeder thread that moves it is the
    next step, and closes #36 and #37 together.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
