### PR TITLE
Add clip and sampler, fix wavstream seeking, and render PlayList through the mixer

### DIFF
--- a/jlib/media/Makefile.am
+++ b/jlib/media/Makefile.am
@@ -17,7 +17,7 @@ libjmedia_la_LIBADD = $(top_builddir)/jlib/sys/libjsys.la \
 
 jmedia_hdrs = Player.hh AudioFile.hh WavFile.hh PlayList.hh stream.hh \
               datastream.hh notestream.hh Type.hh wavstream.hh \
-              instrument.hh voice.hh source.hh source_stream.hh wavetable.hh mixer.hh \
+              instrument.hh voice.hh source.hh source_stream.hh wavetable.hh mixer.hh clip.hh sampler.hh \
               audiofilestream.hh AudioSink.hh PortAudioSink.hh
 
 libjmediaincludedir = $(includedir)/jlib-1.2/jlib/media

--- a/jlib/media/PlayList.cc
+++ b/jlib/media/PlayList.cc
@@ -45,8 +45,15 @@ namespace jlib {
         }
         
         Roll::Roll() 
+            : m_stream(0),
+              m_id(0),
+              m_beats(0),
+              m_bpu(0)
         {
-            set_id(0);
+            // m_stream was left uninitialized here, so get_stream() on a
+            // default-constructed Roll returned whatever was on the stack --
+            // which a null check does not catch, and which render() would then
+            // read audio from.  The other constructor sets all of these.
         }
         
         int Roll::get_id() const { return m_id; }

--- a/jlib/media/PlayList.hh
+++ b/jlib/media/PlayList.hh
@@ -23,11 +23,16 @@
 #ifndef JLIB_MEDIA_PLAYLIST_HH
 #define JLIB_MEDIA_PLAYLIST_HH
 
+#include <map>
+#include <memory>
 #include <vector>
 #include <string>
 
 #include <cmath>
 
