### PR TITLE
Make lookAt an actual look-at

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,12 +16,12 @@ Each subdirectory of `jlib/` is one automake-built libtool library named
 
 | Dir | Library | What it is |
 | --- | --- | --- |
-| `jlib/sys` | `libjsys` | The foundation. iostream-based wrappers over OS facilities: `socketstream`, `sslstream`/`tlsstream`, `proxystream`, `sslproxystream`, `serialstream`, `pstream` (subprocess), `tfstream` (temp file). Plus `Servent`/`ASServent` (threaded worker + command queue), `sync<T>` (mutex-wrapped value, C++11), `pipe`, `Directory`, `joystick`, `Object` (a polymorphic base), `signal<R(Args...)>`. |
+| `jlib/sys` | `libjsys` | The foundation. iostream-based wrappers over OS facilities: `socketstream`, `sslstream`/`tlsstream`, `proxystream`, `sslproxystream`, `serialstream`, `pstream` (subprocess), `tfstream` (temp file). Plus `Servent`/`ASServent` (threaded worker + command queue), `sync<T>` (mutex-wrapped value, C++11), `ringbuffer<T>` (lock-free, one producer and one consumer, written for the audio callback), `pipe`, `Directory`, `joystick`, `Object` (a polymorphic base), `signal<R(Args...)>`. |
 | `jlib/util` | `libjutil` | String/format grab bag: `util.hh` (tokenize, trim, chop, base64/qp/URI codecs, byte `get`/`set`), `Regex` (POSIX `regex.h`), `Date` (RFC-822 etc.), `Headers` (MIME header folding), `MimeType`, `URL`, `Timer`, a hand-rolled XML tokenizer/parser/DOM (`xml.hh`, `xmlparser.hh`, `xmltokenizer.hh`), and `json.hh` (a C++ facade over json-c). |
 | `jlib/crypt` | `libjcrypt` | `crypt.hh` wraps GPGME (OpenPGP encrypt/sign/verify). The `curve`/`schnorr`/`groth` trio is the recent work: ristretto255 `Scalar`/`Point`/`Commitment` over libsodium, Schnorr proofs (single, double, `GeneralProof<N>`), and Groth binary/zero-argument proofs. Built only when libsodium *with* ristretto headers is present. |
 | `jlib/net` | `libjnet` | Email client stack: `Email` (MIME parsing), `MailBox`/`MBox`/`Imap4Box`, `Pop3`, `Imap4`, `MailFolder`, plus `AS*` async variants layered on `sys::ASServent`. `net.cc` has the address-extraction logic the `net_extract_address_*` tests cover. |
-| `jlib/media` | `libjmedia` | Audio via PortAudio. `AudioSink` is the device interface and `PortAudioSink` the implementation; `Player` (a `Servent`), `AudioFile`/`WavFile`, `PlayList`, and streambuf-based `datastream`/`wavstream`/`notestream`/`audiofilestream`. `Type.hh` is a template-specialization table over PCM sample formats. `Dsp` is the retired OSS backend, kept but not built. |
-| `jlib/math` | `libjmath` | Header-only despite being a `lib_LTLIBRARIES` (its `_SOURCES` are all `.hh`). `matrix`, `vertex`, `tensor`, `buffer`, `polynomial` (templated on a Power type so it can hold curve `Scalar`s), and `Plot<T>` — the abstract plotting base. |
+| `jlib/media` | `libjmedia` | Audio via PortAudio, driven from its **callback**: `write()` fills a `sys::ringbuffer` and the device's callback drains it, so nothing in the path sleeps or polls. `AudioSink` is the device interface and `PortAudioSink` the implementation; `Player` (a `Servent`) runs a feeder thread so transport commands never wait on the device. Plus `AudioFile`/`WavFile`, `PlayList`, and streambuf-based `datastream`/`wavstream`/`notestream`/`audiofilestream`. `Type.hh` is a template-specialization table over PCM sample formats. `Dsp` is the retired OSS backend, kept but not built. |
+| `jlib/math` | `libjmath` | Header-only despite being a `lib_LTLIBRARIES` (its `_SOURCES` are all `.hh`). `matrix`, `vertex`, `tensor`, `buffer`, `polynomial` (templated on a Power type so it can hold curve `Scalar`s), and `Plot<T>` — the abstract plotting base, with `projection_mode` for perspective, orthographic or mixed. `object<T>` holds index-based topology — vertices, edges, and 2-faces built lazily — with `cuboid`, `pyramoid`, `spheroid`, `staroid` and `torus` (a flat k-torus in n dimensions; equal radii and k=2 is the Clifford torus). |
 | `jlib/x` | `libjx` | Raw Xlib: `Display`, `Window`, and an X11 `Plot`. |
 | `jlib/gl`, `glu`, `glx`, `glfw` | `libjgl`, … | Thin OpenGL layers: lights/buffers/shapes, textures/projection, a GLX window (Linux only), and a GLFW window that works everywhere. `glx/Plot.hh` and `glfw/Plot.hh` are backends for `math::Plot<T>`. |
 | `jlib/ai` | `libjai` | Norvig-style agent scaffolding (`Agent`, `Environment`, `Percept`, `Action`, `vacuum`) plus `neural.hh`, a templated feed-forward net. |
