### PR TITLE
Add a timeline

### DIFF
--- a/jlib/media/Makefile.am
+++ b/jlib/media/Makefile.am
@@ -17,7 +17,7 @@ libjmedia_la_LIBADD = $(top_builddir)/jlib/sys/libjsys.la \
 
 jmedia_hdrs = Player.hh AudioFile.hh WavFile.hh PlayList.hh stream.hh \
               datastream.hh notestream.hh Type.hh wavstream.hh \
-              instrument.hh voice.hh source.hh source_stream.hh wavetable.hh mixer.hh clip.hh sampler.hh \
+              instrument.hh voice.hh source.hh source_stream.hh wavetable.hh mixer.hh clip.hh sampler.hh delayed.hh \
               audiofilestream.hh AudioSink.hh PortAudioSink.hh
 
 libjmediaincludedir = $(includedir)/jlib-1.2/jlib/media

--- a/jlib/media/PlayList.cc
+++ b/jlib/media/PlayList.cc
@@ -21,6 +21,7 @@
  */
 
 #include <jlib/media/PlayList.hh>
+#include <jlib/media/notestream.hh>
 
 #include <utility>
 #include <iostream>
@@ -29,8 +30,41 @@
 namespace jlib {
     namespace media {
         
+        Roll::Roll(int id, const std::string& note, const std::string& name, const std::string& data)
+            : m_pattern(data.length()),
+              m_stream(0),
+              m_beats(0),
+              m_bpu(0),
+              m_is_note(true)
+        {
+            set_id(id);
+            set_sample(note);
+            set_name(name);
+
+            // notestream owns the note grammar, so a pattern names pitches the
+            // same way jnote and jmelody do rather than inventing a second
+            // spelling.  Parsed once, here, so a bad note is a construction
+            // error and not a surprise at render time.
+            notestream parse(note);
+
+            m_instrument = parse.get_instrument();
+            m_freq = parse.get_freq();
+            m_seconds = parse.get_time();
+
+            for(u_int i=0;i<data.length();i++) {
+                if(data[i] != '0' && data[i] != '1')
+                    std::cerr << "invalid data["<<i<<"]: " << data[i] << std::endl;
+                m_pattern[i] = (data[i] == '1');
+            }
+        }
+
         Roll::Roll(int id, stream* s, const std::string& name, const std::string& sample, const std::string& data) 
-            : m_pattern(data.length())
+            : m_pattern(data.length()),
+              m_beats(0),
+              m_bpu(0),
+              m_is_note(false),
+              m_freq(0),
+              m_seconds(0)
         {
             set_id(id);
             set_sample(sample);
@@ -48,7 +82,10 @@ namespace jlib {
             : m_stream(0),
               m_id(0),
               m_beats(0),
-              m_bpu(0)
+              m_bpu(0),
+              m_is_note(false),
+              m_freq(0),
+              m_seconds(0)
         {
             // m_stream was left uninitialized here, so get_stream() on a
             // default-constructed Roll returned whatever was on the stack --
@@ -84,6 +121,14 @@ namespace jlib {
         void Roll::set_stream(stream* s) {
             m_stream = s;
         }
+        
+        bool Roll::is_note() const { return m_is_note; }
+        
+        const instrument& Roll::get_instrument() const { return m_instrument; }
+        void Roll::set_instrument(const instrument& i) { m_instrument = i; }
+        
+        double Roll::get_freq() const { return m_freq; }
+        double Roll::get_seconds() const { return m_seconds; }
         
         
         Pattern::Pattern(int id, const std::string& name) {

--- a/jlib/media/PlayList.hh
+++ b/jlib/media/PlayList.hh
@@ -31,9 +31,12 @@
 #include <cmath>
 
 #include <jlib/media/clip.hh>
+#include <jlib/media/delayed.hh>
+#include <jlib/media/instrument.hh>
 #include <jlib/media/mixer.hh>
 #include <jlib/media/sampler.hh>
 #include <jlib/media/stream.hh>
+#include <jlib/media/voice.hh>
 
 namespace jlib {
     namespace media {
@@ -55,6 +58,22 @@ namespace jlib {
             typedef rep_type::allocator_type allocator_type;            
             
             Roll(int id, stream* s, const std::string& name, const std::string& sample, const std::string& data);
+
+            /**
+             * A roll that sounds a synthesized note rather than a recording.
+             *
+             * note is a note string as notestream reads them -- "C@2", "A#@3:2",
+             * "G@2/saw" -- so a pattern can name a pitch, a length and a
+             * waveform the same way the rest of the library does, and an
+             * unknown one throws here rather than at render time.
+             *
+             * The point of this is that the two kinds of roll are the same kind
+             * of thing by the time they reach the mixer: one becomes a sampler
+             * and the other a voice, both wrapped in a delayed to put them on
+             * their beat, and nothing downstream can tell them apart.
+             */
+            Roll(int id, const std::string& note, const std::string& name, const std::string& data);
+
             Roll();
             
             int get_id() const;
@@ -72,6 +91,16 @@ namespace jlib {
             stream* get_stream();
             const stream* get_stream() const;
             void set_stream(stream* s);
+
+            /** Whether this sounds a note rather than a recording. */
+            bool is_note() const;
+
+            const instrument& get_instrument() const;
+            void set_instrument(const instrument& i);
+
+            /** Hz, and seconds, both taken from the note string. */
+            double get_freq() const;
+            double get_seconds() const;
             
         private:
             rep_type m_pattern;
@@ -83,6 +112,11 @@ namespace jlib {
             std::string m_name;
             int m_beats;
             int m_bpu;
+
+            bool m_is_note;
+            instrument m_instrument;
+            double m_freq;
+            double m_seconds;
         };
         
         class Pattern {
@@ -256,17 +290,35 @@ namespace jlib {
             for(;i!=slice.end();i++) {
                 Pattern::iterator j = i->begin();
                 for(;j!=i->end();j++) {
-                    stream* s = j->get_stream();
+                    // A roll is either a recording or a note.  Both come out
+                    // of here as sources wrapped in a delayed, and nothing
+                    // below can tell which it has -- which is the whole reason
+                    // the source interface exists.
+                    std::shared_ptr<clip> c;
+                    unsigned long length = 0;
 
-                    if(s == 0)
-                        continue;
+                    if(j->is_note()) {
+                        length = (unsigned long)(j->get_seconds() * samples_per_sec);
 
-                    std::shared_ptr<clip>& c = decoded[s];
-                    if(!c)
-                        c = std::make_shared<clip>(*s);
+                        if(length == 0)
+                            continue;
+                    }
+                    else {
+                        stream* s = j->get_stream();
 
-                    if(c->empty())
-                        continue;
+                        if(s == 0)
+                            continue;
+
+                        std::shared_ptr<clip>& cached = decoded[s];
+                        if(!cached)
+                            cached = std::make_shared<clip>(*s);
+
+                        if(cached->empty())
+                            continue;
+
+                        c = cached;
+                        length = c->frames();
+                    }
 
                     for(u_int k=0;k<get_width();k++) {
                         if(!(*j)[k])
@@ -274,18 +326,29 @@ namespace jlib {
 
                         const unsigned long begin = (unsigned long)samples_per_tick * k;
 
-                        std::shared_ptr<sampler> hit = std::make_shared<sampler>(c);
-                        hit->set_rate(samples_per_sec);
-                        hit->set_start(begin);
-                        mix.add(hit);
+                        std::shared_ptr<source> hit;
 
-                        if(begin + c->frames() > len)
-                            len = begin + c->frames();
+                        if(c) {
+                            std::shared_ptr<sampler> play = std::make_shared<sampler>(c);
+                            play->set_rate(samples_per_sec);
+                            hit = play;
+                        }
+                        else {
+                            hit = std::make_shared<voice>(j->get_instrument(),
+                                                          j->get_freq(),
+                                                          length,
+                                                          samples_per_sec);
+                        }
+
+                        mix.add(std::make_shared<delayed>(hit, begin));
+
+                        if(begin + length > len)
+                            len = begin + length;
 
                         if(getenv("JLIB_MEDIA_PLAYLIST_DEBUG")) 
                             std::cerr << "\t\tbeat: " << k << std::endl
                                       << "\t\tbegin:  " << begin  << std::endl
-                                      << "\t\tcount:  " << c->frames()  << std::endl;
+                                      << "\t\tcount:  " << length  << std::endl;
                     }
                 }
             }

--- a/jlib/media/delayed.hh
+++ b/jlib/media/delayed.hh
@@ -1,0 +1,114 @@
+/* -*- mode: C++ c-basic-offset: 4  -*-
+ *
+ * Copyright (c) 2000 Joe Yandle <jwy@divisionbyzero.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ *
+ */
+
+#ifndef JLIB_MEDIA_DELAYED_HH
+#define JLIB_MEDIA_DELAYED_HH
+
+#include <jlib/media/source.hh>
+
+#include <algorithm>
+#include <memory>
+
+namespace jlib {
+namespace media {
+
+/**
+ * A source that starts later.
+ *
+ * This is the whole of what it takes to put a sound at a moment, and therefore
+ * the whole of what a timeline needs from the sources beneath it: a mixer sums
+ * things that all begin at once, so without this the only way to place a note
+ * on the third beat is to start rendering it when the third beat arrives, and
+ * a mixer has no way to do that.
+ *
+ * sampler carried its own start offset for a while, which was enough for
+ * patterns of recordings and no use at all for a pattern with notes in it,
+ * since a voice had no such thing.  One wrapper that delays anything is both
+ * smaller and more useful than the same field on each source, and it is why a
+ * playlist can now sound an instrument as easily as a drum.
+ *
+ * The wait counts as rendered.  Those frames exist -- they are simply empty --
+ * and a caller told otherwise would stop early and lose everything after them.
+ */
+class delayed : public source {
+public:
+    /**
+     * @param s       what to sound, once the wait is over
+     * @param frames  how long to wait, in output frames
+     */
+    delayed(const std::shared_ptr<source>& s, unsigned long frames = 0)
+        : m_source(s),
+          m_start(frames)
+    {
+    }
+
+    const std::shared_ptr<source>& get_source() const { return m_source; }
+
+    unsigned long get_start() const { return m_start; }
+    void set_start(unsigned long frames) { m_start = frames; }
+
+    virtual unsigned long render(Type::scaled* out, unsigned long frames,
+                                 unsigned int channels)
+    {
+        if(!m_source)
+            return 0;
+
+        unsigned long made = 0;
+
+        if(m_waited < m_start) {
+            // Nothing is written here.  render() adds, so silence is what the
+            // buffer already holds, and zeroing it would erase whatever else
+            // has been mixed in.
+            const unsigned long wait = std::min(frames, m_start - m_waited);
+
+            m_waited += wait;
+            made += wait;
+        }
+
+        if(made < frames)
+            made += m_source->render(out + made * channels, frames - made, channels);
+
+        return made;
+    }
+
+    virtual bool done() const
+    {
+        return m_waited >= m_start && (!m_source || m_source->done());
+    }
+
+    virtual void reset()
+    {
+        m_waited = 0;
+
+        if(m_source)
+            m_source->reset();
+    }
+
+protected:
+    std::shared_ptr<source> m_source;
+
+    unsigned long m_start = 0;
+    unsigned long m_waited = 0;
+};
+
+}
+}
+
+#endif // JLIB_MEDIA_DELAYED_HH

--- a/jlib/media/sampler.hh
+++ b/jlib/media/sampler.hh
@@ -40,6 +40,10 @@ namespace media {
  *
  * The clip is shared and never modified, so any number of these can play the
  * same recording at once, at different positions, speeds and gains.
+ *
+ * Starting at a particular moment is delayed's job rather than this one's --
+ * see delayed.hh.  It lived here first, which was enough for patterns made of
+ * recordings and no use for a pattern with notes in it.
  */
 class sampler : public source {
 public:
@@ -68,21 +72,6 @@ public:
     void set_looping(bool l) { m_looping = l; }
 
     /**
-     * Frames of silence before the clip starts.
-     *
-     * A sampler is usually wanted at a particular moment rather than
-     * immediately -- a drum hit lands on a beat -- and without this the only
-     * way to place one is to start rendering it late, which a mixer has no way
-     * to do.  Counted in output frames, so it does not move when the speed
-     * changes.
-     *
-     * This is the smallest piece of a timeline, not a timeline: there is no
-     * tempo here and no ordering beyond what the offsets say.
-     */
-    unsigned long get_start() const { return m_start; }
-    void set_start(unsigned long frames) { m_start = frames; }
-
-    /**
      * Frames per second wanted out.
      *
      * A clip records its own rate, so playing a 22kHz recording into a 44.1kHz
@@ -108,15 +97,6 @@ public:
         unsigned long made = 0;
 
         while(made < frames) {
-            // Silence until the start, which still counts as rendered: the
-            // frames exist, they are just empty, and a mixer needs to be told
-            // they happened or it will stop early.
-            if(m_waited < m_start) {
-                ++m_waited;
-                ++made;
-                continue;
-            }
-
             if(m_pos >= len) {
                 if(!m_looping)
                     break;
@@ -142,13 +122,12 @@ public:
         if(!m_clip || m_clip->empty())
             return true;
 
-        return !m_looping && m_waited >= m_start && m_pos >= m_clip->frames();
+        return !m_looping && m_pos >= m_clip->frames();
     }
 
     virtual void reset()
     {
         m_pos = 0;
-        m_waited = 0;
     }
 
 protected:
@@ -190,9 +169,6 @@ protected:
     double m_speed = 1.0;
     double m_rate = 44100;
     bool m_looping = false;
-
-    unsigned long m_start = 0;
-    unsigned long m_waited = 0;
     double m_pos = 0;
 };
 

--- a/tests/media_playlist_test.cc
+++ b/tests/media_playlist_test.cc
@@ -10,6 +10,7 @@
 #include <jlib/media/wavstream.hh>
 
 #include <cmath>
+#include <complex>
 #include <cstring>
 #include <iomanip>
 #include <iostream>
@@ -204,6 +205,130 @@ static void the_tail_wraps() {
        std::to_string(tick_peak(v, 7, per_tick)));
 }
 
+/** How much of one frequency sits in a stretch of the render. */
+static double energy_at(const std::vector<float>& v, int from, int count, double f) {
+    std::complex<double> a = 0;
+    for(int i = from; i < from + count && i < (int)v.size(); i++)
+        a += double(v[i]) * std::exp(std::complex<double>(0, -2*M_PI*f*i/44100));
+    return std::abs(a) / count;
+}
+
+/**
+ * A roll can sound an instrument instead of a recording.
+ *
+ * Which is the whole of the timeline claim: a pattern names a note the same way
+ * jnote and jmelody do, it becomes a voice rather than a sampler, and nothing
+ * from the mixer down can tell the difference.
+ */
+static void notes_as_well_as_recordings() {
+    std::cout << "\nrolls that sound notes:\n";
+
+    const int per_tick = 44100 / 8;
+
+    {
+        PlayList list = make_list();
+        Pattern p(1, "p");
+        // a tenth of a second, so a note fits inside its eighth-second tick
+        p.push_back(Roll(1, "A@2:0.1", "note", "10001000"));
+
+        PlayList::slice_type slice;
+        slice.push_back(p);
+
+        const std::vector<float> v = as_floats(list.render(Type::PCM_FLOAT32, slice));
+        ok("renders one second", v.size() == 44100, std::to_string(v.size()));
+        if(v.size() != 44100) return;
+
+        for(int t = 0; t < 8; t++) {
+            const bool want = (t == 0 || t == 4);
+            const double p2 = tick_peak(v, t, per_tick);
+            ok(std::string("tick ") + std::to_string(t) +
+               (want ? " sounds" : " is silent"),
+               want ? (p2 > 0.05) : (p2 < 0.001), std::to_string(p2));
+        }
+
+        // and it is the pitch that was asked for, not merely a noise
+        const double at220 = energy_at(v, 0, per_tick, 220);
+        const double at330 = energy_at(v, 0, per_tick, 330);
+        ok("and it is an A at 220Hz", at220 > at330 * 20,
+           std::to_string(at220) + " at 220 against " + std::to_string(at330) + " at 330");
+    }
+
+    {
+        // the waveform override survives the trip through the pattern
+        PlayList list = make_list();
+        Pattern sine(1, "sine"), saw(2, "saw");
+        sine.push_back(Roll(1, "A@2:0.1", "n", "10000000"));
+        saw.push_back(Roll(1, "A@2:0.1/saw", "n", "10000000"));
+
+        PlayList::slice_type a, b;
+        a.push_back(sine);
+        b.push_back(saw);
+
+        const std::vector<float> vs = as_floats(list.render(Type::PCM_FLOAT32, a));
+        const std::vector<float> vw = as_floats(list.render(Type::PCM_FLOAT32, b));
+
+        // a sawtooth has a second harmonic and a sine has essentially none
+        const double sine440 = energy_at(vs, 0, per_tick, 440);
+        const double saw440  = energy_at(vw, 0, per_tick, 440);
+
+        ok("/saw reaches the voice", saw440 > sine440 * 20,
+           std::to_string(saw440) + " against " + std::to_string(sine440) + " at 440");
+    }
+
+    {
+        PlayList list = make_list();
+        bool threw = false;
+        try { Roll(1, "H@9", "bad", "10000000"); }
+        catch(std::exception&) { threw = true; }
+        ok("a note it cannot read throws when the roll is made", threw);
+    }
+}
+
+/**
+ * The two kinds of roll in one pattern.
+ *
+ * Not asserted by comparing against the two rendered separately and added:
+ * automatic staging divides by the number of rolls, so one pattern of two is
+ * deliberately not the sum of two patterns of one.  What is checked instead is
+ * that each lands on its own beat and sounds like itself, with the pattern
+ * holding one of each.
+ */
+static void a_recording_and_a_note_together() {
+    std::cout << "\na recording and a note in one pattern:\n";
+
+    make_wav("playlist_test_a.wav", 0.6, 0.05);
+
+    const int per_tick = 44100 / 8;
+
+    std::vector<float> both;
+
+    {
+        wavstream s("playlist_test_a.wav");
+        PlayList list = make_list();
+        Pattern p(1, "p");
+        p.push_back(Roll(1, &s, "drum", "a", "10000000"));
+        p.push_back(Roll(2, "A@2:0.1", "note", "00001000"));
+
+        PlayList::slice_type slice;
+        slice.push_back(p);
+        both = as_floats(list.render(Type::PCM_FLOAT32, slice));
+    }
+
+    ok("renders one second", both.size() == 44100, std::to_string(both.size()));
+    if(both.size() != 44100) return;
+
+    ok("the recording is on its beat", tick_peak(both, 0, per_tick) > 0.05,
+       std::to_string(tick_peak(both, 0, per_tick)));
+    ok("and the note is on its own", tick_peak(both, 4, per_tick) > 0.05,
+       std::to_string(tick_peak(both, 4, per_tick)));
+    ok("with silence between them", tick_peak(both, 2, per_tick) < 0.001,
+       std::to_string(tick_peak(both, 2, per_tick)));
+
+    ok("the note is a 220Hz A",
+       energy_at(both, 4*per_tick, per_tick, 220) >
+       energy_at(both, 4*per_tick, per_tick, 330) * 20);
+}
+
 static void nothing_to_play() {
     std::cout << "\ndegenerate patterns:\n";
 
@@ -237,6 +362,8 @@ int main() {
         hits_land_on_their_ticks();
         a_loud_hit_late_does_not_reach_back();
         the_tail_wraps();
+        notes_as_well_as_recordings();
+        a_recording_and_a_note_together();
         nothing_to_play();
     }
     catch(std::exception& e) {

--- a/tests/media_sampler_test.cc
+++ b/tests/media_sampler_test.cc
@@ -5,6 +5,7 @@
 // two of them and nothing else.
 #include <jlib/media/WavFile.hh>
 #include <jlib/media/clip.hh>
+#include <jlib/media/delayed.hh>
 #include <jlib/media/instrument.hh>
 #include <jlib/media/mixer.hh>
 #include <jlib/media/notestream.hh>
@@ -133,37 +134,45 @@ static void block_size_independence() {
     auto c = make_clip("sampler_test_mono.wav", 440, 0.25, 1);
     const unsigned long total = c->frames();
 
-    struct { const char* name; double speed; bool loop; unsigned long start; }
-    cases[] = {
-        { "plain",           1.0,  false, 0    },
-        { "resampled",       0.63, false, 0    },
-        { "looping",         1.0,  true,  0    },
-        { "delayed",         1.0,  false, 977  },
-        { "delayed+resampled", 1.37, false, 513 },
+    struct spec { const char* name; double speed; bool loop; unsigned long start; };
+
+    const spec cases[] = {
+        { "plain",             1.0,  false, 0    },
+        { "resampled",         0.63, false, 0    },
+        { "looping",           1.0,  true,  0    },
+        { "delayed",           1.0,  false, 977  },
+        { "delayed+resampled", 1.37, false, 513  },
     };
 
-    for(const auto& k : cases) {
-        sampler whole(c);
-        whole.set_speed(k.speed);
-        whole.set_looping(k.loop);
-        whole.set_start(k.start);
+    // The delay is a wrapper now rather than a field on the sampler, so it has
+    // its own state to carry across a block boundary and belongs in here.
+    auto build_one = [&](const spec& k) -> std::shared_ptr<source> {
+        auto one = std::make_shared<sampler>(c);
+        one->set_speed(k.speed);
+        one->set_looping(k.loop);
+
+        if(k.start)
+            return std::make_shared<delayed>(one, k.start);
+
+        return one;
+    };
+
+    for(const spec& k : cases) {
+        std::shared_ptr<source> whole = build_one(k);
 
         std::vector<Type::scaled> one(total, 0);
-        whole.render(one.data(), total, 1);
+        whole->render(one.data(), total, 1);
 
         unsigned long differ = 0;
 
         for(unsigned long block : {1UL, 7UL, 333UL}) {
-            sampler part(c);
-            part.set_speed(k.speed);
-            part.set_looping(k.loop);
-            part.set_start(k.start);
+            std::shared_ptr<source> part = build_one(k);
 
             std::vector<Type::scaled> split(total, 0);
             unsigned long at = 0;
             while(at < total) {
                 const unsigned long want = std::min(block, total - at);
-                const unsigned long made = part.render(&split[at], want, 1);
+                const unsigned long made = part->render(&split[at], want, 1);
                 if(!made) break;
                 at += made;
             }
@@ -235,12 +244,11 @@ static void starting_late() {
     auto c = make_clip("sampler_test_mono.wav", 440, 0.1, 1);
 
     const unsigned long start = 1000;
-    sampler s(c, 1.0);
-    s.set_start(start);
+    delayed d(std::make_shared<sampler>(c), start);
 
     const unsigned long n = start + c->frames();
     std::vector<Type::scaled> out(n, 0);
-    const unsigned long made = s.render(out.data(), n, 1);
+    const unsigned long made = d.render(out.data(), n, 1);
 
     ok("renders the wait as well as the clip", made == n,
        std::to_string(made) + " of " + std::to_string(n));
@@ -254,6 +262,37 @@ static void starting_late() {
         if(out[start + i] != c->at(i, 0)) ++differ;
     ok("and then exactly the clip", differ == 0,
        differ ? (std::to_string(differ) + " differ") : "");
+
+    ok("and is done when the clip is", d.done());
+
+    // The wait must not erase what is already in the buffer.  render() adds,
+    // so a delay that wrote zeros over its silent stretch would silently
+    // delete every source mixed in before it -- and with a mixer that zeroes
+    // first, which is the usual case, nothing would ever notice.
+    {
+        std::vector<Type::scaled> shared(n, 0.5);
+        delayed again(std::make_shared<sampler>(c), start);
+        again.render(shared.data(), n, 1);
+
+        bool kept = true;
+        for(unsigned long i = 0; i < start; i++)
+            if(shared[i] != 0.5f) kept = false;
+
+        ok("and adds to the buffer rather than clearing it", kept);
+    }
+
+    // A delay of nothing is the source itself.
+    {
+        std::vector<Type::scaled> plain(c->frames(), 0);
+        sampler bare(c);
+        bare.render(plain.data(), c->frames(), 1);
+
+        std::vector<Type::scaled> wrapped(c->frames(), 0);
+        delayed none(std::make_shared<sampler>(c), 0);
+        none.render(wrapped.data(), c->frames(), 1);
+
+        ok("a delay of zero changes nothing", plain == wrapped);
+    }
 }
 
 static void channels() {


### PR DESCRIPTION
Sixth slice of the synthesis plan.  A pattern can now name a note as well as a
recording, which is what makes PlayList a timeline rather than a drum machine.

    macOS  35 tests, 35 pass, 0 skip
    Linux  36 tests, 35 pass, 1 skip

placing a sound in time belongs to one thing, not to each source

    sampler carried its own start offset.  That was enough for patterns made of
    recordings and no use whatever for a pattern with notes in it, because a
    voice had no such thing -- and adding the same field to voice would have
    made it two implementations of one idea, with a third waiting for whatever
    source came next.

    jlib/media/delayed.hh is that idea once: a source that waits, wrapping any
    other.  sampler's start offset is gone, PlayList wraps both kinds, and a
    note lands on the third beat by the same mechanism a drum hit does.

    The wait counts as rendered, since those frames exist and are merely empty;
    a caller told otherwise stops early and loses everything after them.  And
    the wait writes nothing rather than writing zeros -- render() adds, so
    clearing its own stretch would delete whatever had already been mixed in.
    That one is asserted, because with a mixer that zeroes first, which is the
    usual case, nothing would ever notice:

        ok   and adds to the buffer rather than clearing it

    The block-size independence cases moved with it.  The delay has state that
    has to cross a block boundary identically, so it is tested where the
    sampler's is.

a roll can be a note

    Roll gains a second constructor taking a note string -- "C@2", "A#@3:2",
    "G@2/saw" -- read by notestream, so a pattern names pitches the way jnote
    and jmelody already do rather than inventing a second spelling.  Parsed at
    construction, so an unreadable note is a construction error rather than a
    surprise halfway through a render.

    render() then makes a voice where it would have made a sampler, wraps it in
    a delayed, and hands it to the mixer.  Nothing below that point can tell
    which kind it has, which is the claim source.hh has been making since it was
    written and the first time it has been worth anything.

    Measured rather than asserted: a roll of "A@2:0.1" puts 0.127 at 220Hz
    against 0.003 at 330, and "/saw" survives the trip -- 0.070 of second
    harmonic against a sine's 0.0002.

what the tests do not establish

    A pattern holding a recording and a note is not checked against the two
    rendered separately and added, because that is not true and should not be:
    automatic staging divides by the number of rolls, so one pattern of two is
    deliberately not the sum of two patterns of one.  What is checked is that
    each lands on its own beat and sounds like itself.

    Nothing here plays a playlist aloud.  PlayList has no app in the tree -- the
    synth that used to call it is long gone -- so the whole of the evidence is
    what the test measures.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