+#include <jlib/media/clip.hh>
+#include <jlib/media/mixer.hh>
+#include <jlib/media/sampler.hh>
 #include <jlib/media/stream.hh>
 
 namespace jlib {
@@ -207,90 +212,114 @@ namespace jlib {
             if(getenv("JLIB_MEDIA_PLAYLIST_DEBUG"))
                 std::cerr << "void jlib::media::PlayList::render(): enter" << std::endl;
 
-            int ticks_per_minute = get_measure()*get_bpm();
-            int m_samples_per_sec = 44100;
+            const int ticks_per_minute = get_measure()*get_bpm();
+            const int samples_per_sec = 44100;
 
-            int samples_per_tick = (int)(m_samples_per_sec / (ticks_per_minute / (double)60));
+            const int samples_per_tick = (int)(samples_per_sec / (ticks_per_minute / (double)60));
 
-            const int n = (int)(((double)get_width() / (double)ticks_per_minute)*60*m_samples_per_sec);
+            const int n = (int)(((double)get_width() / (double)ticks_per_minute)*60*samples_per_sec);
 
             // Nothing to render, and every path below would be worse than
-            // useless: the mixing loop takes a remainder modulo n, and a
-            // zero-length array is not something you can declare.
+            // useless: the fold takes a remainder modulo n.
             if(n <= 0)
                 return std::string();
 
-            // Heap, not stack.
-            //
-            // These were declared as arrays of length n, which is not C++ at
-            // all -- a GNU extension the compilers here happen to take -- and
-            // n comes from the playlist rather than from anything bounded.  At
-            // 4/4 and 120bpm the two of them together come to about 33K of
-            // stack per tick of width, so a few hundred ticks of playlist runs
-            // off the end of an 8M stack, and nothing checks.  The commented
-            // out new[] on the old lines says this was on the heap once.
-            //
-            // Value-initialized, which is what the two memsets were for.
-            std::vector<Type::scaled> samples(n);
-            std::vector<typename Type::sample<N>::buf> samples_out(n);
-
-            std::string data;
-            
             if(getenv("JLIB_MEDIA_PLAYLIST_DEBUG")) 
                 std::cerr << "\tnumber of samples: " << n << std::endl
-                          << "\tsamples per sec:   " << m_samples_per_sec << std::endl
+                          << "\tsamples per sec:   " << samples_per_sec << std::endl
                           << "\tsamples per tick:  " << samples_per_tick << std::endl
                           << "\tticks per minute:  " << ticks_per_minute << std::endl
-                          << "\tticks per second:  " << (ticks_per_minute * 60) << std::endl
-                          << "\ttotal seconds:     " << (n / (double)m_samples_per_sec) << std::endl;
-            
+                          << "\ttotal seconds:     " << (n / (double)samples_per_sec) << std::endl;
+
+            // One decode per roll, however many times it is struck.
+            //
+            // This used to rewind the roll's stream and read it again for each
+            // hit, which is the same samples decoded over and over -- and it
+            // did not work at all for a wav-backed roll, because rewind() on a
+            // wavstream set failbit and every read after it returned nothing.
+            // That is fixed in wavstream.hh; this no longer depends on it.
+            std::map<stream*, std::shared_ptr<clip> > decoded;
+
+            // Sources, not a hand-rolled sum.  The gain staging and the limiter
+            // replace what used to be here: the peak over the whole pattern,
+            // with everything divided by it if it came out above one.  That is
+            // the shape of mistake this library has made before -- one loud hit
+            // anywhere quietly dropped the level of the entire bar, and nothing
+            // put it back -- and the mixer holds the level steady instead.
+            mixer mix;
+            mix.set_staging(mixer::staging::automatic);
+            mix.set_rate(samples_per_sec);
+
+            unsigned long len = (unsigned long)n;
+
             slice_type::iterator i = slice.begin();
             for(;i!=slice.end();i++) {
-                int r = 0;
                 Pattern::iterator j = i->begin();
                 for(;j!=i->end();j++) {
-                    Pattern::reference roll = *j;
                     stream* s = j->get_stream();
 
-                    for(u_int k=0;k<get_width();k++) {
-                        if(roll[k]) {
-                            s->rewind();
+                    if(s == 0)
+                        continue;
 
-                            int sample_begin = samples_per_tick * k;
-                            int sample_count = (s->get_length() / (s->get_bits_per_sample() / 8));
-                            
-                            if(getenv("JLIB_MEDIA_PLAYLIST_DEBUG")) 
-                                std::cerr << "\t\tbeat: " << k << std::endl
-                                          << "\t\tbegin:  " << sample_begin  << std::endl
-                                          << "\t\tcount:  " << sample_count  << std::endl;
-                            
-                            for(int x=0;x<(sample_count) && (*s);x++) {
-                                samples[(x+sample_begin)%n] += s->get_scaled();
-                            }
-                        }
+                    std::shared_ptr<clip>& c = decoded[s];
+                    if(!c)
+                        c = std::make_shared<clip>(*s);
+
+                    if(c->empty())
+                        continue;
+
+                    for(u_int k=0;k<get_width();k++) {
+                        if(!(*j)[k])
+                            continue;
+
+                        const unsigned long begin = (unsigned long)samples_per_tick * k;
+
+                        std::shared_ptr<sampler> hit = std::make_shared<sampler>(c);
+                        hit->set_rate(samples_per_sec);
+                        hit->set_start(begin);
+                        mix.add(hit);
+
+                        if(begin + c->frames() > len)
+                            len = begin + c->frames();
+
+                        if(getenv("JLIB_MEDIA_PLAYLIST_DEBUG")) 
+                            std::cerr << "\t\tbeat: " << k << std::endl
+                                      << "\t\tbegin:  " << begin  << std::endl
+                                      << "\t\tcount:  " << c->frames()  << std::endl;
                     }
-                    
-                    r++;
                 }
             }
 
-            Type::scaled max = 1.0;
-            
-            for(int z=0;z<n;z++)
-                if(std::abs(samples[z]) > max)
-                    max = std::abs(samples[z]);
-            
-            // scale to 
-            if(max > 1.0) {
-                if(getenv("JLIB_MEDIA_PLAYLIST_DEBUG")) 
-                    std::cerr << "\tmax > 1.0: " << max << std::endl;
-                for(int z=0;z<n;z++)
-                    samples[z] /= max;
-            }
-            
-            for(int z=0;z<n;z++)
-                samples_out[z] = Type::sample<N>::descale(samples[z]);
+            std::vector<Type::scaled> samples(len, 0);
+            mix.render(samples.data(), len, 1);
 
+            // A hit late in the pattern runs past the end of it, and has always
+            // wrapped round to the start rather than being cut off, so that a
+            // pattern loops seamlessly.  Kept -- but folded after the mix
+            // rather than during it, so that the staging sees each hit once.
+            for(unsigned long z = (unsigned long)n; z < len; z++)
+                samples[z % n] += samples[z];
+
+            std::vector<typename Type::sample<N>::buf> samples_out(n);
+
+            // descale multiplies by 2^(bits-1), so exactly 1.0 lands one past
+            // the top of a signed buffer and wraps -- which is a full-scale
+            // sample of the wrong sign, and audible.  Clamp to what it can
+            // actually represent.  The fold above can put a sample over the
+            // ceiling the limiter held it under, so this is not theoretical.
+            const double full = std::pow(2.0, 8.0*sizeof(typename Type::sample<N>::buf) - 1);
+            const double top = (full - 1) / full;
+
+            for(int z=0;z<n;z++) {
+                double v = samples[z];
+
+                if(v >  top) v =  top;
+                if(v < -1.0) v = -1.0;
+
+                samples_out[z] = Type::sample<N>::descale((Type::scaled)v);
+            }
+
+            std::string data;
             data.assign((const char*)samples_out.data(),
                         n*sizeof(typename Type::sample<N>::buf));
             

--- a/jlib/media/clip.hh
+++ b/jlib/media/clip.hh
@@ -1,0 +1,170 @@
+/* -*- mode: C++ c-basic-offset: 4  -*-
+ *
+ * Copyright (c) 2000 Joe Yandle <jwy@divisionbyzero.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ *
+ */
+
+#ifndef JLIB_MEDIA_CLIP_HH
+#define JLIB_MEDIA_CLIP_HH
+
+#include <jlib/media/Type.hh>
+#include <jlib/media/stream.hh>
+
+#include <cmath>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace jlib {
+namespace media {
+
+/**
+ * Recorded audio, decoded once and held in memory.
+ *
+ * The split between this and sampler is the same one as between wavetable and
+ * voice, for the same reasons.  A clip is immutable and shared; a sampler has a
+ * position, a gain and a speed.  Sounding one drum hit eight times in a bar is
+ * eight samplers over one clip, not eight decodes -- and they can overlap,
+ * which is the thing a single stream cannot do, since a stream has one position
+ * and rewinding it for the second hit abandons the first.
+ *
+ * Decoding up front also keeps stream::get_scaled() out of the render path.  It
+ * is a virtual call, a switch over the format and a read, per sample per
+ * channel, which is not what should be happening while audio is due.
+ */
+class clip {
+public:
+    class exception : public std::runtime_error {
+    public:
+        exception(const std::string& msg)
+            : std::runtime_error("jlib::media::clip::exception: " + msg) {}
+    };
+
+    clip() {}
+
+    /**
+     * Decode the whole of a stream.
+     *
+     * The stream is rewound first and read to its end; nothing is kept but the
+     * samples, so it may be closed or destroyed afterwards.
+     */
+    explicit clip(stream& s) { load(s); }
+
+    void load(stream& s)
+    {
+        const int bytes = s.get_bits_per_sample() / 8;
+        if(bytes <= 0)
+            throw exception("load(): the format says a sample is no bytes");
+
+        m_channels = s.get_channels() > 0 ? s.get_channels() : 1;
+        m_rate = s.get_samples_per_sec() > 0 ? s.get_samples_per_sec() : 44100;
+
+        // get_length() is bytes, and a sample is one channel's worth, so this
+        // is values rather than frames.
+        const unsigned long values =
+            static_cast<unsigned long>(s.get_length()) / bytes;
+
+        s.rewind();
+
+        m_data.clear();
+        m_data.reserve(values);
+
+        // Bounded by the length *and* by the stream going bad, because a
+        // truncated file should give a short clip rather than a stuck loop.
+        for(unsigned long i = 0; i < values && s; i++)
+            m_data.push_back(s.get_scaled());
+
+        // A partial frame at the end cannot be played and would misalign every
+        // channel after it.
+        m_data.resize((m_data.size() / m_channels) * m_channels);
+    }
+
+    unsigned int channels() const { return m_channels; }
+    double rate() const { return m_rate; }
+    unsigned long frames() const { return m_data.size() / m_channels; }
+    bool empty() const { return m_data.empty(); }
+
+    /** Seconds, at the rate it was recorded. */
+    double seconds() const { return m_rate > 0 ? frames() / m_rate : 0; }
+
+    /** One sample.  Out of range reads as silence rather than throwing. */
+    Type::scaled at(unsigned long frame, unsigned int channel) const
+    {
+        if(frame >= frames() || channel >= m_channels)
+            return 0;
+
+        return m_data[frame * m_channels + channel];
+    }
+
+    /**
+     * A sample between two others, for playing at a speed the recording was not
+     * made at.
+     *
+     * Catmull-Rom, matching wavetable, and for the same reason: four
+     * multiply-adds buys about two orders of magnitude over linear.  An exact
+     * frame index short-circuits, so playing at the recorded speed returns the
+     * recorded samples rather than an interpolation of them -- which is what
+     * lets a clip round-trip bit-exactly.
+     */
+    Type::scaled at(double frame, unsigned int channel) const
+    {
+        const double whole = std::floor(frame);
+        const double t = frame - whole;
+
+        if(t == 0)
+            return at(static_cast<unsigned long>(whole), channel);
+
+        const long i = static_cast<long>(whole);
+
+        const double a = held(i - 1, channel);
+        const double b = held(i,     channel);
+        const double c = held(i + 1, channel);
+        const double d = held(i + 2, channel);
+
+        return static_cast<Type::scaled>(
+            b + 0.5 * t * (c - a +
+                 t * (2*a - 5*b + 4*c - d +
+                 t * (3*(b - c) + d - a))));
+    }
+
+protected:
+    /**
+     * at(), with the ends held rather than wrapped.
+     *
+     * A wavetable wraps because a cycle is periodic.  A recording is not: its
+     * last sample is not followed by its first, and interpolating as though it
+     * were puts a discontinuity at both ends of every clip.
+     */
+    double held(long frame, unsigned int channel) const
+    {
+        const long last = static_cast<long>(frames()) - 1;
+        if(last < 0)
+            return 0;
+
+        return at(static_cast<unsigned long>(
+                      frame < 0 ? 0 : (frame > last ? last : frame)), channel);
+    }
+
+    std::vector<Type::scaled> m_data;      /**< interleaved */
+    unsigned int m_channels = 1;
+    double m_rate = 44100;
+};
+
+}
+}
+
+#endif // JLIB_MEDIA_CLIP_HH

--- a/jlib/media/sampler.hh
+++ b/jlib/media/sampler.hh
@@ -1,0 +1,202 @@
+/* -*- mode: C++ c-basic-offset: 4  -*-
+ *
+ * Copyright (c) 2000 Joe Yandle <jwy@divisionbyzero.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ *
+ */
+
+#ifndef JLIB_MEDIA_SAMPLER_HH
+#define JLIB_MEDIA_SAMPLER_HH
+
+#include <jlib/media/clip.hh>
+#include <jlib/media/source.hh>
+
+#include <cmath>
+#include <memory>
+
+namespace jlib {
+namespace media {
+
+/**
+ * Plays a clip.
+ *
+ * A source like any other, which is the point of it: once a recording and a
+ * synthesized voice are both sources, a mixer does not know or care which it
+ * has, and neither does anything downstream.  That is the whole of what makes
+ * samples and instruments mixable.
+ *
+ * The clip is shared and never modified, so any number of these can play the
+ * same recording at once, at different positions, speeds and gains.
+ */
+class sampler : public source {
+public:
+    sampler(const std::shared_ptr<const clip>& c, double gain = 1.0)
+        : m_clip(c),
+          m_gain(gain)
+    {
+    }
+
+    const std::shared_ptr<const clip>& get_clip() const { return m_clip; }
+
+    double get_gain() const { return m_gain; }
+    void set_gain(double g) { m_gain = g; }
+
+    /**
+     * Playback speed, where 1 is as recorded.
+     *
+     * Pitch and duration together, as on tape and for the same reason: there is
+     * no time stretching here, so twice the speed is an octave up and half the
+     * length.
+     */
+    double get_speed() const { return m_speed; }
+    void set_speed(double s) { m_speed = s; }
+
+    bool get_looping() const { return m_looping; }
+    void set_looping(bool l) { m_looping = l; }
+
+    /**
+     * Frames of silence before the clip starts.
+     *
+     * A sampler is usually wanted at a particular moment rather than
+     * immediately -- a drum hit lands on a beat -- and without this the only
+     * way to place one is to start rendering it late, which a mixer has no way
+     * to do.  Counted in output frames, so it does not move when the speed
+     * changes.
+     *
+     * This is the smallest piece of a timeline, not a timeline: there is no
+     * tempo here and no ordering beyond what the offsets say.
+     */
+    unsigned long get_start() const { return m_start; }
+    void set_start(unsigned long frames) { m_start = frames; }
+
+    /**
+     * Frames per second wanted out.
+     *
+     * A clip records its own rate, so playing a 22kHz recording into a 44.1kHz
+     * stream is a resample rather than an octave drop.  Nothing else here
+     * needs it.
+     */
+    double get_rate() const { return m_rate; }
+    void set_rate(double r) { m_rate = r; }
+
+    /** Where playback has reached, in clip frames. */
+    double get_position() const { return m_pos; }
+    void set_position(double frame) { m_pos = frame; }
+
+    virtual unsigned long render(Type::scaled* out, unsigned long frames,
+                                 unsigned int channels)
+    {
+        if(!m_clip || m_clip->empty() || channels == 0)
+            return 0;
+
+        const double step = advance();
+        const unsigned long len = m_clip->frames();
+
+        unsigned long made = 0;
+
+        while(made < frames) {
+            // Silence until the start, which still counts as rendered: the
+            // frames exist, they are just empty, and a mixer needs to be told
+            // they happened or it will stop early.
+            if(m_waited < m_start) {
+                ++m_waited;
+                ++made;
+                continue;
+            }
+
+            if(m_pos >= len) {
+                if(!m_looping)
+                    break;
+
+                // Subtract rather than reset, so a fractional position carries
+                // across the seam instead of being rounded off once a cycle.
+                m_pos -= std::floor(m_pos / len) * len;
+            }
+
+            for(unsigned int c = 0; c < channels; c++)
+                out[made * channels + c] +=
+                    static_cast<Type::scaled>(m_gain * sample(c, channels));
+
+            m_pos += step;
+            ++made;
+        }
+
+        return made;
+    }
+
+    virtual bool done() const
+    {
+        if(!m_clip || m_clip->empty())
+            return true;
+
+        return !m_looping && m_waited >= m_start && m_pos >= m_clip->frames();
+    }
+
+    virtual void reset()
+    {
+        m_pos = 0;
+        m_waited = 0;
+    }
+
+protected:
+    /** Clip frames per output frame: speed, and any difference in rate. */
+    double advance() const
+    {
+        const double r = (m_rate > 0) ? m_rate : 44100;
+        return m_speed * (m_clip->rate() / r);
+    }
+
+    /**
+     * One output channel's worth, whatever the clip happens to have.
+     *
+     * Fewer channels out than in has to fold rather than drop, or a stereo clip
+     * played in mono loses one side entirely -- silently, and only for material
+     * that happens to be stereo, which is the sort of thing that gets found
+     * late.  More channels out than in repeats, so a mono clip is centred.
+     */
+    Type::scaled sample(unsigned int channel, unsigned int channels) const
+    {
+        const unsigned int have = m_clip->channels();
+
+        if(channels >= have)
+            return m_clip->at(m_pos, channel % have);
+
+        double sum = 0;
+        unsigned int n = 0;
+        for(unsigned int c = channel; c < have; c += channels) {
+            sum += m_clip->at(m_pos, c);
+            ++n;
+        }
+
+        return static_cast<Type::scaled>(n ? sum / n : 0);
+    }
+
+    std::shared_ptr<const clip> m_clip;
+
+    double m_gain = 1.0;
+    double m_speed = 1.0;
+    double m_rate = 44100;
+    bool m_looping = false;
+
+    unsigned long m_start = 0;
+    unsigned long m_waited = 0;
+    double m_pos = 0;
+};
+
+}
+}
+
+#endif // JLIB_MEDIA_SAMPLER_HH

--- a/jlib/media/wavstream.hh
+++ b/jlib/media/wavstream.hh
@@ -82,6 +82,25 @@ namespace jlib {
             virtual int_type underflow();
             virtual int_type sync();
 
+            /**
+             * Seeking, which this had none of.
+             *
+             * stream::rewind() is clear() followed by seekg(0), and without
+             * these it went to the default streambuf implementations, which
+             * refuse -- so rewind() set failbit on every wavstream and every
+             * read after it returned nothing.  A datastream has always had
+             * them, so the two halves of the same interface behaved
+             * differently, and only the one nothing called was broken.
+             *
+             * PlayList::render calls rewind() on each roll before each hit, so
+             * a wav-backed pattern would have rendered silence.  Nothing calls
+             * PlayList::render, which is why this survived.
+             */
+            virtual pos_type seekoff(off_type, std::ios_base::seekdir,
+                                     std::ios_base::openmode = std::ios_base::in);
+            virtual pos_type seekpos(pos_type,
+                                     std::ios_base::openmode = std::ios_base::in);
+
             /** The file this was loaded from, empty if it was handed a WavFile. */
             std::string get_file() const;
 
@@ -221,6 +240,55 @@ namespace jlib {
             m_p += count;
 
             return traits_type::to_int_type(*this->gptr());
+        }
+
+        template< typename charT, typename traitT >
+        inline
+        typename basic_wavbuf<charT,traitT>::pos_type
+        basic_wavbuf<charT,traitT>::seekoff(off_type o, std::ios_base::seekdir s,
+                                            std::ios_base::openmode m) {
+            // m_p counts what has been handed to the get area, so the position
+            // actually reached is that less whatever is still sitting in it.
+            const off_type held = (this->egptr() > this->gptr())
+                ? (this->egptr() - this->gptr()) : 0;
+
+            off_type pos;
+
+            switch(s) {
+            case std::ios_base::beg:
+                pos = o;
+                break;
+            case std::ios_base::cur:
+                pos = static_cast<off_type>(m_p) - held + o;
+                break;
+            case std::ios_base::end:
+                pos = static_cast<off_type>(m_wav.get_pcm().length()) + o;
+                break;
+            default:
+                return pos_type(off_type(-1));
+            }
+
+            return this->seekpos(pos_type(pos), m);
+        }
+
+        template< typename charT, typename traitT >
+        inline
+        typename basic_wavbuf<charT,traitT>::pos_type
+        basic_wavbuf<charT,traitT>::seekpos(pos_type p,
+                                            std::ios_base::openmode) {
+            const off_type at = static_cast<off_type>(p);
+
+            if(at < 0 ||
+               at > static_cast<off_type>(m_wav.get_pcm().length()))
+                return pos_type(off_type(-1));
+
+            m_p = static_cast<std::string::size_type>(at);
+
+            // Drop whatever was buffered, so the next read comes from the new
+            // position rather than from what was already in hand.
+            this->setg(this->eback(), this->eback(), this->eback());
+
+            return p;
         }
 
         template< typename charT, typename traitT >

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -27,7 +27,9 @@ MEDIA_TESTS = media_datastream_test \
               media_voice_test \
               media_source_test \
               media_wavetable_test \
-              media_mixer_test
+              media_mixer_test \
+              media_sampler_test \
+              media_playlist_test
 endif
 
 if HAVE_SODIUM
@@ -103,6 +105,12 @@ media_wavetable_test_LDADD    = $(JMEDIA_LA) $(JSYS_LA)
 
 media_mixer_test_SOURCES      = media_mixer_test.cc
 media_mixer_test_LDADD        = $(JMEDIA_LA) $(JSYS_LA)
+
+media_sampler_test_SOURCES    = media_sampler_test.cc
+media_sampler_test_LDADD      = $(JMEDIA_LA) $(JUTIL_LA) $(JSYS_LA)
+
+media_playlist_test_SOURCES   = media_playlist_test.cc
+media_playlist_test_LDADD     = $(JMEDIA_LA) $(JUTIL_LA) $(JSYS_LA)
 
 net_extract_address_test_SOURCES        = net_extract_address_test.cc
 net_extract_address_test_LDADD          = $(JNET_LA)

--- a/tests/media_playlist_test.cc
+++ b/tests/media_playlist_test.cc
@@ -1,0 +1,252 @@
+// PlayList, which has never had a test.
+//
+// render() is reached through the format dispatcher in PlayList.cc, so it has
+// always been compiled; nothing has ever called it.  Two things were broken in
+// it, and neither is the sort a compiler finds.
+#include <jlib/media/PlayList.hh>
+#include <jlib/media/WavFile.hh>
+#include <jlib/media/instrument.hh>
+#include <jlib/media/voice.hh>
+#include <jlib/media/wavstream.hh>
+
+#include <cmath>
+#include <cstring>
+#include <iomanip>
+#include <iostream>
+#include <string>
+#include <vector>
+
+using namespace jlib::media;
+
+static int failures = 0;
+
+static void ok(const std::string& what, bool good, const std::string& detail = "") {
+    if(!good) ++failures;
+    std::cout << (good ? "  ok   " : "  FAIL ") << what;
+    if(!detail.empty()) std::cout << ": " << detail;
+    std::cout << "\n";
+}
+
+/** A short note at a chosen level, as a WAV on disk. */
+static void make_wav(const std::string& path, double gain, double seconds) {
+    const double rate = 44100;
+    const unsigned long frames = static_cast<unsigned long>(rate * seconds);
+
+    instrument inst;
+    inst.set_gain(gain);
+    voice v(inst, 440, frames, rate);
+
+    std::vector<Type::scaled> mix(frames, 0);
+    v.render(mix.data(), frames, 1);
+
+    std::string pcm;
+    pcm.reserve(frames * 2);
+    for(Type::scaled s : mix) {
+        const double c = s > 1 ? 1 : (s < -1 ? -1 : s);
+        const short q = static_cast<short>(std::lround(c * 32767));
+        pcm.push_back(static_cast<char>(q & 0xff));
+        pcm.push_back(static_cast<char>((q >> 8) & 0xff));
+    }
+
+    WavFile out;
+    out.set_format(Type::PCM_S16_LE);
+    out.set_channels(1);
+    out.set_samples_per_sec(static_cast<int>(rate));
+    out.set_bits_per_sample(16);
+    out.set_pcm(pcm);
+    out.save(path);
+}
+
+static std::vector<float> as_floats(const std::string& data) {
+    std::vector<float> v(data.size() / sizeof(float));
+    if(!v.empty())
+        std::memcpy(v.data(), data.data(), v.size() * sizeof(float));
+    return v;
+}
+
+/** Loudest sample in one tick's worth of the render. */
+static double tick_peak(const std::vector<float>& v, int tick, int per_tick) {
+    double p = 0;
+    for(int i = tick * per_tick; i < (tick+1) * per_tick && i < (int)v.size(); i++)
+        p = std::max(p, (double)std::fabs(v[i]));
+    return p;
+}
+
+static PlayList make_list() {
+    PlayList list(1, "test");
+    list.set_bpm(120);
+    list.set_measure(4);       // 480 ticks a minute, so 8 ticks is one second
+    list.set_width(8);
+    return list;
+}
+
+static void hits_land_on_their_ticks() {
+    std::cout << "hits land where the pattern says:\n";
+
+    make_wav("playlist_test_a.wav", 0.6, 0.05);
+    wavstream s("playlist_test_a.wav");
+
+    PlayList list = make_list();
+    Pattern p(1, "p");
+    p.push_back(Roll(1, &s, "roll", "playlist_test_a.wav", "10100001"));
+
+    PlayList::slice_type slice;
+    slice.push_back(p);
+
+    const std::vector<float> v = as_floats(list.render(Type::PCM_FLOAT32, slice));
+
+    ok("renders one second", v.size() == 44100, std::to_string(v.size()));
+    if(v.size() != 44100) return;
+
+    const int per_tick = 44100 / 8;
+
+    for(int t = 0; t < 8; t++) {
+        const bool want = (t == 0 || t == 2 || t == 7);
+        const double p2 = tick_peak(v, t, per_tick);
+
+        std::cout << "     tick " << t << "  peak " << std::fixed
+                  << std::setprecision(4) << p2
+                  << (want ? "   (struck)" : "") << "\n";
+
+        ok(std::string("tick ") + std::to_string(t) +
+           (want ? " sounds" : " is silent"),
+           want ? (p2 > 0.05) : (p2 < 0.001), std::to_string(p2));
+    }
+}
+
+/**
+ * The regression that matters, and the reason this file exists.
+ *
+ * render() used to take the peak over the whole pattern and, if it came out
+ * above one, divide every sample by it.  That is not a limiter and not a
+ * compressor: it is non-causal.  A loud hit at the end of a bar reached back
+ * and quieted the beginning of it, and nothing made up the difference.
+ *
+ * So: sound a quiet hit early and a loud one late, and compare the early hit
+ * against the same pattern with nothing loud in it.  It must not have moved.
+ * Under the old code it moved by whatever the loud hit happened to peak at.
+ */
+static void a_loud_hit_late_does_not_reach_back() {
+    std::cout << "\na loud hit late must not change an earlier quiet one:\n";
+
+    make_wav("playlist_test_quiet.wav", 0.25, 0.05);
+    make_wav("playlist_test_loud.wav",  1.0,  0.05);
+
+    const int per_tick = 44100 / 8;
+    double early[2] = {0, 0};
+
+    for(int pass = 0; pass < 2; pass++) {
+        // pass 0: both rolls quiet.  pass 1: the late roll is loud.
+        // Two rolls strike together late, so their sum is over full scale --
+        // a single clip cannot be, having come off disk as 16-bit PCM, and the
+        // old normalize only triggered strictly above one.  Both passes carry
+        // the same three rolls so the gain staging divisor is identical and
+        // the only thing that changes is how loud the late pair is.
+        wavstream a("playlist_test_quiet.wav");
+        wavstream b(pass ? "playlist_test_loud.wav" : "playlist_test_quiet.wav");
+        wavstream c(pass ? "playlist_test_loud.wav" : "playlist_test_quiet.wav");
+
+        PlayList list = make_list();
+        Pattern p(1, "p");
+        p.push_back(Roll(1, &a, "early", "a", "10000000"));
+        p.push_back(Roll(2, &b, "late",  "b", "00000010"));
+        p.push_back(Roll(3, &c, "also",  "c", "00000010"));
+
+        PlayList::slice_type slice;
+        slice.push_back(p);
+
+        const std::vector<float> v = as_floats(list.render(Type::PCM_FLOAT32, slice));
+        if(v.size() != 44100) { ok("renders", false); return; }
+
+        early[pass] = tick_peak(v, 0, per_tick);
+
+        std::cout << "     " << (pass ? "with a loud hit at tick 6" : "all quiet")
+                  << "   early hit peaks at " << std::fixed << std::setprecision(4)
+                  << early[pass] << "   late hit " << tick_peak(v, 6, per_tick) << "\n";
+    }
+
+    const double ratio = early[1] / early[0];
+    ok("the early hit is untouched", std::fabs(ratio - 1.0) < 0.001,
+       std::to_string(ratio) + "x");
+}
+
+/**
+ * A hit near the end runs past it, and has always wrapped to the start so that
+ * a pattern loops seamlessly.  Kept in the port, so it is worth pinning.
+ */
+static void the_tail_wraps() {
+    std::cout << "\na hit that overruns the bar wraps to the front:\n";
+
+    // Half a second of sample struck on the last of eight ticks, so most of it
+    // lands past the end of a one second pattern.
+    make_wav("playlist_test_long.wav", 0.6, 0.5);
+    wavstream s("playlist_test_long.wav");
+
+    PlayList list = make_list();
+    Pattern p(1, "p");
+    p.push_back(Roll(1, &s, "long", "long", "00000001"));
+
+    PlayList::slice_type slice;
+    slice.push_back(p);
+
+    const std::vector<float> v = as_floats(list.render(Type::PCM_FLOAT32, slice));
+    ok("renders one second", v.size() == 44100, std::to_string(v.size()));
+    if(v.size() != 44100) return;
+
+    const int per_tick = 44100 / 8;
+
+    ok("the tail is audible at the start of the bar",
+       tick_peak(v, 0, per_tick) > 0.05,
+       std::to_string(tick_peak(v, 0, per_tick)));
+
+    ok("and the hit itself is still there",
+       tick_peak(v, 7, per_tick) > 0.05,
+       std::to_string(tick_peak(v, 7, per_tick)));
+}
+
+static void nothing_to_play() {
+    std::cout << "\ndegenerate patterns:\n";
+
+    {
+        PlayList list = make_list();
+        PlayList::slice_type slice;
+        ok("an empty slice renders silence, not a crash",
+           list.render(Type::PCM_FLOAT32, slice).size() == 44100 * sizeof(float));
+    }
+
+    {
+        // A Roll with no stream.  This used to be undefined: the default
+        // constructor left m_stream uninitialized, so the null check that
+        // guards this read whatever was on the stack.
+        PlayList list = make_list();
+        Pattern p(1, "p");
+        p.push_back(Roll());
+
+        PlayList::slice_type slice;
+        slice.push_back(p);
+
+        ok("a roll with no stream is skipped",
+           list.render(Type::PCM_FLOAT32, slice).size() == 44100 * sizeof(float));
+    }
+}
+
+int main() {
+    std::cout << std::unitbuf;
+
+    try {
+        hits_land_on_their_ticks();
+        a_loud_hit_late_does_not_reach_back();
+        the_tail_wraps();
+        nothing_to_play();
+    }
+    catch(std::exception& e) {
+        std::cerr << "playlist test: " << e.what() << std::endl;
+        return 1;
+    }
+
+    for(const char* f : {"playlist_test_a.wav", "playlist_test_quiet.wav",
+                         "playlist_test_loud.wav", "playlist_test_long.wav"})
+        std::remove(f);
+
+    return failures ? 1 : 0;
+}

--- a/tests/media_sampler_test.cc
+++ b/tests/media_sampler_test.cc
@@ -1,0 +1,359 @@
+// A recording, played as a source.
+//
+// The point of the interface is that nothing downstream can tell a sampler from
+// a voice, so the last section mixes one of each and checks that the sum is the
+// two of them and nothing else.
+#include <jlib/media/WavFile.hh>
+#include <jlib/media/clip.hh>
+#include <jlib/media/instrument.hh>
+#include <jlib/media/mixer.hh>
+#include <jlib/media/notestream.hh>
+#include <jlib/media/sampler.hh>
+#include <jlib/media/voice.hh>
+#include <jlib/media/wavstream.hh>
+
+#include <cmath>
+#include <complex>
+#include <iomanip>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
+
+using namespace jlib::media;
+
+static int failures = 0;
+
+static void ok(const std::string& what, bool good, const std::string& detail = "") {
+    if(!good) ++failures;
+    std::cout << (good ? "  ok   " : "  FAIL ") << what;
+    if(!detail.empty()) std::cout << ": " << detail;
+    std::cout << "\n";
+}
+
+/** Write a WAV holding a synthesized note, and read it back as a clip. */
+static std::shared_ptr<clip> make_clip(const std::string& path, double freq,
+                                       double seconds, unsigned int channels)
+{
+    const double rate = 44100;
+    const unsigned long frames = static_cast<unsigned long>(rate * seconds);
+
+    instrument inst;
+    voice v(inst, freq, frames, rate);
+
+    std::vector<Type::scaled> mix(frames * channels, 0);
+    v.render(mix.data(), frames, channels);
+
+    // to PCM by hand, so the test does not depend on source_stream to prove
+    // something about sampler
+    std::string pcm;
+    pcm.reserve(mix.size() * 2);
+    for(Type::scaled s : mix) {
+        const double c = s > 1 ? 1 : (s < -1 ? -1 : s);
+        const short q = static_cast<short>(std::lround(c * 32767));
+        pcm.push_back(static_cast<char>(q & 0xff));
+        pcm.push_back(static_cast<char>((q >> 8) & 0xff));
+    }
+
+    WavFile out;
+    out.set_format(Type::PCM_S16_LE);
+    out.set_channels(channels);
+    out.set_samples_per_sec(static_cast<int>(rate));
+    out.set_bits_per_sample(16);
+    out.set_pcm(pcm);
+    out.save(path);
+
+    wavstream in(path);
+    return std::make_shared<clip>(in);
+}
+
+static void decoding() {
+    std::cout << "decoding:\n";
+
+    auto c = make_clip("sampler_test_mono.wav", 440, 0.25, 1);
+
+    ok("channels", c->channels() == 1, std::to_string(c->channels()));
+    ok("rate", c->rate() == 44100, std::to_string(c->rate()));
+    ok("frames", c->frames() == 11025, std::to_string(c->frames()));
+    ok("seconds", std::fabs(c->seconds() - 0.25) < 1e-9,
+       std::to_string(c->seconds()));
+
+    // A note starts and ends at silence -- the envelope guarantees it -- so a
+    // clip that decoded with an offset or a half-frame slip would not.
+    ok("starts at silence", std::fabs(c->at(0UL, 0)) < 1e-4,
+       std::to_string(c->at(0UL, 0)));
+    ok("ends at silence", std::fabs(c->at(c->frames()-1, 0)) < 1e-4,
+       std::to_string(c->at(c->frames()-1, 0)));
+
+    // Out of range reads as silence rather than throwing or wandering.
+    ok("past the end is silence", c->at(c->frames() + 100, 0) == 0);
+    ok("a channel it has not got is silence", c->at(10UL, 7) == 0);
+
+    auto st = make_clip("sampler_test_stereo.wav", 440, 0.1, 2);
+    ok("stereo: channels", st->channels() == 2, std::to_string(st->channels()));
+    ok("stereo: frames", st->frames() == 4410, std::to_string(st->frames()));
+    ok("stereo: a voice is centred",
+       st->at(2000UL, 0) == st->at(2000UL, 1));
+}
+
+static void plays_back_what_was_recorded() {
+    std::cout << "\nplayback at the recorded speed:\n";
+
+    auto c = make_clip("sampler_test_mono.wav", 440, 0.25, 1);
+
+    sampler s(c);
+    std::vector<Type::scaled> out(c->frames(), 0);
+    const unsigned long made = s.render(out.data(), c->frames(), 1);
+
+    ok("renders the whole clip", made == c->frames(), std::to_string(made));
+
+    // Bit-exact, not merely close.  At speed 1 the position lands on whole
+    // frames, so at(double) short-circuits and returns the stored sample; an
+    // interpolation that ran anyway would be wrong by a hair everywhere and
+    // this is what would notice.
+    unsigned long differ = 0;
+    for(unsigned long i = 0; i < c->frames(); i++)
+        if(out[i] != c->at(i, 0)) ++differ;
+
+    ok("and does it sample for sample", differ == 0,
+       differ ? (std::to_string(differ) + " differ") : "");
+
+    ok("then it is done", s.done());
+
+    // and again from the top
+    s.reset();
+    std::vector<Type::scaled> again(c->frames(), 0);
+    s.render(again.data(), c->frames(), 1);
+    ok("reset replays it identically", again == out);
+}
+
+static void block_size_independence() {
+    std::cout << "\nstill block size independent:\n";
+
+    auto c = make_clip("sampler_test_mono.wav", 440, 0.25, 1);
+    const unsigned long total = c->frames();
+
+    struct { const char* name; double speed; bool loop; unsigned long start; }
+    cases[] = {
+        { "plain",           1.0,  false, 0    },
+        { "resampled",       0.63, false, 0    },
+        { "looping",         1.0,  true,  0    },
+        { "delayed",         1.0,  false, 977  },
+        { "delayed+resampled", 1.37, false, 513 },
+    };
+
+    for(const auto& k : cases) {
+        sampler whole(c);
+        whole.set_speed(k.speed);
+        whole.set_looping(k.loop);
+        whole.set_start(k.start);
+
+        std::vector<Type::scaled> one(total, 0);
+        whole.render(one.data(), total, 1);
+
+        unsigned long differ = 0;
+
+        for(unsigned long block : {1UL, 7UL, 333UL}) {
+            sampler part(c);
+            part.set_speed(k.speed);
+            part.set_looping(k.loop);
+            part.set_start(k.start);
+
+            std::vector<Type::scaled> split(total, 0);
+            unsigned long at = 0;
+            while(at < total) {
+                const unsigned long want = std::min(block, total - at);
+                const unsigned long made = part.render(&split[at], want, 1);
+                if(!made) break;
+                at += made;
+            }
+
+            for(unsigned long i = 0; i < total; i++)
+                if(one[i] != split[i]) ++differ;
+        }
+
+        ok(k.name, differ == 0, differ ? (std::to_string(differ) + " differ") : "");
+    }
+}
+
+static void speed_and_looping() {
+    std::cout << "\nspeed and looping:\n";
+
+    auto c = make_clip("sampler_test_mono.wav", 440, 0.25, 1);
+
+    {
+        // Half speed is twice as long and an octave down.  Measured as an
+        // octave rather than assumed: the clip is a 440Hz note, so the half
+        // speed render should have its energy at 220 and next to none at 440.
+        sampler s(c);
+        s.set_speed(0.5);
+
+        const unsigned long n = c->frames() * 2;
+        std::vector<Type::scaled> out(n, 0);
+        const unsigned long made = s.render(out.data(), n, 1);
+
+        ok("half speed lasts twice as long",
+           made >= n - 2 && made <= n, std::to_string(made) + " of " + std::to_string(n));
+
+        auto energy = [&](double f) {
+            std::complex<double> a = 0;
+            for(unsigned long i = 0; i < made; i++)
+                a += double(out[i]) * std::exp(std::complex<double>(0, -2*M_PI*f*i/44100));
+            return std::abs(a)/made;
+        };
+
+        const double at220 = energy(220), at440 = energy(440);
+        ok("and sounds an octave down",
+           at220 > at440 * 20,
+           std::to_string(at220) + " at 220 against " + std::to_string(at440) + " at 440");
+    }
+
+    {
+        sampler s(c);
+        s.set_looping(true);
+
+        const unsigned long n = c->frames() * 3 + 101;
+        std::vector<Type::scaled> out(n, 0);
+        const unsigned long made = s.render(out.data(), n, 1);
+
+        ok("a loop fills whatever it is given", made == n, std::to_string(made));
+        ok("and never finishes", !s.done());
+
+        // the second time round is the first time round
+        unsigned long differ = 0;
+        for(unsigned long i = 0; i < c->frames(); i++)
+            if(out[i] != out[i + c->frames()]) ++differ;
+
+        ok("and repeats exactly", differ == 0,
+           differ ? (std::to_string(differ) + " differ") : "");
+    }
+}
+
+static void starting_late() {
+    std::cout << "\nstarting late:\n";
+
+    auto c = make_clip("sampler_test_mono.wav", 440, 0.1, 1);
+
+    const unsigned long start = 1000;
+    sampler s(c, 1.0);
+    s.set_start(start);
+
+    const unsigned long n = start + c->frames();
+    std::vector<Type::scaled> out(n, 0);
+    const unsigned long made = s.render(out.data(), n, 1);
+
+    ok("renders the wait as well as the clip", made == n,
+       std::to_string(made) + " of " + std::to_string(n));
+
+    bool quiet = true;
+    for(unsigned long i = 0; i < start; i++) if(out[i] != 0) quiet = false;
+    ok("silent until its moment", quiet);
+
+    unsigned long differ = 0;
+    for(unsigned long i = 0; i < c->frames(); i++)
+        if(out[start + i] != c->at(i, 0)) ++differ;
+    ok("and then exactly the clip", differ == 0,
+       differ ? (std::to_string(differ) + " differ") : "");
+}
+
+static void channels() {
+    std::cout << "\nchannels:\n";
+
+    auto mono = make_clip("sampler_test_mono.wav", 440, 0.05, 1);
+
+    {
+        sampler s(mono);
+        std::vector<Type::scaled> out(mono->frames() * 2, 0);
+        s.render(out.data(), mono->frames(), 2);
+
+        bool centred = true, matches = true;
+        for(unsigned long i = 0; i < mono->frames(); i++) {
+            if(out[i*2] != out[i*2+1]) centred = false;
+            if(out[i*2] != mono->at(i, 0)) matches = false;
+        }
+        ok("a mono clip plays centred in stereo", centred);
+        ok("and unchanged", matches);
+    }
+
+    {
+        // A stereo clip in mono must fold, not drop a side.  Build one with the
+        // channels deliberately different so dropping would be visible.
+        auto st = make_clip("sampler_test_stereo.wav", 440, 0.05, 2);
+
+        sampler s(st);
+        std::vector<Type::scaled> out(st->frames(), 0);
+        s.render(out.data(), st->frames(), 1);
+
+        unsigned long differ = 0;
+        for(unsigned long i = 0; i < st->frames(); i++) {
+            const double want = (double(st->at(i, 0)) + st->at(i, 1)) / 2;
+            if(std::fabs(out[i] - want) > 1e-6) ++differ;
+        }
+        ok("a stereo clip folds down to mono", differ == 0,
+           differ ? (std::to_string(differ) + " differ") : "");
+    }
+}
+
+/**
+ * The interface claim, checked.
+ *
+ * source.hh says a synthesized voice and a recorded sample are the same kind of
+ * thing to whatever is mixing them.  If that is true then a mixer holding one
+ * of each produces their sum, and the mixer has no way to tell them apart --
+ * so rendering the two separately and adding them by hand has to give the same
+ * answer as letting the mixer do it.
+ */
+static void a_sample_and_a_voice_are_the_same_kind_of_thing() {
+    std::cout << "\na sampler and a voice, mixed:\n";
+
+    auto c = make_clip("sampler_test_mono.wav", 440, 0.25, 1);
+    const unsigned long n = c->frames();
+    const double rate = 44100;
+
+    instrument inst;
+
+    auto samp = std::make_shared<sampler>(c);
+    auto note = std::make_shared<voice>(inst, 660, n, rate);
+
+    mixer m;
+    m.set_staging(mixer::staging::none);
+    m.set_limiting(false);
+
+    m.add(samp);
+    m.add(note);
+
+    std::vector<Type::scaled> mixed(n, 0);
+    const unsigned long made = m.render(mixed.data(), n, 1);
+    ok("the mixer renders both", made == n, std::to_string(made));
+
+    std::vector<Type::scaled> by_hand(n, 0);
+    sampler s2(c);
+    voice v2(inst, 660, n, rate);
+    s2.render(by_hand.data(), n, 1);
+    v2.render(by_hand.data(), n, 1);
+
+    unsigned long differ = 0;
+    for(unsigned long i = 0; i < n; i++)
+        if(mixed[i] != by_hand[i]) ++differ;
+
+    ok("and the mix is exactly the two of them", differ == 0,
+       differ ? (std::to_string(differ) + " differ") : "");
+}
+
+int main() {
+    try {
+        decoding();
+        plays_back_what_was_recorded();
+        block_size_independence();
+        speed_and_looping();
+        starting_late();
+        channels();
+        a_sample_and_a_voice_are_the_same_kind_of_thing();
+    }
+    catch(std::exception& e) {
+        std::cerr << "sampler test: " << e.what() << std::endl;
+        return 1;
+    }
+
+    return failures ? 1 : 0;
+}

--- a/tests/media_wavstream_test.cc
+++ b/tests/media_wavstream_test.cc
@@ -95,6 +95,51 @@ int main(int argc, char** argv) {
             check("from WavFile: identical", other == pcm ? 1 : 0, 1);
         }
 
+        // rewind, which had no implementation behind it.
+        //
+        // stream::rewind() is clear() plus seekg(0), and basic_wavbuf had
+        // neither seekoff nor seekpos -- so it fell through to the streambuf
+        // defaults, which refuse, and rewind() left failbit set on every
+        // wavstream with every subsequent read returning nothing.  A
+        // datastream has always had them, so half the interface worked.
+        //
+        // Nothing in the tree called rewind() on a wavstream, which is how it
+        // survived: PlayList::render does, on every roll before every hit, and
+        // nothing calls PlayList::render either.
+        {
+            wavstream w(path);
+
+            std::string first;
+            while(w.good()) {
+                w.read(buf, sizeof(buf));
+                first.append(buf, w.gcount());
+            }
+            check("read to the end", first == pcm ? 1 : 0, 1);
+
+            w.rewind();
+            check("rewind leaves it usable", w.good() ? 1 : 0, 1);
+
+            std::string second;
+            while(w.good()) {
+                w.read(buf, sizeof(buf));
+                second.append(buf, w.gcount());
+            }
+            check("and it reads the same again", second == pcm ? 1 : 0, 1);
+
+            // partway, too -- rewind is only the seek everything happens to use
+            w.rewind();
+            w.seekg(64);
+            check("seeking partway works", w.good() ? 1 : 0, 1);
+
+            std::string rest;
+            while(w.good()) {
+                w.read(buf, sizeof(buf));
+                rest.append(buf, w.gcount());
+            }
+            check("and lands where it was asked",
+                  rest == pcm.substr(64) ? 1 : 0, 1);
+        }
+
         // read-only: a write must fail rather than vanish
         {
             wavstream w(path);


### PR DESCRIPTION
Fifth slice of the synthesis plan.  A recording becomes a source, so a mixer
holding a drum hit and a synthesized note cannot tell which is which -- and
PlayList, the only thing in the library that ever sequenced anything, is
rebuilt on top of that instead of on its own hand-rolled sum.

    macOS  35 tests, 35 pass, 0 skip     (see the note on make check)
    Linux  36 tests, 35 pass, 1 skip

clip and sampler, split the way wavetable and voice are

    A clip is decoded audio, immutable and shared.  A sampler has a position, a
    gain, a speed and a start.  The split is the same one as wavetable/voice and
    exists for the same reason: sounding one hit eight times in a bar is eight
    samplers over one clip, not eight decodes, and they can overlap -- which a
    stream cannot do, having one position, so rewinding it for the second hit
    abandons the first.

    Decoding up front also keeps stream::get_scaled() out of the render path.
    It is a virtual call, a switch over the format and a read, per sample per
    channel, which is not what should be happening while audio is due.

    Playing at the recorded speed returns the recorded samples, bit for bit, and
    the test asserts that rather than a tolerance: an exact frame index
    short-circuits the interpolation instead of interpolating between a sample
    and itself.  Off the grid it is Catmull-Rom, matching wavetable -- but with
    the ends held rather than wrapped, because a recording is not periodic and
    its last sample is not followed by its first.

    Half speed measured an octave down: 0.326 at 220Hz against 0.000027 at 440.

    Channels fold rather than drop.  A stereo clip played in mono averages the
    sides; dropping one would be silent, and only for material that happens to
    be stereo, which is the sort of thing found late.

wavstream could not seek, so rewind() had never worked

    basic_databuf implements seekoff and seekpos.  basic_wavbuf did not, so it
    fell through to the streambuf defaults, which refuse -- and stream::rewind()
    is clear() plus seekg(0), so rewind() set failbit on every wavstream and
    every read after it returned nothing.

    Half of the same interface worked and half did not, and the half that did
    not was the half nothing called.  Found by clip::load, which rewinds before
    decoding and got an empty clip.

    It is not cosmetic: PlayList::render calls rewind() on each roll before each
    hit, so a wav-backed pattern rendered silence.  Tested now in
    media_wavstream_test, which owns wavstream, rather than only where it was
    found.

PlayList renders through the mixer, and the normalize is gone

    The old sum ended like this:

        Type::scaled max = 1.0;
        for(int z=0;z<n;z++) if(std::abs(samples[z]) > max) max = std::abs(samples[z]);
        if(max > 1.0) for(int z=0;z<n;z++) samples[z] /= max;

    Peak over the whole pattern, then divide everything by it, with nothing to
    put it back.  It is not a limiter and not a compressor: it is *non-causal*.
    A loud hit at the end of a bar reached back and quieted the beginning of it.

    That is the same mistake the mixer branch was written to stop making, in the
    code that made it first, and it is now the mixer's staging and limiter
    instead.  The regression test sounds a quiet hit early and a loud pair late,
    against the same pattern with nothing loud in it, and requires the early hit
    not to move: 1.000000x.  Both passes carry the same roll count so the
    staging divisor is identical and only the loudness differs.

    Getting that test to have teeth took two goes.  A single clip cannot exceed
    full scale, having come off disk as 16-bit PCM, and the old normalize only
    triggered strictly above one -- so the first version passed under the old
    code as well.  Two rolls striking the same tick is what actually reproduces
    it.

    Kept: a hit that overruns the bar still wraps to the front, so a pattern
    loops seamlessly.  Folded after the mix rather than during it, so the
    staging sees each hit once.

    Also fixed, both found by writing the first test PlayList has ever had:

    - Roll's default constructor left m_stream uninitialized, so get_stream()
      returned whatever was on the stack.  A null check does not catch that, and
      render() then read audio from it.
    - descale multiplies by 2^(bits-1), so exactly 1.0 lands one past the top of
      a signed buffer and wraps -- a full-scale sample of the wrong sign.  The
      port clamps to what descale can represent.  source_stream scales by 32767
      and has never had this; descale is the older path.

what was actually wrong with the untested code

    render<N> reaches instantiation through the format dispatcher in
    PlayList.cc, so it has always been compiled.  It had simply never been
    called.  Everything above is a runtime fault in code the compiler was
    perfectly happy with, which is the argument for the test rather than for
    more compiling.

make check on macOS

    Unrelated and pre-existing: ImageMagick 7.1.2 removed Magick::Color::
    intensity(), so jneural-zero, -alpha and -search do not compile and `make`
    fails before reaching the tests.  Filed as #71.  The files are identical to
    master; it surfaced here only because a full rebuild stopped reusing stale
    objects.

    `make -C tests check` builds and runs the suite without them: 35 of 35.  The
    Linux container carries an older ImageMagick and runs the whole thing.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