@@ -39,9 +39,14 @@ or `cuda`.
 - `jhyper`, `jglxhyper`, `jglfwhyper`, `jhardhyper` — the 4-D hypercube/torus
   visualizations, named for their backend. Shared logic is in `Hyper.hh`
   (`HyperPlot<T, Plot>`, templated on the plot backend so the same code renders
-  under X11 raster, GLX, or GLFW). `jhardhyper` still carries a forked copy of
-  `HyperPlot` because it reduces N→3 rather than N→2. `jgltorus`, `jglxbox` are
-  simpler GL demos.
+  under X11 raster, GLX, or GLFW), with `color.hh` holding the HSV helpers both
+  it and `jhardhyper` use. The two are deliberately different: **jglfwhyper**
+  reduces all the way to 2-D in software and is where the projection modes are
+  demonstrated; **jhardhyper** reduces N→3 and hands real 3-D to the GPU, so it
+  is the one that draws **solids** — depth-sorted translucent faces, per-frame
+  normals, and a stereographic mode that shows the Hopf foliation as nested
+  tori. It still carries a forked copy of `HyperPlot` for that reason (#28).
+  `jgltorus`, `jglxbox` are simpler GL demos.
 - `jneural-zero`, `jneural-alpha`, `jneural-search` — neural net experiments
   (`-alpha` does image classification via ImageMagick++/MNIST).
 - `jjoystick`, `jjoy2xev` — Linux joystick → X events, with `*-{axes,buttons}-*.map`
@@ -99,19 +104,42 @@ The media tests are silent unless passed `--play` or `--play-all`.
   bodies, not inside them (see `crypt/curve.hh`, `math/tensor.hh`).
 - In `.cc` files, drop redundant `jlib::` qualifiers — the file is already in the
   namespace.
+- Strings that carry a payload go by `const&`, or by value plus `std::move` when
+  the callee stores them. Much of the library predates C++11, when libstdc++'s
+  `std::string` was copy-on-write and passing one by value was free; it is a deep
+  copy now. A handful take by value deliberately — `Headers::decode`,
+  `net::convert_to_crlf`, the note parser — because they modify and return the
+  argument, and say so.
+- A user-declared destructor suppresses the implicit move operations, so an empty
+  one silently costs a class its move semantics. Prefer none; where one is needed
+  (a polymorphic base, or it anchors the vtable), default the other four.
 
 ## State of things
 
 Between 2020 and 2021 the active work was `crypt` (curve/schnorr/groth) and the
 `math::polynomial` support behind it. In 2026 the library was ported to build on
-macOS and modern Linux: autotools modernized to C++20, libsigc++ and glibmm
-replaced with `std::`, OSS replaced with PortAudio, GLUT replaced with GLFW, and
-a number of latent bugs fixed along the way.
+macOS and modern Linux, in a seven-phase plan that is now **complete**: autotools
+modernized to C++20, libsigc++ and glibmm replaced with `std::`, OSS replaced
+with PortAudio, GLUT replaced with GLFW, 4-D objects rendered as solid 3-D
+geometry, and an API pass over copies, moves and exception specifications.
+
+The headline goal since 1999 — rendering 4D+ objects as solid 3-D geometry — is
+done. `jhardhyper` draws translucent depth-sorted faces with per-frame normals,
+for hypercubes and for the flat torus, and under stereographic projection shows
+the Hopf foliation as nested tori.
 
 Both `TODO.md` items are done — libsigc++ is gone, and `sys/sslstream.hh` now
 uses the system trust store and verifies the hostname with `SSL_set1_host`.
 
-Remaining work is tracked in GitHub issues, labelled by phase. The headline goal
-is rendering 4D+ objects as solid 3D geometry: `math::Plot<T>` still reduces all
-the way to 2D on the CPU (`phase-5-4d`), and `math::object<T>` has no faces at
-all, only a 1-skeleton (`phase-6-solids`).
+Remaining work is tracked in GitHub issues; the phase labels are historical now.
+What is left is a normal backlog rather than porting: one network bug (#11,
+SIGPIPE terminates the process on a dropped connection), the graphics chain that
+would let one `HyperPlot` serve both apps (#20 → #24 → #28), tessellation and
+face enumeration for the remaining shapes (#31, #35), and some efficiency and
+API tidying (#47, #53).
+
+Two habits from this work worth keeping. **Measure before diagnosing** — several
+"obvious" causes here were wrong, and the counter-example was usually a ten-line
+program under a counting `operator new` or a sanitizer. And **say what a test
+does not establish**: `sys_ringbuffer_test` passes, and neither it nor TSan
+verifies the memory ordering it depends on, which is written down in both.

--- a/jlib/apps/Hyper.hh
+++ b/jlib/apps/Hyper.hh
@@ -133,7 +133,21 @@ void HyperPlot<T,Plot>::initialize(uint n) {
     change(n);
     
     initialize_rotation(n);
-    (*this) * matrix<T>::lookAt(n, eye, up, center);
+    // A translation, not a camera.
+    //
+    // The eye sits at a positive offset on every axis that gets projected away,
+    // so that each step's frustum has the figure wholly in front of it -- see
+    // initialize_glazzies.  That is not a direction to look in: above D=4 it is
+    // diagonal across several axes at once, and a real lookAt would rotate it
+    // onto one of them and leave the others with no offset at all, putting the
+    // figure outside the clip volume.
+    //
+    // This said lookAt(n, eye, up, center) and got a translation because that
+    // was all lookAt did.  Now that lookAt is a camera, say what is meant.
+    vertex<T> back(n);
+    for(uint i = 0; i < n; i++) back[i] = -eye[i];
+
+    (*this) * matrix<T>::translate(n, back);
 
     switch(shape) {
     case CUBOID: {
@@ -276,7 +290,10 @@ void HyperPlot<T,Plot>::key_pressed(unsigned char key, int x, int y) {
 
         initialize_glazzies(this->D);
         initialize_rotation(this->D);
-        (*this) * matrix<T>::lookAt(this->D, eye, up, center);
+        vertex<T> back(this->D);
+    for(uint i = 0; i < this->D; i++) back[i] = -eye[i];
+
+    (*this) * matrix<T>::translate(this->D, back);
 */
     }
 }

--- a/jlib/apps/jhardhyper.cc
+++ b/jlib/apps/jhardhyper.cc
@@ -955,7 +955,21 @@ void HyperPlot<T,Plot>::initialize(uint n) {
     change(n);
     
     initialize_rotation(n);
-    (*this) * matrix<T>::lookAt(n, eye, up, center);
+    // A translation, not a camera.
+    //
+    // The eye sits at a positive offset on every axis that gets projected away,
+    // so that each step's frustum has the figure wholly in front of it -- see
+    // initialize_glazzies.  That is not a direction to look in: above D=4 it is
+    // diagonal across several axes at once, and a real lookAt would rotate it
+    // onto one of them and leave the others with no offset at all, putting the
+    // figure outside the clip volume.
+    //
+    // This said lookAt(n, eye, up, center) and got a translation because that
+    // was all lookAt did.  Now that lookAt is a camera, say what is meant.
+    vertex<T> back(n);
+    for(uint i = 0; i < n; i++) back[i] = -eye[i];
+
+    (*this) * matrix<T>::translate(n, back);
 
     switch(m_shape) {
     case CUBOID: {

--- a/jlib/math/matrix.hh
+++ b/jlib/math/matrix.hh
@@ -991,19 +991,104 @@ template<typename T>
 inline
 matrix<T> matrix<T>::lookAt(uint n, const vertex<T>& eye, 
                             const vertex<T>& up, const vertex<T>& center) {
+    // A camera: rotate the world so the view direction lies along one axis,
+    // then bring the eye to the origin.
+    //
+    // This used to be translate(-eye) alone, with up and center accepted and
+    // discarded.  That is not a look-at, it is a translation, and the callers
+    // relying on it say translate() now.
+    //
+    // There is no cross product above three dimensions, so the basis comes from
+    // Gram-Schmidt instead, which needs none and reproduces the usual one in
+    // three.  Forward goes to -e_(n-1), matching the convention everything else
+    // here follows -- project() yields w = -x_(d-1), so what the camera faces
+    // has to lie along the negative end of the axis being projected away.  Up
+    // goes to e_1, and whatever axes are left are filled by orthonormalizing
+    // the standard basis against what is already fixed.
+    std::vector< vertex<T> > basis;
+    for(uint i = 0; i < n; i++)
+        basis.push_back(vertex<T>(n));
+
+    std::vector<bool> filled(n, false);
+
+    // forward
+    vertex<T> f(n);
+    T len = 0;
+    for(uint i = 0; i < n; i++) {
+        f[i] = center[i] - eye[i];
+        len += f[i] * f[i];
+    }
+    len = std::sqrt(len);
+
+    if(len < 1e-12)
+        throw typename matrix<T>::mismatch();   // eye and centre coincide
+
+    for(uint i = 0; i < n; i++) f[i] /= len;
+
+    for(uint i = 0; i < n; i++) basis[n-1][i] = -f[i];
+    filled[n-1] = true;
+
+    // up, with the part along forward removed
+    if(n > 1) {
+        vertex<T> u(n);
+        T dot = 0;
+        for(uint i = 0; i < n; i++) dot += up[i] * f[i];
+
+        T ulen = 0;
+        for(uint i = 0; i < n; i++) {
+            u[i] = up[i] - dot * f[i];
+            ulen += u[i] * u[i];
+        }
+        ulen = std::sqrt(ulen);
+
+        // An up parallel to the view direction says nothing about roll; leave
+        // the axis to the completion below rather than guessing.
+        if(ulen > 1e-12) {
+            for(uint i = 0; i < n; i++) basis[1][i] = u[i] / ulen;
+            filled[1] = true;
+        }
+    }
+
+    // whatever is left, from the standard basis
+    uint next = 0;
+    for(uint e = 0; e < n && next < n; e++) {
+        while(next < n && filled[next]) next++;
+        if(next >= n) break;
+
+        vertex<T> v(n);
+        for(uint i = 0; i < n; i++) v[i] = (i == e) ? 1 : 0;
+
+        for(uint b = 0; b < n; b++) {
+            if(!filled[b]) continue;
+
+            T dot = 0;
+            for(uint i = 0; i < n; i++) dot += v[i] * basis[b][i];
+            for(uint i = 0; i < n; i++) v[i] -= dot * basis[b][i];
+        }
+
+        T vlen = 0;
+        for(uint i = 0; i < n; i++) vlen += v[i] * v[i];
+        vlen = std::sqrt(vlen);
+
+        // e lay in the span of what is already fixed; try the next one
+        if(vlen < 1e-9)
+            continue;
+
+        for(uint i = 0; i < n; i++) basis[next][i] = v[i] / vlen;
+        filled[next] = true;
+    }
+
     matrix<T> ret = matrix<T>::identity(n+1);
+    for(uint i = 0; i < n; i++)
+        for(uint j = 0; j < n; j++)
+            ret(i,j) = basis[i][j];
+
     const T neg = static_cast<T>(-1);
     vertex<T> neye(n); neye = (eye() * neg);
-    
-    ret *= translate(n, neye);
 
-    /*
-    for(uint i = 0; i <n; i++) {
-        plane p;
-        p.i = i;
-        p.j = 1;
-    }
-    */
+    // Rotate after translating: the eye reaches the origin first, and the
+    // basis then turns the world about it.
+    ret *= translate(n, neye);
 
     return ret;
 }

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -20,7 +20,8 @@ MEDIA_TESTS = media_datastream_test \
               media_player_test \
               media_wavfile_test \
               media_wavstream_test \
-              sys_ringbuffer_test
+              sys_ringbuffer_test \
+              math_lookat_test
 endif
 
 if HAVE_SODIUM
@@ -75,6 +76,9 @@ media_wavstream_test_LDADD    = $(JMEDIA_LA) $(JSYS_LA)
 
 sys_ringbuffer_test_SOURCES   = sys_ringbuffer_test.cc
 sys_ringbuffer_test_LDADD     = $(JSYS_LA)
+
+math_lookat_test_SOURCES      = math_lookat_test.cc
+math_lookat_test_LDADD        = $(JSYS_LA)
 
 net_extract_address_test_SOURCES        = net_extract_address_test.cc
 net_extract_address_test_LDADD          = $(JNET_LA)

--- a/tests/math_lookat_test.cc
+++ b/tests/math_lookat_test.cc
@@ -1,0 +1,91 @@
+// math::matrix::lookAt.
+// lookAt actually a look-at?
+#include <jlib/math/matrix.hh>
+#include <cmath>
+#include <iomanip>
+#include <iostream>
+using namespace jlib::math;
+typedef double T;
+
+static int failures = 0;
+static void check(const char* what, double got, double want, double tol = 1e-12) {
+    const bool ok = std::fabs(got - want) <= tol;
+    if(!ok) ++failures;
+    std::cout << (ok ? "  ok   " : "  FAIL ") << std::setw(42) << std::left << what
+              << std::scientific << std::setprecision(2) << got
+              << "  (want " << want << ")\n";
+}
+
+int main() {
+    // 1. the apps' old call vs what replaced it: translate(-eye)
+    std::cout << "apps: old lookAt(-eye only) against translate(-eye)\n";
+    for(uint n = 4; n <= 7; n++) {
+        vertex<T> eye(n), back(n);
+        for(uint i = 0; i < n; i++) { eye[i] = 0; back[i] = 0; }
+        for(uint i = 3; i < n; i++) { eye[i] = 3; back[i] = -3; }
+
+        matrix<T> t = matrix<T>::translate(n, back);
+
+        // the old lookAt was exactly this, so a sample point must agree
+        vertex<T> v(n), out(n);
+        for(uint i = 0; i < n; i++) v[i] = 0.5 + i;
+        out = t * v();
+
+        T worst = 0;
+        for(uint i = 0; i < n; i++)
+            worst = std::max(worst, std::fabs(out[i] - (v[i] + back[i])));
+
+        char buf[64]; std::snprintf(buf, sizeof(buf), "D=%u translate matches -eye", n);
+        check(buf, worst, 0.0);
+    }
+
+    // 2. the new lookAt
+    std::cout << "\nlookAt as a camera\n";
+    for(uint n = 3; n <= 6; n++) {
+        vertex<T> eye(n), up(n), center(n);
+        for(uint i = 0; i < n; i++) { eye[i] = 0; up[i] = 0; center[i] = 0; }
+        eye[0] = 2; eye[1] = 3; eye[2] = 5;          // off-axis on purpose
+        if(n > 3) eye[3] = -1;
+        up[1] = 1;
+        center[0] = 1;                                 // and not at the origin
+
+        matrix<T> m = matrix<T>::lookAt(n, eye, up, center);
+
+        // the eye lands on the origin
+        vertex<T> o(n); o = m * eye();
+        T eye_off = 0;
+        for(uint i = 0; i < n; i++) eye_off = std::max(eye_off, std::fabs(o[i]));
+        char b1[64]; std::snprintf(b1, sizeof(b1), "n=%u eye maps to the origin", n);
+        check(b1, eye_off, 0.0, 1e-12);
+
+        // the centre lands on the negative last axis and nowhere else
+        vertex<T> c(n); c = m * center();
+        T off_axis = 0;
+        for(uint i = 0; i + 1 < n; i++) off_axis = std::max(off_axis, std::fabs(c[i]));
+        char b2[64]; std::snprintf(b2, sizeof(b2), "n=%u centre is on one axis", n);
+        check(b2, off_axis, 0.0, 1e-12);
+        char b3[64]; std::snprintf(b3, sizeof(b3), "n=%u centre is in front (negative)", n);
+        check(b3, c[n-1] < 0 ? 1.0 : 0.0, 1.0);
+
+        // the basis is orthonormal: rows dotted with each other give identity
+        T worst = 0;
+        for(uint i = 0; i < n; i++) {
+            for(uint j = 0; j < n; j++) {
+                T dot = 0;
+                for(uint k = 0; k < n; k++) dot += m(i,k) * m(j,k);
+                worst = std::max(worst, std::fabs(dot - (i == j ? 1.0 : 0.0)));
+            }
+        }
+        char b4[64]; std::snprintf(b4, sizeof(b4), "n=%u basis is orthonormal", n);
+        check(b4, worst, 0.0, 1e-12);
+
+        // up, with the forward part taken out, points along +e_1
+        vertex<T> u(n), ru(n);
+        for(uint i = 0; i < n; i++) u[i] = up[i] + eye[i];   // a point, not a direction
+        ru = m * u();
+        char b5[64]; std::snprintf(b5, sizeof(b5), "n=%u up maps to +e_1", n);
+        check(b5, ru[1] > 0 ? 1.0 : 0.0, 1.0);
+    }
+
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
make lookAt an actual look-at

closes #26

    macOS  27 tests, 27 pass, 0 skip
    Linux  28 tests, 27 pass, 1 skip

what it was

    translate(-eye).  up and center were accepted and thrown away, and the
    basis rotation that would have used them was commented out -- as a loop
    that built a plane and did nothing with it, so it had never worked.

what it is

    A camera: an orthonormal basis with the view direction along one axis, then
    the eye brought to the origin.

    There is no cross product above three dimensions, so the basis comes from
    Gram-Schmidt, which needs none and gives the usual answer in three.  Forward
    goes to -e_(n-1), matching the convention the rest of the reduction follows
    -- project() yields w = -x_(d-1), so what the camera faces has to lie along
    the negative end of the axis being projected away.  Up goes to e_1, with its
    component along forward removed, and the axes left over are filled by
    orthonormalizing the standard basis against what is already fixed.

    An up parallel to the view direction says nothing about roll, so rather than
    guess, that axis is left to the completion.  An eye coincident with the
    centre has no direction at all and throws.

the callers wanted a translation, and now say so

    Hyper.hh and jhardhyper called lookAt and relied on it being translate(-eye)
    -- which is what they actually want.  initialize_glazzies puts the eye at a
    positive offset on every axis that will be projected away, so each step's
    frustum has the figure wholly in front of it; that is the #22 fix, and it is
    not a direction to look in.  Above D=4 it is diagonal across several axes at
    once, and a real lookAt would rotate it onto one of them and leave the rest
    with no offset, putting the figure outside the clip volume.

    So they call translate() now.  Bit-identical, checked at D=4 through 7
    rather than assumed: a real camera would have broken them, and quietly,
    since it only diverges above D=4.

tests

    math_lookat_test asserts what a camera has to do without looking at
    anything: the eye lands on the origin, the centre lands on one axis and in
    front, the basis is orthonormal, and up comes out pointing up.  At n=3
    through 6, because three is the case that would come out right by accident.

    It also pins the callers' substitution, which is the part that could regress
    silently.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---

CLAUDE.md is refreshed in the same branch, as its own commit if you prefer.  It
had drifted badly: no torus, no Hopf foliation, no ring buffer or callback audio
path, no apps/color.hh, and it still described phases 5 and 6 as the headline
remaining goal when the whole seven-phase plan is done.  It now says the goal is
met, that the phase labels are historical, and what the actual backlog is.

Two conventions were added because they are the ones this work kept tripping
over: strings that carry a payload go by const& or by value-plus-move, and an
empty destructor silently costs a class its move semantics.
