### PR TITLE
Add live control, and jhypermusic

### DIFF
--- a/jlib/apps/Makefile.am
+++ b/jlib/apps/Makefile.am
@@ -20,7 +20,7 @@ cuda_programs = jcublas
 endif
 
 if HAVE_PORTAUDIO
-media_programs = jnote jmelody
+media_programs = jnote jmelody jhypermusic
 endif
 
 if HAVE_X
@@ -104,6 +104,9 @@ jnote_LDADD   = $(JMEDIA_LA) $(JSYS_LA)
 
 jmelody_SOURCES = jmelody.cc
 jmelody_LDADD   = $(JMEDIA_LA) $(JUTIL_LA) $(JSYS_LA)
+
+jhypermusic_SOURCES = jhypermusic.cc
+jhypermusic_LDADD   = $(JMEDIA_LA) $(JUTIL_LA) $(JSYS_LA)
 
 jpoisoned_SOURCES = jpoisoned.cc
 jpoisoned_LDADD   = $(JX_LA) $(JSYS_LA) $(JUTIL_LA)

--- a/jlib/apps/jhypermusic.cc
+++ b/jlib/apps/jhypermusic.cc
@@ -1,15 +1,439 @@
-/*
-  To convert a jhyper into music, model each vertex as an emmitter of sound at a certain frequency (depending on the color assigned to the vertex).  Do so in N dimensions.  On render, project down to 3 dimensions.  For each frame, consider not only the new position of the vertex, but also its relative position in regards to the past position.  That will give us a velocity towards the viewer, which will be used for doppler effect corrections to the 3d sound.  
-I never implemented a full analog digital instrument.  I will do that in order to make this music full featured, not just crappy sounds sequenced.
-
-Attack, decay, sustain, release.  Each vertex gets a full ASDR instrument.  Pitch is random and is reflective of color; purple is high pitch and red is low pitch.  Volume and pitch will be determined positionally with Doppler corrections (I'll skip the relatavistic corrections for now, though since it's just special relativity I should do it eventually).
-
-The music video consists of animation code which creates objects in the N dimensional space and moves them in time and space.  The observer moves too, both in position and orientation.  It is a dance of an observer moving among moving objects.
-
-It should be sufficient for the video portion to grab the window manager frame buffer, then write to a video stream in some container/codec.  Audio will run a parallel rendering pipeline, running the animation and rendering the audio at each frame.  The audio and video pipelines should fill output queues, each of which is read sequentially by a controller which muxes them and writes the next 
-
-Twiddle the knobs.  See what happens.
- 
-It will eventually be possible to build a live music system, where a dj can twiddle the knobs of time; and allow skewing certain parameters of the animation, especially relating to color and intensity of edges.  all of these twiddles can be mapped to user input devices, like a playstation controller, or dj mixer type thing, or a spacemouse.
-
+/* -*- mode: C++ c-basic-offset: 4  -*-
+ *
+ * Copyright (c) 2000 Joe Yandle <jwy@divisionbyzero.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ *
  */
