### PR TITLE
add a source interface and a stream adapter over it

### DIFF
--- a/jlib/apps/jnote.cc
+++ b/jlib/apps/jnote.cc
@@ -5,6 +5,8 @@
 
 #include <jlib/media/notestream.hh>
 #include <jlib/media/PortAudioSink.hh>
+#include <jlib/media/source_stream.hh>
+#include <jlib/media/voice.hh>
 
 #include <jlib/sys/sys.hh>
 
@@ -13,6 +15,7 @@ const long double 	PI = 3.14159265358979323846264338;
 void play(double freq, int format, int channels, double t);
 void play(const std::string& note, int format, int channels, double t);
 void play(jlib::media::notestream& ns, int format, int channels, double t);
+void play_live(jlib::media::notestream& ns, int format, int channels, double t);
 
 int main(int argc, char** argv) {
 
@@ -24,12 +27,22 @@ int main(int argc, char** argv) {
         int channels = 2;
         std::string note;
         double t = 5;
+        bool given = false;      // was a duration actually asked for?
         bool isnote = false;
+        bool live = false;
 
-        if(argc > 1) {
-            isnote = !std::isdigit(argv[1][0]);
+        // --live generates as it plays, through source_stream, instead of
+        // rendering the note into a buffer first.
+        int arg = 1;
+        if(argc > 1 && std::string(argv[1]) == "--live") {
+            live = true;
+            arg = 2;
+        }
 
-            std::istringstream i(argv[1]);
+        if(argc > arg) {
+            isnote = !std::isdigit(argv[arg][0]);
+
+            std::istringstream i(argv[arg]);
 
             if(isnote)
                 i >> note;
@@ -37,15 +50,30 @@ int main(int argc, char** argv) {
                 i >> freq;
         }
         
-        if(argc > 2) {
-            std::istringstream i(argv[2]);
+        if(argc > arg + 1) {
+            std::istringstream i(argv[arg + 1]);
             i >> t;
+            given = true;
         }
 
-        if(isnote)
-            play(note, format, channels, t);
-        else
-            play(freq, format, channels, t);
+        // A note string carries its own duration -- the :BEATS in A@2:2 -- so
+        // only override it when one was actually asked for on the command line.
+        // This used to call set_time() unconditionally, so "jnote A@2:2" played
+        // for the default five seconds and the :2 was discarded.  A bare
+        // frequency says nothing about duration, so the default stands there.
+        if(isnote) {
+            notestream ns(note);
+            const double d = given ? t : ns.get_time();
+
+            if(live) play_live(ns, format, channels, d);
+            else     play(ns, format, channels, d);
+        }
+        else {
+            notestream ns(freq);
+
+            if(live) play_live(ns, format, channels, t);
+            else     play(ns, format, channels, t);
+        }
     }
     catch(std::exception& e) {
         std::cerr << e.what() << std::endl;
@@ -76,4 +104,31 @@ void play(jlib::media::notestream& ns, int format, int channels, double t) {
 
     dsp.play(ns);
     
+}
+
+/**
+ * The same note, generated as it plays rather than rendered first.
+ *
+ * The point of source_stream, demonstrated: a voice is not a buffer and has no
+ * length, and the sink neither knows nor cares -- it reads a stream, and this
+ * is one.  Everything a live mix will need is here already, with one voice
+ * instead of many.
+ */
+void play_live(jlib::media::notestream& ns, int format, int channels, double t) {
+    using namespace jlib::media;
+
+    ns.set_time(t);
+
+    instrument inst = ns.get_instrument();
+
+    voice v(inst, ns.get_freq(),
+            static_cast<unsigned long>(44100 * t), 44100.0);
+
+    source_stream live(&v);
+    live.set_samples_per_sec(44100);
+    live.set_format(format);
+    live.set_channels(channels);
+
+    PortAudioSink dsp;
+    dsp.play(live);
 }

--- a/jlib/media/Makefile.am
+++ b/jlib/media/Makefile.am
@@ -17,7 +17,7 @@ libjmedia_la_LIBADD = $(top_builddir)/jlib/sys/libjsys.la \
 
 jmedia_hdrs = Player.hh AudioFile.hh WavFile.hh PlayList.hh stream.hh \
               datastream.hh notestream.hh Type.hh wavstream.hh \
-              instrument.hh voice.hh \
+              instrument.hh voice.hh source.hh source_stream.hh \
               audiofilestream.hh AudioSink.hh PortAudioSink.hh
 
 libjmediaincludedir = $(includedir)/jlib-1.2/jlib/media

--- a/jlib/media/source.hh
+++ b/jlib/media/source.hh
@@ -1,0 +1,95 @@
+/* -*- mode: C++ c-basic-offset: 4  -*-
+ *
+ * Copyright (c) 2000 Joe Yandle <jwy@divisionbyzero.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ *
+ */
+
+#ifndef JLIB_MEDIA_SOURCE_HH
+#define JLIB_MEDIA_SOURCE_HH
+
+#include <jlib/media/Type.hh>
+
+namespace jlib {
+namespace media {
+
+/**
+ * Something that produces audio.
+ *
+ * A synthesized voice and a recorded sample are the same kind of thing to
+ * whatever is mixing them; only their insides differ.  This is that thing.
+ *
+ * ## Float, not PCM
+ *
+ * Sources deal in Type::scaled, nominally [-1,1].  Summing in an integer format
+ * overflows, and converting at every hop of a graph loses precision at every
+ * hop -- so the format is an output concern, handled once by source_stream.
+ * PlayList::render has always worked this way; this generalizes it.
+ *
+ * ## Additive
+ *
+ * render() *adds* into the buffer rather than overwriting it, so mixing costs
+ * nothing beyond the sources themselves.  The caller zeroes first.
+ *
+ * ## Block-size independence, which is a requirement and not an accident
+ *
+ * Rendering N frames in one call must produce exactly the same samples as
+ * rendering them in any sequence of smaller calls.  Not nearly the same:
+ * identical, bit for bit.
+ *
+ * That is what makes an offline render reproducible -- bouncing a project has
+ * to give the same file every time, and has to match what was heard while it
+ * played, even though the live path used whatever block size the device asked
+ * for and the render used whatever was convenient.  It is easy to preserve by
+ * driving everything from a running frame count, and painful to recover once
+ * something has been written that carries state across a block boundary.
+ *
+ * media_source_test asserts it.
+ *
+ * ## Channels
+ *
+ * Interleaved, and the source is told how many to write.  A mono source writes
+ * the same value across the frame; a stereo one writes its own.  Carrying it
+ * here rather than assuming mono means a stereo sampler is not a special case
+ * bolted on later.
+ */
+class source {
+public:
+    virtual ~source() {}
+
+    /**
+     * Add up to frames frames of interleaved audio into out.
+     *
+     * @param out       at least frames*channels values, already zeroed or
+     *                  holding something to add to
+     * @param frames    frames wanted
+     * @param channels  values per frame
+     * @return          frames actually produced, which is fewer at the end
+     */
+    virtual unsigned long render(Type::scaled* out, unsigned long frames,
+                                 unsigned int channels) = 0;
+
+    /** Nothing further will be produced.  A mixer drops these. */
+    virtual bool done() const { return false; }
+
+    /** Back to the beginning, as if nothing had been rendered. */
+    virtual void reset() {}
+};
+
+}
+}
+
+#endif // JLIB_MEDIA_SOURCE_HH

--- a/jlib/media/source_stream.hh
+++ b/jlib/media/source_stream.hh
@@ -1,0 +1,205 @@
+/* -*- mode: C++ c-basic-offset: 4  -*-
+ *
+ * Copyright (c) 2000 Joe Yandle <jwy@divisionbyzero.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ *
+ */
+
+#ifndef JLIB_MEDIA_SOURCE_STREAM_HH
+#define JLIB_MEDIA_SOURCE_STREAM_HH
+
+#include <jlib/media/source.hh>
+#include <jlib/media/stream.hh>
+
+#include <cstdint>
+
+#include <cmath>
+#include <cstring>
+#include <vector>
+
+namespace jlib {
+namespace media {
+
+/**
+ * A media::stream over a source.
+ *
+ * The one place float becomes PCM, and the reason the rest of the library needs
+ * to know nothing about any of this: Player, PortAudioSink, WavFile and the
+ * feeder thread all take streams, so wrapping a source in one makes a live mix
+ * playable by every one of them unchanged.
+ *
+ * Unlike datastream and notestream this does not hold the whole thing up front.
+ * It pulls a block from the source whenever the get area runs out, which is
+ * what makes it usable for something being generated as it plays.  The
+ * consequence is that it has no length and cannot seek; rewind() resets the
+ * source, which is the only meaning seeking to zero can have here.
+ */
+template< typename charT, typename traitT = std::char_traits<charT> >
+class basic_source_streambuf : public basic_streambuf<charT,traitT> {
+public:
+    class exception : public std::exception {
+    public:
+        exception(const std::string& msg = "") {
+            m_msg = std::string("jlib::media::basic_source_streambuf::exception")+(msg==""?"":": ")+msg;
+        }
+        virtual ~exception() {}
+        virtual const char* what() const noexcept { return m_msg.c_str(); }
+    protected:
+        std::string m_msg;
+    };
+
+    typedef charT                               char_type;
+    typedef traitT                              traits_type;
+    typedef typename traits_type::int_type      int_type;
+
+    /**
+     * @param s       not owned; it has to outlive this
+     * @param frames  how much to pull at a time
+     */
+    basic_source_streambuf(source* s = 0, unsigned long frames = 1024)
+        : m_source(s),
+          m_frames(frames)
+    {
+    }
+
+    void set_source(source* s) { m_source = s; }
+    source* get_source() const { return m_source; }
+
+    virtual int_type underflow()
+    {
+        if(m_source == 0 || m_source->done())
+            return traits_type::eof();
+
+        const unsigned int channels = this->get_channels();
+        const int frame = channels * (this->get_bits_per_sample() / 8);
+
+        if(frame <= 0)
+            throw exception("underflow(): the format says a frame is no bytes");
+
+        m_mix.assign(m_frames * channels, 0);
+
+        const unsigned long made = m_source->render(m_mix.data(), m_frames, channels);
+        if(made == 0)
+            return traits_type::eof();
+
+        m_pcm.assign(made * frame, '\0');
+
+        for(unsigned long i = 0; i < made * channels; i++)
+            write_one(m_pcm, i * (frame / channels), m_mix[i]);
+
+        this->setg(&m_pcm[0], &m_pcm[0], &m_pcm[0] + m_pcm.size());
+
+        return traits_type::to_int_type(*this->gptr());
+    }
+
+    virtual void rewind()
+    {
+        if(m_source)
+            m_source->reset();
+
+        this->setg(0, 0, 0);
+    }
+
+protected:
+    /**
+     * One value, converted and clamped.
+     *
+     * The clamp is the point of doing this in one place.  A source is nominally
+     * in [-1,1] but nothing enforces it -- a mix of several is routinely over,
+     * and a truncated Fourier series overshoots on its own -- and llround of an
+     * out-of-range value into an integer wraps rather than saturates, which
+     * sounds far worse than the clipping it replaces.
+     */
+    void write_one(std::string& out, std::size_t at, Type::scaled v) const
+    {
+        if(v >  1) v =  1;
+        if(v < -1) v = -1;
+
+        switch(this->get_format()) {
+        case Type::PCM_FLOAT32:
+            // Not util::byte_copy: it takes a non-const pointer and casts the
+            // constness away, so it cannot take the address of a local.
+            std::memcpy(&out[at], &v, sizeof(v));
+            return;
+
+        case Type::PCM_U8:
+            out[at] = static_cast<char>(
+                static_cast<unsigned char>(std::llround(v * 127.0) + 128));
+            return;
+
+        case Type::PCM_S8:
+            out[at] = static_cast<char>(std::llround(v * 127.0));
+            return;
+
+        case Type::PCM_S16_LE: {
+            const std::int16_t s = static_cast<std::int16_t>(std::llround(v * 32767.0));
+            out[at]     = static_cast<char>(s & 0xff);
+            out[at + 1] = static_cast<char>((s >> 8) & 0xff);
+            return;
+        }
+
+        case Type::PCM_S16_BE: {
+            const std::int16_t s = static_cast<std::int16_t>(std::llround(v * 32767.0));
+            out[at]     = static_cast<char>((s >> 8) & 0xff);
+            out[at + 1] = static_cast<char>(s & 0xff);
+            return;
+        }
+
+        case Type::PCM_U16_LE: {
+            const std::uint16_t s =
+                static_cast<std::uint16_t>(std::llround(v * 32767.0) + 32768);
+            out[at]     = static_cast<char>(s & 0xff);
+            out[at + 1] = static_cast<char>((s >> 8) & 0xff);
+            return;
+        }
+
+        case Type::PCM_U16_BE: {
+            const std::uint16_t s =
+                static_cast<std::uint16_t>(std::llround(v * 32767.0) + 32768);
+            out[at]     = static_cast<char>((s >> 8) & 0xff);
+            out[at + 1] = static_cast<char>(s & 0xff);
+            return;
+        }
+
+        default:
+            throw exception("unsupported format");
+        }
+    }
+
+    source* m_source;
+    unsigned long m_frames;
+
+    std::vector<Type::scaled> m_mix;
+    std::string m_pcm;
+};
+
+template<typename charT, typename traitT = std::char_traits<charT> >
+class basic_source_stream : public basic_stream<charT,traitT> {
+public:
+    basic_source_stream(source* s = 0, unsigned long frames = 1024)
+        : basic_stream<charT,traitT>()
+    {
+        this->m_buf.reset(new basic_source_streambuf<charT,traitT>(s, frames));
+        this->init(this->m_buf.get());
+    }
+};
+
+typedef basic_source_stream<char> source_stream;
+
+}
+}
+
+#endif // JLIB_MEDIA_SOURCE_STREAM_HH

--- a/jlib/media/voice.hh
+++ b/jlib/media/voice.hh
@@ -23,6 +23,7 @@
 
 #include <jlib/media/Type.hh>
 #include <jlib/media/instrument.hh>
+#include <jlib/media/source.hh>
 
 #include <cmath>
 
@@ -54,7 +55,7 @@ namespace media {
  * The harmonic count is also a brightness control, for free: ask for four and
  * the saw is dull, ask for everything and it is bright.
  */
-class voice {
+class voice : public source {
 public:
     /**
      * @param i        the instrument, copied
@@ -83,8 +84,35 @@ public:
     }
 
     unsigned long size() const { return m_samples; }
-    bool done() const { return m_pos >= m_samples; }
-    void reset() { m_pos = 0; }
+
+    virtual bool done() const { return m_pos >= m_samples; }
+    virtual void reset() { m_pos = 0; }
+
+    /**
+     * Add this voice to a buffer.
+     *
+     * Block-size independent by construction: everything comes from m_pos,
+     * which counts frames since the voice started, so a call boundary is not
+     * something the output can notice.  See the note on source.
+     */
+    virtual unsigned long render(Type::scaled* out, unsigned long frames,
+                                 unsigned int channels)
+    {
+        unsigned long made = 0;
+
+        while(made < frames && !done()) {
+            const Type::scaled s = next();
+
+            // Mono, spread across the frame.  A voice has no stereo image of
+            // its own; the mixer places it.
+            for(unsigned int c = 0; c < channels; c++)
+                out[made * channels + c] += s;
+
+            ++made;
+        }
+
+        return made;
+    }
 
     /** The next frame, in [-1,1].  Silence once the note is over. */
     Type::scaled next()

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -24,7 +24,8 @@ MEDIA_TESTS = media_datastream_test \
               math_lookat_test \
               sys_sigpipe_test \
               sys_tls_sigpipe_test \
-              media_voice_test
+              media_voice_test \
+              media_source_test
 endif
 
 if HAVE_SODIUM
@@ -91,6 +92,9 @@ sys_tls_sigpipe_test_LDADD    = $(JSYS_LA) $(OPENSSL_LIBS)
 
 media_voice_test_SOURCES      = media_voice_test.cc
 media_voice_test_LDADD        = $(JMEDIA_LA) $(JSYS_LA)
+
+media_source_test_SOURCES     = media_source_test.cc
+media_source_test_LDADD       = $(JMEDIA_LA) $(JSYS_LA)
 
 net_extract_address_test_SOURCES        = net_extract_address_test.cc
 net_extract_address_test_LDADD          = $(JNET_LA)

--- a/tests/media_source_test.cc
+++ b/tests/media_source_test.cc
@@ -1,0 +1,205 @@
+// The source interface, and the one invariant it has to keep.
+//
+// Rendering N frames in a single call must produce exactly the same samples as
+// rendering them in any sequence of smaller calls -- identical, bit for bit,
+// not nearly.
+//
+// That is what makes an offline render reproducible and what makes it match
+// what was heard live, even though the live path used whatever block size the
+// device asked for and the render used whatever was convenient.  It is nearly
+// free to keep, since everything is driven from a running frame count, and very
+// expensive to recover once something has been written that carries state
+// across a block boundary.  So it is asserted rather than assumed, before there
+// is anything complicated enough to break it.
+#include <jlib/media/instrument.hh>
+#include <jlib/media/source_stream.hh>
+#include <jlib/media/voice.hh>
+
+#include <cmath>
+#include <cstring>
+#include <iomanip>
+#include <iostream>
+#include <string>
+#include <vector>
+
+using namespace jlib::media;
+
+static int failures = 0;
+
+static void ok(const std::string& what, bool good, const std::string& detail = "") {
+    if(!good) ++failures;
+    std::cout << (good ? "  ok   " : "  FAIL ") << what;
+    if(!detail.empty()) std::cout << ": " << detail;
+    std::cout << "\n";
+}
+
+/** Render a voice in blocks of the given size, into one buffer. */
+static std::vector<Type::scaled> in_blocks(const instrument& inst, double freq,
+                                           unsigned long total, double rate,
+                                           unsigned long block,
+                                           unsigned int channels) {
+    voice v(inst, freq, total, rate);
+
+    std::vector<Type::scaled> out(total * channels, 0);
+    unsigned long at = 0;
+
+    while(at < total) {
+        const unsigned long want = std::min(block, total - at);
+        const unsigned long made = v.render(&out[at * channels], want, channels);
+
+        if(made == 0) break;
+        at += made;
+    }
+
+    return out;
+}
+
+static void block_size_independence() {
+    std::cout << "block size independence:\n";
+
+    const double rate = 44100;
+    const unsigned long total = 4096;
+
+    for(auto w : {instrument::wave::sine, instrument::wave::saw,
+                  instrument::wave::square, instrument::wave::triangle}) {
+        instrument inst;
+        inst.set_wave(w);
+        inst.set_envelope(instrument::envelope{0.01, 0.02, 0.6, 0.03});
+
+        const std::vector<Type::scaled> whole =
+            in_blocks(inst, 431.0, total, rate, total, 1);
+
+        // Awkward sizes on purpose: powers of two would hide anything that
+        // depends on a block boundary landing somewhere convenient.
+        for(unsigned long block : {1UL, 7UL, 64UL, 333UL, 1024UL}) {
+            const std::vector<Type::scaled> split =
+                in_blocks(inst, 431.0, total, rate, block, 1);
+
+            unsigned long differ = 0;
+            for(unsigned long i = 0; i < total; i++)
+                if(std::memcmp(&whole[i], &split[i], sizeof(Type::scaled)) != 0)
+                    ++differ;
+
+            ok(instrument::name_of(w) + " in blocks of " + std::to_string(block),
+               differ == 0,
+               differ ? (std::to_string(differ) + " samples differ") : "");
+        }
+    }
+}
+
+static void additive_and_channels() {
+    std::cout << "\nrender:\n";
+
+    const double rate = 44100;
+    const unsigned long n = 512;
+
+    instrument inst;
+
+    {
+        // render adds rather than overwrites, which is what makes mixing free
+        voice a(inst, 431.0, n, rate), b(inst, 431.0, n, rate);
+
+        std::vector<Type::scaled> one(n, 0), two(n, 0);
+        a.render(one.data(), n, 1);
+        b.render(two.data(), n, 1);
+        b.reset();
+        b.render(two.data(), n, 1);          // a second time, into the same buffer
+
+        unsigned long wrong = 0;
+        for(unsigned long i = 0; i < n; i++)
+            if(std::fabs(two[i] - 2*one[i]) > 1e-6) ++wrong;
+
+        ok("rendering twice into a buffer sums", wrong == 0);
+    }
+
+    {
+        // a mono voice fills every channel of the frame
+        voice v(inst, 431.0, n, rate);
+
+        std::vector<Type::scaled> st(n * 2, 0);
+        v.render(st.data(), n, 2);
+
+        unsigned long wrong = 0;
+        for(unsigned long i = 0; i < n; i++)
+            if(st[i*2] != st[i*2 + 1]) ++wrong;
+
+        ok("a mono voice fills both channels", wrong == 0);
+    }
+
+    {
+        voice v(inst, 431.0, n, rate);
+        std::vector<Type::scaled> out(n * 4, 0);
+
+        const unsigned long made = v.render(out.data(), n * 4, 1);
+
+        ok("asking for more than there is returns what there was",
+           made == n, std::to_string(made));
+        ok("and the voice says it is done", v.done());
+    }
+}
+
+static void through_a_stream() {
+    std::cout << "\nas a stream:\n";
+
+    const double rate = 44100;
+    const unsigned long n = 4096;
+
+    instrument inst;
+    voice v(inst, 431.0, n, rate);
+
+    source_stream s(&v);
+    s.set_format(Type::PCM_S16_LE);
+    s.set_channels(1);
+    s.set_samples_per_sec((int)rate);
+
+    std::string pcm;
+    char buf[997];                            // not a multiple of the block size
+    while(s.good()) {
+        s.read(buf, sizeof(buf));
+        pcm.append(buf, s.gcount());
+    }
+
+    ok("a source reads out as a stream", pcm.size() == n * 2,
+       std::to_string(pcm.size()) + " bytes for " + std::to_string(n) + " frames");
+
+    // the envelope reaches silence at both ends, as everything else asserts
+    ok("starts silent", pcm.size() >= 2 && pcm[0] == 0 && pcm[1] == 0);
+    ok("ends silent", pcm.size() >= 2 &&
+       pcm[pcm.size()-2] == 0 && pcm[pcm.size()-1] == 0);
+
+    {
+        // clamping: a source over full scale must saturate, not wrap.  llround
+        // of an out-of-range value into an int16 wraps, which is a far worse
+        // noise than the clipping it replaces.
+        instrument loud;
+        loud.set_gain(4.0);                   // deliberately way over
+
+        voice hot(loud, 431.0, 256, rate);
+        source_stream ls(&hot);
+        ls.set_format(Type::PCM_S16_LE);
+        ls.set_channels(1);
+
+        std::string out;
+        char b2[512];
+        while(ls.good()) { ls.read(b2, sizeof(b2)); out.append(b2, ls.gcount()); }
+
+        long over = 0;
+        for(std::size_t i = 0; i + 1 < out.size(); i += 2) {
+            const std::int16_t s16 = (std::int16_t)((unsigned char)out[i] |
+                                                    ((unsigned char)out[i+1] << 8));
+            // a wrap shows up as a sign flip where the waveform was heading up
+            if(s16 == -32768) ++over;
+        }
+
+        ok("an over-driven source clips rather than wrapping", over == 0,
+           over ? (std::to_string(over) + " wrapped samples") : "");
+    }
+}
+
+int main() {
+    block_size_independence();
+    additive_and_channels();
+    through_a_stream();
+
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
Second slice of the synthesis plan, and a refactor rather than a feature: a
voice is a source now, and a source can present itself as a stream.  Nothing
sounds different.

    macOS  31 tests, 31 pass, 0 skip
    Linux  32 tests, 31 pass, 1 skip
    jnote and jnote --live verified by ear, and against each other

what a source is

    virtual unsigned long render(Type::scaled* out, unsigned long frames,
                                 unsigned int channels)

    A synthesized voice and a recorded sample are the same kind of thing to
    whatever mixes them, and this is that thing.  It deals in float rather than
    PCM because summing in an integer format overflows and converting at every
    hop of a graph loses precision at every hop -- PlayList::render has always
    worked this way, and this generalizes it.  It adds rather than overwrites,
    so mixing costs nothing beyond the sources themselves.

source_stream

    A media::stream over any source, and the one place float becomes PCM.  That
    is what lets a live mix be played by everything that already exists: Player,
    PortAudioSink, WavFile and the feeder thread all take streams and none of
    them need to know the audio did not exist a moment ago.

    Unlike datastream and notestream it does not hold the whole thing.  It pulls
    a block whenever the get area runs out, so it has no length and cannot seek;
    rewind() resets the source, which is the only meaning seeking to zero has
    for something being generated.

    The clamp lives here, which is the point of having one place.  A source is
    nominally in [-1,1] and nothing enforces it -- a mix of several is routinely
    over -- and llround of an out-of-range value into an integer wraps rather
    than saturates, which is a far worse noise than the clipping it replaces.
    Tested with a source driven four times over full scale.

three things the interface deliberately does not decide

    Written down because the intent is both real-time generation and exact
    offline rendering, and each of these is cheap now and expensive later.

    **Block size independence.**  Rendering N frames in one call produces
    exactly the same samples as rendering them in any sequence of smaller calls
    -- identical, bit for bit.  That is what makes an offline bounce
    reproducible and what makes it match what was heard live, given that the
    live path uses whatever block size the device asks for and the render uses
    whatever is convenient.

    Asserted rather than assumed: media_source_test renders 4096 frames in
    blocks of 1, 7, 64, 333 and 1024 and compares against a single call, for
    every waveform.  The awkward sizes are deliberate -- powers of two would
    hide anything that depends on where a boundary lands.

    **Channels go through render().**  A mono source fills every channel of the
    frame; a stereo one writes its own.  Deciding this here rather than assuming
    mono means a stereo sampler is not a special case bolted on later.

    **Quality stays a setting, not a type.**  The same voice will sum harmonics
    exactly for an offline render or read a table live.  Nothing here forces
    either.

why that matters, measured

    Additive synthesis is a build-time technique, not a run-time one.  On one
    core, rendering one second of audio:

        64 voices at 110Hz (200 partials)   122% of real time
        64 voices at 440Hz (50 partials)     30%

    So about fifty low voices is the ceiling, and a D=10 hypercube is 1024
    vertices.  A wavetable read instead of a sum, with the tables built by the
    same additive generator:

        64 voices        0.1%
        1024 voices      1.2%
        16384 (D=14)    12.5%

    Tables build in 12ms, once.  So phase 1's generator is not replaced, it
    moves from per-sample to per-startup, and the band limiting is identical
    because it is the same code.  That is the next phase; the interface here
    does not have to change for it.

jnote --live

    The same note, generated as it plays rather than rendered first.  One voice
    through source_stream through PortAudioSink, which is everything a live mix
    needs with one voice instead of many -- and it demonstrates end to end what
    the tests can only assert.

    It also turned up a bug older than any of this work.  jnote called
    set_time() unconditionally, so a note string's own duration was always
    discarded: "jnote A@2:2" played for the default five seconds and the :2 was
    thrown away.  An explicit duration wins now, a note string otherwise uses
    its own, and a bare frequency keeps the default, since a frequency says
    nothing about how long to play it.

    That has been true for as long as the grammar has had :BEATS.  It became
    worth noticing now because note strings do more, so people will write them.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
