### PR TITLE
stop a write to a closed peer from killing the process

### DIFF
--- a/jlib/sys/socketstream.hh
+++ b/jlib/sys/socketstream.hh
@@ -30,6 +30,8 @@
 #include <cstring>
 #include <cstdlib>
 
+#include <jlib/sys/sys.hh>
+
 #include <netinet/in.h>
 #include <sys/types.h>
 #include <sys/socket.h>
@@ -134,6 +136,11 @@ namespace jlib {
             virtual int_type sync() {
                 if(std::getenv("JLIB_SYS_SOCKET_DEBUG"))
                     std::cerr << "basic_socketbuf::sync()"<<std::endl;
+                // Where SO_NOSIGPIPE exists this is a no-op and the socket
+                // option has already dealt with it; where it does not, this is
+                // what keeps a dead peer from killing us.
+                sigpipe_guard guard;
+
                 int sofar = 0;
                 int total = this->pptr() - this->pbase();
                 int diff;
@@ -150,6 +157,7 @@ namespace jlib {
                         if(errno == EINTR) {
                             m_eintr = true;
                         }
+                        // EPIPE arrives here now instead of as a signal.
                         return traits_type::eof();
                     }
                     sofar += count;
@@ -214,6 +222,11 @@ namespace jlib {
                     throw exception("error connecting to " + host + ":" + o.str());
                 }
                 
+                // Before anything is written: a write to a peer that has gone
+                // away raises SIGPIPE, whose default action is to kill the
+                // process outright, so the error checking below never runs.
+                nosigpipe(m_sock);
+
                 if(fcntl(m_sock, F_SETFD, 1) == -1) {
                     if(std::getenv("JLIB_SYS_SOCKET_DEBUG"))
                         std::cerr <<"throwing exception from jlib::sys::socketstream::open_socket()"<<std::endl

--- a/jlib/sys/sslstream.hh
+++ b/jlib/sys/sslstream.hh
@@ -93,6 +93,11 @@ namespace jlib {
             }
 
             virtual int_type sync() {
+                // OpenSSL writes to the socket itself, so MSG_NOSIGNAL cannot
+                // reach it; on a platform without SO_NOSIGPIPE the guard is the
+                // only thing standing between a dead peer and the process.
+                sigpipe_guard guard;
+
                 if(m_delay)
                     return basic_socketbuf<charT,traitT>::sync();
 

--- a/jlib/sys/sys.cc
+++ b/jlib/sys/sys.cc
@@ -19,6 +19,9 @@
  */
 
 #include <jlib/sys/sys.hh>
+
+#include <pthread.h>
+#include <cerrno>
 #include <jlib/sys/tfstream.hh>
 
 #include <map>
@@ -57,6 +60,67 @@ namespace jlib {
             }
 
         }
+
+        void nosigpipe(int fd) {
+#ifdef SO_NOSIGPIPE
+            int on = 1;
+
+            // Best effort: a socket that will not take the option still works,
+            // it just leaves the job to sigpipe_guard, and failing the connect
+            // over it would be worse than the problem.
+            ::setsockopt(fd, SOL_SOCKET, SO_NOSIGPIPE, &on, sizeof(on));
+#else
+            (void)fd;
+#endif
+        }
+
+#ifdef SO_NOSIGPIPE
+
+        sigpipe_guard::sigpipe_guard() {}
+        sigpipe_guard::~sigpipe_guard() {}
+
+#else
+
+        sigpipe_guard::sigpipe_guard()
+            : m_blocked(false)
+        {
+            sigset_t pipe_only;
+            sigemptyset(&pipe_only);
+            sigaddset(&pipe_only, SIGPIPE);
+
+            if(pthread_sigmask(SIG_BLOCK, &pipe_only, &m_old) != 0)
+                return;
+
+            // Only unblock on the way out if it was us who blocked it; a caller
+            // that had already blocked SIGPIPE keeps its own arrangement, and
+            // its pending signal is not ours to consume.
+            m_blocked = !sigismember(&m_old, SIGPIPE);
+        }
+
+        sigpipe_guard::~sigpipe_guard() {
+            if(!m_blocked)
+                return;
+
+            sigset_t pending;
+            sigemptyset(&pending);
+
+            if(sigpending(&pending) == 0 && sigismember(&pending, SIGPIPE)) {
+                sigset_t pipe_only;
+                sigemptyset(&pipe_only);
+                sigaddset(&pipe_only, SIGPIPE);
+
+                // Take it off the pending set before unblocking, or it lands on
+                // the caller the instant the mask is restored -- the same
+                // termination, just later and harder to explain.
+                const struct timespec none = { 0, 0 };
+                while(sigtimedwait(&pipe_only, 0, &none) == -1 && errno == EINTR)
+                    ;
+            }
+
+            pthread_sigmask(SIG_SETMASK, &m_old, 0);
+        }
+
+#endif
 
         void getline(std::istream& is, std::string& s) {
             std::getline(is,s);

--- a/jlib/sys/sys.hh
+++ b/jlib/sys/sys.hh
@@ -27,6 +27,9 @@
 
 #include <functional>
 
+#include <signal.h>
+#include <sys/socket.h>
+
 namespace jlib {
     namespace sys {
 
@@ -55,6 +58,52 @@ namespace jlib {
         /**
          * read a line from is into s, doing intelligent buffering
          */
+        /**
+         * Stop writes to this socket from killing the process.
+         *
+         * Writing to a socket whose peer has closed raises SIGPIPE, and the
+         * default disposition of SIGPIPE is to terminate -- so the error return
+         * the caller is carefully checking never arrives.  For a mail client
+         * that is not an exotic case: a server dropping an idle IMAP connection
+         * is routine, and the symptom is the program vanishing without a word.
+         *
+         * Where the platform has SO_NOSIGPIPE this sets it, which covers every
+         * write on the descriptor including the ones OpenSSL makes internally.
+         * Where it does not -- Linux -- this does nothing and sigpipe_guard is
+         * what does the work.
+         */
+        void nosigpipe(int fd);
+
+        /**
+         * Blocks SIGPIPE for the calling thread, and consumes one if it comes.
+         *
+         * For platforms without SO_NOSIGPIPE, where the alternatives are worse:
+         * MSG_NOSIGNAL is per-call and so cannot cover OpenSSL's own writes, and
+         * ignoring SIGPIPE process-wide is not a library's decision to make.
+         *
+         * Blocking it is, since the block is per-thread and undone on the way
+         * out.  A SIGPIPE raised while blocked stays pending, so the destructor
+         * drains it before unblocking; otherwise it would be delivered to the
+         * caller the moment the mask was restored, which is the same crash a
+         * little later.
+         *
+         * A no-op where nosigpipe() has already dealt with it.
+         */
+        class sigpipe_guard {
+        public:
+            sigpipe_guard();
+            ~sigpipe_guard();
+
+            sigpipe_guard(const sigpipe_guard&) = delete;
+            sigpipe_guard& operator=(const sigpipe_guard&) = delete;
+
+        private:
+#ifndef SO_NOSIGPIPE
+            sigset_t m_old;
+            bool m_blocked;   // we are the ones who blocked it
+#endif
+        };
+
         void getline(std::istream& is, std::string& s);
 
         /**

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -21,7 +21,9 @@ MEDIA_TESTS = media_datastream_test \
               media_wavfile_test \
               media_wavstream_test \
               sys_ringbuffer_test \
-              math_lookat_test
+              math_lookat_test \
+              sys_sigpipe_test \
+              sys_tls_sigpipe_test
 endif
 
 if HAVE_SODIUM
@@ -79,6 +81,12 @@ sys_ringbuffer_test_LDADD     = $(JSYS_LA)
 
 math_lookat_test_SOURCES      = math_lookat_test.cc
 math_lookat_test_LDADD        = $(JSYS_LA)
+
+sys_sigpipe_test_SOURCES      = sys_sigpipe_test.cc
+sys_sigpipe_test_LDADD        = $(JSYS_LA)
+
+sys_tls_sigpipe_test_SOURCES  = sys_tls_sigpipe_test.cc
+sys_tls_sigpipe_test_LDADD    = $(JSYS_LA) $(OPENSSL_LIBS)
 
 net_extract_address_test_SOURCES        = net_extract_address_test.cc
 net_extract_address_test_LDADD          = $(JNET_LA)

--- a/tests/sys_sigpipe_test.cc
+++ b/tests/sys_sigpipe_test.cc
@@ -1,0 +1,188 @@
+// Writing to a socket whose peer has closed must not kill the process.
+//
+// The default disposition of SIGPIPE is to terminate, so the error return that
+// basic_socketbuf::sync() carefully checks never arrived -- the process was
+// already gone.  For a mail client that is not exotic: a server dropping an
+// idle IMAP connection is routine, and the symptom is jlib-mail vanishing
+// without a word.
+//
+// Reproduced over loopback, which needs no server and no network.  The first
+// write usually succeeds, because it only has to reach the kernel's buffer;
+// the second is the one that finds out the peer is gone.
+//
+// The first section deliberately writes to a raw, unprotected socket in a
+// child process, to show the signal really does fire here.  Without that this
+// test could pass on a platform that never raises SIGPIPE at all, and would be
+// saying nothing.
+#include <jlib/sys/socketstream.hh>
+#include <jlib/sys/sys.hh>
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <csignal>
+#include <cstring>
+#include <iostream>
+#include <string>
+
+static int failures = 0;
+
+static void check(const char* what, long got, long want) {
+    const bool ok = (got == want);
+    if(!ok) ++failures;
+    std::cout << (ok ? "  ok   " : "  FAIL ") << what
+              << ": got " << got << ", expected " << want << "\n";
+}
+
+/** A listener on loopback that accepts one connection and then drops it. */
+static int listener(unsigned short* port) {
+    const int fd = ::socket(AF_INET, SOCK_STREAM, 0);
+    if(fd < 0) return -1;
+
+    int on = 1;
+    ::setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &on, sizeof(on));
+
+    struct sockaddr_in a;
+    std::memset(&a, 0, sizeof(a));
+    a.sin_family = AF_INET;
+    a.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    a.sin_port = 0;                       // any free port
+
+    if(::bind(fd, reinterpret_cast<struct sockaddr*>(&a), sizeof(a)) < 0) return -1;
+    if(::listen(fd, 1) < 0) return -1;
+
+    socklen_t len = sizeof(a);
+    if(::getsockname(fd, reinterpret_cast<struct sockaddr*>(&a), &len) < 0) return -1;
+
+    *port = ntohs(a.sin_port);
+    return fd;
+}
+
+/**
+ * Does an unprotected write to a dead peer actually raise SIGPIPE here?
+ *
+ * In a child, because if the answer is yes the child dies -- which is the
+ * point.  A test that cannot demonstrate the failure cannot demonstrate the
+ * fix either.
+ */
+static int raw_write_dies() {
+    unsigned short port = 0;
+    const int lfd = listener(&port);
+    if(lfd < 0) return -1;
+
+    const pid_t pid = ::fork();
+    if(pid < 0) { ::close(lfd); return -1; }
+
+    if(pid == 0) {
+        const int fd = ::socket(AF_INET, SOCK_STREAM, 0);
+
+        struct sockaddr_in a;
+        std::memset(&a, 0, sizeof(a));
+        a.sin_family = AF_INET;
+        a.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+        a.sin_port = htons(port);
+
+        if(::connect(fd, reinterpret_cast<struct sockaddr*>(&a), sizeof(a)) < 0)
+            ::_exit(2);
+
+        // deliberately no nosigpipe() here
+        const int peer = ::accept(lfd, 0, 0);
+        ::close(peer);
+
+        // Paced deliberately.  Closing a TCP peer sends a FIN, and writes keep
+        // succeeding until the RST comes back -- so a tight loop of small
+        // writes can finish before the failure ever arrives, and this probe
+        // then reports "no SIGPIPE here" on a platform that raises it.
+        for(int i = 0; i < 40; i++) {
+            if(::write(fd, "this goes nowhere\r\n", 19) < 0) break;
+            ::usleep(20000);
+        }
+
+        ::_exit(0);        // survived: no SIGPIPE on this platform
+    }
+
+    ::close(lfd);
+
+    int status = 0;
+    ::waitpid(pid, &status, 0);
+
+    return (WIFSIGNALED(status) && WTERMSIG(status) == SIGPIPE) ? 1 : 0;
+}
+
+int main() {
+    using namespace jlib::sys;
+
+    const int raw = raw_write_dies();
+    if(raw < 0) {
+        std::cerr << "could not set up a loopback socket, skipping" << std::endl;
+        return 77;
+    }
+
+    std::cout << "unprotected write to a dead peer raises SIGPIPE here: "
+              << (raw ? "yes" : "no") << "\n";
+
+    if(!raw) {
+        // Nothing to protect against on this platform, so nothing to prove.
+        std::cerr << "this platform does not raise SIGPIPE for it; skipping"
+                  << std::endl;
+        return 77;
+    }
+
+    check("unprotected write to a dead peer dies", 1, 1);
+
+    // The same writes through socketstream, and in a child for the same reason
+    // the probe above used one: if it is going to be killed, this process has
+    // to survive in order to say so.  Checking sock.good() in-process would
+    // pass whether or not any write ever happened.
+    unsigned short port = 0;
+    const int lfd = listener(&port);
+    if(lfd < 0) {
+        std::cerr << "could not set up a loopback socket, skipping" << std::endl;
+        return 77;
+    }
+
+    const pid_t pid = ::fork();
+    if(pid < 0) { ::close(lfd); return 77; }
+
+    if(pid == 0) {
+        ::alarm(20);        // rather than hang the suite
+
+        try {
+            socketstream sock("127.0.0.1", port);
+
+            const int peer = ::accept(lfd, 0, 0);
+            if(peer < 0) ::_exit(3);
+            ::close(peer);
+
+            for(int i = 0; i < 40 && sock; i++) {
+                sock << "this goes nowhere\r\n";
+                sock.flush();
+                ::usleep(20000);
+            }
+        }
+        catch(std::exception&) {
+            // An exception is a fine outcome; being killed is not.
+        }
+
+        ::_exit(0);
+    }
+
+    ::close(lfd);
+
+    int status = 0;
+    ::waitpid(pid, &status, 0);
+
+    if(WIFEXITED(status) && WEXITSTATUS(status) == 3) {
+        std::cerr << "could not connect over loopback, skipping" << std::endl;
+        return 77;
+    }
+
+    const bool killed = WIFSIGNALED(status) && WTERMSIG(status) == SIGPIPE;
+
+    check("the same through socketstream survives", killed ? 0 : 1, 1);
+
+    return failures ? 1 : 0;
+}

--- a/tests/sys_tls_sigpipe_test.cc
+++ b/tests/sys_tls_sigpipe_test.cc
@@ -1,0 +1,207 @@
+// The same as sys_sigpipe_test, but over TLS.
+//
+// Worth having separately because it is a different write path.  OpenSSL calls
+// write(2) on the socket itself, so MSG_NOSIGNAL cannot reach it and the plain
+// test says nothing about it: on a platform with SO_NOSIGPIPE the socket option
+// covers both by construction, and on one without, sigpipe_guard has to be in
+// the SSL sync() as well as the plain one.  This is the test that would notice
+// if it were not.
+//
+// Entirely local.  A self-signed certificate for localhost is generated at
+// runtime, SSL_CERT_FILE points the client's trust store at it -- which
+// basic_sslbuf reaches through SSL_CTX_set_default_verify_paths, and which the
+// comment there says is overridable for exactly this sort of reason -- and the
+// server side runs in this process.  No network, no external server, and no
+// weakening of the verification the client normally does: the handshake is
+// real, the hostname is checked, and it succeeds because the certificate is
+// genuinely trusted for this run.
+#include <jlib/sys/sslstream.hh>
+#include <jlib/sys/sys.hh>
+
+#include <openssl/err.h>
+#include <openssl/pem.h>
+#include <openssl/ssl.h>
+#include <openssl/x509v3.h>
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <csignal>
+#include <cstdio>
+#include <cstring>
+#include <iostream>
+#include <string>
+
+static int failures = 0;
+
+static void check(const char* what, long got, long want) {
+    const bool ok = (got == want);
+    if(!ok) ++failures;
+    std::cout << (ok ? "  ok   " : "  FAIL ") << what
+              << ": got " << got << ", expected " << want << "\n";
+}
+
+/** A self-signed certificate for localhost, written to cert_path and key_path. */
+static bool make_cert(const std::string& cert_path, const std::string& key_path) {
+    EVP_PKEY* key = EVP_RSA_gen(2048);
+    if(key == 0) return false;
+
+    X509* x = X509_new();
+    if(x == 0) { EVP_PKEY_free(key); return false; }
+
+    ASN1_INTEGER_set(X509_get_serialNumber(x), 1);
+    X509_gmtime_adj(X509_getm_notBefore(x), 0);
+    X509_gmtime_adj(X509_getm_notAfter(x), 60 * 60);
+    X509_set_pubkey(x, key);
+
+    X509_NAME* name = X509_get_subject_name(x);
+    X509_NAME_add_entry_by_txt(name, "CN", MBSTRING_ASC,
+                               reinterpret_cast<const unsigned char*>("localhost"),
+                               -1, -1, 0);
+    X509_set_issuer_name(x, name);
+
+    // A subject alternative name, not just a CN: SSL_set1_host checks the SAN,
+    // and modern OpenSSL will not fall back to the common name.
+    X509V3_CTX ctx;
+    X509V3_set_ctx_nodb(&ctx);
+    X509V3_set_ctx(&ctx, x, x, 0, 0, 0);
+
+    X509_EXTENSION* san = X509V3_EXT_conf_nid(0, &ctx, NID_subject_alt_name,
+                                              "DNS:localhost,IP:127.0.0.1");
+    if(san) { X509_add_ext(x, san, -1); X509_EXTENSION_free(san); }
+
+    if(!X509_sign(x, key, EVP_sha256())) { X509_free(x); EVP_PKEY_free(key); return false; }
+
+    bool ok = false;
+    FILE* cf = std::fopen(cert_path.c_str(), "wb");
+    FILE* kf = std::fopen(key_path.c_str(), "wb");
+    if(cf && kf)
+        ok = PEM_write_X509(cf, x) && PEM_write_PrivateKey(kf, key, 0, 0, 0, 0, 0);
+    if(cf) std::fclose(cf);
+    if(kf) std::fclose(kf);
+
+    X509_free(x);
+    EVP_PKEY_free(key);
+    return ok;
+}
+
+static int listener(unsigned short* port) {
+    const int fd = ::socket(AF_INET, SOCK_STREAM, 0);
+    if(fd < 0) return -1;
+
+    int on = 1;
+    ::setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &on, sizeof(on));
+
+    struct sockaddr_in a;
+    std::memset(&a, 0, sizeof(a));
+    a.sin_family = AF_INET;
+    a.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    a.sin_port = 0;
+
+    if(::bind(fd, reinterpret_cast<struct sockaddr*>(&a), sizeof(a)) < 0) return -1;
+    if(::listen(fd, 1) < 0) return -1;
+
+    socklen_t len = sizeof(a);
+    if(::getsockname(fd, reinterpret_cast<struct sockaddr*>(&a), &len) < 0) return -1;
+
+    *port = ntohs(a.sin_port);
+    return fd;
+}
+
+int main() {
+    const std::string cert = "tls_sigpipe_cert.pem";
+    const std::string key  = "tls_sigpipe_key.pem";
+
+    if(!make_cert(cert, key)) {
+        std::cerr << "could not generate a test certificate, skipping" << std::endl;
+        return 77;
+    }
+
+    // What the client will trust, and only for this run.
+    ::setenv("SSL_CERT_FILE", cert.c_str(), 1);
+
+    unsigned short port = 0;
+    const int lfd = listener(&port);
+    if(lfd < 0) {
+        std::cerr << "could not set up a loopback socket, skipping" << std::endl;
+        std::remove(cert.c_str()); std::remove(key.c_str());
+        return 77;
+    }
+
+    const pid_t pid = ::fork();
+    if(pid < 0) {
+        std::remove(cert.c_str()); std::remove(key.c_str());
+        return 77;
+    }
+
+    if(pid == 0) {
+        // The client, in the child, because it is the one that might be killed
+        // and somebody has to survive to report it.
+        ::alarm(30);
+        ::close(lfd);
+
+        try {
+            jlib::sys::sslstream sock("localhost", port);
+
+            if(!sock)
+                ::_exit(3);                 // handshake failed; not what we test
+
+            for(int i = 0; i < 40 && sock; i++) {
+                sock << "this goes nowhere\r\n";
+                sock.flush();
+                ::usleep(20000);            // let the RST get back
+            }
+        }
+        catch(std::exception&) {
+            // An exception is a fine outcome; being killed is not.
+        }
+
+        ::_exit(0);
+    }
+
+    // The server: accept, complete the handshake, then drop the connection.
+    SSL_CTX* ctx = SSL_CTX_new(TLS_server_method());
+    bool served = false;
+
+    if(ctx) {
+        SSL_CTX_use_certificate_file(ctx, cert.c_str(), SSL_FILETYPE_PEM);
+        SSL_CTX_use_PrivateKey_file(ctx, key.c_str(), SSL_FILETYPE_PEM);
+
+        const int peer = ::accept(lfd, 0, 0);
+        if(peer >= 0) {
+            SSL* ssl = SSL_new(ctx);
+            if(ssl) {
+                SSL_set_fd(ssl, peer);
+                served = (SSL_accept(ssl) == 1);
+
+                // Away without a close_notify, which is how a server that has
+                // gone down leaves things.
+                SSL_free(ssl);
+            }
+            ::close(peer);
+        }
+        SSL_CTX_free(ctx);
+    }
+
+    ::close(lfd);
+
+    int status = 0;
+    ::waitpid(pid, &status, 0);
+
+    std::remove(cert.c_str());
+    std::remove(key.c_str());
+
+    if(!served || (WIFEXITED(status) && WEXITSTATUS(status) == 3)) {
+        std::cerr << "TLS handshake did not complete, skipping" << std::endl;
+        return 77;
+    }
+
+    const bool killed = WIFSIGNALED(status) && WTERMSIG(status) == SIGPIPE;
+
+    check("TLS write to a dead peer survives", killed ? 0 : 1, 1);
+
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
closes #11

The last of the phase-2 bugs, and the only one left that could take a running
program down.

    macOS  29 tests, 29 pass, 0 skip
    Linux  30 tests, 29 pass, 1 skip

the bug

    basic_socketbuf::sync() wrote with write(2) and nothing suppressed SIGPIPE,
    whose default disposition is to terminate.  So writing to a socket whose
    peer had closed killed the process outright -- and the error handling right
    below the write, which already distinguishes EINTR, never ran, because
    there was nothing left to run it.

    Not an exotic case for what this library is for.  A server dropping an idle
    IMAP connection is routine, and the symptom is jlib-mail vanishing without
    a word.

two platforms, two mechanisms

    They are exactly complementary, which is why this needs both:

        SO_NOSIGPIPE     macOS yes   Linux no
        sigtimedwait     macOS no    Linux yes

    Where SO_NOSIGPIPE exists, nosigpipe() sets it on the socket as soon as it
    is created.  That covers every write on the descriptor, including the ones
    OpenSSL makes internally, which matters because basic_sslbuf derives from
    basic_socketbuf and writes through the same m_sock.

    Where it does not, sigpipe_guard blocks SIGPIPE for the calling thread
    around the write.  The alternatives are worse: MSG_NOSIGNAL is per-call and
    so cannot reach OpenSSL's own writes, and ignoring SIGPIPE process-wide is
    not a library's decision to make.  Blocking is per-thread and undone on the
    way out.

    A SIGPIPE raised while blocked stays pending, so the destructor drains it
    with sigtimedwait before restoring the mask -- otherwise it would be
    delivered the instant the mask came back, which is the same termination a
    moment later and much harder to explain.  It also leaves the mask alone if
    the caller had already blocked SIGPIPE: that is their arrangement, and the
    pending signal is not ours to consume.

    Both are macros, so this needs no configure changes.

the test, and what it took to make it mean anything

    Over loopback, which needs no server and no network.

    It runs in a child process, because the failure is death by signal and the
    parent has to survive to report it.  The first half writes to a raw,
    unprotected socket and expects to be killed; without that the test could
    pass on a platform that never raises SIGPIPE and would be asserting
    nothing.  The second half does the same writes through socketstream and
    expects to live.

    The first version was racy and I nearly kept it.  Closing a TCP peer sends
    a FIN, and writes keep succeeding until the RST comes back, so a tight loop
    of small writes finishes before the failure arrives -- the probe reported
    "no SIGPIPE on this platform" about half the time, on a platform that
    plainly has it.  A pause between attempts fixes it: twenty runs, twenty
    detections.

    It also passed with the fix disabled, which is the more embarrassing half.
    The in-process version checked sock.good() after the writes, which is false
    whether the writes failed or never happened at all.  Running the guarded
    case in a child and asking how it died is the check that cannot be
    satisfied by accident.

    Verified both ways round: with SO_NOSIGPIPE commented out the test fails,
    and with it restored it passes.  A test for a crash that has never been
    seen to fail is not evidence of anything.

the TLS path, which is a different write

    Worth its own test rather than an argument.  OpenSSL calls write(2) on the
    socket itself, so MSG_NOSIGNAL cannot reach it, and the plain test says
    nothing about it either way.

    sys_tls_sigpipe_test is entirely local: a self-signed certificate for
    localhost generated at runtime, SSL_CERT_FILE pointing the client's trust
    store at it, and the server side in this process.  No network, no external
    server, and nothing about the client's verification weakened -- the
    handshake is real and the hostname is checked, and it succeeds because the
    certificate is genuinely trusted for the duration of the run.  That the
    library reads SSL_CERT_FILE at all is the thing the comment in sslstream
    already noted as deliberate.

what removing each mechanism actually breaks

    Checked one at a time, since a test that passes either way is not evidence.

                     macOS                    Linux
        plain        fails without it         fails without it
        TLS          fails without it         PASSES without it

    Three of the four are load-bearing and demonstrated so.  The fourth is not:
    with sigpipe_guard taken out of the SSL write path, the TLS test still
    passes on Linux, so OpenSSL there is not raising SIGPIPE on its own writes.

    The guard stays anyway, and that is a judgement rather than a measurement.
    It costs two signal-mask calls per flush, it is the only thing that would
    stand between a dead peer and the process if that behaviour differs by
    OpenSSL version or by platform, and the failure it prevents is termination
    rather than an error.  What is not defensible is leaving the impression it
    was proven necessary, so: it is not, on that one combination.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
