### PR TITLE
Draw what jhypermusic plays

### DIFF
--- a/jlib/apps/Makefile.am
+++ b/jlib/apps/Makefile.am
@@ -20,7 +20,11 @@ cuda_programs = jcublas
 endif
 
 if HAVE_PORTAUDIO
-media_programs = jnote jmelody jhypermusic
+media_programs = jnote jmelody
+# jhypermusic draws what it plays, so it wants a window as well as a device.
+if HAVE_GLFW
+media_programs += jhypermusic
+endif
 endif
 
 if HAVE_X
@@ -105,8 +109,10 @@ jnote_LDADD   = $(JMEDIA_LA) $(JSYS_LA)
 jmelody_SOURCES = jmelody.cc
 jmelody_LDADD   = $(JMEDIA_LA) $(JUTIL_LA) $(JSYS_LA)
 
-jhypermusic_SOURCES = jhypermusic.cc
-jhypermusic_LDADD   = $(JMEDIA_LA) $(JUTIL_LA) $(JSYS_LA)
+jhypermusic_SOURCES  = jhypermusic.cc
+jhypermusic_CPPFLAGS = $(AM_CPPFLAGS) $(GLFW_CFLAGS)
+jhypermusic_LDADD    = $(JGLFW_LA) $(JGLU_LA) $(JGL_LA) $(JMEDIA_LA) \
+                       $(JUTIL_LA) $(JSYS_LA) $(GLFW_LIBS) $(GLU_LIBS) $(GL_LIBS)
 
 jpoisoned_SOURCES = jpoisoned.cc
 jpoisoned_LDADD   = $(JX_LA) $(JSYS_LA) $(JUTIL_LA)

--- a/jlib/apps/jhypermusic.cc
+++ b/jlib/apps/jhypermusic.cc
@@ -38,11 +38,16 @@
     low pitch.  Volume and pitch will be determined positionally with Doppler
     corrections.
 
-  What is here now is the audio half of that.  Each vertex of an n-cube holds a
-  sustaining voice; its pitch comes from its hue and its level from how near it
-  is, and both are moved every control block as the shape turns.  The video half
-  -- grabbing frames and muxing a stream -- is not here, and jhardhyper already
-  draws the same geometry.
+  What is here now is both halves, live rather than muxed to a file.  Each vertex
+  of an n-cube holds a sustaining voice; its pitch comes from its hue and its
+  level from how near it is, and both move every control block as the shape
+  turns.  The same corners are drawn in the same hues, sized by the same levels,
+  so what is heard is what is seen -- a bright fat corner is a loud near one.
+
+  The audio owns the clock, because it is the one that cannot be late: geometry
+  advances inside render(), on the thread feeding the device, and the window
+  draws whatever pose it finds.  A dropped video frame is invisible; a dropped
+  audio block is a hole.
 
   The pieces it needs are the ones the last few branches added: voices that can
   be retuned while sounding without clicking, a mixer whose faders can move
@@ -51,6 +56,10 @@
  */
 
 #include <jlib/apps/color.hh>
+
+#include <jlib/glfw/Plot.hh>
+
+#include "Hyper.hh"
 
 #include <jlib/math/matrix.hh>
 
@@ -61,8 +70,11 @@
 #include <jlib/media/voice.hh>
 #include <jlib/media/wavetable.hh>
 
+#include <atomic>
 #include <cmath>
 #include <cstdlib>
+#include <mutex>
+#include <thread>
 #include <iomanip>
 #include <iostream>
 #include <memory>
@@ -86,20 +98,15 @@ public:
      *  enough that the trigonometry is nothing next to the synthesis. */
     static const unsigned long CONTROL = 512;
 