+
+/*
+  The note this file used to be, kept because it is the specification and it
+  waited a long time:
+
+    To convert a jhyper into music, model each vertex as an emmitter of sound at
+    a certain frequency (depending on the color assigned to the vertex).  Do so
+    in N dimensions.  On render, project down to 3 dimensions.  For each frame,
+    consider not only the new position of the vertex, but also its relative
+    position in regards to the past position.  That will give us a velocity
+    towards the viewer, which will be used for doppler effect corrections to the
+    3d sound.
+
+    I never implemented a full analog digital instrument.  I will do that in
+    order to make this music full featured, not just crappy sounds sequenced.
+
+    Attack, decay, sustain, release.  Each vertex gets a full ASDR instrument.
+    Pitch is random and is reflective of color; purple is high pitch and red is
+    low pitch.  Volume and pitch will be determined positionally with Doppler
+    corrections.
+
+  What is here now is the audio half of that.  Each vertex of an n-cube holds a
+  sustaining voice; its pitch comes from its hue and its level from how near it
+  is, and both are moved every control block as the shape turns.  The video half
+  -- grabbing frames and muxing a stream -- is not here, and jhardhyper already
+  draws the same geometry.
+
+  The pieces it needs are the ones the last few branches added: voices that can
+  be retuned while sounding without clicking, a mixer whose faders can move
+  without zipper noise, gain staging that holds the level as the voice count
+  changes, and a limiter that stays out of the way.
+ */
+
+#include <jlib/apps/color.hh>
+
+#include <jlib/math/matrix.hh>
+
+#include <jlib/media/PortAudioSink.hh>
+#include <jlib/media/instrument.hh>
+#include <jlib/media/mixer.hh>
+#include <jlib/media/source_stream.hh>
+#include <jlib/media/voice.hh>
+#include <jlib/media/wavetable.hh>
+
+#include <cmath>
+#include <cstdlib>
+#include <iomanip>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
+
+using namespace jlib;
+
+/**
+ * An n-cube, turning, heard rather than seen.
+ *
+ * A source, so it reaches the device the way everything else does: through
+ * source_stream and the sink, with the feeder thread pulling on it.  The
+ * animation therefore runs from the audio pipeline rather than beside it, which
+ * is what the note meant by the two pipelines being driven together -- except
+ * that with no video half there is only one, and it is this one.
+ */
+class hypermusic : public media::source {
+public:
+    /** Geometry moves this often.  Fine enough to hear as motion, coarse
+     *  enough that the trigonometry is nothing next to the synthesis. */
+    static const unsigned long CONTROL = 512;
+
+    hypermusic(unsigned int d, double rate, std::size_t voices, double spin)
+        : m_shape(d),
+          m_rate(rate),
+          m_spin(math::matrix<double>::identity(d + 1))
+    {
+        // Turn in two planes at once, at rates that do not divide each other,
+        // so the figure never repeats exactly.
+        math::plane a; a.i = 0; a.j = 1;
+        math::plane b; b.i = (d > 3) ? 2 : 0; b.j = (d > 3) ? 3 : 1;
+
+        const double per_block = spin * CONTROL / m_rate;
+
+        m_spin = math::matrix<double>::rotate(d, a, per_block) *
+                 math::matrix<double>::rotate(d, b, per_block * 0.61803398875);
+
+        media::instrument inst;
+        inst.set_wave(media::instrument::wave::saw);
+
+        media::instrument::envelope e;
+        e.attack = 0.4;          // slow, so nothing lands as a click
+        e.decay = 0.6;
+        e.sustain = 0.7;
+        e.release = 0.5;
+        inst.set_envelope(e);
+
+        m_mix.set_staging(media::mixer::staging::automatic);
+        m_mix.set_rate(rate);
+        m_mix.set_max_voices(voices);
+
+        m_at.reserve(m_shape.size());
+        m_was.reserve(m_shape.size());
+
+        for(uint i = 0; i < m_shape.size(); i++) {
+            // Hue spread around the wheel, so the corners are all different
+            // colours and therefore all different pitches.
+            const double hue = double(i) / m_shape.size();
+
+            auto v = std::make_shared<media::voice>(inst, pitch(hue), rate);
+
+            // Tables, not summing.  A 10-cube is 1024 voices, which is 19.5% of
+            // a core from tables and hopeless without them.  Built up front:
+            // building one allocates, and the feeder thread should not.
+            v->set_quality(media::voice::quality::fast, &m_tables);
+
+            m_hue.push_back(hue);
+            m_voices.push_back(v);
+            m_mix.add(v, 0.0);
+
+            m_at.push_back(m_shape[i]);
+            m_was.push_back(m_shape[i]);
+        }
+
+        // The shape's own scale, so the geometry reads the same at any D.
+        double radius = 0;
+        for(uint i = 0; i < m_shape.size(); i++) {
+            double sum = 0;
+            for(uint j = 0; j < m_shape.D; j++)
+                sum += double(m_shape[i][j]) * double(m_shape[i][j]);
+            radius = std::max(radius, std::sqrt(sum));
+        }
+
+        m_listen = radius * 1.6;
+
+        // How near a corner actually gets, which is what the level is referred
+        // to.  Taken from the starting pose; a corner that swings nearer later
+        // simply reaches full gain, which is what the clamp is for.
+        const math::vertex<double> here = ear();
+
+        m_near = distance(m_at[0], here);
+        for(std::size_t i = 1; i < m_at.size(); i++)
+            m_near = std::min(m_near, distance(m_at[i], here));
+
+        std::cout << "  " << m_shape.size() << " vertices in " << d
+                  << " dimensions, sounding at most " << voices << "\n"
+                  << "  radius " << std::fixed << std::setprecision(2) << radius
+                  << ", listener at " << m_listen
+                  << ", nearest corner " << m_near << "\n";
+
+        step();
+    }
+
+    /**
+     * How long to play for, in frames.
+     *
+     * Given a length so the stream ends, which is what lets the sink drive this
+     * the way it drives a note: play() configures itself from the stream and
+     * pulls until EOF.  Without one there is nothing to configure the device
+     * from and nothing to stop it.
+     */
+    void set_length(unsigned long frames)
+    {
+        m_total = frames;
+
+        // Let the voices go early enough that the release finishes inside the
+        // length, so the piece fades rather than being cut off.  The envelope
+        // has had a release segment since the first branch of this work and
+        // nothing has used it until now.
+        m_release_at = (m_total > m_fade) ? m_total - m_fade : 0;
+    }
+
+    virtual unsigned long render(media::Type::scaled* out, unsigned long frames,
+                                 unsigned int channels)
+    {
+        unsigned long made = 0;
+
+        if(m_total > 0 && m_made >= m_total)
+            return 0;
+
+        if(m_total > 0)
+            frames = std::min(frames, m_total - m_made);
+
+        while(made < frames) {
+            if(m_until == 0) {
+                step();
+                m_until = CONTROL;
+            }
+
+            const unsigned long want = std::min(frames - made, m_until);
+            const unsigned long got =
+                m_mix.render(out + made * channels, want, channels);
+
+            if(got == 0)
+                break;
+
+            made += got;
+            m_until -= got;
+        }
+
+        m_made += made;
+
+        return made;
+    }
+
+    virtual bool done() const { return m_total > 0 && m_made >= m_total; }
+
+    media::mixer& mix() { return m_mix; }
+
+protected:
+    /**
+     * Hue to pitch: red low, purple high, as the note asks.
+     *
+     * Snapped to a minor pentatonic across three octaves.  A continuous mapping
+     * is the obvious reading of "pitch is reflective of colour" and sounds like
+     * a swarm rather than a chord -- sixteen corners at arbitrary frequencies
+     * beat against each other at every interval at once.  On a scale the same
+     * sixteen are consonant however they land, which is the difference between
+     * this being music and being an effect.
+     */
+    double pitch(double hue) const
+    {
+        static const int scale[] = { 0, 3, 5, 7, 10 };
+        static const int steps = 5;
+
+        const int octaves = 3;
+        const int n = int(hue * steps * octaves);
+
+        const int semitone = scale[n % steps] + 12 * (n / steps);
+
+        return 55.0 * std::pow(2.0, semitone / 12.0);      // from A1
+    }
+
+    /**
+     * Where the listener stands, on the third axis if there is one.
+     *
+     * Set from the size of the shape rather than fixed.  A cuboid's corners are
+     * at +-1 on every axis, so its radius is sqrt(D) and grows without bound --
+     * at a fixed distance of 2.5 a 4-cube sits comfortably in front of the
+     * listener and a 10-cube, radius 3.16, has swallowed them.
+     */
+    math::vertex<double> ear() const
+    {
+        math::vertex<double> e(m_shape.D);
+
+        for(uint i = 0; i < m_shape.D; i++)
+            e[i] = 0;
+
+        e[(m_shape.D > 2) ? 2 : m_shape.D - 1] = m_listen;
+
+        return e;
+    }
+
+    static double distance(const math::vertex<double>& a,
+                           const math::vertex<double>& b)
+    {
+        double sum = 0;
+
+        for(uint i = 0; i < a.D && i < b.D; i++) {
+            const double d = double(a[i]) - double(b[i]);
+            sum += d * d;
+        }
+
+        return std::sqrt(sum);
+    }
+
+    /** Turn the shape, then retune and re-level every voice from where it is. */
+    void step()
+    {
+        if(m_release_at > 0 && m_made >= m_release_at && !m_letting_go) {
+            m_letting_go = true;
+
+            for(std::size_t i = 0; i < m_voices.size(); i++)
+                m_voices[i]->release();
+        }
+
+        const math::vertex<double> here = ear();
+        const double seconds = CONTROL / m_rate;
+
+        for(uint i = 0; i < m_shape.size(); i++) {
+            m_was[i] = m_at[i];
+            m_at[i] = turn(m_at[i]);
+
+            const double now = distance(m_at[i], here);
+            const double before = distance(m_was[i], here);
+
+            // Away from the listener is positive, so it flattens.
+            const double radial = (now - before) / seconds;
+
+            // Doppler.  SPEED is not the speed of sound in anything; it is
+            // whatever makes the shift audible at the rate these corners move.
+            const double shift = SPEED / (SPEED + radial);
+
+            m_voices[i]->set_freq(pitch(m_hue[i]) * shift);
+
+            // Nearer is louder, falling off with distance as sound does.  The
+            // mixer ramps this rather than stepping it, which is what keeps a
+            // corner swinging past from ticking once a control block.
+            // Inverse square, referred to how near the nearest corner gets
+            // rather than to an absolute distance.  1/(1+d*d) is the tidier
+            // formula and it made everything quiet: every corner of a 4-cube is
+            // between 2.3 and 3.9 away, so every gain came out near 0.1 and the
+            // mix peaked at 0.111 with the limiter idle and nothing to do.
+            // What matters here is the ratio between near and far, which is
+            // what carries the sense of something moving past.
+            const double g = (now > 0) ? (m_near / now) * (m_near / now) : 1.0;
+
+            m_mix.set_gain(i, (g > 1.0) ? 1.0 : g);
+        }
+    }
+
+    math::vertex<double> turn(const math::vertex<double>& v) const
+    {
+        const uint d = m_shape.D;
+
+        math::vertex<double> out(d);
+
+        // Homogeneous: the rotation is (d+1) square with the last row and
+        // column carrying the translation this has none of.
+        for(uint r = 0; r < d; r++) {
+            double sum = m_spin(r, d);
+
+            for(uint c = 0; c < d; c++)
+                sum += m_spin(r, c) * double(v[c]);
+
+            out[r] = sum;
+        }
+
+        return out;
+    }
+
+
+    /** Sets how much Doppler a given radial speed is worth. */
+    static constexpr double SPEED = 12.0;
+
+    math::cuboid<double> m_shape;
+    double m_rate;
+    math::matrix<double> m_spin;
+
+    std::vector<math::vertex<double> > m_at, m_was;
+    std::vector<double> m_hue;
+
+    media::wavetable_set m_tables;
+    media::mixer m_mix;
+    std::vector<std::shared_ptr<media::voice> > m_voices;
+
+    double m_listen = 0;
+    double m_near = 1;
+
+    unsigned long m_until = 0;
+    unsigned long m_total = 0;
+    unsigned long m_made = 0;
+    unsigned long m_release_at = 0;
+    unsigned long m_fade = 22050;      /**< half a second */
+    bool m_letting_go = false;
+};
+
+int main(int argc, char** argv) {
+    unsigned int d = 4;
+    double seconds = 20;
+    std::size_t voices = 64;
+    double spin = 0.6;
+
+    for(int i = 1; i < argc; i++) {
+        const std::string a = argv[i];
+
+        if((a == "-d" || a == "--dimension") && i + 1 < argc)
+            d = std::atoi(argv[++i]);
+        else if((a == "-t" || a == "--seconds") && i + 1 < argc)
+            seconds = std::atof(argv[++i]);
+        else if((a == "-v" || a == "--voices") && i + 1 < argc)
+            voices = std::atol(argv[++i]);
+        else if((a == "-s" || a == "--spin") && i + 1 < argc)
+            spin = std::atof(argv[++i]);
+        else {
+            std::cerr << "usage: " << argv[0]
+                      << " [-d DIMENSION] [-t SECONDS] [-v VOICES] [-s SPIN]\n"
+                      << "  an n-cube turning, with a voice at every corner:\n"
+                      << "  pitch from its colour, level from how near it is,\n"
+                      << "  and both shifted by how fast it is moving away.\n";
+            return (a == "-h" || a == "--help") ? 0 : 1;
+        }
+    }
+
+    if(d < 2 || d > 16) {
+        std::cerr << "dimension must be between 2 and 16\n";
+        return 1;
+    }
+
+    try {
+        const double rate = 44100;
+
+        std::cout << "jhypermusic\n";
+
+        hypermusic music(d, rate, voices, spin);
+
+        media::source_stream live(&music);
+        live.set_samples_per_sec(static_cast<unsigned int>(rate));
+        live.set_format(media::Type::PCM_FLOAT32);
+        live.set_channels(2);
+
+        media::PortAudioSink dsp;
+
+        music.set_length(static_cast<unsigned long>(rate * seconds));
+
+        std::cout << "  playing for " << seconds << "s\n";
+
+        // Exactly what jnote and jmelody do: the sink takes its format from the
+        // stream and pulls until the stream says it is finished.
+        dsp.play(live);
+
+        std::cout << "  peak " << std::fixed << std::setprecision(3)
+                  << music.mix().peak()
+                  << ", limiter " << 20 * std::log10(music.mix().reduction())
+                  << " dB\n";
+    }
+    catch(std::exception& e) {
+        std::cerr << argv[0] << ": " << e.what() << std::endl;
+        return 1;
+    }
+
+    return 0;
+}

