### PR TITLE
give notes a waveform and an ADSR envelope

### DIFF
--- a/jlib/media/Makefile.am
+++ b/jlib/media/Makefile.am
@@ -17,6 +17,7 @@ libjmedia_la_LIBADD = $(top_builddir)/jlib/sys/libjsys.la \
 
 jmedia_hdrs = Player.hh AudioFile.hh WavFile.hh PlayList.hh stream.hh \
               datastream.hh notestream.hh Type.hh wavstream.hh \
+              instrument.hh voice.hh \
               audiofilestream.hh AudioSink.hh PortAudioSink.hh
 
 libjmediaincludedir = $(includedir)/jlib-1.2/jlib/media

--- a/jlib/media/instrument.hh
+++ b/jlib/media/instrument.hh
@@ -1,0 +1,171 @@
+/* -*- mode: C++ c-basic-offset: 4  -*-
+ *
+ * Copyright (c) 2000 Joe Yandle <jwy@divisionbyzero.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ *
+ */
+
+#ifndef JLIB_MEDIA_INSTRUMENT_HH
+#define JLIB_MEDIA_INSTRUMENT_HH
+
+#include <stdexcept>
+#include <string>
+
+namespace jlib {
+namespace media {
+
+/**
+ * What a note sounds like, separately from which note it is.
+ *
+ * Pitch and duration belong to the note; timbre belongs here, and is meant to
+ * be set up once and used by many notes.  A note string can override any of it
+ * for itself -- see basic_notebuf::set_note -- but the instrument is where the
+ * settings live.
+ */
+class instrument {
+public:
+    class exception : public std::runtime_error {
+    public:
+        exception(const std::string& msg)
+            : std::runtime_error("jlib::media::instrument::exception: " + msg) {}
+    };
+
+    /**
+     * The waveforms, all built by adding harmonics rather than by drawing the
+     * shape directly.  See voice.hh for why.
+     */
+    enum class wave { sine, saw, square, triangle };
+
+    /**
+     * Attack, decay, sustain, release: how loud the note is over its life.
+     *
+     * Attack, decay and release are seconds; sustain is the level held between
+     * decay and release, from 0 to 1.  The whole thing replaces the fixed 5ms
+     * fade that used to be hardcoded in create_data(), and inherits its job:
+     * a note that stops mid-swing clicks, so the envelope has to reach exact
+     * silence at both ends whatever the settings say.  See clamped().
+     */
+    struct envelope {
+        double attack  = 0.005;
+        double decay   = 0.0;
+        double sustain = 1.0;
+        double release = 0.005;
+    };
+
+    /**
+     * Shortest attack or release that still removes the click.
+     *
+     * The fade this replaced was 5ms, chosen because it is short enough to be
+     * inaudible as a volume change and long enough to remove the discontinuity
+     * at any frequency.  A zero-length attack or release is honoured up to this
+     * and no further.
+     */
+    static constexpr double MIN_RAMP = 0.005;
+
+    instrument() {}
+
+    wave get_wave() const { return m_wave; }
+    void set_wave(wave w) { m_wave = w; }
+
+    const envelope& get_envelope() const { return m_envelope; }
+    void set_envelope(const envelope& e) { m_envelope = e; }
+
+    double get_gain() const { return m_gain; }
+    void set_gain(double g) { m_gain = g; }
+
+    /**
+     * Harmonics to build a waveform from, or 0 for as many as will fit.
+     *
+     * Fewer is duller: this is the brightness knob, and it falls out of the
+     * additive generation for nothing.  The default asks for everything below
+     * Nyquist, which is what makes the result band-limited.
+     */
+    unsigned int get_harmonics() const { return m_harmonics; }
+    void set_harmonics(unsigned int n) { m_harmonics = n; }
+
+    /**
+     * The envelope with its ramps clamped and, if the note is too short to
+     * hold all four segments, its segments scaled to fit.
+     *
+     * A note shorter than attack+decay+release has no sustain at all, and the
+     * segments have to give way proportionally rather than run past the end or
+     * be silently truncated.  The ramps keep their minimum in either case,
+     * because reaching silence at the ends matters more than the shape.
+     */
+    envelope clamped(double seconds) const {
+        envelope e = m_envelope;
+
+        if(e.attack  < MIN_RAMP) e.attack  = MIN_RAMP;
+        if(e.release < MIN_RAMP) e.release = MIN_RAMP;
+        if(e.decay   < 0)        e.decay   = 0;
+
+        if(e.sustain < 0) e.sustain = 0;
+        if(e.sustain > 1) e.sustain = 1;
+
+        const double want = e.attack + e.decay + e.release;
+
+        if(seconds > 0 && want > seconds) {
+            const double scale = seconds / want;
+
+            e.attack  *= scale;
+            e.decay   *= scale;
+            e.release *= scale;
+        }
+
+        return e;
+    }
+
+    /** The name a note string uses, e.g. the "saw" in A#@4:2/saw. */
+    static wave wave_from_name(const std::string& name) {
+        if(name == "sine")     return wave::sine;
+        if(name == "saw")      return wave::saw;
+        if(name == "square")   return wave::square;
+        if(name == "triangle") return wave::triangle;
+
+        throw exception("unknown waveform '" + name +
+                        "', must be sine, saw, square or triangle");
+    }
+
+    static std::string name_of(wave w) {
+        switch(w) {
+        case wave::sine:     return "sine";
+        case wave::saw:      return "saw";
+        case wave::square:   return "square";
+        case wave::triangle: return "triangle";
+        }
+
+        return "sine";
+    }
+
+protected:
+    wave m_wave = wave::sine;
+    envelope m_envelope;
+
+    /**
+     * Overall level.
+     *
+     * Was a local called vol in create_data(), at 0.666 -- chosen to leave
+     * headroom rather than for any musical reason, and not settable.
+     */
+    double m_gain = 0.666;
+
+    unsigned int m_harmonics = 0;
+};
+
+}
+}
+
+#endif // JLIB_MEDIA_INSTRUMENT_HH