-    hypermusic(unsigned int d, double rate, std::size_t voices, double spin)
+    hypermusic(unsigned int d, double rate, std::size_t voices, double spin,
+               double doppler)
         : m_shape(d),
           m_rate(rate),
           m_spin(math::matrix<double>::identity(d + 1))
     {
-        // Turn in two planes at once, at rates that do not divide each other,
-        // so the figure never repeats exactly.
-        math::plane a; a.i = 0; a.j = 1;
-        math::plane b; b.i = (d > 3) ? 2 : 0; b.j = (d > 3) ? 3 : 1;
-
-        const double per_block = spin * CONTROL / m_rate;
-
-        m_spin = math::matrix<double>::rotate(d, a, per_block) *
-                 math::matrix<double>::rotate(d, b, per_block * 0.61803398875);
+        // Rate first; the planes are built from it below.
+        m_step = spin * CONTROL / m_rate;
+        m_doppler = doppler;
 
         media::instrument inst;
         inst.set_wave(media::instrument::wave::saw);
@@ -113,15 +120,27 @@ public:
 
         m_mix.set_staging(media::mixer::staging::automatic);
         m_mix.set_rate(rate);
+
+        // Less headroom than the mixer's default, which is unusual and is
+        // because these levels are already attenuated: distance puts the
+        // typical corner near 0.4 rather than near 1, so the sum arrives some
+        // 8dB below what the default is holding room for.  Not none, though --
+        // every pitch here comes from one pentatonic scale, so the voices are
+        // harmonically related and sum closer to linearly than 1/sqrt(N)
+        // assumes.  Measured idle at every dimension from four to twelve.
+        m_mix.set_headroom(1);
         m_mix.set_max_voices(voices);
 
         m_at.reserve(m_shape.size());
         m_was.reserve(m_shape.size());
 
         for(uint i = 0; i < m_shape.size(); i++) {
-            // Hue spread around the wheel, so the corners are all different
-            // colours and therefore all different pitches.
-            const double hue = double(i) / m_shape.size();
+            // The same hue the wireframe is drawn in.  HyperPlot colours
+            // vertex i with golden_hue(i), so taking the pitch from the same
+            // function is what makes "pitch is reflective of colour" true of
+            // this program rather than merely intended: the corner you hear
+            // high is the corner you see violet, because it is one number.
+            const double hue = jlib::apps::golden_hue<double>(i);
 
             auto v = std::make_shared<media::voice>(inst, pitch(hue), rate);
 
@@ -134,8 +153,20 @@ public:
             m_voices.push_back(v);
             m_mix.add(v, 0.0);
 
-            m_at.push_back(m_shape[i]);
-            m_was.push_back(m_shape[i]);
+            // Constructed fresh, then assigned -- never copy-constructed from
+            // the shape.  See own() below: a copied vertex shares its storage,
+            // and two corners sharing one buffer is how the Doppler came out as
+            // exactly zero.
+            m_at.push_back(math::vertex<double>(d));
+            m_was.push_back(math::vertex<double>(d));
+            m_shown.push_back(math::vertex<double>(d));
+
+            m_at.back() = m_shape[i];
+            m_was.back() = m_shape[i];
+            m_shown.back() = m_shape[i];
+
+            m_level.push_back(0);
+            m_level_shown.push_back(0);
         }
 
         // The shape's own scale, so the geometry reads the same at any D.
@@ -149,17 +180,25 @@ public:
 
         m_listen = radius * 1.6;
 
-        // How near a corner actually gets, which is what the level is referred
-        // to.  Taken from the starting pose; a corner that swings nearer later
-        // simply reaches full gain, which is what the clamp is for.
-        const math::vertex<double> here = ear();
+        // How near a corner can ever get, which is what the level is referred
+        // to.  A rotation preserves length, so every corner stays on a sphere
+        // of the shape's radius, and the closest approach is the listener's
+        // distance less that radius -- reached when a corner swings onto the
+        // axis they stand on.
+        //
+        // This was the nearest corner in the *starting* pose, which is a good
+        // deal further out, so anything that came closer later had its gain
+        // clamped at full: a fifth of every level was pinned to 1.0, and the
+        // corners that should have been the most dramatic were the flattest.
+        m_near = std::max(0.1, m_listen - radius);
 
-        m_near = distance(m_at[0], here);
-        for(std::size_t i = 1; i < m_at.size(); i++)
-            m_near = std::min(m_near, distance(m_at[i], here));
+        // Every plane, as the other hyper apps do.  r and f change it.
+        set_planes(d);
 
         std::cout << "  " << m_shape.size() << " vertices in " << d
-                  << " dimensions, sounding at most " << voices << "\n"
+                  << " dimensions, sounding at most " << voices
+                  << ", turning in " << (m_planes * (m_planes - 1)) / 2
+                  << " planes\n"
                   << "  radius " << std::fixed << std::setprecision(2) << radius
                   << ", listener at " << m_listen
                   << ", nearest corner " << m_near << "\n";
@@ -219,7 +258,80 @@ public:
         return made;
     }
 
