### PR TITLE
Fix make check on macOS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -158,6 +158,38 @@ PKG_CHECK_MODULES([MAGICK], [Magick++-7.Q16HDRI], [have_magick=yes],
   [PKG_CHECK_MODULES([MAGICK], [Magick++-6.Q16], [have_magick=yes],
     [PKG_CHECK_MODULES([MAGICK], [ImageMagick++ >= 6.0.0],
                        [have_magick=yes], [have_magick=no])])])
+
+dnl ImageMagick installs libtool archives naming -lltdl in dependency_libs, so
+dnl libtool puts it on the link line even though pkg-config never mentions it.
+dnl Homebrew keeps libltdl in a keg it does not link into the default search
+dnl path, and the link then fails with "library 'ltdl' not found" -- on the
+dnl jneural apps only, which is enough to stop make and therefore make check.
+dnl
+dnl So: ask the linker, and only go looking if it says no.
+AS_IF([test "x$have_magick" = xyes], [
+  AC_MSG_CHECKING([whether the linker can find ltdl])
+  jlib_save_LIBS="$LIBS"
+  LIBS="-lltdl $LIBS"
+  AC_LINK_IFELSE([AC_LANG_PROGRAM([], [])],
+    [AC_MSG_RESULT([yes])
+     LIBS="$jlib_save_LIBS"],
+    [LIBS="$jlib_save_LIBS"
+     jlib_ltdl_dir=
+     for jlib_d in `brew --prefix libtool 2>/dev/null`/lib \
+                    /opt/homebrew/opt/libtool/lib \
+                    /usr/local/opt/libtool/lib \
+                    /opt/local/lib; do
+       AS_IF([test -f "$jlib_d/libltdl.dylib" -o -f "$jlib_d/libltdl.so"],
+             [jlib_ltdl_dir="$jlib_d"; break])
+     done
+     AS_IF([test -n "$jlib_ltdl_dir"],
+       [AC_MSG_RESULT([no, using $jlib_ltdl_dir])
+        MAGICK_LIBS="$MAGICK_LIBS -L$jlib_ltdl_dir"],
+       [AC_MSG_RESULT([no])
+        AC_MSG_WARN([libltdl was not found, and ImageMagick asks for it: the jneural apps may fail to link])])
+    ])
+])
+
 AM_CONDITIONAL([HAVE_MAGICK], [test "x$have_magick" = xyes])
 
 dnl ------------------------------------------------------------------

--- a/jlib/apps/Makefile.am
+++ b/jlib/apps/Makefile.am
@@ -58,7 +58,7 @@ dist_pkgdata_DATA = wow-buttons-ps3.map wow-axes-ps3.map \
                     ksp-axes-ps3.map ksp-buttons-ps3.map \
                     tor-axes-ps3.map tor-buttons-ps3.map
 
-EXTRA_DIST = Hyper.hh color.hh
+EXTRA_DIST = Hyper.hh color.hh magick.hh
 
 JCRYPT_LA  = $(top_builddir)/jlib/crypt/libjcrypt.la
 JNET_LA    = $(top_builddir)/jlib/net/libjnet.la

--- a/jlib/apps/jneural-alpha.cc
+++ b/jlib/apps/jneural-alpha.cc
@@ -10,6 +10,7 @@
 #include <jlib/sys/Directory.hh>
 #include <jlib/sys/sys.hh>
 #include <jlib/ai/neural.hh>
+#include <jlib/apps/magick.hh>
 
 #include <functional>
 #include <random>
