### PR TITLE
Move audio onto a feeder thread

### DIFF
--- a/jlib/media/Player.cc
+++ b/jlib/media/Player.cc
@@ -70,11 +70,28 @@ namespace jlib {
 
         
         Player::~Player() {
-            // The worker touches m_sink and m_stream, both members of Player.
-            // Leaving this empty meant those were destroyed -- closing the
-            // audio device -- while the worker was potentially still inside
-            // play_slot(), because ~Servent only runs after ~Player returns.
-            stop();
+            // Both threads have to stop before any member does.
+            //
+            // The feeder and the Servent worker each touch m_sink and
+            // m_stream, which are Player's, and ~Servent runs after Player's
+            // members are already gone -- so its own stop() is too late to
+            // help.  This used to call stop(), which resolves to Player::stop()
+            // and merely posts a STOP command before returning; the worker was
+            // still running when the members went away.  Servent::stop() is the
+            // one that joins, and it has to be named explicitly because the
+            // transport stop() hides it.
+            //
+            // The feeder goes first: it is the one that blocks, and it blocks
+            // inside the sink, so it has to be let out before anything closes
+            // the device.
+            m_feeding.store(false, std::memory_order_release);
+            m_sink.interrupt();
+            update_feed_state();
+
+            if(m_feeder.joinable())
+                m_feeder.join();
+
+            Servent::stop();
         }
             
         
@@ -100,11 +117,11 @@ namespace jlib {
             map(FFWD, [this](auto&&... a) { return this->ffwd_signal(a...); });
             map(RELOAD, [this](auto&&... a) { return this->reload_signal(a...); });
 
-            // Built as the pair's own type rather than with std::make_pair,
-            // which would deduce the two lambda types and leave no conversion
-            // to pair<function<bool()>, function<void()>>.
-            add(condition_list_type::value_type([this]() { return is_playing(); },
-                                                [this]() { play_slot(); }));
+            // Audio moves on its own thread, not as a condition of the
+            // command loop.  play_slot() blocks while the sink's ring is full,
+            // and the command loop is the one thing that must not.
+            m_feeding.store(true, std::memory_order_release);
+            m_feeder = std::thread([this]() { feed(); });
 
             run();
         }
@@ -129,6 +146,8 @@ namespace jlib {
             m_playing = !m_playing;
             if(!m_playing)
                 m_sink.reset();
+
+            update_feed_state();
         }
 
         void Player::pause_signal() { 
@@ -136,9 +155,14 @@ namespace jlib {
                 std::cerr << "\treceived PAUSE command" << std::endl;
             m_playing = false;
             m_sink.reset();
+
+            update_feed_state();
         }
 
         void Player::stop_signal() { 
+            // The feeder is reading this stream on its own thread now.
+            std::lock_guard<std::mutex> lock(m_stream_lock);
+
             if(getenv("JLIB_MEDIA_PLAYER_DEBUG")) 
                 std::cerr << "\treceived STOP command" << std::endl;
             m_playing = false;
@@ -149,9 +173,14 @@ namespace jlib {
                 send_pulse(true);
             }
 
+
+            update_feed_state();
         }
 
         void Player::rewind_signal() { 
+            // The feeder is reading this stream on its own thread now.
+            std::lock_guard<std::mutex> lock(m_stream_lock);
+
             if(getenv("JLIB_MEDIA_PLAYER_DEBUG")) 
                 std::cerr << "\treceived REWIND command" << std::endl;
 
@@ -170,9 +199,14 @@ namespace jlib {
                 send_pulse(true);
             }
 
+
+            update_feed_state();
         }
 
         void Player::ffwd_signal() { 
+            // The feeder is reading this stream on its own thread now.
+            std::lock_guard<std::mutex> lock(m_stream_lock);
+
             if(getenv("JLIB_MEDIA_PLAYER_DEBUG")) 
                 std::cerr << "\treceived FFWD command" << std::endl;
             
@@ -192,9 +226,14 @@ namespace jlib {
                 send_pulse(true);
             }
 
+
+            update_feed_state();
         }
 
         void Player::reload_signal() { 
+            // The feeder is reading this stream on its own thread now.
+            std::lock_guard<std::mutex> lock(m_stream_lock);
+
             if(getenv("JLIB_MEDIA_PLAYER_DEBUG")) 
                 std::cerr << "\treceived RELOAD command" << std::endl;
 
@@ -207,6 +246,8 @@ namespace jlib {
 
             m_sink.config(*m_stream);
             m_sink.reset();
+
+            update_feed_state();
         }
 
         void Player::send_pulse(bool force) {
@@ -222,36 +263,96 @@ namespace jlib {
         }
 
 
+        void Player::feed() {
+            while(m_feeding.load(std::memory_order_acquire)) {
+                {
+                    std::unique_lock<std::mutex> lock(m_feed_lock);
+                    m_feed_wake.wait(lock, [this]() {
+                        return !m_feeding.load(std::memory_order_acquire) ||
+                               m_feed_go.load(std::memory_order_acquire);
+                    });
+                }
+
+                if(!m_feeding.load(std::memory_order_acquire))
+                    break;
+
+                try {
+                    play_slot();
+                }
+                catch(std::exception& e) {
+                    // An exception leaving a thread function calls terminate,
+                    // and the sink throws readily enough -- there being no
+                    // device at all is the ordinary case in a container.  Stop
+                    // playing rather than retrying, or a persistent failure
+                    // becomes a spin.
+                    std::cerr << "jlib::media::Player::feed(): "
+                              << e.what() << std::endl;
+
+                    m_playing = false;
+                    update_feed_state();
+                }
+            }
+        }
+
+        void Player::update_feed_state() {
+            m_feed_go.store(is_playing() && m_stream != 0,
+                            std::memory_order_release);
+
+            // Taking the feeder's lock before notifying, even though what it
+            // waits on is an atomic held elsewhere.  If the feeder is between
+            // testing its predicate and going to sleep it holds this lock, so
+            // this blocks until it is genuinely waiting -- which is what keeps
+            // the wakeup from being lost.
+            {
+                std::lock_guard<std::mutex> lock(m_feed_lock);
+            }
+
+            m_feed_wake.notify_all();
+        }
+
         void Player::play_slot() {
             if(getenv("JLIB_MEDIA_PLAYER_DEBUG")) {
                 std::cerr << "enter jlib::media::Player::play_slot()" << std::endl;
             }
 
-            if(!m_stream->eof()) {
-                send_pulse(false);
+            std::string buf;
+            bool ended = false;
 
-                // Top the device up to m_periods_desired periods queued.  This
-                // is counted in frames now rather than OSS fragments, which
-                // were a byte count unrelated to frame size.
-                const int want = m_periods_desired * m_sink.get_period();
-                const int have = m_sink.queued();
+            {
+                // The stream, briefly.  A command may be seeking or replacing
+                // it, and until the feeder existed that could not happen while
+                // it was being read.
+                std::lock_guard<std::mutex> lock(m_stream_lock);
 
-                if(have < want) {
-                    const int periods = (want - have + m_sink.get_period() - 1) / m_sink.get_period();
-                    m_sink.play_frag(*m_stream, periods);
+                if(m_stream == 0)
+                    return;
+
+                if(!m_stream->eof()) {
+                    send_pulse(false);
+
+                    jlib::sys::getstring(*m_stream, buf,
+                                         m_periods_desired * m_sink.get_period() *
+                                         m_sink.get_frame_size());
                 }
 
-                if(getenv("JLIB_MEDIA_PLAYER_DEBUG")) {
-                    std::cerr << "\t" << have << "/" << want << " frames queued" << std::endl;
+                if(m_stream->eof()) {
+                    if(m_loop)
+                        m_stream->rewind();
+                    else
+                        ended = true;
                 }
             }
-            
-            if(m_stream->eof()) {
-                if(m_loop)
-                    m_stream->rewind();
-                else
-                    m_playing = false;
+
+            // Outside the lock, because this blocks until the sink's ring has
+            // room -- and a transport command must not wait on that.
+            if(!buf.empty())
+                m_sink.write(buf);
+
+            if(ended) {
+                m_playing = false;
+                update_feed_state();
             }
+
             if(getenv("JLIB_MEDIA_PLAYER_DEBUG")) {
                 std::cerr << "leave jlib::media::Player::play_slot()" << std::endl;
             }

--- a/jlib/media/Player.hh
+++ b/jlib/media/Player.hh
@@ -29,6 +29,11 @@
 #include <jlib/media/stream.hh>
 #include <jlib/media/PortAudioSink.hh>
 
+#include <atomic>
+#include <condition_variable>
+#include <mutex>
+#include <thread>
+
 #include <sys/poll.h>
 
 namespace jlib {
@@ -85,6 +90,25 @@ namespace jlib {
 
             void play_slot();
 
+            /**
+             * The feeder: moves samples from the stream into the sink.
+             *
+             * Its own thread, because the write it makes blocks when the sink's
+             * ring is full.  That used to happen on the Servent worker, which
+             * is also the thread reading the command pipe, so a PAUSE or a STOP
+             * waited behind the device -- #36.  Nothing on this thread reads
+             * commands, so blocking here costs nothing.
+             */
+            void feed();
+
+            /**
+             * Recompute whether the feeder has work, and wake it.
+             *
+             * Call after anything that changes whether there is audio to move:
+             * play, pause, stop, a new stream, end of stream.
+             */
+            void update_feed_state();
+
             void send_pulse(bool force);
 
             stream* m_stream;
@@ -98,6 +122,41 @@ namespace jlib {
 
             PortAudioSink m_sink;
             int m_periods_desired;
+
+            std::thread m_feeder;
+
+            /** False tells the feeder to finish; see ~Player. */
+            std::atomic<bool> m_feeding;
+
+            /**
+             * Whether the feeder has anything to do, as a plain atomic.
+             *
+             * Deliberately not read from m_playing, which is a sync<bool> with
+             * a lock of its own.  The feeder holds m_feed_lock while testing
+             * its predicate, and the setters hold m_playing's lock before
+             * taking m_feed_lock -- reading m_playing inside the predicate
+             * would take the two in opposite orders and could deadlock.  One
+             * atomic, written under the same discipline as the rest, avoids it.
+             */
+            std::atomic<bool> m_feed_go;
+
+            std::mutex m_feed_lock;
+            std::condition_variable m_feed_wake;
+
+            /**
+             * Guards m_stream and the position within it.
+             *
+             * The feeder reads samples out of the stream while the command
+             * worker may be seeking it, swapping it, or rewinding it -- which
+             * were the same thread until the feeder existed, and so needed
+             * nothing.
+             *
+             * Held only across the read, never across the write to the sink.
+             * The write blocks until the device has room, and holding this
+             * over it would make every transport command wait for the device
+             * again -- the very thing the feeder exists to avoid.
+             */
+            std::mutex m_stream_lock;
         };
     }
 }

--- a/jlib/media/PortAudioSink.cc
+++ b/jlib/media/PortAudioSink.cc
@@ -67,7 +67,9 @@ PortAudioSink::PortAudioSink()
       m_rebias(false),
       m_frame(0),
       m_ticks(0),
-      m_underran(false)
+      m_underran(false),
+      m_interrupt(false),
+      m_silence(0)
 {
     require_portaudio();
 }
@@ -145,6 +147,9 @@ void PortAudioSink::config(int samples_per_sec, int channels, int format) {
 
     m_frame = get_frame_size();
 
+    // Unsigned 8-bit puts silence at the middle of the range, not at zero.
+    m_silence = (m_pa_format == paUInt8) ? 0x80 : 0x00;
+
     // Eight periods of slack between write() and the device.
     //
     // The ring is the whole of the tolerance for the feeding thread being late:
@@ -221,7 +226,7 @@ int PortAudioSink::process(void* out, unsigned long frames) noexcept {
         // Silence for the rest.  The ring ran dry while the device wanted
         // samples, so there is a gap either way; filling it with zeroes is the
         // only choice that does not also play whatever was in the buffer.
-        std::memset(dst + got, 0, want - got);
+        std::memset(dst + got, m_silence, want - got);
         m_underran.store(true, std::memory_order_relaxed);
     }
 
@@ -270,6 +275,15 @@ const std::string& PortAudioSink::convert(const std::string& pcm, std::string& s
     return scratch;
 }
 
+void PortAudioSink::interrupt() {
+    m_interrupt.store(true, std::memory_order_release);
+
+    // Bump the counter as well as setting the flag, so a writer already parked
+    // in the wait comes back to look at it.
+    m_ticks.fetch_add(1, std::memory_order_release);
+    m_ticks.notify_all();
+}
+
 void PortAudioSink::resume() {
     if(m_stream == 0)
         return;
@@ -297,8 +311,14 @@ void PortAudioSink::write(const std::string& pcm) {
     // callback can never hand the device a torn frame.
     const std::size_t n = (out.size() / m_frame) * m_frame;
 
+    // A fresh call is not interrupted; only one already in progress can be.
+    m_interrupt.store(false, std::memory_order_release);
+
     std::size_t sent = 0;
     while(sent < n) {
+        if(m_interrupt.load(std::memory_order_acquire))
+            return;
+
         sent += m_ring->write(out.data() + sent, n - sent);
 
         // Start the device once it has something to play, and before waiting on
@@ -343,6 +363,9 @@ void PortAudioSink::reset() {
     // nowhere else, because the abort above has stopped it running.
     m_ring->clear();
     m_underran.store(false, std::memory_order_relaxed);
+
+    // Whoever was writing is now writing into a ring nobody is draining.
+    interrupt();
 
     // Left stopped.  Restarting on an empty ring is the startup underrun all
     // over again; the next write() resumes it.

--- a/jlib/media/PortAudioSink.hh
+++ b/jlib/media/PortAudioSink.hh
@@ -98,6 +98,20 @@ public:
      */
     bool underran();
 
+    /**
+     * Abandon a write() that is waiting for room.
+     *
+     * write() parks until the callback frees space, and the callback stops
+     * running when the stream does -- so a thread blocked in it would wait for
+     * a wakeup that is never coming.  reset() calls this, and anything that
+     * stops the device while another thread might be writing needs to.
+     *
+     * The write gives up where it is; the samples it had not placed are lost.
+     * That is the right outcome for the things that call it, which are stop,
+     * pause and shutdown, all of which discard the ring anyway.
+     */
+    void interrupt();
+
     virtual void reset();
     virtual void drain();
     virtual void close();
@@ -173,6 +187,19 @@ protected:
 
     /** Set by the callback when it padded with silence. */
     std::atomic<bool> m_underran;
+
+    /** Tells a waiting write() to give up; see interrupt(). */
+    std::atomic<bool> m_interrupt;
+
+    /**
+     * The byte that means silence in the configured format.
+     *
+     * Zero for every signed and floating format, and 0x80 for unsigned 8-bit,
+     * where zero is full-scale negative rather than the middle.  The callback
+     * pads underruns with this, and padding an unsigned stream with zeroes is
+     * a loud click rather than a gap.
+     */
+    unsigned char m_silence;
 };
 
 }

--- a/tests/media_player_test.cc
+++ b/tests/media_player_test.cc
@@ -8,6 +8,10 @@
 #include <jlib/media/datastream.hh>
 #include <jlib/media/notestream.hh>
 #include <jlib/media/Player.hh>
+
+#include <chrono>
+#include <cstdlib>
+#include <thread>
 #include <jlib/media/PortAudioSink.hh>
 
 #include <jlib/sys/sys.hh>
@@ -18,17 +22,94 @@ const long double 	PI = 3.14159265358979323846264338;
 
 
 
+/**
+ * Fail rather than hang.
+ *
+ * Everything below is about starting and stopping threads, so the way it goes
+ * wrong is a deadlock, and a deadlocked test hangs the whole suite until
+ * somebody notices.  A watchdog turns that into an ordinary failure with a
+ * message saying where.
+ */
+static void watchdog(const char* what, int seconds) {
+    std::thread([what, seconds]() {
+        std::this_thread::sleep_for(std::chrono::seconds(seconds));
+        std::cerr << "media_player_test: deadlock in " << what
+                  << " -- gave up after " << seconds << "s" << std::endl;
+        std::abort();
+    }).detach();
+}
+
+/**
+ * Start and stop a Player without ever playing anything.
+ *
+ * Worth running with no device and no sound, because it covers the part most
+ * likely to be wrong: Player now runs two threads, a command worker and a
+ * feeder, and both touch members of Player.  Both have to be stopped before
+ * those members are destroyed, and the feeder can be parked inside the sink
+ * waiting for room when the time comes to stop it.
+ *
+ * The sink only opens a device on the first play, so all of this runs
+ * anywhere -- including the container, where there is no device at all.
+ */
+static int lifecycle() {
+    using namespace jlib::media;
+
+    int failures = 0;
+
+    watchdog("lifecycle", 30);
+
+    {
+        // built and destroyed, never told to do anything
+        notestream note(220.0);
+        Player p(&note);
+    }
+    std::cout << "  ok   construct and destroy\n";
+
+    {
+        // told to stop without ever having played
+        notestream note(220.0);
+        Player p(&note);
+        p.stop();
+    }
+    std::cout << "  ok   stop without play\n";
+
+    {
+        // the stream swapped underneath it, which reload_signal handles on the
+        // worker while the feeder is waiting on the same state
+        notestream a(220.0), b(440.0);
+        Player p(&a);
+        p.set_stream(&b);
+        p.stop();
+    }
+    std::cout << "  ok   stream replaced\n";
+
+    {
+        // several in a row, since a leaked or unjoined thread shows up here
+        for(int i = 0; i < 8; i++) {
+            notestream note(220.0);
+            Player p(&note);
+            p.stop();
+        }
+    }
+    std::cout << "  ok   eight in succession\n";
+
+    return failures;
+}
+
 int main(int argc, char** argv) {
     using namespace jlib::media;
     using namespace jlib::tests;
 
-    // Player drives a real device, so unlike the other media tests there is
-    // nothing to verify without one.  Silent by default means skip.
+    if(lifecycle() != 0)
+        return 1;
+
+    // The rest drives a real device, so there is nothing to verify without
+    // one.  Silent by default means skip.
     const audio_mode mode = get_audio_mode(argc, argv);
 
     if(mode == AUDIO_SILENT) {
-        std::cerr << "Player needs a device; pass --play to exercise it" << std::endl;
-        return 77;
+        std::cerr << "playback needs a device; pass --play to exercise it" << std::endl;
+        return 0;
     }
 
     if(!PortAudioSink::have_output_device()) {
@@ -38,14 +119,24 @@ int main(int argc, char** argv) {
 
     try {
         notestream note(220.0);
-        note.set_format(Type::PCM_U8);
+        // Float32, not U8.  The other media tests moved to clean formats when
+        // is_clean_format() went into audio_test.hh -- 8-bit is about 48dB of
+        // signal to noise and the quantization is plainly audible -- and this
+        // one was missed.
+        note.set_format(Type::PCM_FLOAT32);
         note.set_channels(2);
         note.set_time(1);
+
+        watchdog("playback", 30);
 
         Player p(&note);
         p.play();
         for(int i=0;i<2;i++)
             sleep(1);
+
+        // stop while the feeder may be parked inside the sink waiting for the
+        // ring to drain: it has to be woken, not left there
+        p.stop();
     }
     catch(std::exception& e) {
         std::cerr << e.what() << std::endl;


### PR DESCRIPTION
closes #36, closes #37, closes #60

Last step of the callback work.  Player ran audio as a condition of its command
loop, so the thread that would notice a PAUSE or a STOP was the thread waiting
on the device.  Now nothing that reads commands ever waits for audio.

    macOS  26 tests, 26 pass, 0 skip
    Linux  27 tests, 26 pass, 1 skip
    the lifecycle tests are clean under ThreadSanitizer

    Linux gained a pass rather than a skip: media_player_test used to skip
    outright without a device, and now runs its lifecycle half anywhere.

the feeder

    A thread of Player's own, moving samples from the stream into the sink.  It
    waits on a condition variable when there is nothing to play and blocks
    inside the sink when the ring is full -- and blocking there is now free,
    because it is the only thing that thread does.

    The top-up arithmetic went with it.  play_slot() used to ask queued() how
    full the device was and write the difference; the ring is the run-ahead
    now, and it is sized for that.

    Commands set state and wake the feeder.  Every handler that changes whether
    there is audio to move calls update_feed_state(), which recomputes one
    atomic and notifies.

three things that had to be got right

    Waking a writer that is parked in the sink.  write() waits on a counter the
    callback bumps, and the callback stops when the stream does -- so stopping
    the device would leave a feeder waiting for a wakeup that was never coming.
    PortAudioSink::interrupt() sets a flag and bumps the counter; reset() calls
    it, and so does ~Player.  The interrupted write abandons what it had left,
    which is right for the things that call it: stop, pause and shutdown all
    discard the ring anyway.

    The stream, which two threads now touch.  reload_signal replaces it while
    the feeder is dereferencing it, and stop, rewind and ffwd seek it while the
    feeder is reading -- all of which were safe only because they were the same
    thread.  m_stream_lock guards it, held across the read and never across the
    write, since holding it over a blocking write would make transport commands
    wait on the device again and undo the point of the exercise.

    Not reading m_playing in the feeder's wait predicate.  It is a sync<bool>
    with its own lock, and the setters take that lock before m_feed_lock -- so
    testing it inside the predicate, which runs holding m_feed_lock, would take
    the two in opposite orders.  m_feed_go is a plain atomic written under the
    same discipline, and the predicate reads only atomics.

three bugs found on the way

    ~Player called stop(), which resolves to Player::stop() -- the transport
    stop, which posts a command and returns.  It hides Servent::stop(), the one
    that joins the worker.  So the comment there described a fix that was not
    happening: the worker was still running when Player's members, including
    the sink and the stream it touches, were destroyed.  Both threads are now
    stopped explicitly, feeder first, since it is the one that blocks.

    feed() could let an exception escape a thread function, which calls
    terminate.  The sink throws readily -- no device at all is the ordinary
    case in a container -- so the feeder catches, reports, and stops playing
    rather than retrying, which would turn a persistent failure into a spin.

    The callback padded underruns with zero bytes, and zero is not silence in
    every format.  Unsigned 8-bit puts silence in the middle of the range, so
    zero is full-scale negative: when the note ended and the ring drained, the
    padding stepped hard to the bottom of the range and held there -- an
    audible pop, and then DC until the stream stopped.  Heard as a pop at the
    end of media_player_test, which was the only test still playing U8.

    The sink works out the silence byte from the configured format now, at
    config() time, so it stays right whatever the format rather than for the
    ones that happen to be exercised.

tests

    media_player_test moved to float32.  Every other media test moved to a
    clean format when is_clean_format() went into audio_test.hh -- 8-bit is
    about 48dB of signal to noise and the quantization is plainly audible --
    and this one was missed.  Playing it is what turned up the padding bug
    above.

    media_player_test grew a lifecycle half that needs no device, because the
    device is only opened on the first play.  Construct and destroy, stop
    without ever playing, replace the stream underneath it, and eight in
    succession to catch a thread that is leaked rather than joined.

    Behind a watchdog.  The way this goes wrong is a deadlock, and a
    deadlocked test hangs the suite until somebody notices; the watchdog turns
    that into an ordinary failure that says where.

    TSan is worth something here, unlike on the ring buffer: this is ordinary
    shared state between two threads rather than atomics, which is exactly what
    it detects.

not covered

    Playback itself, as ever: the audible half still needs --play and a device.
    media_player_test --play is the one that exercises this, since jnote and
    jmelody drive the sink directly and never construct a Player.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