-    virtual bool done() const { return m_total > 0 && m_made >= m_total; }
+    virtual bool done() const
+    {
+        return m_stop.load(std::memory_order_acquire) ||
+               (m_total > 0 && m_made >= m_total);
+    }
+
+    /** Finish early, so closing the window ends the piece. */
+    void stop() { m_stop.store(true, std::memory_order_release); }
+
+    uint get_planes() const { return m_planes; }
+
+    /**
+     * Turn in every plane spanned by the first r axes.
+     *
+     * Two planes was not enough and was the reason a high-dimensional figure
+     * looked flat: rotating only (0,1) and (2,3) leaves every axis from the
+     * fifth up fixed, so an 8-cube tumbled as though it were a 4-cube with
+     * sixteen extra corners painted on.  Every plane below r turns instead,
+     * each at its own rate, which is how HyperPlot::initialize_rotation has
+     * always done it -- sin(d++) gives each plane a different angle, so nothing
+     * moves in step with anything else and the figure everts.
+     *
+     * The audio holds the geometry, so this is where r and f have to land.  The
+     * matrix is rebuilt here rather than per block: it is C(r,2) multiplies,
+     * which is 45 of them at ten dimensions and none of them per frame.
+     */
+    void set_planes(uint r)
+    {
+        m_planes = (r > m_shape.D) ? m_shape.D : r;
+
+        m_spin = math::matrix<double>::identity(m_shape.D + 1);
+
+        int d = 1;
+
+        for(uint i = 0; i < m_planes; i++) {
+            for(uint j = i + 1; j < m_planes; j++) {
+                math::plane p;
+                p.i = i;
+                p.j = j;
+
+                m_spin *= math::matrix<double>::rotate(m_shape.D, p,
+                                                       std::sin(d++) * m_step);
+            }
+        }
+    }
+
+    /**
+     * The current pose, for whoever is drawing it.
+     *
+     * Copied under a lock rather than read in place.  The geometry is written
+     * on the thread feeding the device and read on the one drawing, at
+     * different rates -- 86 poses a second against 60 frames -- so without this
+     * a frame could be drawn from half of one pose and half of the next.  The
+     * lock is held for a copy of a few thousand doubles, by a feeder thread
+     * that may block; the device callback is nowhere near it.
+     */
+    void pose(std::vector<math::vertex<double> >& at,
+              std::vector<double>& level) const
+    {
+        std::lock_guard<std::mutex> lock(m_pose);
+
+        // Sized with vertices of their own before anything is assigned, for
+        // the same reason: at = m_shown would share, and the drawing thread
+        // would be reading the buffers the audio thread is writing.
+        while(at.size() < m_shown.size())
+            at.push_back(math::vertex<double>(m_shape.D));
+
+        for(std::size_t k = 0; k < m_shown.size(); k++)
+            at[k] = m_shown[k];
+
+        level = m_level_shown;
+    }
+
+    double hue(std::size_t i) const { return m_hue[i]; }
 
     media::mixer& mix() { return m_mix; }
 
@@ -305,23 +417,53 @@ protected:
 
             // Doppler.  SPEED is not the speed of sound in anything; it is
             // whatever makes the shift audible at the rate these corners move.
-            const double shift = SPEED / (SPEED + radial);
+            const double shift = (m_doppler > 0)
+                ? m_doppler / (m_doppler + radial) : 1.0;
 
             m_voices[i]->set_freq(pitch(m_hue[i]) * shift);
 
             // Nearer is louder, falling off with distance as sound does.  The
             // mixer ramps this rather than stepping it, which is what keeps a
             // corner swinging past from ticking once a control block.
-            // Inverse square, referred to how near the nearest corner gets
-            // rather than to an absolute distance.  1/(1+d*d) is the tidier
-            // formula and it made everything quiet: every corner of a 4-cube is
-            // between 2.3 and 3.9 away, so every gain came out near 0.1 and the
-            // mix peaked at 0.111 with the limiter idle and nothing to do.
-            // What matters here is the ratio between near and far, which is
-            // what carries the sense of something moving past.
-            const double g = (now > 0) ? (m_near / now) * (m_near / now) : 1.0;
+            // Inverse distance, not inverse square.  Intensity falls as
+            // 1/d*d; amplitude, which is what a gain multiplies, falls as 1/d,
+            // and squaring it here was applying the law to the wrong quantity.
+            // It showed up as everything being too quiet -- gains ran 0.05 to
+            // 0.9 and the mix peaked at 0.084 -- because the far corners, which
+            // are most of them, were attenuated twice over.
+            //
+            // Referred to how near a corner can ever come rather than to an
+            // absolute distance: what carries the sense of something moving
+            // past is the ratio between near and far, and the ratio is what
+            // stays the same as the figure grows with D.
+            const double g = (now > 0) ? (m_near / now) : 1.0;
 
             m_mix.set_gain(i, (g > 1.0) ? 1.0 : g);
