### PR TITLE
Add a mixer

### DIFF
--- a/jlib/apps/Makefile.am
+++ b/jlib/apps/Makefile.am
@@ -103,7 +103,7 @@ jnote_SOURCES = jnote.cc
 jnote_LDADD   = $(JMEDIA_LA) $(JSYS_LA)
 
 jmelody_SOURCES = jmelody.cc
-jmelody_LDADD   = $(JMEDIA_LA) $(JSYS_LA)
+jmelody_LDADD   = $(JMEDIA_LA) $(JUTIL_LA) $(JSYS_LA)
 
 jpoisoned_SOURCES = jpoisoned.cc
 jpoisoned_LDADD   = $(JX_LA) $(JSYS_LA) $(JUTIL_LA)

--- a/jlib/apps/jmelody.cc
+++ b/jlib/apps/jmelody.cc
@@ -1,12 +1,17 @@
 #include <iostream>
+#include <memory>
 #include <sstream>
 
 #include <cmath>
 
+#include <jlib/media/mixer.hh>
 #include <jlib/media/notestream.hh>
 #include <jlib/media/PortAudioSink.hh>
+#include <jlib/media/source_stream.hh>
+#include <jlib/media/voice.hh>
 
 #include <jlib/sys/sys.hh>
+#include <jlib/util/util.hh>
 
 void play(std::vector<std::string> song, int format, int channels);
 