--- a/jlib/media/mixer.hh
+++ b/jlib/media/mixer.hh
@@ -70,7 +70,7 @@ public:
 
     void add(const std::shared_ptr<source>& s, double gain = 1.0)
     {
-        m_children.push_back(child{s, gain});
+        m_children.push_back(child{s, gain, gain});
     }
 
     void remove(const std::shared_ptr<source>& s)
@@ -88,6 +88,25 @@ public:
     std::size_t size() const { return m_children.size(); }
 
     double get_gain(std::size_t i) const { return m_children.at(i).gain; }
+
+    /**
+     * Move a fader.
+     *
+     * Takes effect over the next render rather than at the start of it: a gain
+     * that steps between blocks is a discontinuity in the output, and a
+     * discontinuity is a click.  A live controller setting levels every frame
+     * would otherwise produce one per frame, which is the zipper noise that
+     * gets blamed on the synthesis.
+     *
+     * Nothing ramps unless a gain actually changed, so a mix whose faders are
+     * not being touched -- an offline render, every test here bar one --
+     * renders exactly as it did before this existed.  When one is being moved,
+     * the ramp spans whatever block it lands in, so the result depends on the
+     * block size.  That is inherent to live control rather than a lapse: there
+     * is no single stream to be independent of when something outside is
+     * changing the mix as it plays.  Offline work uses the timeline, where the
+     * gain is a property of the render and not of when someone moved it.
+     */
     void set_gain(std::size_t i, double g) { m_children.at(i).gain = g; }
 
     staging get_staging() const { return m_staging; }