+            m_level[i] = (g > 1.0) ? 1.0 : g;
+
+            // What the geometry is actually worth, reported at the end.  The
+            // question "is the Doppler doing anything" has a number.
+            m_dmin = std::min(m_dmin, now);
+            m_dmax = std::max(m_dmax, now);
+            m_gmin = std::min(m_gmin, m_level[i]);
+            m_gmax = std::max(m_gmax, m_level[i]);
+            m_smin = std::min(m_smin, shift);
+            m_smax = std::max(m_smax, shift);
+            if(g > 1.0) m_clamped++;
+            m_counted++;
+        }
+
+        {
+            std::lock_guard<std::mutex> lock(m_pose);
+
+            // Element by element.  m_shown = m_at assigns the vector, which
+            // copy-constructs its elements, which shares their storage -- so
+            // the drawn pose would have been the live one under another name
+            // and this lock would have been guarding nothing.
+            for(std::size_t k = 0; k < m_shown.size() && k < m_at.size(); k++)
+                m_shown[k] = m_at[k];
+
+            m_level_shown = m_level;
         }
     }
 
@@ -346,8 +488,6 @@ protected:
     }
 
 
-    /** Sets how much Doppler a given radial speed is worth. */
-    static constexpr double SPEED = 12.0;
 
     math::cuboid<double> m_shape;
     double m_rate;
@@ -362,6 +502,34 @@ protected:
 
     double m_listen = 0;
     double m_near = 1;
+    double m_step = 0;
+    uint m_planes = 0;
+
+    /**
+     * Sets how much Doppler a given radial speed is worth.
+     *
+     * Not the speed of sound in anything: the corners move at whatever the spin
+     * makes them, so this is the number that decides whether the shift is a
+     * shimmer or a siren.  Taste, so it is on the command line -- the default
+     * gives about four semitones at four dimensions and ten at eight, where
+     * more planes turn and the corners move faster.
+     */
+    double m_doppler = 12.0;
+
+public:
+    double m_dmin = 1e9, m_dmax = 0;
+    double m_gmin = 1e9, m_gmax = 0;
+    double m_smin = 1e9, m_smax = 0;
+    unsigned long m_clamped = 0, m_counted = 0;
+protected:
+
+    std::vector<double> m_level;
+
+    mutable std::mutex m_pose;
+    std::vector<math::vertex<double> > m_shown;
+    std::vector<double> m_level_shown;
+
+    std::atomic<bool> m_stop{false};
 
     unsigned long m_until = 0;
     unsigned long m_total = 0;
@@ -371,11 +539,154 @@ protected:
     bool m_letting_go = false;
 };
 