@@ -409,7 +410,7 @@ math::matrix<T> load(const std::string& path, uint r, uint c, bool greyscale) {
     for(uint y = 0; y < image.rows(); y++) {
         for(uint x = 0; x < image.columns(); x++) {
             Magick::Color color = image.pixelColor(x, y);
-            input(y*image.columns() + x, 0) = ((QMAX - color.intensity()) / double(QMAX)) * 0.99 + 0.01;
+            input(y*image.columns() + x, 0) = ((QMAX - jlib::apps::luma(color)) / double(QMAX)) * 0.99 + 0.01;
             //std::cout << "Setting color intensity to " << input(y*image.columns() + x, 0) << std::endl;
         }
     }

--- a/jlib/apps/jneural-search.cc
+++ b/jlib/apps/jneural-search.cc
@@ -10,6 +10,7 @@
 #include <jlib/sys/Directory.hh>
 #include <jlib/sys/sys.hh>
 #include <jlib/ai/neural.hh>
+#include <jlib/apps/magick.hh>
 
 #include <functional>
 #include <random>
@@ -372,7 +373,7 @@ math::matrix<T> load(const std::string& path, uint r, uint c, bool greyscale) {
     for(uint y = 0; y < image.rows(); y++) {
         for(uint x = 0; x < image.columns(); x++) {
             Magick::Color color = image.pixelColor(x, y);
-            input(y*image.columns() + x, 0) = ((QMAX - color.intensity()) / double(QMAX)) * 0.99 + 0.01;
+            input(y*image.columns() + x, 0) = ((QMAX - jlib::apps::luma(color)) / double(QMAX)) * 0.99 + 0.01;
             //std::cout << "Setting color intensity to " << input(y*image.columns() + x, 0) << std::endl;
         }
     }

--- a/jlib/apps/jneural-zero.cc
+++ b/jlib/apps/jneural-zero.cc
@@ -9,6 +9,7 @@
 #include <jlib/util/json.hh>
 #include <jlib/sys/Directory.hh>
 #include <jlib/sys/sys.hh>
+#include <jlib/apps/magick.hh>
 
 #include <functional>
 #include <random>
@@ -313,7 +314,7 @@ int main(int argc, char** argv) {
                 for(uint y = 0; y < image.rows(); y++) {
                     for(uint x = 0; x < image.columns(); x++) {
                         Magick::Color color = image.pixelColor(x, y);
-                        input(y*image.columns() + x, 0) = ((QMAX - color.intensity()) / double(QMAX)) * 0.99 + 0.01;
+                        input(y*image.columns() + x, 0) = ((QMAX - jlib::apps::luma(color)) / double(QMAX)) * 0.99 + 0.01;
                         //std::cout << "Setting color intensity to " << input(y*image.columns() + x, 0) << std::endl;
                     }
                 }

--- a/jlib/apps/magick.hh
+++ b/jlib/apps/magick.hh
@@ -1,0 +1,59 @@
+/* -*- mode: C++ c-basic-offset: 4  -*-
+ *
+ * Copyright (c) 2000 Joe Yandle <jwy@divisionbyzero.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ *
+ */
+
+#ifndef JLIB_APPS_MAGICK_HH
+#define JLIB_APPS_MAGICK_HH
+
+#include <Magick++.h>
+
+namespace jlib {
+namespace apps {
+
+/**
+ * How bright a pixel is, on the quantum scale, as Magick::Color::intensity()
+ * used to say.
+ *
+ * That method is gone in ImageMagick 7.1.2, and the three jneural apps all
+ * called it in the same line to turn a pixel into a network input.  Shared
+ * rather than pasted into each of them, because the three have to agree: they
+ * read the same images and a net trained by one is fed by another, so a
+ * difference here would show up as a quietly worse classifier rather than as
+ * anything that looks like a bug.
+ *
+ * These are the coefficients MagickCore still uses in GetPixelLuma and in
+ * GetPixelIntensity's default Rec709Luminance case
+ * (MagickCore/pixel-accessor.h), which is what the old method was computing.
+ * Copied from the library rather than recalled, since being a few percent off
+ * would be invisible.
+ *
+ * No gamma encoding: GetPixelLuma does not apply any, and neither did
+ * intensity().  Rec709Luma, the sibling that does, is a different measure.
+ */
+inline double luma(const Magick::Color& c)
+{
+    return 0.212656 * c.quantumRed() +
+           0.715158 * c.quantumGreen() +
+           0.072186 * c.quantumBlue();
+}
+
+}
+}
+
+#endif // JLIB_APPS_MAGICK_HH


### PR DESCRIPTION
Two unrelated breakages from one ImageMagick upgrade, both of which stop `make`
before it reaches the tests, and neither of which the Linux container sees.
Closes #71.

    macOS  35 tests, 35 pass, 0 skip     (make check, whole thing)
    Linux  36 tests, 35 pass, 1 skip

Magick::Color::intensity() is gone in 7.1.2

    All three jneural apps called it in the same line, turning a pixel into a
    network input:

        input(...) = ((QMAX - color.intensity()) / double(QMAX)) * 0.99 + 0.01;

    Replaced by jlib/apps/magick.hh, holding the one function, shared rather
    than pasted into each of the three -- they read the same images and a net
    trained by one is fed by another, so a difference between them would show up
    as a quietly worse classifier rather than as anything that looks like a bug.

    The coefficients are copied out of MagickCore/pixel-accessor.h, from
    GetPixelLuma and from GetPixelIntensity's default Rec709Luminance case,
    which is what the old method computed.  Taken from the library rather than
    recalled, because being a few percent out would be invisible -- and because
    intensity() has been Rec.601 in some versions and Rec.709 in others.

    No gamma encoding, since GetPixelLuma applies none and neither did
    intensity().  Rec709Luma, the sibling that does, is a different measure.

    Checked rather than assumed, which matters because these nets are already
    trained: the three coefficients sum to exactly 1, so a grey pixel returns
    its own level, and the MNIST inputs are therefore bit-identical to what the
    old call produced.  Colour goes 0.2127 / 0.7152 / 0.0722 for pure red, green
    and blue, so it is a luma and not merely the red channel -- which is what
    ColorGray::shade() would have given, and would have been wrong for anything
    that is not already grey.

ImageMagick asks libtool for a library Homebrew does not put on the path

    Fixing the first one turned the compile error into a link error:

        ld: library 'ltdl' not found

    ImageMagick installs libtool archives naming -lltdl in dependency_libs, so
    libtool puts it on the link line although pkg-config never mentions it --
    `pkg-config --libs Magick++-7.Q16HDRI` has no trace of it.  Homebrew keeps
    libltdl in a keg whose lib directory is not in the default search path, so
    the flag arrives and resolves to nothing.

    configure now asks the linker whether it can find ltdl, and only goes
    looking if it says no: `brew --prefix libtool`/lib first, then the usual
    Homebrew and MacPorts locations, and a warning rather than an error if none
    of them has it, since only three apps need it.

        checking whether the linker can find ltdl... no, using /opt/homebrew/opt/libtool/lib

why the container did not catch either

    Ubuntu 24.04 carries an older ImageMagick, which still has intensity() and
    whose .la files resolve, so the Docker build stayed green throughout.  Both
    faults were on master and had been for as long as the local ImageMagick had
    been at 7.1.2; they surfaced only when a full rebuild stopped reusing stale
    object files.

    Worth saying plainly: these apps have no tests, so nothing here establishes
    that they still classify correctly -- only that they build, and that the one
    line that changed produces the same numbers it used to for grey input.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