@@ -226,9 +245,9 @@ public:
 
         // Loudest first when there is a cap, so what gets dropped is what would
         // have been least audible.
-        std::vector<const child*> play;
+        std::vector<child*> play;
         play.reserve(m_children.size());
-        for(const child& c : m_children) play.push_back(&c);
+        for(child& c : m_children) play.push_back(&c);
 
         if(m_max > 0 && play.size() > m_max) {
             std::partial_sort(play.begin(), play.begin() + m_max, play.end(),
@@ -240,14 +259,32 @@ public:
 
         unsigned long most = 0;
 
-        for(const child* c : play) {
+        for(child* c : play) {
             m_scratch.assign(frames * channels, 0);
 
             const unsigned long made = c->s->render(m_scratch.data(), frames, channels);
             if(made > most) most = made;
 
-            for(unsigned long i = 0; i < made * channels; i++)
-                m_mix[i] += static_cast<Type::scaled>(m_scratch[i] * c->gain);
+            if(c->applied == c->gain) {
+                for(unsigned long i = 0; i < made * channels; i++)
+                    m_mix[i] += static_cast<Type::scaled>(m_scratch[i] * c->gain);
+            }
+            else {
+                // Slide from where the fader was to where it now is, across
+                // this block, arriving exactly on the new value at its end.
+                const double from = c->applied, to = c->gain;
+
+                for(unsigned long f = 0; f < made; f++) {
+                    const double g = from + (to - from) * double(f + 1) / made;
+
+                    for(unsigned int ch = 0; ch < channels; ch++)
+                        m_mix[f * channels + ch] +=
+                            static_cast<Type::scaled>(m_scratch[f * channels + ch] * g);
+                }
+
+                if(made > 0)
+                    c->applied = to;
+            }
         }
 
         if(most == 0)
@@ -376,7 +413,8 @@ protected:
 
     struct child {
         std::shared_ptr<source> s;
-        double gain;
+        double gain;      /**< where the fader is */
+        double applied;   /**< where it was when this last rendered */
     };
 
     std::vector<child> m_children;

--- a/jlib/media/voice.hh
+++ b/jlib/media/voice.hh
@@ -92,13 +92,7 @@ public:
         // Harmonics up to Nyquist, and no further.  This is the whole of the
         // band limiting: an aliased partial is one that was generated in the
         // first place.
-        const double nyquist = m_rate / 2;
-
-        m_partials = (m_freq > 0) ? static_cast<unsigned int>(nyquist / m_freq) : 0;
-
-        const unsigned int asked = m_instrument.get_harmonics();
-        if(asked > 0 && asked < m_partials)
-            m_partials = asked;
+        partials_from_pitch();
 
         // The envelope segments, in samples, worked out once.  gain_at() ran
         // this arithmetic per sample, and it depends on nothing that changes.
@@ -107,7 +101,86 @@ public:
         m_release = ramp_samples(m_envelope.release);
     }
 
+    /**
+     * A voice with no end, which sounds until it is released.
+     *
+     * The other constructor makes a note of a known length, which is what a
+     * score is made of.  This one is what a keyboard is made of, and what
+     * jhypermusic wants: something held while a vertex exists, its pitch and
+     * level moving underneath it.
+     *
+     * The envelope runs attack, decay, then holds at sustain for as long as it
+     * takes.  release() starts the last segment, from wherever the level had
+     * got to.
+     */
+    voice(const instrument& i, double freq, double rate)
+        : m_instrument(i),
+          m_freq(freq),
+          m_samples(0),
+          m_rate(rate),
+          m_envelope(i.get_envelope()),
+          m_pos(0),
+          m_sustaining(true)
+    {
+        partials_from_pitch();
+
+        // Not ramp_samples: that clamps to half the note, and there is no note.
+        m_attack  = seconds_to_samples(m_envelope.attack);
+        m_decay   = seconds_to_samples(m_envelope.decay);
+        m_release = seconds_to_samples(m_envelope.release);
+
+        // The ramps still have to reach silence, or releasing clicks.
+        if(m_attack  == 0) m_attack  = seconds_to_samples(instrument::MIN_RAMP);
+        if(m_release == 0) m_release = seconds_to_samples(instrument::MIN_RAMP);
+    }
+
     unsigned long size() const { return m_samples; }
+
+    bool is_sustaining() const { return m_sustaining; }
+    bool is_released() const { return m_released; }
+
+    /**
+     * Let a held voice go, starting its release.
+     *
+     * From wherever the envelope had reached, rather than from the sustain
+     * level -- releasing during the attack would otherwise jump up to sustain
+     * first, which is a click.  Ignored if it is not held, or already let go.
+     */
+    void release()
+    {
+        if(!m_sustaining || m_released)
+            return;
+
+        m_release_from = gain_at(m_pos);
+        m_released_at = m_pos;
+        m_released = true;
+    }
+
+    double get_freq() const { return m_freq; }
+
+    /**
+     * Retune, while it is sounding.
+     *
+     * The phase carries across, so this does not click: what changes is how
+     * fast the phase advances from here, not where it is.  That is why the
+     * oscillator accumulates phase rather than deriving it from the sample
+     * index -- see next().
+     *
+     * The partial count and, in fast quality, the table both depend on the
+     * pitch, so both are worked out again here.  In fast quality that is a
+     * mutex and a map lookup, which is fine once a frame and would not be once
+     * a sample.
+     */
+    void set_freq(double freq)
+    {
+        if(freq == m_freq)
+            return;
+
+        m_freq = freq;
+
+        partials_from_pitch();
+        resolve_table();
+    }
 
     quality get_quality() const { return m_quality; }
 
@@ -120,10 +193,12 @@ public:
     void set_quality(quality q, wavetable_set* set = 0)
     {
         m_quality = q;
+        m_set = set;
         m_table = 0;
 
         if(q != quality::fast || set == 0) {
             m_quality = quality::exact;
+            m_set = 0;
             return;
         }
 
@@ -136,11 +211,25 @@ public:
         //
         // Building it may allocate, so this is also the point a realtime caller
         // must reach before its deadline starts.
-        m_table = &set->get(m_instrument.get_wave(), m_freq, m_rate);
+        resolve_table();
     }
 
-    virtual bool done() const { return m_pos >= m_samples; }
-    virtual void reset() { m_pos = 0; }
+    virtual bool done() const
+    {
+        if(m_sustaining)
+            return m_released && m_pos >= m_released_at + m_release;
+
+        return m_pos >= m_samples;
+    }
+
+    virtual void reset()
+    {
+        m_pos = 0;
+        m_phase = 0;
+        m_released = false;
+        m_released_at = 0;
+        m_release_from = 0;
+    }
 
     /**
      * Add this voice to a buffer.
@@ -176,9 +265,21 @@ public:
 
         const unsigned long i = m_pos++;
 
-        // Phase from the sample index rather than accumulated, so it cannot
-        // drift and so a voice can be restarted exactly.
-        const double phase = (m_rate > 0) ? std::fmod(m_freq * i / m_rate, 1.0) : 0.0;
+        // Accumulated rather than derived from the sample index.  The index
+        // form could not drift, which is why it was written that way, but it
+        // also pins the phase to one frequency for the life of the voice --
+        // retuning would restart fmod(f*i/rate) somewhere unrelated to where
+        // the waveform had got to, and jump.  Accumulating is what makes
+        // set_freq() continuous, and the drift it admits is a rounding error
+        // per frame: about 1e-13 of a cycle after a minute, in a double.
+        const double phase = m_phase;
+
+        if(m_rate > 0) {
+            m_phase += m_freq / m_rate;
+
+            if(m_phase >= 1.0)
+                m_phase -= std::floor(m_phase);
+        }
 
         return static_cast<Type::scaled>(
             gain_at(i) * m_instrument.get_gain() * oscillator(phase));
@@ -224,6 +325,30 @@ protected:
      */
     double gain_at(unsigned long i) const
     {
+        static const double pi = 3.14159265358979323846;
+
+        if(m_sustaining) {
+            if(m_released) {
+                const unsigned long since = i - m_released_at;
+
+                if(m_release == 0 || since >= m_release)
+                    return 0;
+
+                return m_release_from * 0.5 * (1.0 + std::cos(pi * since / m_release));
+            }
+
+            if(m_attack > 0 && i < m_attack)
+                return 0.5 * (1.0 - std::cos(pi * i / m_attack));
+
+            if(m_decay > 0 && i < m_attack + m_decay) {
+                const double through = double(i - m_attack) / m_decay;
+
+                return 1.0 + through * (m_envelope.sustain - 1.0);
+            }
+
+            return m_envelope.sustain;
+        }
+
         if(m_samples == 0)
             return 0;
 
@@ -232,8 +357,6 @@ protected:
         const unsigned long attack  = m_attack;
         const unsigned long decay   = m_decay;
         const unsigned long release = m_release;
-
-        static const double pi = 3.14159265358979323846;
 
         if(attack > 0 && i < attack)
             return 0.5 * (1.0 - std::cos(pi * i / attack));
@@ -251,6 +374,32 @@ protected:
         }
 
         return m_envelope.sustain;
+    }
+
+    /** Harmonics up to Nyquist for the current pitch, and no further. */
+    void partials_from_pitch()
+    {
+        const double nyquist = m_rate / 2;
+
+        m_partials = (m_freq > 0) ? static_cast<unsigned int>(nyquist / m_freq) : 0;
+
+        const unsigned int asked = m_instrument.get_harmonics();
+        if(asked > 0 && asked < m_partials)
+            m_partials = asked;
+    }
+
+    /** Which band-limited table serves the current pitch, if any does. */
+    void resolve_table()
+    {
+        m_table = (m_quality == quality::fast && m_set)
+            ? &m_set->get(m_instrument.get_wave(), m_freq, m_rate)
+            : 0;
+    }
+
+    unsigned long seconds_to_samples(double seconds) const
+    {
+        return (seconds > 0 && m_rate > 0)
+            ? static_cast<unsigned long>(seconds * m_rate) : 0;
     }
 
     unsigned long ramp_samples(double seconds) const
@@ -274,7 +423,15 @@ protected:
     unsigned long m_attack = 0, m_decay = 0, m_release = 0;
     unsigned long m_pos;
 
+    double m_phase = 0;
+
+    bool m_sustaining = false;
+    bool m_released = false;
+    unsigned long m_released_at = 0;
+    double m_release_from = 0;
+
     quality m_quality = quality::exact;
+    wavetable_set* m_set = 0;
 
     /** Resolved by set_quality; not owned, and null when summing directly. */
     const wavetable* m_table = 0;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -29,7 +29,8 @@ MEDIA_TESTS = media_datastream_test \
               media_wavetable_test \
               media_mixer_test \
               media_sampler_test \
-              media_playlist_test
+              media_playlist_test \
+              media_live_test
 endif
 
 if HAVE_SODIUM
@@ -111,6 +112,9 @@ media_sampler_test_LDADD      = $(JMEDIA_LA) $(JUTIL_LA) $(JSYS_LA)
 
 media_playlist_test_SOURCES   = media_playlist_test.cc
 media_playlist_test_LDADD     = $(JMEDIA_LA) $(JUTIL_LA) $(JSYS_LA)
+
+media_live_test_SOURCES       = media_live_test.cc
+media_live_test_LDADD         = $(JMEDIA_LA) $(JUTIL_LA) $(JSYS_LA)
 
 net_extract_address_test_SOURCES        = net_extract_address_test.cc
 net_extract_address_test_LDADD          = $(JNET_LA)

--- a/tests/media_live_test.cc
+++ b/tests/media_live_test.cc
@@ -1,0 +1,269 @@
+// Changing things while they sound.
+//
+// Everything before this branch fixed a voice's pitch and a mixer's faders
+// before rendering started.  A live controller does neither, and the two ways
+// that goes wrong are both discontinuities: a retune that restarts the waveform
+// somewhere else, and a fader that steps between blocks.  Both are clicks.
+#include <jlib/media/instrument.hh>
+#include <jlib/media/mixer.hh>
+#include <jlib/media/voice.hh>
+
+#include <cmath>
+#include <iomanip>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
+
+using namespace jlib::media;
+
+static int failures = 0;
+
+static void ok(const std::string& what, bool good, const std::string& detail = "") {
+    if(!good) ++failures;
+    std::cout << (good ? "  ok   " : "  FAIL ") << what;
+    if(!detail.empty()) std::cout << ": " << detail;
+    std::cout << "\n";
+}
+
+static double biggest_step(const std::vector<Type::scaled>& v,
+                           unsigned long from, unsigned long to) {
+    double worst = 0;
+    for(unsigned long i = from; i + 1 < to && i + 1 < v.size(); i++)
+        worst = std::max(worst, (double)std::fabs(v[i+1] - v[i]));
+    return worst;
+}
+
+static void retuning_does_not_click() {
+    std::cout << "retuning a sounding voice:\n";
+
+    const double rate = 44100;
+    const unsigned long half = 4410;
+
+    instrument inst;
+    voice v(inst, 220, rate);          // held, so the envelope is flat by then
+
+    std::vector<Type::scaled> out(half * 2, 0);
+    v.render(out.data(), half, 1);
+
+    v.set_freq(330);
+    v.render(out.data() + half, half, 1);
+
+    // Away from the seam a sine moves by at most 2*pi*f/rate per sample: 0.031
+    // at 220Hz and 0.047 at 330Hz, times the amplitude.  A phase jump would put
+    // a step of order the amplitude itself right at the seam.
+    const double before = biggest_step(out, 100, half - 1);
+    const double after  = biggest_step(out, half + 1, half * 2 - 100);
+    const double seam   = std::fabs(out[half] - out[half - 1]);
+
+    std::cout << "     step before " << std::fixed << std::setprecision(5) << before
+              << "   after " << after << "   at the seam " << seam << "\n";
+
+    ok("the seam is no worse than the waveform itself", seam <= after * 1.5,
+       std::to_string(seam) + " against " + std::to_string(after));
+
+    // and it really did retune
+    ok("and the new pitch is faster", after > before * 1.3,
+       std::to_string(after) + " against " + std::to_string(before));
+
+    // Setting the same frequency is not a change and must do nothing at all.
+    {
+        voice a(inst, 220, rate), b(inst, 220, rate);
+        std::vector<Type::scaled> x(half, 0), y(half, 0);
+
+        a.render(x.data(), half, 1);
+
+        b.render(y.data(), half/2, 1);
+        b.set_freq(220);
+        b.render(y.data() + half/2, half - half/2, 1);
+
+        ok("retuning to the same pitch changes nothing", x == y);
+    }
+}
+
+static void holding_and_letting_go() {
+    std::cout << "\nholding a voice and letting it go:\n";
+
+    const double rate = 44100;
+
+    instrument inst;
+    instrument::envelope e;
+    e.attack = 0.01;
+    e.decay = 0;
+    e.sustain = 1.0;
+    e.release = 0.05;
+    inst.set_envelope(e);
+
+    voice v(inst, 220, rate);
+
+    ok("a held voice is not done before it starts", !v.done());
+
+    std::vector<Type::scaled> out(static_cast<unsigned long>(rate), 0);
+    const unsigned long made = v.render(out.data(), out.size(), 1);
+
+    ok("it fills whatever it is given", made == out.size(),
+       std::to_string(made));
+    ok("and is still not done after a second", !v.done());
+
+    auto peak = [&](unsigned long from, unsigned long n) {
+        double p = 0;
+        for(unsigned long i = from; i < from + n && i < out.size(); i++)
+            p = std::max(p, (double)std::fabs(out[i]));
+        return p;
+    };
+
+    ok("it starts from silence", std::fabs(out[0]) < 1e-6, std::to_string(out[0]));
+    ok("and holds at its sustain level",
+       std::fabs(peak(rate/2, 2000) - peak(rate/4, 2000)) < 0.01,
+       std::to_string(peak(rate/4, 2000)) + " then " + std::to_string(peak(rate/2, 2000)));
+
+    // now let it go
+    v.release();
+    ok("released, it is not done yet", !v.done());
+
+    const unsigned long tail = static_cast<unsigned long>(e.release * rate) + 10;
+    std::vector<Type::scaled> fade(tail, 0);
+    v.render(fade.data(), tail, 1);
+
+    ok("it fades to silence", std::fabs(fade[tail-1]) < 1e-6,
+       std::to_string(fade[tail-1]));
+    ok("and then it is done", v.done());
+
+    // Releasing during the attack must fade from where the envelope had got
+    // to, not jump up to the sustain level first.
+    //
+    // Compared against a voice released once it has reached sustain, rather
+    // than against a number: the first version of this compared the peak of the
+    // release tail against the last *sample* before it, which at 220Hz happened
+    // to be near a zero crossing, and so demanded that a fade from 0.081 stay
+    // under 0.003.  The envelope level and a sample of the waveform are not the
+    // same quantity.
+    {
+        voice early(inst, 220, rate);
+        std::vector<Type::scaled> a(100, 0);
+        early.render(a.data(), 100, 1);      // 100 frames into a 441 frame attack
+        early.release();
+
+        std::vector<Type::scaled> b(tail, 0);
+        early.render(b.data(), tail, 1);
+
+        voice late(inst, 220, rate);
+        std::vector<Type::scaled> c(static_cast<unsigned long>(rate/2), 0);
+        late.render(c.data(), c.size(), 1);  // well past the attack
+        late.release();
+
+        std::vector<Type::scaled> d(tail, 0);
+        late.render(d.data(), tail, 1);
+
+        auto loudest = [](const std::vector<Type::scaled>& v) {
+            double p = 0;
+            for(Type::scaled s : v) p = std::max(p, (double)std::fabs(s));
+            return p;
+        };
+
+        const double from_attack  = loudest(b);
+        const double from_sustain = loudest(d);
+
+        std::cout << "     released mid-attack, fades from " << std::fixed
+                  << std::setprecision(4) << from_attack
+                  << ";  released at sustain, from " << from_sustain << "\n";
+
+        ok("released at sustain it fades from the sustain level",
+           std::fabs(from_sustain - inst.get_gain()) < 0.02,
+           std::to_string(from_sustain));
+
+        ok("released mid-attack it fades from where it had got to",
+           from_attack < from_sustain * 0.3,
+           std::to_string(from_attack / from_sustain) + " of it");
+    }
+}
+
+static void moving_a_fader_does_not_click() {
+    std::cout << "\nmoving a fader while it plays:\n";
+
+    const double rate = 44100;
+    const unsigned long block = 1024;
+
+    instrument inst;
+
+    // the same voice twice: one through the mixer, one bare for reference
+    auto through = std::make_shared<voice>(inst, 220, rate);
+    voice bare(inst, 220, rate);
+
+    mixer m;
+    m.set_staging(mixer::staging::none);
+    m.set_limiting(false);
+    m.add(through, 1.0);
+
+    std::vector<Type::scaled> mixed(block * 2, 0), ref(block * 2, 0);
+
+    m.render(mixed.data(), block, 1);
+    bare.render(ref.data(), block * 2, 1);
+
+    m.set_gain(0, 0.5);
+    m.render(mixed.data() + block, block, 1);
+
+    // Across the second block the applied gain should walk from 1 to 0.5.
+    double first = 0, last = 0;
+    bool monotone = true, previous_set = false;
+    double previous = 0;
+
+    for(unsigned long i = 0; i < block; i++) {
+        if(std::fabs(ref[block + i]) < 0.2)
+            continue;
+
+        const double g = mixed[block + i] / ref[block + i];
+
+        if(!previous_set) { first = g; previous_set = true; }
+        else if(g > previous + 1e-6) monotone = false;
+
+        previous = g;
+        last = g;
+    }
+
+    std::cout << "     gain across the block: " << std::fixed << std::setprecision(4)
+              << first << " to " << last << "\n";
+
+    ok("it starts near where the fader was", first > 0.95, std::to_string(first));
+    ok("and arrives at where it now is", std::fabs(last - 0.5) < 0.01,
+       std::to_string(last));
+    ok("without going back up on the way", monotone);
+
+    const double seam = std::fabs(mixed[block] - mixed[block - 1]);
+    const double typical = biggest_step(mixed, 100, block - 1);
+
+    ok("so the block boundary is not a step", seam <= typical * 1.5,
+       std::to_string(seam) + " against " + std::to_string(typical));
+
+    // And a fader nobody touches must cost nothing: an offline render has to
+    // come out exactly as it did before ramping existed.
+    {
+        auto still = std::make_shared<voice>(inst, 220, rate);
+        voice plain(inst, 220, rate);
+
+        mixer q;
+        q.set_staging(mixer::staging::none);
+        q.set_limiting(false);
+        q.add(still, 0.75);
+
+        std::vector<Type::scaled> a(block * 2, 0), b(block * 2, 0);
+
+        q.render(a.data(), block, 1);
+        q.render(a.data() + block, block, 1);
+
+        plain.render(b.data(), block * 2, 1);
+        for(Type::scaled& s : b) s = static_cast<Type::scaled>(s * 0.75);
+
+        ok("an untouched fader is exact", a == b);
+    }
+}
+
+int main() {
+    std::cout << std::unitbuf;
+
+    retuning_does_not_click();
+    holding_and_letting_go();
+    moving_a_fader_does_not_click();
+
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
Last slice of the synthesis plan.  jhypermusic.cc has been a paragraph of intent
since the beginning of this library; it is now a program, and the paragraph is
kept at the top of it because it is the specification.

    macOS  36 tests, 36 pass, 0 skip
    Linux  37 tests, 36 pass, 1 skip

two things had to be able to move while sounding

    Retuning.  voice derived its phase from the sample index, fmod(f*i/rate),
    which could not drift and could not be retuned either -- changing f restarts
    the waveform wherever the new frequency happens to put that index, which is
    a step, which is a click.  Phase is accumulated now.  The drift that admits
    is a rounding error per frame, about 1e-13 of a cycle after a minute in a
    double; the comment claiming index-based phase was the safer choice has been
    replaced with why it is not.

    Faders.  A controller setting levels every frame stepped the gain between
    blocks, once per frame, which is the zipper noise usually blamed on the
    synthesis.  mixer ramps a changed gain across the block instead, arriving
    exactly on the new value.  Nothing ramps unless a gain actually changed, so
    an offline render is bit-identical to before -- asserted, because that is
    the property worth keeping:

        ok   an untouched fader is exact

    Both are measured rather than described.  The retune seam is 0.0209 against
    a within-waveform step of 0.0313, so the join is quieter than the wave; a
    phase jump would have been of order the amplitude.

and a voice had to be able to be held

    voice gained a constructor with no length and a release().  The score case
    -- a note of known length -- was all there was, and a keyboard is not that:
    something is held while a key is down, or while a vertex exists, and let go
    later.

    release() fades from wherever the envelope had reached rather than from the
    sustain level, so letting go during the attack does not jump up first.
    Measured at 0.1216 of the sustain level after 100 frames of a 441 frame
    attack, against a theoretical 0.1215.

    That first test was wrong and passed for the wrong reason once: it compared
    the peak of the release tail against the last *sample* before it, which at
    220Hz sat near a zero crossing, and so demanded a fade from 0.081 stay under
    0.003.  An envelope level and a sample of a waveform are not the same
    quantity.  It is compared against a voice released at sustain now, which
    makes it a ratio and gives it something to be wrong about.

jhypermusic

    An n-cube turns; every corner holds a sustaining voice; pitch comes from its
    hue and level from how near it is, both moved every 512 frames, both shifted
    by how fast the corner is receding.  It is a source, so it reaches the
    device through source_stream and the sink exactly as a note does -- the
    animation runs from the audio pipeline, which is what the note meant.

        jhypermusic -d 10 -t 20

        1024 vertices in 10 dimensions, sounding at most 64
        radius 3.16, listener at 5.06, nearest corner 4.42
        peak 0.990, limiter -0.228 dB

    D=10 renders 3 seconds of audio in 0.38 of a second, about an eighth of a
    core, which is the wavetable branch's 19.5% figure paying for itself.

    Two things the geometry taught, both by sounding wrong first:

    Pitch is snapped to a minor pentatonic over three octaves.  Mapping hue
    straight to frequency is the obvious reading of "pitch is reflective of
    colour" and it sounds like a swarm -- sixteen corners at arbitrary
    frequencies beat against each other at every interval at once.  On a scale
    the same sixteen are consonant however they land.

    Level is inverse square referred to how near the nearest corner gets, not
    1/(1+d*d).  The tidier formula made everything quiet: every corner of a
    4-cube is between 2.3 and 3.9 from the listener, so every gain came out near
    0.1 and the mix peaked at 0.111 with the limiter idle and nothing to do.
    The listener's distance is set from the shape's radius too, since a cuboid's
    radius is sqrt(D) and at a fixed 2.5 a 10-cube has swallowed them.

    Peak is 0.656 at D=4 and 0.990 at D=10, so the limiter does a fifth of a dB
    of work at the top end and nothing below it.

what is not here

    The video half.  No frame grabbing and no muxing; jhardhyper already draws
    this geometry, and joining them is a larger piece of work than this branch.

    Nothing about jhypermusic is under test -- it is an app, and the suite has
    never covered apps.  What the tests cover is the machinery beneath it:
    retuning, holding, releasing and fader ramps, in media_live_test.

    One question left open rather than answered.  Automatic staging divides by
    the number of children, and set_max_voices caps how many of them sound, so a
    10-cube divides by sqrt(1024) while 64 voices play.  That is not obviously
    right -- the level would arguably follow what is sounding -- but the two
    happen to offset here, and the pentatonic pitches are harmonically related
    enough to sum linearly rather than in power, which is the case the divisor
    does not model anyway.  Changing it late in a branch, on a mix that sounds
    correct, was the worse option.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