@@ -17,17 +22,22 @@ int main(int argc, char** argv) {
 
         int format = Type::PCM_FLOAT32;
         int channels = 2;
-        std::string note;
-        double t = 5;
         std::vector<std::string> melody;
 
-        for(int i = 1; i < argc; i++) {
-            // parse the note and play it
-            std::string note = argv[i];
-
-            // note is tone(letter)octave(number):time
-            melody.push_back(note);
+        if(argc < 2) {
+            std::cerr << "usage: " << argv[0] << " NOTE [NOTE ...]\n"
+                      << "  a note is tone(letter)octave(number):beats, "
+                      << "optionally /waveform\n"
+                      << "  join notes with + to sound them together:\n"
+                      << "    " << argv[0] << " C@3:1 E@3:1 G@3:1        "
+                      << "three notes, one after another\n"
+                      << "    " << argv[0] << " C@3:1+E@3:1+G@3:1        "
+                      << "the same three as a chord\n";
+            exit(1);
         }
+
+        for(int i = 1; i < argc; i++)
+            melody.push_back(argv[i]);
 
         play(melody, format, channels);
         
@@ -40,16 +50,52 @@ int main(int argc, char** argv) {
     exit(0);
 }
 
+/**
+ * Sound one entry of the melody, which may be several notes at once.
+ *
+ * Notes joined by + become voices in a mixer, and a mixer is a source like any
+ * other, so a chord reaches the device by exactly the route a single note does.
+ * That is the whole argument for the interface: nothing below here can tell how
+ * many notes are sounding.
+ *
+ * Automatic staging, because this is generated rather than mixed -- there is no
+ * engineer riding faders over a chord, and without it a triad would be louder
+ * than the notes around it purely for having three of something.
+ */
+static void sound(jlib::media::PortAudioSink& dsp, const std::string& entry,
+                  int format, int channels)
+{
+    using namespace jlib::media;
+
+    const std::vector<std::string> notes = jlib::util::tokenize(entry, "+");
+
+    const double rate = 44100;
+
+    mixer m;
+    m.set_staging(mixer::staging::automatic);
+    m.set_rate(rate);     // the limiter turns its release time into samples
+
+    // The voices have to outlive the render, and the mixer holds them, so this
+    // is only here to spell out that they are not stack temporaries.
+    for(const std::string& n : notes) {
+        notestream ns(n);
+
+        m.add(std::make_shared<voice>(ns.get_instrument(), ns.get_freq(),
+                                      static_cast<unsigned long>(rate * ns.get_time()),
+                                      rate));
+    }
+
+    source_stream live(&m);
+    live.set_samples_per_sec(static_cast<unsigned int>(rate));
+    live.set_format(format);
+    live.set_channels(channels);
+
+    dsp.play(live);
+}
+
 void play(std::vector<std::string> song, int format, int channels) {
     jlib::media::PortAudioSink dsp;
 
-    for(auto s : song) {
-        jlib::media::notestream note(s);
-
-        note.set_format(format);
-        note.set_channels(channels);
-
-        dsp.play(note);
-    }
+    for(const std::string& s : song)
+        sound(dsp, s, format, channels);
 }
-

--- a/jlib/media/Makefile.am
+++ b/jlib/media/Makefile.am
@@ -17,7 +17,7 @@ libjmedia_la_LIBADD = $(top_builddir)/jlib/sys/libjsys.la \
 
 jmedia_hdrs = Player.hh AudioFile.hh WavFile.hh PlayList.hh stream.hh \
               datastream.hh notestream.hh Type.hh wavstream.hh \
-              instrument.hh voice.hh source.hh source_stream.hh wavetable.hh \
+              instrument.hh voice.hh source.hh source_stream.hh wavetable.hh mixer.hh \
               audiofilestream.hh AudioSink.hh PortAudioSink.hh
 
 libjmediaincludedir = $(includedir)/jlib-1.2/jlib/media

--- a/jlib/media/mixer.hh
+++ b/jlib/media/mixer.hh
@@ -1,0 +1,364 @@
+/* -*- mode: C++ c-basic-offset: 4  -*-
+ *
+ * Copyright (c) 2000 Joe Yandle <jwy@divisionbyzero.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ *
+ */
+
+#ifndef JLIB_MEDIA_MIXER_HH
+#define JLIB_MEDIA_MIXER_HH
+
+#include <jlib/media/source.hh>
+
+#include <algorithm>
+#include <cmath>
+#include <memory>
+#include <vector>
+
+namespace jlib {
+namespace media {
+
+/**
+ * Sums sources.
+ *
+ * Three separate things live here and are deliberately not the same thing:
+ *
+ * **Per-child gain** is the fader.  It is always available, never automatic,
+ * and nothing here overrides it.  Balancing a mix is an artistic decision.
+ *
+ * **Automatic staging** is a default for when nobody is riding faders --
+ * jhypermusic generates a voice per vertex from geometry, and there is no
+ * engineer.  It is off unless asked for, because a gain that moves when you add
+ * a track is hostile to somebody who has just set a level by ear.
+ *
+ * **The limiter** is a safety net, not a mixing policy.  It catches peaks that
+ * get through; it does not decide the balance.
+ *
+ * And it reports.  peak(), rms() and reduction() are there so a meter can be
+ * built on this, which is the difference between a tool and a black box: a
+ * limiter working hard means the gain staging is wrong, and that is only
+ * actionable if it can be seen.
+ */
+class mixer : public source {
+public:
+    /**
+     * How the sum is scaled as sources come and go.
+     *
+     * none leaves it alone: the sum is the sum, and the levels are whatever the
+     * faders say.  Right when somebody is mixing.
+     *
+     * automatic divides by the square root of the number of children.
+     * Uncorrelated sources sum in power rather than amplitude, so N of them
+     * give sqrt(N) times the RMS -- dividing by N, which is the intuitive
+     * choice, is what makes a dense mix quieter the more you put in it.
+     */
+    enum class staging { none, automatic };
+
+    void add(const std::shared_ptr<source>& s, double gain = 1.0)
+    {
+        m_children.push_back(child{s, gain});
+    }
+
+    void remove(const std::shared_ptr<source>& s)
+    {
+        for(std::size_t i = 0; i < m_children.size(); i++) {
+            if(m_children[i].s == s) {
+                m_children.erase(m_children.begin() + i);
+                return;
+            }
+        }
+    }
+
+    void clear() { m_children.clear(); }
+
+    std::size_t size() const { return m_children.size(); }
+
+    double get_gain(std::size_t i) const { return m_children.at(i).gain; }
+    void set_gain(std::size_t i, double g) { m_children.at(i).gain = g; }
+
+    staging get_staging() const { return m_staging; }
+    void set_staging(staging s) { m_staging = s; }
+
+    /**
+     * Drop the children that have finished.
+     *
+     * Explicit, and not something render() does for itself, which matters more
+     * than it looks.  Automatic staging divides by the number of children, so
+     * if render() reaped as it went the gain would depend on how many happened
+     * to finish inside a particular block -- and the mix would then come out
+     * differently depending on the block size, which is the one thing the
+     * source contract promises it will not do.  An offline bounce would stop
+     * matching what was heard.
+     *
+     * So finished children keep their place until the owner says otherwise,
+     * between renders.
+     */
+    void prune()
+    {
+        for(std::size_t i = m_children.size(); i > 0; i--) {
+            if(m_children[i-1].s->done())
+                m_children.erase(m_children.begin() + (i-1));
+        }
+    }
+
+    /**
+     * Sound at most this many children at once, loudest first.
+     *
+     * Zero means all of them.  A D=14 hypercube is 16384 vertices, which is
+     * both more than a core can render and more than anyone can hear as
+     * anything but noise -- so this is a musical control as much as a
+     * computational one.
+     */
+    void set_max_voices(std::size_t n) { m_max = n; }
+    std::size_t get_max_voices() const { return m_max; }
+
+    // --- metering, since the point is to be able to see what is happening ---
+
+    /** Largest absolute sample since the last read.  Reading clears it. */
+    Type::scaled peak() { const Type::scaled p = m_peak; m_peak = 0; return p; }
+
+    /** Root mean square since the last read.  Reading clears it. */
+    Type::scaled rms()
+    {
+        const Type::scaled r = (m_rms_n > 0)
+            ? static_cast<Type::scaled>(std::sqrt(m_rms_sum / m_rms_n)) : 0;
+
+        m_rms_sum = 0;
+        m_rms_n = 0;
+
+        return r;
+    }
+
+    /**
+     * Most the limiter pulled down since the last read, as a factor.
+     *
+     * One means it did nothing.  Anything much below one, for long, means the
+     * gain staging wants attention rather than the limiter -- which is the
+     * thing a meter is for.
+     */
+    Type::scaled reduction() { const Type::scaled r = m_reduction; m_reduction = 1; return r; }
+
+    // --- the limiter ---
+
+    bool get_limiting() const { return m_limit; }
+    void set_limiting(bool on) { m_limit = on; }
+
+    /** Where it starts working.  Just under full scale by default. */
+    double get_ceiling() const { return m_ceiling; }
+    void set_ceiling(double c) { m_ceiling = c; }
+
+    /**
+     * How long the limiter takes to let go, in seconds.
+     *
+     * This is not a detail.  A limiter that releases quickly follows the
+     * envelope it is riding, and if that envelope repeats at a musical rate the
+     * gain repeats with it -- which is heard as tremolo, not as limiting.
+     *
+     * The default is deliberately slow enough not to track anything in the
+     * range a beat or a chord's own beating occupies.  See limit().
+     */
+    double get_release() const { return m_release; }
+    void set_release(double seconds) { m_release = seconds; }
+
+    /**
+     * Frames per second, which the limiter needs to turn its release time into
+     * a per-sample coefficient.  Nothing else here cares.
+     */
+    double get_rate() const { return m_rate; }
+    void set_rate(double r) { m_rate = r; }
+
+    virtual unsigned long render(Type::scaled* out, unsigned long frames,
+                                 unsigned int channels)
+    {
+        if(m_children.empty())
+            return 0;
+
+        m_mix.assign(frames * channels, 0);
+
+        // Loudest first when there is a cap, so what gets dropped is what would
+        // have been least audible.
+        std::vector<const child*> play;
+        play.reserve(m_children.size());
+        for(const child& c : m_children) play.push_back(&c);
+
+        if(m_max > 0 && play.size() > m_max) {
+            std::partial_sort(play.begin(), play.begin() + m_max, play.end(),
+                              [](const child* a, const child* b) {
+                                  return a->gain > b->gain;
+                              });
+            play.resize(m_max);
+        }
+
+        unsigned long most = 0;
+
+        for(const child* c : play) {
+            m_scratch.assign(frames * channels, 0);
+
+            const unsigned long made = c->s->render(m_scratch.data(), frames, channels);
+            if(made > most) most = made;
+
+            for(unsigned long i = 0; i < made * channels; i++)
+                m_mix[i] += static_cast<Type::scaled>(m_scratch[i] * c->gain);
+        }
+
+        if(most == 0)
+            return 0;
+
+        // The staging divisor comes from how many children there are, not how
+        // many are still sounding; see prune().
+        const double stage = (m_staging == staging::automatic && !m_children.empty())
+            ? 1.0 / std::sqrt(static_cast<double>(m_children.size()))
+            : 1.0;
+
+        const double release = release_coefficient();
+
+        for(unsigned long i = 0; i < most * channels; i++) {
+            Type::scaled v = static_cast<Type::scaled>(m_mix[i] * stage);
+
+            if(m_limit)
+                v = limit(v, release);
+
+            const Type::scaled a = std::fabs(v);
+            if(a > m_peak) m_peak = a;
+
+            m_rms_sum += double(v) * v;
+            m_rms_n++;
+
+            out[i] += v;
+        }
+
+        return most;
+    }
+
+    virtual bool done() const
+    {
+        for(const child& c : m_children)
+            if(!c.s->done()) return false;
+
+        return true;
+    }
+
+    virtual void reset()
+    {
+        for(child& c : m_children) c.s->reset();
+
+        m_gain = 1.0;
+        m_peak = 0;
+        m_rms_sum = 0;
+        m_rms_n = 0;
+        m_reduction = 1;
+    }
+
+protected:
+    /**
+     * A limiter, not a compressor.
+     *
+     * The difference matters and is the reason an earlier attempt at this made
+     * everything quiet: a compressor pulls the level down across the board and
+     * needs makeup gain to put it back, and with a slow release it never
+     * recovers between transients, so one loud moment ducks the next several
+     * seconds.
+     *
+     * This only ever acts above the ceiling, so anything already below it comes
+     * through untouched and there is nothing to make up.  It grabs immediately,
+     * since a peak that is already through cannot be caught later.
+     *
+     * Letting go is the part that wants care, and the first version got it
+     * wrong by releasing in 20ms.  Automatic staging divides by sqrt(N), which
+     * holds the RMS steady and says nothing whatever about peaks: three sine
+     * voices at the default gain reach 0.666*sqrt(3) = 1.15 when they drift
+     * into phase, so the limiter fires every time they do.  For an equal
+     * tempered triad that is once per 11.3Hz -- the difference between the
+     * chord's two difference tones, 136.0 and 124.7Hz -- and a 20ms release is
+     * quick enough to follow it, so the gain wobbles at 11.3Hz and the chord
+     * sounds like it has a tremolo pedal on it.  Measured at 0.90dB, which is
+     * audible; a sawtooth hides it only because its peak is high and steady, so
+     * the reduction is steady too.
+     *
+     * Turning the instruments up is not the answer, and the numbers are worth
+     * having because it is the obvious thing to try.  On that same triad, going
+     * from a gain of 0.573 -- where the chord peaks at 0.992 and the limiter
+     * never fires -- all the way to 1.0 moves the output RMS from 0.405 to
+     * 0.435.  That is 0.6dB of level, bought with 4.2dB of limiting and 0.87dB
+     * of wobble.  Past the ceiling, input gain buys distortion and not loudness,
+     * because the ceiling is where the output was going to sit regardless.
+     *
+     * Releasing over a quarter of a second instead puts the gain movement well
+     * below anything musical: 0.23dB at 11.3Hz, for 0.5dB of level.  That is
+     * not the compressor failure this is written to avoid -- the reduction
+     * here is bounded by how far over the ceiling the signal went, 1.3dB in
+     * that case, and it is still zero for anything below it.
+     */
+    Type::scaled limit(Type::scaled v, double release)
+    {
+        const double a = std::fabs(v);
+
+        // What the gain would have to be for this sample to fit.
+        const double want = (a > m_ceiling) ? (m_ceiling / a) : 1.0;
+
+        if(want < m_gain)
+            m_gain = want;                       // instantly
+        else
+            m_gain += (want - m_gain) * release; // gradually
+
+        if(m_gain < m_reduction)
+            m_reduction = static_cast<Type::scaled>(m_gain);
+
+        return static_cast<Type::scaled>(v * m_gain);
+    }
+
+    /**
+     * The release as a per-sample coefficient.
+     *
+     * Read once per render rather than per sample, and it must not change
+     * within one -- the limiter carries gain from sample to sample, and that
+     * state has to advance identically however the frames are divided up, or
+     * an offline bounce stops matching what was heard.
+     */
+    double release_coefficient() const
+    {
+        return (m_release > 0 && m_rate > 0)
+            ? 1.0 - std::exp(-1.0 / (m_release * m_rate))
+            : 1.0;
+    }
+
+    struct child {
+        std::shared_ptr<source> s;
+        double gain;
+    };
+
+    std::vector<child> m_children;
+    std::vector<Type::scaled> m_mix, m_scratch;
+
+    staging m_staging = staging::none;
+    std::size_t m_max = 0;
+
+    bool m_limit = true;
+    double m_ceiling = 0.99;
+    double m_gain = 1.0;
+    double m_release = 0.25;
+    double m_rate = 44100;
+
+    Type::scaled m_peak = 0;
+    double m_rms_sum = 0;
+    unsigned long m_rms_n = 0;
+    Type::scaled m_reduction = 1;
+};
+
+}
+}
+
+#endif // JLIB_MEDIA_MIXER_HH

--- a/jlib/media/mixer.hh
+++ b/jlib/media/mixer.hh
@@ -60,10 +60,11 @@ public:
      * none leaves it alone: the sum is the sum, and the levels are whatever the
      * faders say.  Right when somebody is mixing.
      *
-     * automatic divides by the square root of the number of children.
-     * Uncorrelated sources sum in power rather than amplitude, so N of them
-     * give sqrt(N) times the RMS -- dividing by N, which is the intuitive
-     * choice, is what makes a dense mix quieter the more you put in it.
+     * automatic divides by the square root of the number of children, and then
+     * by the headroom.  Uncorrelated sources sum in power rather than
+     * amplitude, so N of them give sqrt(N) times the RMS -- dividing by N,
+     * which is the intuitive choice, is what makes a dense mix quieter the more
+     * you put in it.  See set_headroom() for the rest of it.
      */
     enum class staging { none, automatic };
 
@@ -91,6 +92,41 @@ public:
 
     staging get_staging() const { return m_staging; }
     void set_staging(staging s) { m_staging = s; }
+
+    /**
+     * Room left below the ceiling by automatic staging, in dB.
+     *
+     * Dividing by sqrt(N) holds the RMS and says nothing about peaks, so
+     * without this the sum runs over the ceiling as soon as there are three
+     * voices, and the limiter becomes a routine participant rather than a
+     * safety net.  That costs more than it looks: the limiter engages on dense
+     * material and not on sparse, so a chord comes out quieter than a single
+     * note and the level consistency staging exists to provide is lost exactly
+     * where it was wanted.
+     *
+     * A constant works here, which is not obvious and is why it is worth
+     * measuring rather than reasoning about.  The worst case for N voices is
+     * that they align, giving gain*sqrt(N) and growing without limit -- but
+     * alignment stops happening as N rises, and the peak that actually occurs
+     * plateaus.  Sine voices at the default gain, staged, unlimited:
+     *
+     *     N        1      3      8     16     32     64
+     *     peak  0.666  1.153  1.572  1.777  1.717  1.678
+     *     rms   0.471  0.471  0.469  0.471  0.471  0.472
+     *
+     * So the whole range from a single note to sixty-four of them needs about
+     * 5dB, and any voice count needs no more than that.
+     *
+     * The default is smaller than 5dB deliberately.  It keeps the limiter out
+     * of the path for the sparse material where its engaging would be most
+     * audible as inconsistency, and leaves it to do its job on dense material,
+     * where it is both rarer and better masked.  Headroom is not free -- it is
+     * level, given up -- so this is a balance and not a maximum.  Raise it
+     * toward 5dB to keep the limiter idle at any voice count; set it to zero
+     * for the loudest possible mix and let the limiter earn its keep.
+     */
+    double get_headroom() const { return m_headroom; }
+    void set_headroom(double db) { m_headroom = db; }
 
     /**
      * Drop the children that have finished.
@@ -218,9 +254,12 @@ public:
             return 0;
 
         // The staging divisor comes from how many children there are, not how
-        // many are still sounding; see prune().
+        // many are still sounding; see prune().  Headroom is a constant and so
+        // cancels out of any comparison between voice counts, which is what
+        // keeps the level consistent rather than merely lower.
         const double stage = (m_staging == staging::automatic && !m_children.empty())
-            ? 1.0 / std::sqrt(static_cast<double>(m_children.size()))
+            ? std::pow(10.0, -m_headroom / 20.0) /
+              std::sqrt(static_cast<double>(m_children.size()))
             : 1.0;
 
         const double release = release_coefficient();
@@ -351,6 +390,7 @@ protected:
     double m_gain = 1.0;
     double m_release = 0.25;
     double m_rate = 44100;
+    double m_headroom = 3.0;
 
     Type::scaled m_peak = 0;
     double m_rms_sum = 0;

--- a/jlib/media/wavetable.hh
+++ b/jlib/media/wavetable.hh
@@ -208,10 +208,26 @@ protected:
  * The waveforms, as their Fourier series truncated at `partials`.
  *
  * Each is scaled so all four have the RMS of a unit sine.  Matching peaks
- * instead would make changing waveform change loudness -- a square at a given
- * peak is 3dB louder than a sine at the same peak -- so the peaks differ
+ * instead would make changing waveform change level by 3dB -- that is how much
+ * louder a square is than a sine at the same peak -- so the peaks differ
  * instead: a sawtooth reaches about 1.22 before gain, plus the ~9% a truncated
  * series overshoots by at the discontinuity.
+ *
+ * What this does not do is make them equally *loud*, and it is worth being
+ * exact about that, because matching RMS looks like it should.  The ear sums
+ * loudness across critical bands, so the same energy spread over many bands is
+ * louder than the same energy in one -- and that is the entire difference
+ * between these waveforms.  Measured on a C major triad, limiter engaged:
+ *
+ *     sine      3 partials in  3 bands   energy -10.7dB   loudness 1.33
+ *     triangle  103        in 18 bands          -11.7dB            2.32
+ *     saw       103        in 18 bands          -12.1dB            4.32
+ *     square    103        in 18 bands           -9.7dB            3.96
+ *
+ * A sawtooth carries 1.4dB *less* energy than a sine here and sounds markedly
+ * louder.  So equal RMS is the right thing to hold -- it is at least a property
+ * of the signal rather than of the listener -- but the fader still has work to
+ * do when the waveform changes, and no scaling here can do it instead.
  */
 inline double wavetable::shape(instrument::wave w, double phase,
                                unsigned int partials)

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -26,7 +26,8 @@ MEDIA_TESTS = media_datastream_test \
               sys_tls_sigpipe_test \
               media_voice_test \
               media_source_test \
-              media_wavetable_test
+              media_wavetable_test \
+              media_mixer_test
 endif
 
 if HAVE_SODIUM
@@ -99,6 +100,9 @@ media_source_test_LDADD       = $(JMEDIA_LA) $(JSYS_LA)
 
 media_wavetable_test_SOURCES  = media_wavetable_test.cc
 media_wavetable_test_LDADD    = $(JMEDIA_LA) $(JSYS_LA)
+
+media_mixer_test_SOURCES      = media_mixer_test.cc
+media_mixer_test_LDADD        = $(JMEDIA_LA) $(JSYS_LA)
 
 net_extract_address_test_SOURCES        = net_extract_address_test.cc
 net_extract_address_test_LDADD          = $(JNET_LA)

--- a/tests/media_mixer_test.cc
+++ b/tests/media_mixer_test.cc
@@ -1,0 +1,395 @@
+// The mixer: gain staging, the limiter, and the metering that makes both
+// visible.
+//
+// The first section is the one that matters most, and it deliberately runs with
+// the limiter switched off.  An earlier attempt at this problem used a dynamic
+// compressor and made everything quiet -- which is what happens when gain is
+// pulled down and nothing puts it back.  The failure is not subtle once it is
+// measured, and it was never measured.  So: RMS as the voice count goes 1 to
+// 64, with nothing downstream to rescue it.
+#include <jlib/media/instrument.hh>
+#include <jlib/media/mixer.hh>
+#include <jlib/media/voice.hh>
+
+#include <cmath>
+#include <iomanip>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
+
+using namespace jlib::media;
+
+static int failures = 0;
+
+static void ok(const std::string& what, bool good, const std::string& detail = "") {
+    if(!good) ++failures;
+    std::cout << (good ? "  ok   " : "  FAIL ") << what;
+    if(!detail.empty()) std::cout << ": " << detail;
+    std::cout << "\n";
+}
+
+/** A mix of n voices, all different pitches so they do not sum coherently. */
+static std::shared_ptr<mixer> build(int n, unsigned long len, double rate,
+                                    mixer::staging st, bool limit,
+                                    double gain = 1.0) {
+    auto m = std::make_shared<mixer>();
+    m->set_staging(st);
+    m->set_limiting(limit);
+
+    instrument inst;
+
+    for(int i = 0; i < n; i++) {
+        // Spread over three octaves by the golden ratio, so no two voices land
+        // on the same pitch and none are harmonically related.  This matters
+        // more than it looks: an earlier version stepped by semitones modulo an
+        // octave, which gave 64 voices only 24 distinct pitches.  Duplicates sum
+        // in amplitude rather than in power, so the mix came out 1.6x too loud
+        // and the staging appeared to be at fault when the pitches were.
+        const double freq = 220.0 * std::pow(2.0, std::fmod(i * 0.6180339887, 3.0));
+        m->add(std::make_shared<voice>(inst, freq, len, rate), gain);
+    }
+
+    return m;
+}
+
+static double rms_of(mixer& m, unsigned long len, unsigned int channels) {
+    std::vector<Type::scaled> out(len * channels, 0);
+    m.render(out.data(), len, channels);
+    return m.rms();
+}
+
+static void staging_holds_the_level() {
+    std::cout << "gain staging, limiter off:\n";
+
+    const double rate = 44100;
+    const unsigned long len = 8192;
+
+    double first = 0;
+
+    for(int n : {1, 2, 4, 16, 64}) {
+        auto m = build(n, len, rate, mixer::staging::automatic, false);
+        const double r = rms_of(*m, len, 1);
+
+        if(n == 1) first = r;
+
+        const double ratio = r / first;
+
+        std::cout << "     " << std::setw(3) << n << " voices   rms "
+                  << std::fixed << std::setprecision(4) << r
+                  << "   " << std::setprecision(2) << ratio << "x the single voice\n";
+
+        // Uncorrelated sources sum in power, so dividing by sqrt(N) holds the
+        // level where one voice put it.  Measured 1.00 to 0.93 over this range;
+        // the band is deliberately not much wider than that, since a band wide
+        // enough to pass anything is what let the original go quiet unnoticed.
+        ok(std::to_string(n) + " voices stay near the level of one",
+           ratio > 0.85 && ratio < 1.15, std::to_string(ratio) + "x");
+    }
+
+    std::cout << "\n  and without staging, for comparison:\n";
+
+    double bare_first = 0;
+    for(int n : {1, 64}) {
+        auto m = build(n, len, rate, mixer::staging::none, false);
+        const double r = rms_of(*m, len, 1);
+
+        if(n == 1) bare_first = r;
+        else {
+            const double ratio = r / bare_first;
+
+            std::cout << "     64 voices unstaged   " << std::fixed
+                      << std::setprecision(2) << ratio << "x, about sqrt(64) = 8\n";
+
+            // If this did not grow, the staging above would be proving
+            // nothing.  Asserting it against sqrt(N) rather than merely
+            // "louder" makes it a check on the reasoning as well: the divisor
+            // is 1/sqrt(N) precisely because this is what N voices do.
+            ok("unstaged, 64 voices are about sqrt(64) louder",
+               ratio > 6.0 && ratio < 10.0, std::to_string(ratio) + "x");
+        }
+    }
+}
+
+static void the_limiter() {
+    std::cout << "\nlimiter:\n";
+
+    const double rate = 44100;
+    const unsigned long len = 8192;
+
+    {
+        // Genuinely below the ceiling -- four voices at a fifth of full gain
+        // cannot reach it even if they align -- so the limiter must do nothing
+        // whatsoever.  This is the compressor failure: pulling down what was
+        // already fine, and never putting it back.
+        auto m = build(4, len, rate, mixer::staging::automatic, false, 0.2);
+        std::vector<Type::scaled> quiet(len, 0);
+        m->render(quiet.data(), len, 1);
+        const double without = m->rms();
+
+        auto m2 = build(4, len, rate, mixer::staging::automatic, true, 0.2);
+        std::vector<Type::scaled> limited(len, 0);
+        m2->render(limited.data(), len, 1);
+        const double with = m2->rms();
+
+        ok("a quiet mix is untouched by the limiter",
+           std::fabs(with - without) / without < 1e-6,
+           std::to_string(with) + " against " + std::to_string(without));
+
+        // One read only: the meters clear when read, so asking twice reports
+        // the state after the first ask rather than the one being tested.
+        const double did = m2->reduction();
+        ok("and it says it did nothing", did > 0.999, std::to_string(did));
+    }
+
+    {
+        // Deliberately far too hot: 32 voices, no staging, all gain up.
+        auto m = build(32, len, rate, mixer::staging::none, true);
+        m->set_ceiling(0.5);
+
+        std::vector<Type::scaled> out(len, 0);
+        m->render(out.data(), len, 1);
+
+        double peak = 0;
+        for(Type::scaled v : out) peak = std::max(peak, (double)std::fabs(v));
+
+        // A little over the ceiling is expected at the very first sample: the
+        // limiter cannot know a peak is coming before it arrives.
+        ok("a hot mix is held near the ceiling", peak < 0.6,
+           std::to_string(peak));
+
+        const double worked = m->reduction();
+        ok("and it says how hard it worked", worked < 0.5, std::to_string(worked));
+    }
+}
+
+/**
+ * Level over time, in 10ms windows.
+ *
+ * A window this short holds only a period or so of the 130Hz composite these
+ * chords sit on, so its energy depends heavily on where it happened to land.
+ * That would ruin an absolute measurement -- it once reported 7.8dB of swing
+ * for a signal that has under 1dB, and a single unaccompanied sine showing the
+ * same swing is what gave it away.  Here the same windows are used on both
+ * renders and one is divided by the other, so the artefact is identical in
+ * numerator and denominator and cancels; the unlimited case reading exactly
+ * 0.00dB is the check on that.
+ *
+ * Short matters because the thing being measured is an 88ms wobble, and a 50ms
+ * window averages a good half of it away: the same signal reads 0.50dB there
+ * against 0.90dB measured on the limiter's gain directly.
+ */
+static std::vector<double> level(const std::vector<Type::scaled>& x) {
+    const unsigned long w = 441, hop = 147;
+    std::vector<double> e;
+    for(unsigned long i = 0; i + w <= x.size(); i += hop) {
+        double s = 0;
+        for(unsigned long j = 0; j < w; j++) s += double(x[i+j]) * x[i+j];
+        e.push_back(std::sqrt(s / w));
+    }
+    return e;
+}
+
+/**
+ * How much the limiter modulates the level at a given rate, in dB.
+ *
+ * Dividing the limited level by the unlimited one gives the gain the limiter
+ * applied, over time, without needing to reach inside it.
+ */
+static double tremolo(bool limiting, double release, double at_hz) {
+    const double rate = 44100;
+    const unsigned long N = 132300;                 // 3s
+
+    // an equal tempered major triad, the case that provoked this
+    const double C = 523.251;
+    const double freqs[3] = { C, C * 1.2599210499, C * 1.4983070769 };
+
+    std::vector<double> lvl[2];
+
+    for(int pass = 0; pass < 2; pass++) {
+        mixer m;
+        m.set_staging(mixer::staging::automatic);
+        m.set_limiting(pass == 1 && limiting);
+        m.set_release(release);
+
+        instrument inst;
+        for(double f : freqs)
+            m.add(std::make_shared<voice>(inst, f, N, rate));
+
+        std::vector<Type::scaled> out(N, 0);
+        m.render(out.data(), N, 1);
+        lvl[pass] = level(out);
+    }
+
+    // the sustained middle, away from attack and release
+    const std::size_t lo = lvl[0].size()/4, hi = lvl[0].size()*3/4;
+
+    std::vector<double> gain;
+    for(std::size_t i = lo; i < hi; i++) gain.push_back(lvl[1][i] / lvl[0][i]);
+
+    double mean = 0;
+    for(double g : gain) mean += g;
+    mean /= gain.size();
+
+    // one bin of a DFT, at the rate we care about
+    const double hop_rate = rate / 147;
+    double re = 0, im = 0;
+    for(std::size_t i = 0; i < gain.size(); i++) {
+        const double t = 2 * M_PI * at_hz * i / hop_rate;
+        re += (gain[i] - mean) * std::cos(t);
+        im -= (gain[i] - mean) * std::sin(t);
+    }
+    const double amp = 2 * std::sqrt(re*re + im*im) / gain.size();
+
+    return 20 * std::log10((mean + amp) / (mean - amp));
+}
+
+/**
+ * The limiter must not turn into a tremolo pedal.
+ *
+ * 1/sqrt(N) staging holds the RMS and says nothing about peaks, so three sine
+ * voices at the default gain reach 0.666*sqrt(3) = 1.15 whenever they drift
+ * into phase.  For an equal tempered triad that happens at 11.3Hz -- the gap
+ * between its two difference tones, 136.0 and 124.7Hz -- so the limiter fires
+ * at 11.3Hz, and if it lets go quickly enough to follow, the chord audibly
+ * wobbles.  A sawtooth hides it because its peak is high and steady.
+ */
+static void not_a_tremolo_pedal() {
+    std::cout << "\nthe limiter is not a tremolo pedal:\n";
+
+    const double slow = tremolo(true, 0.25, 11.268);
+    const double fast = tremolo(true, 0.02, 11.268);
+    const double none = tremolo(false, 0.25, 11.268);
+
+    std::cout << "     release 250ms   " << std::fixed << std::setprecision(2)
+              << slow << " dB at 11.3 Hz\n"
+              << "     release  20ms   " << fast << " dB\n"
+              << "     no limiter      " << none << " dB\n";
+
+    ok("the default release does not wobble the chord", slow < 0.35,
+       std::to_string(slow) + " dB");
+
+    // Without this the test could pass by measuring nothing at all.
+    ok("and the measurement can see a release that does", fast > 0.7,
+       std::to_string(fast) + " dB");
+
+    ok("with no limiter there is nothing to see", std::fabs(none) < 0.02,
+       std::to_string(none) + " dB");
+}
+
+static void metering() {
+    std::cout << "\nmetering:\n";
+
+    const double rate = 44100;
+    const unsigned long len = 4096;
+
+    auto m = build(4, len, rate, mixer::staging::automatic, true);
+
+    std::vector<Type::scaled> out(len, 0);
+    m->render(out.data(), len, 1);
+
+    double peak = 0;
+    for(Type::scaled v : out) peak = std::max(peak, (double)std::fabs(v));
+
+    const Type::scaled reported = m->peak();
+
+    ok("peak matches what came out",
+       std::fabs(reported - peak) < 1e-6,
+       std::to_string(reported) + " against " + std::to_string(peak));
+
+    ok("and reading it clears it", m->peak() == 0);
+}
+
+static void housekeeping() {
+    std::cout << "\nchildren:\n";
+
+    const double rate = 44100;
+    instrument inst;
+
+    {
+        auto m = std::make_shared<mixer>();
+        m->add(std::make_shared<voice>(inst, 220, 128, rate));
+        m->add(std::make_shared<voice>(inst, 330, 4096, rate));
+
+        std::vector<Type::scaled> out(4096, 0);
+        m->render(out.data(), 256, 1);          // long enough to finish the first
+
+        ok("a finished child stays until pruned", m->size() == 2);
+        m->prune();
+        ok("and goes when it is", m->size() == 1);
+    }
+
+    {
+        // the cap sounds the loudest, since that is what would be missed least
+        auto m = std::make_shared<mixer>();
+        m->set_limiting(false);   // else both sides clamp to the ceiling and
+                                  // the comparison measures nothing
+        for(int i = 0; i < 8; i++)
+            m->add(std::make_shared<voice>(inst, 220.0 * (i+1), 512, rate),
+                   0.1 * (i + 1));
+
+        m->set_max_voices(3);
+
+        std::vector<Type::scaled> capped(512, 0);
+        m->render(capped.data(), 512, 1);
+        const Type::scaled with_cap = m->peak();
+
+        m->reset();
+        m->set_max_voices(0);
+
+        std::vector<Type::scaled> all(512, 0);
+        m->render(all.data(), 512, 1);
+        const Type::scaled without = m->peak();
+
+        ok("a voice cap sounds fewer of them", with_cap < without,
+           std::to_string(with_cap) + " against " + std::to_string(without));
+    }
+}
+
+static void block_size_independence() {
+    std::cout << "\nstill block size independent:\n";
+
+    const double rate = 44100;
+    const unsigned long total = 4096;
+
+    for(auto st : {mixer::staging::none, mixer::staging::automatic}) {
+        for(bool limit : {false, true}) {
+            auto whole_m = build(8, total, rate, st, limit);
+            std::vector<Type::scaled> whole(total, 0);
+            whole_m->render(whole.data(), total, 1);
+
+            unsigned long worst = 0;
+
+            for(unsigned long block : {1UL, 7UL, 333UL}) {
+                auto m = build(8, total, rate, st, limit);
+                std::vector<Type::scaled> split(total, 0);
+
+                unsigned long at = 0;
+                while(at < total) {
+                    const unsigned long want = std::min(block, total - at);
+                    const unsigned long made = m->render(&split[at], want, 1);
+                    if(!made) break;
+                    at += made;
+                }
+
+                for(unsigned long i = 0; i < total; i++)
+                    if(whole[i] != split[i]) ++worst;
+            }
+
+            ok(std::string(st == mixer::staging::none ? "unstaged" : "staged") +
+               (limit ? ", limited" : ", unlimited"),
+               worst == 0, worst ? (std::to_string(worst) + " differ") : "");
+        }
+    }
+}
+
+int main() {
+    staging_holds_the_level();
+    the_limiter();
+    not_a_tremolo_pedal();
+    metering();
+    housekeeping();
+    block_size_independence();
+
+    return failures ? 1 : 0;
+}

--- a/tests/media_mixer_test.cc
+++ b/tests/media_mixer_test.cc
@@ -196,7 +196,8 @@ static std::vector<double> level(const std::vector<Type::scaled>& x) {
  * Dividing the limited level by the unlimited one gives the gain the limiter
  * applied, over time, without needing to reach inside it.
  */
-static double tremolo(bool limiting, double release, double at_hz) {
+static double tremolo(bool limiting, double release, double at_hz,
+                      double headroom) {
     const double rate = 44100;
     const unsigned long N = 132300;                 // 3s
 
@@ -211,6 +212,7 @@ static double tremolo(bool limiting, double release, double at_hz) {
         m.set_staging(mixer::staging::automatic);
         m.set_limiting(pass == 1 && limiting);
         m.set_release(release);
+        m.set_headroom(headroom);
 
         instrument inst;
         for(double f : freqs)
@@ -253,28 +255,106 @@ static double tremolo(bool limiting, double release, double at_hz) {
  * between its two difference tones, 136.0 and 124.7Hz -- so the limiter fires
  * at 11.3Hz, and if it lets go quickly enough to follow, the chord audibly
  * wobbles.  A sawtooth hides it because its peak is high and steady.
+ *
+ * Headroom now keeps the limiter off a chord entirely, so this cannot arise as
+ * shipped.  The rest of the measurements deliberately switch the headroom off,
+ * because a release short enough to wobble is still a bug wherever the limiter
+ * does engage, and a test that only exercised the shipping configuration would
+ * stop watching for it.
  */
 static void not_a_tremolo_pedal() {
     std::cout << "\nthe limiter is not a tremolo pedal:\n";
 
-    const double slow = tremolo(true, 0.25, 11.268);
-    const double fast = tremolo(true, 0.02, 11.268);
-    const double none = tremolo(false, 0.25, 11.268);
+    mixer defaults;
 
-    std::cout << "     release 250ms   " << std::fixed << std::setprecision(2)
-              << slow << " dB at 11.3 Hz\n"
-              << "     release  20ms   " << fast << " dB\n"
-              << "     no limiter      " << none << " dB\n";
+    // Two independent defences, so they are measured separately.  The headroom
+    // stops the limiter engaging on a chord at all; the release stops it
+    // wobbling when something does engage it.  Either alone is enough here,
+    // which is why the second is measured with the first switched off.
+    const double both = tremolo(true, defaults.get_release(), 11.268,
+                                defaults.get_headroom());
+    const double slow = tremolo(true, 0.25, 11.268, 0.0);
+    const double fast = tremolo(true, 0.02, 11.268, 0.0);
+    const double none = tremolo(false, 0.25, 11.268, 0.0);
 
-    ok("the default release does not wobble the chord", slow < 0.35,
+    std::cout << "     as shipped              " << std::fixed << std::setprecision(2)
+              << both << " dB at 11.3 Hz\n"
+              << "     no headroom, 250ms      " << slow << " dB\n"
+              << "     no headroom,  20ms      " << fast << " dB\n"
+              << "     no headroom, no limiter " << none << " dB\n";
+
+    ok("as shipped the chord does not wobble at all", std::fabs(both) < 0.02,
+       std::to_string(both) + " dB");
+
+    ok("and the release alone would have handled it", slow < 0.35,
        std::to_string(slow) + " dB");
 
     // Without this the test could pass by measuring nothing at all.
-    ok("and the measurement can see a release that does", fast > 0.7,
+    ok("and the measurement can see a release that would not", fast > 0.7,
        std::to_string(fast) + " dB");
 
     ok("with no limiter there is nothing to see", std::fabs(none) < 0.02,
        std::to_string(none) + " dB");
+}
+
+/**
+ * Level must not depend on how many voices are sounding.
+ *
+ * This is what staging is for and it is the thing the limiter was quietly
+ * taking away.  Holding the RMS says nothing about peaks, so a chord went over
+ * the ceiling where a single note did not, the limiter engaged on one and not
+ * the other, and the chord came out a dB quieter -- the inconsistency arriving
+ * by exactly the mechanism meant to prevent it.
+ *
+ * With headroom the limiter stays out of the path and the levels match, which
+ * is asserted here by requiring that it reports having done nothing at all.
+ */
+static void level_does_not_depend_on_voice_count() {
+    std::cout << "\nlevel against voice count, as shipped:\n";
+
+    const double rate = 44100;
+    const unsigned long len = 8192;
+
+    double first = 0;
+
+    for(int n : {1, 2, 3, 4}) {
+        auto m = build(n, len, rate, mixer::staging::automatic, true);
+        std::vector<Type::scaled> out(len, 0);
+        m->render(out.data(), len, 1);
+
+        const double r = m->rms();
+        const double red = m->reduction();
+        if(n == 1) first = r;
+
+        double peak = 0;
+        for(Type::scaled v : out) peak = std::max(peak, (double)std::fabs(v));
+
+        std::cout << "     " << n << " voices   rms " << std::fixed
+                  << std::setprecision(4) << r << "   peak " << std::setprecision(3)
+                  << peak << "   limiter " << std::setprecision(2)
+                  << 20*std::log10(red) << " dB\n";
+
+        ok(std::to_string(n) + " voices: the limiter stays out of it", red > 0.9999,
+           std::to_string(red));
+
+        ok(std::to_string(n) + " voices: and the level matches one voice",
+           std::fabs(r/first - 1.0) < 0.02, std::to_string(r/first) + "x");
+    }
+
+    // What this does NOT establish.  Three dB of headroom covers a handful of
+    // voices, not any number of them: the peak plateaus around 5dB over the
+    // ceiling, so past roughly six voices the limiter starts engaging again and
+    // the level sags by up to a dB.  That is the intended division of labour --
+    // headroom for the sparse case where inconsistency would be audible, the
+    // limiter for the dense case where it is masked -- but it is a balance and
+    // not a guarantee, and set_headroom(5) buys the guarantee for 2dB.
+    auto dense = build(32, len, rate, mixer::staging::automatic, true);
+    std::vector<Type::scaled> out(len, 0);
+    dense->render(out.data(), len, 1);
+    std::cout << "     32 voices  rms " << std::fixed << std::setprecision(4)
+              << dense->rms() << "   limiter " << std::setprecision(2)
+              << 20*std::log10(dense->reduction()) << " dB   (headroom is a"
+              << " balance, not a guarantee)\n";
 }
 
 static void metering() {
@@ -387,6 +467,7 @@ int main() {
     staging_holds_the_level();
     the_limiter();
     not_a_tremolo_pedal();
+    level_does_not_depend_on_voice_count();
     metering();
     housekeeping();
     block_size_independence();


### PR DESCRIPTION
Fourth slice of the synthesis plan.  Sources sum here, and the three things
that could each be called "gain" are deliberately kept apart, because
conflating them is what made the earlier attempt at this go quiet.

    macOS  33 tests, 33 pass, 0 skip
    Linux  34 tests, 33 pass, 1 skip

three kinds of gain, and they are not the same kind

    Per-child gain is the fader.  Always available, never automatic, never
    overridden by anything here.  Balancing a mix is an artistic decision and
    the mixer does not have opinions about it.

    Automatic staging is a default for when nobody is riding faders.
    jhypermusic will generate a voice per vertex out of geometry and there is
    no engineer in that loop.  It is off unless asked for, because a gain that
    moves when you add a track is hostile to somebody who has just set a level
    by ear -- which is the Logic workflow, and it still works.

    The limiter is a safety net.  It catches what gets through; it does not
    decide the balance.

    And all of it is visible: peak(), rms() and reduction(), clear-on-read, so
    a meter can be built on this.  A limiter working hard means the staging is
    wrong, and that is only actionable if it can be seen.

why the divisor is 1/sqrt(N)

    Uncorrelated sources sum in power, not in amplitude, so N of them give
    sqrt(N) times the RMS.  Dividing by N -- the intuitive choice -- is
    therefore exactly what makes a dense mix quieter the more goes into it.

    Measured, RMS against a single voice, limiter off so it is the staging
    being read and not the limiter covering for it:

        1 voice    1.00
        2          1.00
        4          1.00
        16         0.98
        64         0.93

    and the same 64 unstaged come out 7.43x, against a predicted sqrt(64) = 8.
    The test asserts the band 0.85 to 1.15, which is not much wider than the
    measurement -- a band wide enough to pass anything is what let the original
    go quiet without anybody noticing.

a limiter, not a compressor

    The distinction is the whole reason the first attempt failed.  A compressor
    pulls the level down across the board and needs makeup gain to put it back;
    with a slow release it never recovers between transients, so one loud
    moment ducks the next several seconds.

    This only ever acts above the ceiling, so anything already below it passes
    through untouched and there is nothing to make up.  Asserted rather than
    claimed: a mix below the ceiling renders bit-identical with the limiter on
    and off, and reduction() reports exactly 1.0.  It grabs instantly, since a
    peak already through cannot be caught later.

the headroom is in the staging, not in the instrument

    Dividing by sqrt(N) holds the RMS and says nothing about peaks, so the sum
    went over the ceiling as soon as there were three voices.  That made the
    limiter a routine participant rather than a safety net, and cost more than
    it looks: it engaged on dense material and not on sparse, so a chord came
    out a dB quieter than a single note -- the inconsistency arriving by exactly
    the mechanism meant to prevent it.

    automatic staging now leaves 3dB, and set_headroom() moves it.

    A constant is enough, which is not obvious and is the reason this was
    measured rather than reasoned about.  The worst case for N voices is that
    they align, which gives gain*sqrt(N) and grows without limit -- and it was
    wrong to plan against, because alignment stops happening as N rises and the
    peak that actually occurs plateaus.  Sine voices, staged, unlimited:

        N        1      3      8     16     32     64
        peak  0.666  1.153  1.572  1.777  1.717  1.678
        rms   0.471  0.471  0.469  0.471  0.471  0.472

    Five dB covers any voice count at all.  The default is deliberately less
    than that: headroom is level given up, so it is spent where the limiter
    engaging would be most audible as inconsistency -- one to four voices, now
    exact, with reduction() reporting 1.000000 -- and the limiter keeps the
    dense case, where it is rarer and better masked.  Thirty-two voices sit at
    0.68dB of reduction.  set_headroom(5) buys the guarantee for another 2dB.

    Everything is therefore 3dB quieter than the previous commit.  That is the
    trade and it is the whole of it: turning the instruments up instead does not
    work, for the reason measured below.

    The test asserts the property rather than the number -- that the limiter
    reports having done nothing, and that the levels match -- and says in as
    many words what it does not establish, which is that this holds for any
    voice count.  It does not.

and it is not a tremolo pedal either, which took a listening test

    A sine chord wobbled and a sawtooth chord did not, which was heard before it
    was measured and is the reason the release is a quarter of a second rather
    than the 20ms it started at.  Confirmed gone by ear afterwards, which is the
    only way this one could be confirmed: the suite cannot listen, and every
    numerical measurement taken before the right one said the signal was fine.

    1/sqrt(N) staging holds the RMS and says precisely nothing about peaks.
    Three sine voices at the default 0.666 reach 0.666*sqrt(3) = 1.15 when they
    drift into phase, so the limiter fires every time they do -- and for an
    equal tempered triad they do so at 11.3Hz, the gap between the chord's two
    difference tones, 136.0 and 124.7Hz.  A 20ms release is quick enough to
    follow that, so the gain wobbled at 11.3Hz.  Measured on the limiter's own
    gain: 0.90dB, which is audible.  A sawtooth hid it because its peak is high
    and steady, so the reduction was steady too.

    Releasing over 250ms puts the movement below anything musical -- 0.22dB --
    for half a dB of level, and the headroom above then removes the cause
    outright: as shipped the figure is 0.00dB, because the limiter never
    engages on a chord.  Both are kept, and the test measures the release with
    the headroom switched off, because a release short enough to wobble is
    still a bug wherever the limiter does engage.  Still not the compressor failure: the reduction is
    bounded by how far over the ceiling the signal went, 1.3dB here, and is
    exactly zero below it.

        release      rms      wobble at 11.3Hz
        20ms         0.4415   0.90 dB
        250ms        0.4168   0.22 dB
        500ms        0.4132   0.12 dB

    The limiter's own distortion was the obvious suspect and was not it:
    intermodulation products sit at -88dB with it engaged.

    set_release() and set_rate() are exposed because a DAW has to expose them,
    and because the wrong value here is inaudible as limiting and audible as
    something else entirely.

and a sawtooth is louder than a sine, which is not the limiter's doing

    Asked while listening, and the first two measurements said the opposite of
    what the ear did, so both are recorded.

    The limiter is not the cause and pushes the other way: it takes 2.75dB off
    the saw chord and 1.06dB off the sine one, because a sawtooth's crest factor
    is higher.  A-weighted energy says the same thing -- saw -12.9dB against
    sine -12.4dB -- and A-weighting is simply the wrong instrument here, since
    it is one frequency response and cannot see what is going on.

    What is going on is that the ear sums loudness across critical bands, and
    energy spread across many is louder than the same energy in one.  Binning
    the partials into Bark bands and summing band^0.23:

        sine      3 partials in  3 bands   energy -10.7dB   loudness 1.33
        triangle  103        in 18 bands          -11.7dB            2.32
        saw       103        in 18 bands          -12.1dB            4.32
        square    103        in 18 bands           -9.7dB            3.96

    A sawtooth carries 1.4dB less energy than a sine and is about three times as
    loud.  The waveforms are deliberately RMS-matched -- see wavetable.hh, where
    matching peaks was rejected because a square is 3dB louder than a sine at
    equal peak -- and that comment has been corrected, because it claimed
    RMS-matching keeps loudness constant across waveforms and it does not.  It
    fixed the peak problem and left a larger one.

    Nothing is changed in the code for this: it is inherent, every synthesiser
    has it, and per-instrument gain is exactly the control for it.  Recorded so
    the next person does not go looking in the limiter, which is where this
    started.

two measurements that were wrong before they were right

    Short-time RMS in 5ms windows said the sine chord swung 7.8dB.  It does not;
    it swings under 1dB.  A 5ms window holds two thirds of a period of the 130Hz
    composite a triad sits on, so its energy mostly reports where the window
    landed.  A single unaccompanied sine measured the same way showed the same
    7.8dB, which is what gave it away.

    The fix in the test is to divide the limited render's level by the
    unlimited one's, window for window.  The artefact is then identical top and
    bottom and cancels, which lets the window be short enough not to average
    away the 88ms wobble being looked for.  The unlimited case reading exactly
    0.00dB is the check that the cancellation works, and at 10ms the test agrees
    with the limiter's gain directly to 0.89 against 0.90dB.

    The test asserts both directions: under 0.35dB at the default release, and
    over 0.7dB at 20ms, so it cannot pass by measuring nothing.

reaping children is not something render() may do

    prune() is explicit and never called from render(), which looks like an
    omission and is not.  Automatic staging divides by the number of children,
    so a render that reaped as it went would have a divisor depending on how
    many happened to finish inside a particular block -- and the mix would then
    depend on the block size, which is the one thing the source contract
    promises it will not.  An offline bounce would stop matching what was
    heard.

    So finished children keep their place until the owner says otherwise.  Both
    staging modes, with the limiter on and off, are bit-identical rendered in
    blocks of 1, 7 or 333 against one call, and the limiter carries per-sample
    state across those boundaries.

voice limiting

    set_max_voices(n) sounds the loudest n, by std::partial_sort.  This is the
    answer to the D=14 figure from the previous branch -- 16384 voices at 315%
    of a core -- and it was already the musical answer, since sixteen thousand
    simultaneous tones is noise whatever it costs.

chords

    jmelody takes + to sound notes together: C@3:1+E@3:1+G@3:1 instead of one
    after another.  It goes through mixer and source_stream, so a chord reaches
    the device by exactly the route a single note does and nothing below can
    tell how many notes are sounding.  Staging is automatic there, so a triad
    is not louder than its neighbours purely for having three of something.

    Checked spectrally as well as by ear: three equal peaks of 0.178 at 523,
    659 and 784Hz, and 250 to 500 times less between them.

the test's own bug, since it is the interesting one

    The first run showed 64 voices at 1.58x and it looked like the staging.  It
    was the pitches: the voices stepped by semitones modulo an octave, so 64 of
    them had only 24 distinct frequencies, and duplicates sum in amplitude
    rather than in power.  sqrt(24 * 2.67^2 / 64) = 1.63, which is what came
    out.  Spread by the golden ratio instead, so no two coincide.

    Also: the meters clear when read, and asserting on one while printing
    another read of the same meter reports the state after the first ask.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