+
+/**
+ * The same corners, drawn.
+ *
+ * A HyperPlot, so the projection, the clip volume, the camera and the keys all
+ * come from the code the other hyper apps use -- the first attempt at this
+ * subclassed glfw::Plot directly and crashed on the first frame, because
+ * setting up an N-dimensional projection is most of what HyperPlot::initialize
+ * does and none of it is optional.
+ *
+ * What it overrides is where the geometry comes from.  HyperPlot turns the
+ * shape itself on a timer; here the audio has already turned it, and this draws
+ * whatever pose it finds.  Corners are sized and brightened by the level they
+ * are sounding at, which is the entire reason to look at it: a fat bright
+ * corner is a loud near one.
+ */
+class hyperview : public HyperPlot<double, jlib::glfw::Plot<double> > {
+public:
+    typedef HyperPlot<double, jlib::glfw::Plot<double> > base;
+
+    hyperview(hypermusic& music, uint d, uint w, uint h)
+        : base(d, std::vector< std::pair<double,double> >(), w, h),
+          m_music(music)
+    {
+        key_press.connect([this](const std::string& k, int x, int y) {
+            if(k.empty())
+                return;
+
+            // Not HyperPlot's q, which calls exit() and would leave the device
+            // being fed by a thread nobody joined.
+            if(k[0] == 'q' || k[0] == 27) {
+                this->set_should_close(true);
+                return;
+            }
+
+            // r and f belong to the audio, which owns the geometry.  Left to
+            // HyperPlot they rebuild a rotation matrix that nothing applies,
+            // since every vertex is overwritten from the pose each frame --
+            // which is why they appeared to do nothing at all.
+            if(k[0] == 'r' || k[0] == 'f') {
+                const uint was = m_music.get_planes();
+                const uint now = (k[0] == 'r') ? was + 1 : (was ? was - 1 : 0);
+
+                if(now <= this->D) {
+                    m_music.set_planes(now);
+
+                    std::cout << "  turning in "
+                              << (now * (now - 1)) / 2 << " planes\n";
+                }
+
+                return;
+            }
+
+            this->key_pressed(k[0], x, y);
+        });
+
+        button_press.connect([this](int b, int x, int y) {
+            this->button_pressed(b, 0, x, y);
+        });
+
+        timeout.connect([this]() { this->on_timeout(); });
+
+        set_timeout(16000);          // about sixty a second
+    }
+
+    /** Take the pose the audio has reached, and show it. */
+    void on_timeout()
+    {
+        m_music.pose(m_at, m_level);
+
+        if(!objects.empty() && !m_at.empty()) {
+            math::object<double>& o = **objects.begin();
+
+            for(uint i = 0; i < o.size() && i < m_at.size(); i++)
+                o[i] = m_at[i];
+        }
+
+        draw();
+
+        // The piece decides when it is over, not the window.
+        if(m_music.done())
+            set_should_close(true);
+    }
+
+    virtual void set_color(const jlib::apps::triple<double>& c)
+    {
+        glColor3d(c.r, c.g, c.b);
+    }
+
+    virtual void draw_point(std::pair<uint,uint> p, uint index)
+    {
+        shade(index, 1.0);
+
+        // Size as well as brightness: a corner going quiet against a dark
+        // background is easy to lose track of, and the point of this is to be
+        // able to follow one.
+        glPointSize(static_cast<GLfloat>(2.0 + 10.0 * level(index)));
+
+        jlib::glfw::Plot<double>::draw_point(p, index);
+    }
+
+    virtual void draw_line(std::pair<uint,uint> p1, std::pair<uint,uint> p2,
+                           uint i1, uint i2)
+    {
+        // Dimmer than the corners, so the edges read as the structure holding
+        // them and the things actually sounding stay the bright part.
+        shade(i1, 0.4);
+
+        jlib::glfw::Plot<double>::draw_line(p1, p2, i1, i2);
+    }
+
+protected:
+    double level(uint i) const
+    {
+        return (i < m_level.size()) ? m_level[i] : 0.0;
+    }
+
+    /** The vertex's own hue, at a brightness set by how loud it is. */
+    void shade(uint i, double scale)
+    {
+        if(i >= hues.size())
+            return;
+
+        const jlib::apps::triple<double> c = jlib::apps::hsv(hues[i]);
+
+        // A floor, so a distant corner dims rather than vanishing: it is still
+        // there, and going quiet should look different from being gone.
+        const double b = scale * (0.25 + 0.75 * level(i));
+
+        glColor3d(c.r * b, c.g * b, c.b * b);
+    }
+
+    hypermusic& m_music;
+
+    std::vector<math::vertex<double> > m_at;
+    std::vector<double> m_level;
+};
+
 int main(int argc, char** argv) {
+    std::cout << std::unitbuf;
+
     unsigned int d = 4;
     double seconds = 20;
     std::size_t voices = 64;
     double spin = 0.6;
+    double doppler = 12;
+    bool silent = false;          /**< no window, just the sound */
+    unsigned int side = 700;
 
     for(int i = 1; i < argc; i++) {
         const std::string a = argv[i];
@@ -388,12 +699,22 @@ int main(int argc, char** argv) {
             voices = std::atol(argv[++i]);
         else if((a == "-s" || a == "--spin") && i + 1 < argc)
             spin = std::atof(argv[++i]);
+        else if((a == "-p" || a == "--doppler") && i + 1 < argc)
+            doppler = std::atof(argv[++i]);
+        else if(a == "-q" || a == "--silent")
+            silent = true;
+        else if((a == "-w" || a == "--window") && i + 1 < argc)
+            side = std::atoi(argv[++i]);
         else {
             std::cerr << "usage: " << argv[0]
-                      << " [-d DIMENSION] [-t SECONDS] [-v VOICES] [-s SPIN]\n"
+                      << " [-d DIMENSION] [-t SECONDS] [-v VOICES] [-s SPIN]"
+                      << " [-p DOPPLER] [-w PIXELS] [-q]\n"
                       << "  an n-cube turning, with a voice at every corner:\n"
                       << "  pitch from its colour, level from how near it is,\n"
-                      << "  and both shifted by how fast it is moving away.\n";
+                      << "  and both shifted by how fast it is moving away.\n"
+                      << "  the same corners are drawn in the same hues, sized\n"
+                      << "  by the same levels.  -q leaves the window out.\n"
+                      << "  q or escape closes it.\n";
             return (a == "-h" || a == "--help") ? 0 : 1;
         }
     }
@@ -408,7 +729,7 @@ int main(int argc, char** argv) {
 
         std::cout << "jhypermusic\n";
 
-        hypermusic music(d, rate, voices, spin);
+        hypermusic music(d, rate, voices, spin, doppler);
 
         media::source_stream live(&music);
         live.set_samples_per_sec(static_cast<unsigned int>(rate));
@@ -421,9 +742,49 @@ int main(int argc, char** argv) {
 
         std::cout << "  playing for " << seconds << "s\n";
 
-        // Exactly what jnote and jmelody do: the sink takes its format from the
-        // stream and pulls until the stream says it is finished.
-        dsp.play(live);
+        if(silent) {
+            // Exactly what jnote and jmelody do: the sink takes its format from
+            // the stream and pulls until the stream says it is finished.
+            dsp.play(live);
+        }
+        else {
+            hyperview view(music, d, side, side);
+
+            // The device is fed on its own thread so the main one can draw.
+            // play() pulls until the stream ends, and would otherwise hold the
+            // thread that has to be running the window.
+            std::thread audio([&]() {
+                try {
+                    dsp.play(live);
+                }
+                catch(std::exception& e) {
+                    std::cerr << "  audio stopped: " << e.what() << std::endl;
+                }
+
+                // However it ended -- finished, or failed for want of a device
+                // -- the window should not outlive it.
+                music.stop();
+            });
+
+            view.run();
+
+            // And the other way round: closing the window ends the piece, which
+            // ends the stream, which returns play().
+            music.stop();
+
+            audio.join();
+        }
+
+        std::cout << "  distance " << std::fixed << std::setprecision(2)
+                  << music.m_dmin << " to " << music.m_dmax
+                  << "   gain " << std::setprecision(3)
+                  << music.m_gmin << " to " << music.m_gmax
+                  << " (" << (100.0 * music.m_clamped / (music.m_counted ? music.m_counted : 1))
+                  << "% clamped)\n"
+                  << "  doppler " << std::setprecision(4)
+                  << music.m_smin << " to " << music.m_smax
+                  << "  = " << std::setprecision(2)
+                  << 12 * std::log2(music.m_smax / music.m_smin) << " semitones\n";
 
         std::cout << "  peak " << std::fixed << std::setprecision(3)
                   << music.mix().peak()

--- a/jlib/media/mixer.hh
+++ b/jlib/media/mixer.hh
@@ -290,13 +290,23 @@ public:
         if(most == 0)
             return 0;
 
-        // The staging divisor comes from how many children there are, not how
-        // many are still sounding; see prune().  Headroom is a constant and so
-        // cancels out of any comparison between voice counts, which is what
-        // keeps the level consistent rather than merely lower.
-        const double stage = (m_staging == staging::automatic && !m_children.empty())
+        // From how many are being sounded, which is not the same as how many
+        // are still making a noise and not the same as how many there are.
+        //
+        // Finished children still count, and deliberately: reaping them inside
+        // a render would make the divisor depend on where block boundaries fell
+        // (see prune()).  But a child the voice cap has excluded is not being
+        // rendered at all, and counting it divided a mix by voices that
+        // contributed nothing -- a 10-cube in jhypermusic has 1024 corners and
+        // sounds 64 of them, so it came out four times quieter than the 8-cube
+        // beside it, sounding the same 64.  Eight dB between two dimensions of
+        // the same figure, from an argument about book-keeping.
+        //
+        // play.size() is fixed before any rendering happens and does not depend
+        // on the block size, so this keeps what prune() is protecting.
+        const double stage = (m_staging == staging::automatic && !play.empty())
             ? std::pow(10.0, -m_headroom / 20.0) /
-              std::sqrt(static_cast<double>(m_children.size()))
+              std::sqrt(static_cast<double>(play.size()))
             : 1.0;
 
         const double release = release_coefficient();

--- a/tests/media_mixer_test.cc
+++ b/tests/media_mixer_test.cc
@@ -357,6 +357,49 @@ static void level_does_not_depend_on_voice_count() {
               << " balance, not a guarantee)\n";
 }
 
+/**
+ * A capped mix is as loud as the voices it sounds, not as the ones it holds.
+ *
+ * Automatic staging divides by how many are being sounded.  Dividing by how
+ * many exist instead sounds reasonable and is wrong once the voice cap is doing
+ * anything: jhypermusic's 10-cube holds 1024 corners and sounds 64, and came
+ * out four times quieter than the 8-cube next to it sounding the same 64 --
+ * eight dB between two dimensions of one figure, from book-keeping.
+ *
+ * Finished children are a separate question and still count; see prune().
+ */
+static void the_cap_sets_the_divisor() {
+    std::cout << "\nlevel against the voice cap:\n";
+
+    const double rate = 44100;
+    const unsigned long len = 8192;
+
+    auto few = build(8, len, rate, mixer::staging::automatic, false);
+    const double small = rms_of(*few, len, 1);
+
+    auto many = build(64, len, rate, mixer::staging::automatic, false);
+    many->set_max_voices(8);
+    const double capped = rms_of(*many, len, 1);
+
+    auto all = build(64, len, rate, mixer::staging::automatic, false);
+    const double whole = rms_of(*all, len, 1);
+
+    std::cout << "     8 voices              rms " << std::fixed
+              << std::setprecision(4) << small << "\n"
+              << "     64 capped to 8        rms " << capped << "\n"
+              << "     64 voices             rms " << whole << "\n";
+
+    ok("64 capped to 8 sounds like 8",
+       std::fabs(capped / small - 1.0) < 0.15,
+       std::to_string(capped / small) + "x");
+
+    // Not a contrast -- the staging is meant to hold the level for 64 as well,
+    // and does.  It is here so the first assertion cannot pass by everything
+    // being the same level for some reason unrelated to the divisor.
+    ok("and 64 uncapped holds that level too",
+       std::fabs(whole / small - 1.0) < 0.2, std::to_string(whole / small) + "x");
+}
+
 static void metering() {
     std::cout << "\nmetering:\n";
 
@@ -468,6 +511,7 @@ int main() {
     the_limiter();
     not_a_tremolo_pedal();
     level_does_not_depend_on_voice_count();
+    the_cap_sets_the_divisor();
     metering();
     housekeeping();
     block_size_independence();


### PR DESCRIPTION
The other half of the 1999 note.  The same corners that hold the voices are now
drawn, in the hues that set their pitches and at sizes set by the levels they
are sounding at, so a fat bright corner is a loud near one.

    macOS  36 tests, 36 pass, 0 skip
    Linux  37 tests, 36 pass, 1 skip

one hue, not two

    The audio picked its pitches from hue = i/count and HyperPlot draws vertex i
    in golden_hue(i).  Two different colourings of the same corners, which would
    have made "pitch is reflective of colour" a thing the program said about
    itself rather than a thing that was true of it -- the corner you heard high
    would not have been the corner you saw violet.

    hypermusic takes its hue from apps::golden_hue now, the same call the
    renderer makes.  It is one number per corner with two consequences.

the audio owns the clock

    Geometry advances inside render(), on the thread feeding the device, and the
    window draws whatever pose it finds.  That way round because a dropped video
    frame is invisible and a dropped audio block is a hole -- the pipeline that
    cannot be late should be the one setting the pace.

    The pose is published under a lock and copied out, rather than read in
    place: it is written 86 times a second and read 60, so a frame drawn from
    the live vectors could be half one pose and half the next.  The lock is held
    for a copy of a few thousand doubles by a feeder thread that may block; the
    device callback is nowhere near it.

    play() pulls until the stream ends, so it runs on its own thread and the
    main one runs the window.  Either ending stops the other: closing the window
    stops the piece, and the audio thread stops the window on its way out --
    including when it stops because there is no device, which would otherwise
    have left a window running against silence forever.

it was only turning in two planes

    Reported from the window: r and f did nothing, and a high-dimensional figure
    looked flat.  Two faults, one behind the other.

    The keys did nothing because HyperPlot rebuilds a rotation matrix that
    nothing here applies -- every vertex is overwritten from the audio's pose
    each frame, so its own turning was being drawn over.  They are intercepted
    now and land on the audio, which owns the geometry.

    The figure looked flat because it was.  hypermusic turned in planes (0,1)
    and (2,3) and no others, so every axis from the fifth up was fixed and an
    8-cube tumbled as though it were a 4-cube with sixteen extra corners painted
    on.  It turns in every plane below r now, each at its own rate -- sin(d++),
    the same construction HyperPlot::initialize_rotation has always used -- so
    at ten dimensions that is 45 planes rather than 2, and the figure everts.

eight dB between two dimensions, from book-keeping

    Fixing the rotation made a level fault visible that had been noted as an
    open question in the previous branch and is now answered.

    Automatic staging divided by how many children the mixer held.  The voice
    cap means that is not how many it sounds: jhypermusic's 10-cube holds 1024
    corners and sounds 64, so it came out four times quieter than the 8-cube
    beside it sounding the same 64.  It divides by how many are being sounded
    now.  Finished children still count, which is a different question and the
    one prune() exists for; play.size() is fixed before any rendering starts, so
    nothing about block-size independence changes.

        8 voices          rms 0.3241
        64 capped to 8    rms 0.3241
        64 voices         rms 0.3042

    That left the limiter doing 5dB of work on an 8-cube, which is it doing the
    staging's job.  The cause is particular to this program and worth naming:
    1/sqrt(N) holds the level for sources that sum in power, and every pitch
    here comes from one pentatonic scale, so they are harmonically related and
    sum closer to linearly.  set_headroom(9) is the app saying so.  Across four
    to twelve dimensions the peak now runs 0.40 to 0.89 with the limiter idle
    throughout, where before it sat pinned at the ceiling with up to 5dB of
    reduction.

the doppler was doing nothing at all, and the reason is a trap

    Reported as not much variation as the shape turns.  Measured, which is what
    the report deserved: the shift ran from 1.0000 to 1.0000.  Exactly one, not
    approximately -- which says the two poses it is computed from were equal
    bit for bit rather than merely close, and that is not an arithmetic fault.

    Copy-constructing a math::vertex shares its storage.  Assigning one copies
    the values.  matrix holds a buffer<T>, buffer holds an array<T>::ptr, and
    neither declares a copy constructor, so:

        m_at.push_back(m_shape[i]);     // both alias m_shape[i],
        m_was.push_back(m_shape[i]);    // and so each other

        m_was[i] = m_at[i];             // no-op: one buffer
        m_at[i] = turn(m_at[i]);        // moves both

    Every corner therefore had a radial velocity of exactly zero, while the
    shape visibly turned and the distance gain visibly moved -- it is the one
    quantity computed from two poses, so it was the only thing wrong, and it
    was wrong in a way that looks like a tuning problem.

    The same trap had quietly disarmed the pose lock: m_shown = m_at assigns
    the vector, which copy-constructs the elements, which shares them, so the
    drawn pose was the live one under another name and the mutex guarded
    nothing.  Every vertex here is constructed with its own storage now and
    assigned element by element.

    Filed as #76.  The failure is silent, plausible, and invisible at the call
    site, and object::clone() has the same shape -- it has not broken only
    because its callers happen to pass temporaries.

two more things the measurement caught

    A fifth of every gain was pinned at 1.0.  The level was referred to the
    nearest corner in the starting pose, and rotation brings corners nearer than
    that, so the ones that should have been most dramatic were the flattest.
    Referred to the nearest a corner can ever come -- the listener's distance
    less the shape's radius, since rotation preserves length -- nothing clamps.

    And the falloff was inverse square, which is the law for intensity.  A gain
    multiplies amplitude, and amplitude falls as 1/d.  Squaring it attenuated
    the far corners, which are most of them, twice over: gains ran 0.05 to 0.9
    and the mix peaked at 0.084.

    With both fixed the geometry is worth something, measured across four to
    twelve dimensions: gain 0.23 to 0.97 with nothing clamped, Doppler four
    semitones at D=4 rising to fourteen at D=12, peak 0.45 to 0.80 and the
    limiter idle throughout.

    Doppler strength is on the command line now (-p), because it is taste
    rather than physics -- the corners move at whatever the spin makes them, so
    the number decides between a shimmer and a siren.

    Headroom went the other way, from 9dB to 1.  The 9 was tuned when gains sat
    near 1.0 and every level is attenuated by distance now, so the sum arrives
    about 8dB below what the mixer default holds room for.

subclassing the wrong thing, and the crash that said so

    The first version subclassed glfw::Plot directly, added a cuboid and drew
    it.  It segfaulted on the first frame.

    Setting up an N-dimensional projection is most of what HyperPlot::initialize
    does -- initialize_glazzies, setClip, change(n), and a translation putting
    the figure in front of each step's frustum -- and none of it is optional.
    Drawing without it projects through an empty clip volume.

    So this is a HyperPlot, and inherits the projection, the camera, the
    projection modes and the keys along with it.  What it overrides is where the
    geometry comes from: HyperPlot turns the shape on its own timer, and this
    takes the pose the audio has already turned it to.

    q and escape close the window rather than reaching HyperPlot's q, which
    calls exit() and would leave the device being fed by a thread nobody joined.

    Worth saying: the crash was the useful part.  A wireframe drawn through a
    projection that was never set up might have come out looking plausible and
    wrong, and this failed loudly instead.

what is still not here

    Nothing is muxed to a file.  The note wanted frames grabbed and written to a
    container alongside the audio; this plays and draws live, which is the half
    that is worth watching and the half that does not need an encoder.

    jhypermusic now needs GLFW as well as PortAudio, so it is built only where
    both are present -- -q leaves the window out but does not remove the
    dependency.  Both platforms here have both.

    Still no test.  It is an app, and the suite has never covered apps; what is
    under test is the machinery beneath it.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