--- a/jlib/media/notestream.hh
+++ b/jlib/media/notestream.hh
@@ -43,6 +43,8 @@
 #include <netinet/in.h>
 
 #include <jlib/media/datastream.hh>
+#include <jlib/media/instrument.hh>
+#include <jlib/media/voice.hh>
 #include <jlib/util/util.hh>
 
 namespace jlib {
@@ -114,13 +116,23 @@ namespace jlib {
             virtual void set_format(int s); 
 
             static double get_freq(int step, double base);
+
+            /**
+             * How the note sounds, as against which note it is.
+             *
+             * Setting it regenerates, like the other setters here.  A note
+             * string may override parts of it for itself; see set_note.
+             */
+            const instrument& get_instrument() const;
+            void set_instrument(const instrument& i);
+
         protected:
             std::string create_data(double freq) const;
 
+            instrument m_instrument;
             double m_freq;
             double m_time;
             std::string m_note;
-            std::string m_data;
         };
         
         template<typename charT, typename traitT=std::char_traits<charT> >
@@ -140,7 +152,14 @@ namespace jlib {
             void set_time(double time);
             void set_nearest_time(double time);
 
+            double get_freq() const;
+
+            const instrument& get_instrument() const;
+            void set_instrument(const instrument& i);
+
         protected:
+            /** The buffer, or throw.  Every forwarder below wants this. */
+            basic_notebuf<charT,traitT>* buf() const;
         };
         
         typedef basic_notestream<char> notestream;
@@ -149,16 +168,24 @@ namespace jlib {
         template< typename charT, typename traitT >
         inline
         basic_notebuf<charT,traitT>::basic_notebuf() 
-            : basic_databuf<charT,traitT>()
+            : basic_databuf<charT,traitT>(),
+              m_freq(0),
+              m_time(1)
         {
-            set_note("A1");
-            set_time(1);
+            // "A" and not "A1".  The grammar became STEP@OCTAVE:BEATS, so "A1"
+            // reaches the two-character check and throws "two char notes must
+            // be either 'Ab' or 'C#'" -- this constructor could not be called
+            // at all.  It never was, in the tree or the tests, which is why
+            // nobody noticed.
+            set_note("A");
         }
         
         template< typename charT, typename traitT >
         inline
         basic_notebuf<charT,traitT>::basic_notebuf(std::string note) 
-            : basic_databuf<charT,traitT>()
+            : basic_databuf<charT,traitT>(),
+              m_freq(0),
+              m_time(1)
         {
             set_note(note);
         }
@@ -166,19 +193,85 @@ namespace jlib {
         template< typename charT, typename traitT >
         inline
         basic_notebuf<charT,traitT>::basic_notebuf(double freq) 
-            : basic_databuf<charT,traitT>()
+            : basic_databuf<charT,traitT>(),
+              m_freq(0),
+              m_time(1)
         {
+            // m_time initialized before this, not after.  set_note(double)
+            // generates immediately, and it used to read an m_time that nothing
+            // had written -- so the sample count came from whatever was on the
+            // stack, and could be negative (generating nothing) or enormous
+            // (allocating a string to match).  Every notestream note(440.0) in
+            // the tests went through it.
             set_note(freq);
-            set_time(1);
         }
         
         template< typename charT, typename traitT >
         inline
         basic_notebuf<charT,traitT>::basic_notebuf(int step, double base) 
-            : basic_databuf<charT,traitT>()
+            : basic_databuf<charT,traitT>(),
+              m_freq(0),
+              m_time(1)
         {
+            // as above: m_time before, not after
             set_note(step,base);
-            set_time(1);
+        }
+
+        template< typename charT, typename traitT >
+        inline
+        basic_notebuf<charT,traitT>* basic_notestream<charT,traitT>::buf() const {
+            typedef typename basic_notebuf<charT,traitT>::exception oops;
+
+            if(!this->m_buf)
+                throw oops("m_buf == null");
+
+            basic_notebuf<charT,traitT>* b =
+                dynamic_cast< basic_notebuf<charT,traitT>* >(this->m_buf.get());
+
+            if(!b)
+                throw oops("buf == null");
+
+            return b;
+        }
+
+        template< typename charT, typename traitT >
+        inline
+        double basic_notestream<charT,traitT>::get_freq() const {
+            return buf()->get_freq();
+        }
+
+        template< typename charT, typename traitT >
+        inline
+        const instrument& basic_notestream<charT,traitT>::get_instrument() const {
+            return buf()->get_instrument();
+        }
+
+        template< typename charT, typename traitT >
+        inline
+        void basic_notestream<charT,traitT>::set_instrument(const instrument& i) {
+            buf()->set_instrument(i);
+        }
+
+        template< typename charT, typename traitT >
+        inline
+        double basic_notebuf<charT,traitT>::get_freq() const {
+            // Declared since forever and never defined, so any call failed to
+            // link -- which is why set_nearest_time() below has never been
+            // usable and jnote.cc:72 has its call commented out.
+            return m_freq;
+        }
+
+        template< typename charT, typename traitT >
+        inline
+        const instrument& basic_notebuf<charT,traitT>::get_instrument() const {
+            return m_instrument;
+        }
+
+        template< typename charT, typename traitT >
+        inline
+        void basic_notebuf<charT,traitT>::set_instrument(const instrument& i) {
+            m_instrument = i;
+            this->set_data(create_data(m_freq));
         }
 
         template< typename charT, typename traitT >
@@ -190,11 +283,31 @@ namespace jlib {
         template< typename charT, typename traitT >
         inline
         void basic_notebuf<charT,traitT>::set_note(std::string note) {
-            // note format is STEP@OCTAVE:BEATS
+            // note format is STEP@OCTAVE:BEATS[/WAVE]
 
             // default to third octave and one beat
             int octave = 3;
             double beats = 1;
+
+            // A waveform for this note only, overriding the instrument's:
+            //
+            //     A#@4:2/saw
+            //
+            // Taken off the front of the parse rather than the back of it, so
+            // the delimiters below see the string they always did.  Only the
+            // waveform is expressible here on purpose -- it is the one thing
+            // worth saying per note, and an ADSR written out as four numbers in
+            // a string is the point at which this wants escaping and a grammar,
+            // rather than a suffix.  Everything else is a setter.
+            std::size_t wpos = note.find("/");
+            if(wpos != std::string::npos) {
+                const std::string w = note.substr(wpos+1);
+
+                note = note.substr(0, wpos);
+
+                // throws by name, as the step parser below does
+                m_instrument.set_wave(instrument::wave_from_name(w));
+            }
             
             // first parse the beats
             std::size_t bpos = note.find(":");
@@ -252,10 +365,19 @@ namespace jlib {
                 throw std::runtime_error("unknown step '" + note + "' must be [ABCDEFGR]");
             }
             
-            if(note.size() == 2) {
+            if(note.size() > 1) {
                 // was "!note[1] == 'b'": the ! binds to note[1] alone, so this
                 // compared a bool against 'b' and was always false, meaning
                 // the whole condition was false and the throw never fired.
+                //
+                // And the test was == 2 rather than > 1, so anything longer
+                // fell through with its accidental silently ignored: "C##" was
+                // a C, not a D.  Reject the length as well as the character.
+                if(note.size() > 2) {
+                    throw std::runtime_error("note '" + note +
+                                             "' has more than one accidental");
+                }
+
                 if(note[1] != '#' && note[1] != 'b') {
                     throw std::runtime_error("two char notes must be either 'Ab' or 'C#'");
                 }
@@ -327,8 +449,6 @@ namespace jlib {
             const int samples = (int)(this->get_samples_per_sec() * this->get_time());
             const int bytes_per_sample = (this->get_bits_per_sample()/8);
             const int size = samples * bytes_per_sample * this->get_channels();
-            double vol = 0.666;
-            static const long double pi = 3.14159265358979323846264338;
 
             u_int64_t amp = (u_int64_t)pow(2,this->get_bits_per_sample()-1);
 
@@ -346,35 +466,39 @@ namespace jlib {
                 std::cerr << "channels         " << this->get_channels() << std::endl;
             }
 
-            // A note lasts get_time() seconds whatever its frequency, so
-            // freq*time is hardly ever a whole number of cycles: the waveform
-            // stops wherever it happens to be and drops straight to silence.
-            // At 443.7Hz for one second that last sample is -20287 out of a
-            // 21823 peak -- a 93% full-scale step, which is a click, and a
-            // melody is a train of them.
+            // The instrument makes the sound; this function only writes it
+            // down.  What used to be here was a sine and a fixed 5ms fade --
+            // that fade being a degenerate envelope, instant attack, no decay,
+            // full sustain, 5ms release, and it existed because a note lasts
+            // get_time() seconds whatever its frequency, so freq*time is hardly
+            // ever a whole number of cycles.  The waveform stopped wherever it
+            // happened to be and dropped straight to silence: at 443.7Hz for
+            // one second the last sample was -20287 out of a 21823 peak, a 93%
+            // full-scale step, which is a click, and a melody is a train of
+            // them.
             //
-            // Ramp the first and last few milliseconds instead.  That is
-            // short enough to be inaudible as a volume change and long
-            // enough to remove the discontinuity at any frequency, without
-            // altering the note's duration the way set_nearest_time() would.
-            const int fade = std::min(samples / 2,
-                                      static_cast<int>(this->get_samples_per_sec() * 0.005));
+            // The ADSR subsumes it and inherits the requirement -- see
+            // instrument::clamped(), which will not let attack or release go
+            // below the 5ms that made this work.
+            voice v(m_instrument, freq, static_cast<unsigned long>(samples),
+                    static_cast<double>(this->get_samples_per_sec()));
 
             for(int i=0;i<samples;i++) {
-
-                double envelope = 1.0;
-                if(fade > 0) {
-                    if(i < fade)
-                        envelope = 0.5 * (1.0 - cos(pi * i / fade));
-                    else if(i >= samples - fade)
-                        envelope = 0.5 * (1.0 - cos(pi * (samples - 1 - i) / fade));
-                }
 
                 // The waveform in [-1,1], before it is committed to any
                 // particular sample format.  PCM_FLOAT32 wants exactly this;
                 // the integer formats scale and quantize it below.
-                const double raw =
-                    envelope*vol*sin(freq*this->get_time()*(2*pi)*(i/double(samples)));
+                //
+                // Clamped, because it is not guaranteed to arrive in range: a
+                // truncated Fourier series overshoots at a discontinuity by
+                // about 9%, and the waveforms are scaled to match each other in
+                // RMS rather than in peak, so a sawtooth reaches about 1.43
+                // before gain.  At the default gain that is 0.95 and nothing
+                // happens, but at a gain of 1 it would wrap rather than clip --
+                // llround of an out-of-range value straight into an int16.
+                double raw = v.next();
+                if(raw >  1.0) raw =  1.0;
+                if(raw < -1.0) raw = -1.0;
 
                 // Round rather than truncate.  A cast truncates toward zero,
                 // which both doubles the worst-case quantization error and
@@ -556,12 +680,12 @@ namespace jlib {
         basic_notestream<charT,traitT>::get_note() const
         {
             if(!this->m_buf)
-                throw basic_notebuf<charT,traitT>::exception("this->m_buf == null");
+                throw typename basic_notebuf<charT,traitT>::exception("this->m_buf == null");
             basic_notebuf<charT,traitT>* buf = dynamic_cast< basic_notebuf<charT,traitT>* >(this->m_buf.get());
             if(buf)
                 return buf->get_note();
             else
-                throw basic_notebuf<charT,traitT>::exception("buf == null");
+                throw typename basic_notebuf<charT,traitT>::exception("buf == null");
         }
 
         template< typename charT, typename traitT >
@@ -570,12 +694,12 @@ namespace jlib {
         basic_notestream<charT,traitT>::set_note(std::string note) 
         {
             if(!this->m_buf)
-                throw basic_notebuf<charT,traitT>::exception("this->m_buf == null");
+                throw typename basic_notebuf<charT,traitT>::exception("this->m_buf == null");
             basic_notebuf<charT,traitT>* buf = dynamic_cast< basic_notebuf<charT,traitT>* >(this->m_buf.get());
             if(buf)
                 buf->set_note(note);
             else
-                throw basic_notebuf<charT,traitT>::exception("buf == null");
+                throw typename basic_notebuf<charT,traitT>::exception("buf == null");
         }
 
         template< typename charT, typename traitT >
@@ -584,12 +708,12 @@ namespace jlib {
         basic_notestream<charT,traitT>::set_note(double freq) 
         {
             if(!this->m_buf)
-                throw basic_notebuf<charT,traitT>::exception("this->m_buf == null");
+                throw typename basic_notebuf<charT,traitT>::exception("this->m_buf == null");
             basic_notebuf<charT,traitT>* buf = dynamic_cast< basic_notebuf<charT,traitT>* >(this->m_buf.get());
             if(buf)
                 buf->set_note(freq);
             else
-                throw basic_notebuf<charT,traitT>::exception("buf == null");
+                throw typename basic_notebuf<charT,traitT>::exception("buf == null");
         }
 
         template< typename charT, typename traitT >
@@ -598,12 +722,12 @@ namespace jlib {
         basic_notestream<charT,traitT>::set_note(int step, double base) 
         {
             if(!this->m_buf)
-                throw basic_notebuf<charT,traitT>::exception("this->m_buf == null");
+                throw typename basic_notebuf<charT,traitT>::exception("this->m_buf == null");
             basic_notebuf<charT,traitT>* buf = dynamic_cast< basic_notebuf<charT,traitT>* >(this->m_buf.get());
             if(buf)
                 buf->set_note(step,base);
             else
-                throw basic_notebuf<charT,traitT>::exception("buf == null");
+                throw typename basic_notebuf<charT,traitT>::exception("buf == null");
         }
 
         template< typename charT, typename traitT >
@@ -612,12 +736,12 @@ namespace jlib {
         basic_notestream<charT,traitT>::get_time() const
         {
             if(!this->m_buf)
-                throw basic_notebuf<charT,traitT>::exception("this->m_buf == null");
+                throw typename basic_notebuf<charT,traitT>::exception("this->m_buf == null");
             basic_notebuf<charT,traitT>* buf = dynamic_cast< basic_notebuf<charT,traitT>* >(this->m_buf.get());
             if(buf)
                 return buf->get_time();
             else
-                throw basic_notebuf<charT,traitT>::exception("buf == null");
+                throw typename basic_notebuf<charT,traitT>::exception("buf == null");
         }
 
         template< typename charT, typename traitT >

--- a/jlib/media/voice.hh
+++ b/jlib/media/voice.hh
@@ -1,0 +1,235 @@
+/* -*- mode: C++ c-basic-offset: 4  -*-
+ *
+ * Copyright (c) 2000 Joe Yandle <jwy@divisionbyzero.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ *
+ */
+
+#ifndef JLIB_MEDIA_VOICE_HH
+#define JLIB_MEDIA_VOICE_HH
+
+#include <jlib/media/Type.hh>
+#include <jlib/media/instrument.hh>
+
+#include <cmath>
+
+namespace jlib {
+namespace media {
+
+/**
+ * One note being played by one instrument.
+ *
+ * Produces samples in [-1,1] a frame at a time, which is deliberate: rendering
+ * a whole note into a buffer is then a loop over this, and so is mixing several
+ * of them live.  Nothing here knows about sample formats, channels or streams.
+ *
+ * ## Why the waveforms are built by adding sine waves
+ *
+ * The obvious way to make a sawtooth is a ramp, and a square is sign(sin).
+ * Both alias badly.  A ramp has energy at every harmonic of the fundamental,
+ * without limit, and everything above half the sample rate cannot be
+ * represented -- it folds back down and comes out as an inharmonic tone that
+ * has nothing to do with the note.  It is quiet at the bottom of the keyboard
+ * and unmistakable at the top, and no amount of filtering afterwards removes it,
+ * because by then the aliases are indistinguishable from real signal.
+ *
+ * Adding harmonics up to Nyquist and stopping cannot alias, because nothing
+ * above Nyquist is ever generated.  It costs a sin() per harmonic per sample,
+ * which is why it is not what a real-time synthesiser does -- but a note here is
+ * rendered ahead of being played, so the cost is paid once and is not felt.
+ *
+ * The harmonic count is also a brightness control, for free: ask for four and
+ * the saw is dull, ask for everything and it is bright.
+ */
+class voice {
+public:
+    /**
+     * @param i        the instrument, copied
+     * @param freq     Hz; zero or less is a rest and produces silence
+     * @param samples  how long the note is, in frames
+     * @param rate     frames per second
+     */
+    voice(const instrument& i, double freq, unsigned long samples, double rate)
+        : m_instrument(i),
+          m_freq(freq),
+          m_samples(samples),
+          m_rate(rate),
+          m_envelope(i.clamped(rate > 0 ? samples / rate : 0)),
+          m_pos(0)
+    {
+        // Harmonics up to Nyquist, and no further.  This is the whole of the
+        // band limiting: an aliased partial is one that was generated in the
+        // first place.
+        const double nyquist = m_rate / 2;
+
+        m_partials = (m_freq > 0) ? static_cast<unsigned int>(nyquist / m_freq) : 0;
+
+        const unsigned int asked = m_instrument.get_harmonics();
+        if(asked > 0 && asked < m_partials)
+            m_partials = asked;
+    }
+
+    unsigned long size() const { return m_samples; }
+    bool done() const { return m_pos >= m_samples; }
+    void reset() { m_pos = 0; }
+
+    /** The next frame, in [-1,1].  Silence once the note is over. */
+    Type::scaled next()
+    {
+        if(done())
+            return 0;
+
+        const unsigned long i = m_pos++;
+
+        // Phase from the sample index rather than accumulated, so it cannot
+        // drift and so a voice can be restarted exactly.
+        const double phase = (m_rate > 0) ? std::fmod(m_freq * i / m_rate, 1.0) : 0.0;
+
+        return static_cast<Type::scaled>(
+            gain_at(i) * m_instrument.get_gain() * oscillator(phase));
+    }
+
+protected:
+    /**
+     * The waveform at a phase in [0,1).
+     *
+     * Each is its Fourier series truncated at m_partials, scaled so that all
+     * four have the same RMS as a unit sine -- otherwise changing waveform
+     * changes loudness, since a square at a given peak is 3dB louder than a
+     * sine at the same peak.  Matching RMS means the peaks differ instead: a
+     * saw reaches about 1.22, and with the default gain of 0.666 that is 0.81,
+     * still inside full scale with room for the ~9% Gibbs overshoot that a
+     * truncated series adds at the discontinuity.
+     */
+    double oscillator(double phase) const
+    {
+        if(m_freq <= 0 || m_partials == 0)
+            return 0;
+
+        static const double pi = 3.14159265358979323846;
+        const double w = 2 * pi * phase;
+
+        switch(m_instrument.get_wave()) {
+        case instrument::wave::sine:
+            return std::sin(w);
+
+        case instrument::wave::saw: {
+            // (2/pi) * sum sin(k w)/k, alternating, peak 1 -> scaled to sine RMS
+            double sum = 0;
+            for(unsigned int k = 1; k <= m_partials; k++)
+                sum += ((k % 2) ? 1.0 : -1.0) * std::sin(k * w) / k;
+
+            return SAW_RMS * (2.0 / pi) * sum;
+        }
+
+        case instrument::wave::square: {
+            // (4/pi) * sum over odd k of sin(k w)/k
+            double sum = 0;
+            for(unsigned int k = 1; k <= m_partials; k += 2)
+                sum += std::sin(k * w) / k;
+
+            return SQUARE_RMS * (4.0 / pi) * sum;
+        }
+
+        case instrument::wave::triangle: {
+            // (8/pi^2) * sum over odd k of (-1)^((k-1)/2) sin(k w)/k^2
+            double sum = 0;
+            for(unsigned int k = 1; k <= m_partials; k += 2) {
+                const double sign = (((k - 1) / 2) % 2) ? -1.0 : 1.0;
+                sum += sign * std::sin(k * w) / (double(k) * k);
+            }
+
+            return TRIANGLE_RMS * (8.0 / (pi * pi)) * sum;
+        }
+        }
+
+        return 0;
+    }
+
+    /**
+     * The envelope at a sample index.
+     *
+     * Worked out in samples rather than seconds so that it is exactly zero at
+     * the first and the last one.  That is not tidiness: a note that stops
+     * mid-swing drops straight to silence and clicks, which is why the fade
+     * this replaced existed, and tests/audio_test.hh asserts first frame equals
+     * last frame because of it.
+     *
+     * Attack and release are raised cosines rather than lines -- same reason
+     * the old fade was, no corner at either end.  Decay is linear, as an ADSR's
+     * usually is.
+     */
+    double gain_at(unsigned long i) const
+    {
+        if(m_samples == 0)
+            return 0;
+
+        const double last = (m_samples > 1) ? double(m_samples - 1) : 1.0;
+
+        const unsigned long attack  = ramp_samples(m_envelope.attack);
+        const unsigned long decay   = ramp_samples(m_envelope.decay);
+        const unsigned long release = ramp_samples(m_envelope.release);
+
+        static const double pi = 3.14159265358979323846;
+
+        if(attack > 0 && i < attack)
+            return 0.5 * (1.0 - std::cos(pi * i / attack));
+
+        // from the end, so the last sample is exactly silent
+        const unsigned long from_end = static_cast<unsigned long>(last) - i;
+
+        if(release > 0 && from_end < release)
+            return m_envelope.sustain * 0.5 * (1.0 - std::cos(pi * from_end / release));
+
+        if(decay > 0 && i < attack + decay) {
+            const double through = double(i - attack) / decay;
+
+            return 1.0 + through * (m_envelope.sustain - 1.0);
+        }
+
+        return m_envelope.sustain;
+    }
+
+    unsigned long ramp_samples(double seconds) const
+    {
+        if(seconds <= 0 || m_rate <= 0)
+            return 0;
+
+        const unsigned long n = static_cast<unsigned long>(seconds * m_rate);
+
+        // Never longer than half the note, or attack and release overlap and
+        // neither reaches where it was going.
+        return (n > m_samples / 2) ? m_samples / 2 : n;
+    }
+
+    /** Peak scaling that gives each waveform the RMS of a unit sine. */
+    static constexpr double SAW_RMS      = 1.2247448713915890;   // sqrt(3/2)
+    static constexpr double SQUARE_RMS   = 0.7071067811865476;   // 1/sqrt(2)
+    static constexpr double TRIANGLE_RMS = 1.2247448713915890;   // sqrt(3/2)
+
+    instrument m_instrument;
+    double m_freq;
+    unsigned long m_samples;
+    double m_rate;
+    instrument::envelope m_envelope;
+    unsigned int m_partials = 0;
+    unsigned long m_pos;
+};
+
+}
+}
+
+#endif // JLIB_MEDIA_VOICE_HH

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -23,7 +23,8 @@ MEDIA_TESTS = media_datastream_test \
               sys_ringbuffer_test \
               math_lookat_test \
               sys_sigpipe_test \
-              sys_tls_sigpipe_test
+              sys_tls_sigpipe_test \
+              media_voice_test
 endif
 
 if HAVE_SODIUM
@@ -87,6 +88,9 @@ sys_sigpipe_test_LDADD        = $(JSYS_LA)
 
 sys_tls_sigpipe_test_SOURCES  = sys_tls_sigpipe_test.cc
 sys_tls_sigpipe_test_LDADD    = $(JSYS_LA) $(OPENSSL_LIBS)
+
+media_voice_test_SOURCES      = media_voice_test.cc
+media_voice_test_LDADD        = $(JMEDIA_LA) $(JSYS_LA)
 
 net_extract_address_test_SOURCES        = net_extract_address_test.cc
 net_extract_address_test_LDADD          = $(JNET_LA)

--- a/tests/media_voice_test.cc
+++ b/tests/media_voice_test.cc
@@ -1,0 +1,264 @@
+// The oscillator and the envelope.
+//
+// The claim worth checking is that the waveforms are band-limited.  A sawtooth
+// drawn as a ramp has energy at every harmonic without limit, and everything
+// above half the sample rate folds back down as an inharmonic tone that has
+// nothing to do with the note -- quiet at the bottom of the keyboard,
+// unmistakable at the top.  Building the wave by adding harmonics up to Nyquist
+// and stopping cannot do that, because nothing above Nyquist is ever generated.
+//
+// So the test measures the spectrum and asks how much energy sits somewhere
+// other than on a harmonic of the fundamental.  It also generates the same
+// waveform the naive way and measures that, which is what makes the number mean
+// something: without a case that fails, "small" is not evidence.
+//
+// The fundamentals are chosen to land exactly on a DFT bin.  A first attempt
+// used round frequencies, and the harmonics smeared across neighbouring bins --
+// which the classifier counted as off-harmonic energy and reported as aliasing
+// that was not there.
+#include <jlib/media/instrument.hh>
+#include <jlib/media/notestream.hh>
+#include <jlib/media/voice.hh>
+
+#include <cmath>
+#include <iomanip>
+#include <iostream>
+#include <string>
+#include <vector>
+
+using namespace jlib::media;
+
+static int failures = 0;
+static const double pi = 3.14159265358979323846;
+
+static void ok(const char* what, bool good, const std::string& detail = "") {
+    if(!good) ++failures;
+    std::cout << (good ? "  ok   " : "  FAIL ") << what;
+    if(!detail.empty()) std::cout << ": " << detail;
+    std::cout << "\n";
+}
+
+static void below(const char* what, double got, double limit) {
+    const bool good = (got < limit);
+    if(!good) ++failures;
+    std::cout << (good ? "  ok   " : "  FAIL ") << what << ": " << std::scientific
+              << std::setprecision(2) << got << " < " << limit << "\n";
+}
+
+static std::vector<float> render(const instrument& i, double freq,
+                                 unsigned long n, double rate) {
+    voice v(i, freq, n, rate);
+    std::vector<float> x;
+    x.reserve(n);
+    while(!v.done()) x.push_back(v.next());
+    return x;
+}
+
+/** Fraction of spectral energy not sitting on a harmonic of the fundamental. */
+static double off_harmonic(const std::vector<float>& x, int off, int n, int bins) {
+    double harm = 0, junk = 0;
+
+    for(int k = 1; k < n/2; k++) {
+        double re = 0, im = 0;
+        for(int i = 0; i < n; i++) {
+            re += x[off+i] * std::cos(2*pi*k*i/n);
+            im -= x[off+i] * std::sin(2*pi*k*i/n);
+        }
+        const double e = re*re + im*im;
+
+        if(k % bins == 0) harm += e; else junk += e;
+    }
+
+    return (harm + junk > 0) ? junk / (harm + junk) : 0;
+}
+
+static void band_limiting() {
+    std::cout << "band limiting:\n";
+
+    const double rate = 44100;
+    const int N = 2048;
+    const double bin = rate / N;
+
+    // 431Hz, 2153Hz, 4306Hz -- all exactly on a bin
+    for(int mult : {20, 100, 200}) {
+        const double freq = mult * bin;
+
+        for(auto w : {instrument::wave::saw, instrument::wave::square}) {
+            instrument inst;
+            inst.set_wave(w);
+
+            const unsigned long n = (unsigned long)rate;
+            const std::vector<float> x = render(inst, freq, n, rate);
+
+            // the same waveform the obvious way, which does alias
+            std::vector<float> naive;
+            naive.reserve(n);
+            for(unsigned long i = 0; i < n; i++) {
+                const double ph = std::fmod(freq * i / rate, 1.0);
+                naive.push_back((float)(w == instrument::wave::saw
+                                        ? (2*ph - 1) : (ph < 0.5 ? 1.0 : -1.0)));
+            }
+
+            const int off = (int)n/2 - N/2;
+            const double add = off_harmonic(x, off, N, mult);
+            const double nai = off_harmonic(naive, off, N, mult);
+
+            std::string tag = instrument::name_of(w) + " at " +
+                std::to_string((int)freq) + "Hz";
+
+            below((tag + ", additive").c_str(), add, 1e-9);
+
+            // and the measurement can tell the difference
+            ok((tag + ", naive is worse").c_str(), nai > add * 1000,
+               "naive " + std::to_string(nai));
+        }
+    }
+}
+
+static void envelope() {
+    std::cout << "\nenvelope:\n";
+
+    const double rate = 44100;
+    const unsigned long n = (unsigned long)rate;
+
+    {
+        // Silence at both ends, whatever was asked for.  A note that stops
+        // mid-swing clicks; this is the invariant audio_test.hh's check_pcm
+        // has been asserting all along, here at the source.
+        instrument inst;
+        inst.set_envelope(instrument::envelope{0.0, 0.0, 1.0, 0.0});   // asks for none
+
+        const std::vector<float> x = render(inst, 440, n, rate);
+
+        ok("zero-length ramps still start silent", x.front() == 0.0f);
+        ok("zero-length ramps still end silent", x.back() == 0.0f);
+    }
+
+    {
+        instrument inst;
+        inst.set_envelope(instrument::envelope{0.1, 0.1, 0.5, 0.1});
+        inst.set_gain(1.0);
+
+        const std::vector<float> x = render(inst, 440, n, rate);
+
+        // peak somewhere in the attack, sustain level in the middle
+        double peak_in_attack = 0;
+        for(unsigned long i = 0; i < (unsigned long)(0.1*rate); i++)
+            peak_in_attack = std::max(peak_in_attack, (double)std::fabs(x[i]));
+
+        double peak_in_sustain = 0;
+        for(unsigned long i = (unsigned long)(0.4*rate); i < (unsigned long)(0.6*rate); i++)
+            peak_in_sustain = std::max(peak_in_sustain, (double)std::fabs(x[i]));
+
+        ok("attack reaches full level", peak_in_attack > 0.95,
+           std::to_string(peak_in_attack));
+        ok("sustain holds the stated level",
+           std::fabs(peak_in_sustain - 0.5) < 0.02, std::to_string(peak_in_sustain));
+    }
+
+    {
+        // A note too short to hold attack, decay and release: the segments give
+        // way proportionally rather than run past the end.
+        instrument inst;
+        inst.set_envelope(instrument::envelope{0.5, 0.5, 0.8, 0.5});
+
+        const unsigned long tiny = (unsigned long)(rate * 0.1);
+        const std::vector<float> x = render(inst, 440, tiny, rate);
+
+        ok("a note shorter than its envelope still starts silent", x.front() == 0.0f);
+        ok("a note shorter than its envelope still ends silent", x.back() == 0.0f);
+
+        double peak = 0;
+        for(float s : x) peak = std::max(peak, (double)std::fabs(s));
+        ok("and still makes a sound", peak > 0.1, std::to_string(peak));
+    }
+}
+
+static void levels() {
+    std::cout << "\nlevels:\n";
+
+    const double rate = 44100;
+    const unsigned long n = (unsigned long)rate;
+
+    double first_rms = 0;
+
+    for(auto w : {instrument::wave::sine, instrument::wave::saw,
+                  instrument::wave::square, instrument::wave::triangle}) {
+        instrument inst;
+        inst.set_wave(w);
+
+        const std::vector<float> x = render(inst, 220, n, rate);
+
+        double peak = 0, sumsq = 0;
+        for(float s : x) { peak = std::max(peak, (double)std::fabs(s)); sumsq += (double)s*s; }
+        const double rms = std::sqrt(sumsq / n);
+
+        // Peak matters because create_data quantizes straight into an integer;
+        // out of range would wrap rather than clip.
+        ok((instrument::name_of(w) + " stays inside full scale").c_str(),
+           peak < 1.0, std::to_string(peak));
+
+        // Changing waveform should not change how loud the note is.  They are
+        // scaled to match in RMS rather than in peak for that reason -- a square
+        // at a given peak is 3dB louder than a sine at the same peak.
+        if(first_rms == 0) first_rms = rms;
+        else
+            ok((instrument::name_of(w) + " matches sine in loudness").c_str(),
+               std::fabs(rms - first_rms) / first_rms < 0.05,
+               std::to_string(rms) + " against " + std::to_string(first_rms));
+    }
+}
+
+static void note_strings() {
+    std::cout << "\nnote strings:\n";
+
+    {
+        notestream n("A#@4:2/saw");
+        ok("waveform override parses",
+           n.get_instrument().get_wave() == instrument::wave::saw);
+        ok("and the rest of the note survives it",
+           std::fabs(n.get_time() - 2.0) < 1e-9, std::to_string(n.get_time()));
+    }
+
+    {
+        notestream n("A");
+        ok("no override leaves the instrument alone",
+           n.get_instrument().get_wave() == instrument::wave::sine);
+    }
+
+    {
+        bool threw = false;
+        try { notestream n("A/wobble"); } catch(std::exception&) { threw = true; }
+        ok("an unknown waveform is refused", threw);
+    }
+
+    {
+        // used to be silently ignored: "C##" was a C
+        bool threw = false;
+        try { notestream n("C##"); } catch(std::exception&) { threw = true; }
+        ok("a second accidental is refused", threw);
+    }
+
+    {
+        // this constructor threw for years; nothing called it
+        bool threw = false;
+        try { notestream n; } catch(std::exception&) { threw = true; }
+        ok("the default note works", !threw);
+    }
+
+    {
+        // get_freq() was declared and never defined, so this did not link
+        notestream n(440.0);
+        ok("get_freq reports the frequency",
+           std::fabs(n.get_freq() - 440.0) < 1e-9, std::to_string(n.get_freq()));
+    }
+}
+
+int main() {
+    band_limiting();
+    envelope();
+    levels();
+    note_strings();
+
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
closes #39

First slice of the synthesis plan.  A note was a sine at a hardcoded volume with
a fixed 5ms fade; it now has an instrument behind it, and the instrument is a
separate reusable thing rather than a set of locals in the render loop.

    macOS  30 tests, 30 pass, 0 skip
    Linux  31 tests, 30 pass, 1 skip
    jnote and jmelody verified by ear, including saw, square and triangle

shape

    instrument.hh   waveform, ADSR, gain, harmonic count.  Set up once, used by
                    many notes.
    voice.hh        the oscillator and envelope.  Produces samples in [-1,1] a
                    frame at a time and knows nothing about formats, channels or
                    streams -- so rendering a note is a loop over it, and so is
                    mixing several of them, which is what the later phases need.
    notestream      unchanged from outside.  create_data() runs a voice instead
                    of computing a sine inline.

    Only one line of create_data() was ever sine-specific.  The 5ms fade was
    already a degenerate envelope -- instant attack, no decay, full sustain, 5ms
    release -- and the ADSR subsumes it.

the waveforms are built by adding harmonics

    The obvious sawtooth is a ramp and the obvious square is sign(sin).  Both
    alias: a ramp has energy at every harmonic without limit, everything above
    half the sample rate folds back down, and what comes out is an inharmonic
    tone unrelated to the note.  Quiet at the bottom of the keyboard,
    unmistakable at the top, and unfixable afterwards, because by then the
    aliases are indistinguishable from signal.

    Summing harmonics up to Nyquist and stopping cannot do that, since nothing
    above Nyquist is generated.  It costs a sin() per harmonic per sample, which
    is why a real-time synthesiser would not do it -- but a note here is rendered
    before it is played, so the cost is paid once.  The harmonic count is a
    brightness control for nothing.

    Measured, off-harmonic energy:

                     additive     naive
        430Hz         5e-16       0.011
        2153Hz        5e-16       0.058
        4306Hz        6e-16       0.110

    The naive column is generated by the test itself, for the same reason a
    crash test has to be shown crashing: "small" is not evidence without a case
    that fails.  Thirteen orders of magnitude between them.

    The first version of that measurement was wrong and said aliasing was
    present when it was not.  Round frequencies do not land on DFT bins, so
    every harmonic smears across its neighbours, and the classifier counted the
    smear as off-harmonic energy -- at the hundredth harmonic the smear exceeds
    any sensible tolerance.  The fundamentals are chosen to land exactly on a
    bin now.

matched in loudness, not in peak

    A square at a given peak is 3dB louder than a sine at the same peak, so
    scaling the waveforms to a common peak would make changing waveform change
    how loud the note is.  They are scaled to a common RMS instead -- measured
    within 0.4% of each other.

    The cost is that the peaks differ: a sawtooth reaches 0.95 at the default
    gain, partly from the ~9% overshoot a truncated Fourier series has at a
    discontinuity.  So create_data() clamps before quantizing, which it did not
    need to when everything was a sine inside 0.666.  llround of an out-of-range
    value into an int16 wraps rather than clips, which is a much worse noise
    than the clipping it would replace.

the envelope may not reintroduce the click

    The fade existed because a note lasts get_time() seconds whatever its
    frequency, so freq*time is hardly ever a whole number of cycles: at 443.7Hz
    for one second the last sample was -20287 against a 21823 peak, a 93%
    full-scale step.  check_pcm in tests/audio_test.hh asserts the first frame
    equals the last because of it, and that is the only synthesis assertion the
    suite had.

    So instrument::clamped() will not let attack or release go below the 5ms
    that made the fade work, whatever the settings ask for, and a note too short
    to hold attack, decay and release has its segments scaled proportionally
    rather than truncated.  Tested at both ends: zero-length ramps still start
    and end silent, and a note shorter than its own envelope still makes a sound.

note strings

    A#@4:2/saw.  The waveform only -- it is the one thing worth saying per note,
    and an ADSR written as four numbers in a string is the point at which this
    would want escaping and a real grammar rather than another delimiter.
    Everything else is a setter, which is also what the later phases need, since
    a voice driven by geometry never comes from text at all.

five latent bugs, all in the code this touches

    The default constructor called set_note("A1"), which throws under the
    grammar the string parser actually implements.  It could not be called at
    all; nothing in the tree or the tests does.

    set_note(double) read an uninitialized m_time when called from the
    constructor, so the sample count came from whatever was on the stack --
    negative and it generated nothing, large and it allocated to match.  Every
    notestream note(440.0) in the tests went through it.

    get_freq() const was declared and never defined, so any call failed to link;
    set_nearest_time() has therefore never been usable and jnote.cc:72 has its
    call commented out.

    A note with more than one accidental silently ignored it: "C##" was a C.
    The length test was == 2 rather than > 1.

    And ten forwarders on basic_notestream were missing typename before a
    dependent type, so they could not be instantiated -- get_time() among them.
    Found by the new test calling it.

not covered

    The seven-way format dispatch in create_data() is untouched.  The waveform
    produces a value in [-1,1] and everything downstream is as it was, and
    Type.hh cannot absorb the dispatch anyway: its S16_LE and S16_BE
    specializations are byte-identical, so the table cannot express endianness.

    Nothing is polyphonic yet, and nothing is live.  voice is shaped for both --
    a frame at a time, no format knowledge -- and the next phases put a source
    interface and a mixer on top of it.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
