### PR TITLE
Normalize every copyright notice to Joey Yandle <xoloki@gmail.com>

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,1 +1,1 @@
-Joe Yandle <jwy@divisionbyzero.com>
+Joey Yandle <xoloki@gmail.com>

--- a/README
+++ b/README
@@ -43,7 +43,7 @@ for details.
 
 CONTACT
 -------
-Copyright (c) 2000 Joe Yandle <jwy@divisionbyzero.com>
+Copyright (c) 2000 Joey Yandle <xoloki@gmail.com>
 
 jlib homepage:	
 

--- a/jlib/ai/action.cc
+++ b/jlib/ai/action.cc
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 2010 Joe Yandle <joey@divisionbyzero.com>
+ * Copyright (c) 2010 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/ai/action.hh
+++ b/jlib/ai/action.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 2010 Joe Yandle <joey@divisionbyzero.com>
+ * Copyright (c) 2010 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/ai/agent.cc
+++ b/jlib/ai/agent.cc
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 2010 Joe Yandle <joey@divisionbyzero.com>
+ * Copyright (c) 2010 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/ai/agent.hh
+++ b/jlib/ai/agent.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 2010 Joe Yandle <joey@divisionbyzero.com>
+ * Copyright (c) 2010 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/ai/environment.cc
+++ b/jlib/ai/environment.cc
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 2010 Joe Yandle <joey@divisionbyzero.com>
+ * Copyright (c) 2010 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/ai/environment.hh
+++ b/jlib/ai/environment.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 2010 Joe Yandle <joey@divisionbyzero.com>
+ * Copyright (c) 2010 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/ai/percept.cc
+++ b/jlib/ai/percept.cc
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 2010 Joe Yandle <joey@divisionbyzero.com>
+ * Copyright (c) 2010 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/ai/percept.hh
+++ b/jlib/ai/percept.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 2010 Joe Yandle <joey@divisionbyzero.com>
+ * Copyright (c) 2010 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/ai/vacuum.cc
+++ b/jlib/ai/vacuum.cc
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 2010 Joe Yandle <joey@divisionbyzero.com>
+ * Copyright (c) 2010 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/ai/vacuum.hh
+++ b/jlib/ai/vacuum.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 2010 Joe Yandle <joey@divisionbyzero.com>
+ * Copyright (c) 2010 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/apps/Hyper.hh
+++ b/jlib/apps/Hyper.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 1999 Joe Yandle <joey@divisionbyzero.com>
+ * Copyright (c) 1999 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/apps/color.hh
+++ b/jlib/apps/color.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  *
- * Copyright (c) 1999 Joe Yandle <joey@divisionbyzero.com>
+ * Copyright (c) 1999 Joey Yandle <xoloki@gmail.com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/apps/jcrypt.cc
+++ b/jlib/apps/jcrypt.cc
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 2008 Joe Yandle <joey@divisionbyzero.com>
+ * Copyright (c) 2008 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/apps/jcurve.cc
+++ b/jlib/apps/jcurve.cc
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 2021 Joe Yandle <dragon@dancingdragon.net>
+ * Copyright (c) 2021 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/apps/jglfwhyper.cc
+++ b/jlib/apps/jglfwhyper.cc
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 1999 Joe Yandle <joey@divisionbyzero.com>
+ * Copyright (c) 1999 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/apps/jgltorus.cc
+++ b/jlib/apps/jgltorus.cc
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 1999 Joe Yandle <joey@divisionbyzero.com>
+ * Copyright (c) 1999 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/apps/jglxbox.cc
+++ b/jlib/apps/jglxbox.cc
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 1999 Joe Yandle <joey@divisionbyzero.com>
+ * Copyright (c) 1999 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/apps/jglxhyper.cc
+++ b/jlib/apps/jglxhyper.cc
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 2008 Joe Yandle <joey@divisionbyzero.com>
+ * Copyright (c) 2008 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/apps/jhardhyper.cc
+++ b/jlib/apps/jhardhyper.cc
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 1999 Joe Yandle <joey@divisionbyzero.com>
+ * Copyright (c) 1999 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/apps/jhyper.cc
+++ b/jlib/apps/jhyper.cc
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 1999 Joe Yandle <joey@divisionbyzero.com>
+ * Copyright (c) 1999 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/apps/jhypermusic.cc
+++ b/jlib/apps/jhypermusic.cc
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4  -*-
  *
- * Copyright (c) 2000 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 2000 Joey Yandle <xoloki@gmail.com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/apps/jjoy2xev.cc
+++ b/jlib/apps/jjoy2xev.cc
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 2008 Joe Yandle <joey@divisionbyzero.com>
+ * Copyright (c) 2008 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/apps/jjoystick.cc
+++ b/jlib/apps/jjoystick.cc
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 2008 Joe Yandle <joey@divisionbyzero.com>
+ * Copyright (c) 2008 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/apps/jlib-mail.cc
+++ b/jlib/apps/jlib-mail.cc
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 1999 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 1999 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/apps/jm3u.cc
+++ b/jlib/apps/jm3u.cc
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 2008 Joe Yandle <joey@divisionbyzero.com>
+ * Copyright (c) 2008 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/apps/jpoisoned.cc
+++ b/jlib/apps/jpoisoned.cc
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 1999 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 1999 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/apps/magick.hh
+++ b/jlib/apps/magick.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4  -*-
  *
- * Copyright (c) 2000 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 2000 Joey Yandle <xoloki@gmail.com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/bio/bio.hh
+++ b/jlib/bio/bio.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 1999 Joey Yandle <dragon@dancingdragon.net>
+ * Copyright (c) 1999 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/crypt/crypt.cc
+++ b/jlib/crypt/crypt.cc
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 1999 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 1999 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/crypt/crypt.hh
+++ b/jlib/crypt/crypt.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 1999 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 1999 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/crypt/curve.cc
+++ b/jlib/crypt/curve.cc
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 1999 Joey Yandle <dragon@dancingdragon.net>
+ * Copyright (c) 1999 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/crypt/curve.hh
+++ b/jlib/crypt/curve.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 1999 Joey Yandle <dragon@dancingdragon.net>
+ * Copyright (c) 1999 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/crypt/groth.cc
+++ b/jlib/crypt/groth.cc
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 2020 Joey Yandle <dragon@dancingdragon.net>
+ * Copyright (c) 2020 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/crypt/groth.hh
+++ b/jlib/crypt/groth.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 1999 Joey Yandle <dragon@dancingdragon.net>
+ * Copyright (c) 1999 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/crypt/schnorr.cc
+++ b/jlib/crypt/schnorr.cc
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 2020 Joey Yandle <dragon@dancingdragon.net>
+ * Copyright (c) 2020 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/crypt/schnorr.hh
+++ b/jlib/crypt/schnorr.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 1999 Joey Yandle <dragon@dancingdragon.net>
+ * Copyright (c) 1999 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/gl/buffers.hh
+++ b/jlib/gl/buffers.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 2008 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 2008 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/gl/lights.hh
+++ b/jlib/gl/lights.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 2008 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 2008 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/gl/opengl.hh
+++ b/jlib/gl/opengl.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  *
- * Copyright (c) 2000 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 2000 Joey Yandle <xoloki@gmail.com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/gl/shapes.cc
+++ b/jlib/gl/shapes.cc
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  *
- * Copyright (c) 2000 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 2000 Joey Yandle <xoloki@gmail.com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/gl/shapes.hh
+++ b/jlib/gl/shapes.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  *
- * Copyright (c) 2000 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 2000 Joey Yandle <xoloki@gmail.com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/glfw/Plot.hh
+++ b/jlib/glfw/Plot.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  *
- * Copyright (c) 2000 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 2000 Joey Yandle <xoloki@gmail.com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/glfw/Window.cc
+++ b/jlib/glfw/Window.cc
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  *
- * Copyright (c) 2000 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 2000 Joey Yandle <xoloki@gmail.com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/glfw/Window.hh
+++ b/jlib/glfw/Window.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  *
- * Copyright (c) 2000 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 2000 Joey Yandle <xoloki@gmail.com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/glu/projection.cc
+++ b/jlib/glu/projection.cc
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 2008 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 2008 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/glu/projection.hh
+++ b/jlib/glu/projection.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 2008 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 2008 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/glu/textures.cc
+++ b/jlib/glu/textures.cc
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 2008 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 2008 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/glu/textures.hh
+++ b/jlib/glu/textures.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 2008 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 2008 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/glx/Plot.hh
+++ b/jlib/glx/Plot.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 1999 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 1999 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/glx/Window.cc
+++ b/jlib/glx/Window.cc
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 1999 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 1999 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/glx/Window.hh
+++ b/jlib/glx/Window.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 2008 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 2008 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/math/Plot.hh
+++ b/jlib/math/Plot.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 1999 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 1999 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/math/buffer.hh
+++ b/jlib/math/buffer.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 1999 Joe Yandle <joey@divisionbyzero.com>
+ * Copyright (c) 1999 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/math/dump.hh
+++ b/jlib/math/dump.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  *
- * Copyright (c) 1999 Joe Yandle <joey@divisionbyzero.com>
+ * Copyright (c) 1999 Joey Yandle <xoloki@gmail.com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/math/math.hh
+++ b/jlib/math/math.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 1999 Joe Yandle <joey@divisionbyzero.com>
+ * Copyright (c) 1999 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/math/matrix.hh
+++ b/jlib/math/matrix.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 1999 Joe Yandle <joey@divisionbyzero.com>
+ * Copyright (c) 1999 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/math/polynomial.hh
+++ b/jlib/math/polynomial.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 2020 Joe Yandle <dragon@dancingdragon.net>
+ * Copyright (c) 2020 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/math/tensor.hh
+++ b/jlib/math/tensor.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 1999 Joe Yandle <joey@divisionbyzero.com>
+ * Copyright (c) 1999 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/media/AudioFile.cc
+++ b/jlib/media/AudioFile.cc
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * AudioFile.C - source file for class AudioFile
- * Copyright (c) 2000 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 2000 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/media/AudioFile.hh
+++ b/jlib/media/AudioFile.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * AudioFile.h
- * Copyright (c) 2000 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 2000 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/media/AudioSink.cc
+++ b/jlib/media/AudioSink.cc
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  *
- * Copyright (c) 2000 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 2000 Joey Yandle <xoloki@gmail.com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/media/AudioSink.hh
+++ b/jlib/media/AudioSink.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  *
- * Copyright (c) 2000 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 2000 Joey Yandle <xoloki@gmail.com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/media/Dsp.cc
+++ b/jlib/media/Dsp.cc
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * AudioFile.h
- * Copyright (c) 2000 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 2000 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/media/Dsp.hh
+++ b/jlib/media/Dsp.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * AudioFile.h
- * Copyright (c) 2000 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 2000 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/media/PlayList.cc
+++ b/jlib/media/PlayList.cc
@@ -2,7 +2,7 @@
 
 /* pattern.cc
  * 
- * Copyright (C) 2002 Joey Yandle
+ * Copyright (C) 2002 Joey Yandle <xoloki@gmail.com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/media/PlayList.hh
+++ b/jlib/media/PlayList.hh
@@ -2,7 +2,7 @@
 
 /* pattern.hh
  * 
- * Copyright (C) 2002 Joey Yandle
+ * Copyright (C) 2002 Joey Yandle <xoloki@gmail.com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/media/Player.cc
+++ b/jlib/media/Player.cc
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * Player.cc
- * Copyright (c) 2002 Joey Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 2002 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/media/Player.hh
+++ b/jlib/media/Player.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * Player.hh
- * Copyright (c) 2002 Joey Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 2002 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/media/PortAudioSink.cc
+++ b/jlib/media/PortAudioSink.cc
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  *
- * Copyright (c) 2000 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 2000 Joey Yandle <xoloki@gmail.com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/media/PortAudioSink.hh
+++ b/jlib/media/PortAudioSink.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  *
- * Copyright (c) 2000 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 2000 Joey Yandle <xoloki@gmail.com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/media/Type.hh
+++ b/jlib/media/Type.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * AudioFile.h
- * Copyright (c) 2000 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 2000 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/media/WavFile.cc
+++ b/jlib/media/WavFile.cc
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * WavFile.C - source file for class WavFile
- * Copyright (c) 2000 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 2000 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/media/WavFile.hh
+++ b/jlib/media/WavFile.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * AudioFile.h
- * Copyright (c) 2000 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 2000 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/media/audiofilestream.hh
+++ b/jlib/media/audiofilestream.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4  -*-
  * 
- * Copyright (c) 2000 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 2000 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/media/clip.hh
+++ b/jlib/media/clip.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4  -*-
  *
- * Copyright (c) 2000 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 2000 Joey Yandle <xoloki@gmail.com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/media/datastream.hh
+++ b/jlib/media/datastream.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4  -*-
  * 
- * Copyright (c) 2000 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 2000 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/media/delayed.hh
+++ b/jlib/media/delayed.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4  -*-
  *
- * Copyright (c) 2000 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 2000 Joey Yandle <xoloki@gmail.com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/media/instrument.hh
+++ b/jlib/media/instrument.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4  -*-
  *
- * Copyright (c) 2000 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 2000 Joey Yandle <xoloki@gmail.com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/media/mixer.hh
+++ b/jlib/media/mixer.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4  -*-
  *
- * Copyright (c) 2000 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 2000 Joey Yandle <xoloki@gmail.com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/media/notestream.hh
+++ b/jlib/media/notestream.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4  -*-
  * 
- * Copyright (c) 2000 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 2000 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/media/sampler.hh
+++ b/jlib/media/sampler.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4  -*-
  *
- * Copyright (c) 2000 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 2000 Joey Yandle <xoloki@gmail.com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/media/source.hh
+++ b/jlib/media/source.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4  -*-
  *
- * Copyright (c) 2000 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 2000 Joey Yandle <xoloki@gmail.com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/media/source_stream.hh
+++ b/jlib/media/source_stream.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4  -*-
  *
- * Copyright (c) 2000 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 2000 Joey Yandle <xoloki@gmail.com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/media/stream.hh
+++ b/jlib/media/stream.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4  -*-
  * 
- * Copyright (c) 2000 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 2000 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/media/voice.hh
+++ b/jlib/media/voice.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4  -*-
  *
- * Copyright (c) 2000 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 2000 Joey Yandle <xoloki@gmail.com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/media/wavetable.hh
+++ b/jlib/media/wavetable.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4  -*-
  *
- * Copyright (c) 2000 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 2000 Joey Yandle <xoloki@gmail.com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/media/wavstream.hh
+++ b/jlib/media/wavstream.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4  -*-
  * 
- * Copyright (c) 2000 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 2000 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/net/ASImapBox.cc
+++ b/jlib/net/ASImapBox.cc
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 1999 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 1999 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/net/ASImapBox.hh
+++ b/jlib/net/ASImapBox.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 1999 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 1999 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/net/ASMBox.cc
+++ b/jlib/net/ASMBox.cc
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 1999 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 1999 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/net/ASMBox.hh
+++ b/jlib/net/ASMBox.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 1999 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 1999 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/net/ASMailBox.cc
+++ b/jlib/net/ASMailBox.cc
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 1999 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 1999 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/net/ASMailBox.hh
+++ b/jlib/net/ASMailBox.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 1999 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 1999 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/net/Email.cc
+++ b/jlib/net/Email.cc
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 1999 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 1999 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/net/Email.hh
+++ b/jlib/net/Email.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 1999 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 1999 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/net/Imap4.cc
+++ b/jlib/net/Imap4.cc
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 1999 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 1999 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/net/Imap4.hh
+++ b/jlib/net/Imap4.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 1999 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 1999 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/net/Imap4Box.cc
+++ b/jlib/net/Imap4Box.cc
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 1999 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 1999 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/net/Imap4Box.hh
+++ b/jlib/net/Imap4Box.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 1999 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 1999 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/net/Imap4Fetch.cc
+++ b/jlib/net/Imap4Fetch.cc
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 1999 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 1999 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/net/Imap4Fetch.hh
+++ b/jlib/net/Imap4Fetch.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 1999 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 1999 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/net/Imap4Folder.cc
+++ b/jlib/net/Imap4Folder.cc
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 1999 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 1999 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/net/Imap4Folder.hh
+++ b/jlib/net/Imap4Folder.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 1999 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 1999 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/net/MBox.cc
+++ b/jlib/net/MBox.cc
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 1999 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 1999 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/net/MBox.hh
+++ b/jlib/net/MBox.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 1999 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 1999 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/net/MFolder.cc
+++ b/jlib/net/MFolder.cc
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 1999 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 1999 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/net/MFolder.hh
+++ b/jlib/net/MFolder.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 1999 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 1999 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/net/MailBox.cc
+++ b/jlib/net/MailBox.cc
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 1999 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 1999 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/net/MailBox.hh
+++ b/jlib/net/MailBox.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 1999 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 1999 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/net/MailFetch.hh
+++ b/jlib/net/MailFetch.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 1999 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 1999 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/net/MailFolder.cc
+++ b/jlib/net/MailFolder.cc
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 1999 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 1999 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/net/MailFolder.hh
+++ b/jlib/net/MailFolder.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 1999 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 1999 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/net/Pop3.cc
+++ b/jlib/net/Pop3.cc
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 1999 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 1999 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/net/Pop3.hh
+++ b/jlib/net/Pop3.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 1999 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 1999 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/net/net.cc
+++ b/jlib/net/net.cc
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 1999 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 1999 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/net/net.hh
+++ b/jlib/net/net.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 1999 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 1999 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/sys/ASServent.hh
+++ b/jlib/sys/ASServent.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4  -*-
  * 
- * Copyright (c) 2002 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 2002 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/sys/Directory.cc
+++ b/jlib/sys/Directory.cc
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * Directory.C
- * Copyright (c) 2000 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 2000 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/sys/Directory.hh
+++ b/jlib/sys/Directory.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * Directory.h
- * Copyright (c) 2000 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 2000 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/sys/Servent.cc
+++ b/jlib/sys/Servent.cc
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4  -*-
  * 
- * Copyright (c) 2002 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 2002 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/sys/Servent.hh
+++ b/jlib/sys/Servent.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4  -*-
  * 
- * Copyright (c) 2002 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 2002 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/sys/auto.hh
+++ b/jlib/sys/auto.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4  -*-
  * 
- * Copyright (c) 2000 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 2000 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/sys/joystick.hh
+++ b/jlib/sys/joystick.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4  -*-
  * 
- * Copyright (c) 2008 Joe Yandle <joey@divisionbyzero.com>
+ * Copyright (c) 2008 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/sys/object.hh
+++ b/jlib/sys/object.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  *
- * Copyright (c) 2000 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 2000 Joey Yandle <xoloki@gmail.com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/sys/pipe.cc
+++ b/jlib/sys/pipe.cc
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4  -*-
  * 
- * Copyright (c) 2002 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 2002 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/sys/pipe.hh
+++ b/jlib/sys/pipe.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4  -*-
  * 
- * Copyright (c) 2002 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 2002 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/sys/proxystream.hh
+++ b/jlib/sys/proxystream.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4  -*-
  * 
- * Copyright (c) 2000 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 2000 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/sys/pstream.hh
+++ b/jlib/sys/pstream.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4  -*-
  * 
- * Copyright (c) 2000 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 2000 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/sys/ringbuffer.hh
+++ b/jlib/sys/ringbuffer.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4  -*-
  *
- * Copyright (c) 2000 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 2000 Joey Yandle <xoloki@gmail.com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/sys/serialstream.hh
+++ b/jlib/sys/serialstream.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4  -*-
  * 
- * Copyright (c) 2000 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 2000 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/sys/signal.hh
+++ b/jlib/sys/signal.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  *
- * Copyright (c) 2000 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 2000 Joey Yandle <xoloki@gmail.com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/sys/socketstream.hh
+++ b/jlib/sys/socketstream.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4  -*-
  * 
- * Copyright (c) 2000 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 2000 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/sys/sslproxystream.hh
+++ b/jlib/sys/sslproxystream.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4  -*-
  * 
- * Copyright (c) 2000 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 2000 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/sys/sslstream.hh
+++ b/jlib/sys/sslstream.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4  -*-
  * 
- * Copyright (c) 2000 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 2000 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/sys/sync.hh
+++ b/jlib/sys/sync.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4  -*-
  * 
- * Copyright (c) 2000 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 2000 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/sys/sys.cc
+++ b/jlib/sys/sys.cc
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4  -*-
  * 
- * Copyright (c) 2000 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 2000 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/sys/sys.hh
+++ b/jlib/sys/sys.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4  -*-
  * 
- * Copyright (c) 2000 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 2000 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/sys/tfstream.cc
+++ b/jlib/sys/tfstream.cc
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4  -*-
  * 
- * Copyright (c) 2000 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 2000 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/sys/tfstream.hh
+++ b/jlib/sys/tfstream.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4  -*-
  * 
- * Copyright (c) 2000 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 2000 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/util/Date.cc
+++ b/jlib/util/Date.cc
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 1999 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 1999 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/util/Date.hh
+++ b/jlib/util/Date.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 1999 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 1999 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/util/Headers.cc
+++ b/jlib/util/Headers.cc
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 2001 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 2001 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/util/Headers.hh
+++ b/jlib/util/Headers.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 2001 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 2001 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/util/MimeType.cc
+++ b/jlib/util/MimeType.cc
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4  -*-
  * 
- * Copyright (c) 1999 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 1999 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/util/MimeType.hh
+++ b/jlib/util/MimeType.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4  -*-
  * 
- * Copyright (c) 1999 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 1999 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/util/Regex.cc
+++ b/jlib/util/Regex.cc
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 1999 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 1999 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/util/Regex.hh
+++ b/jlib/util/Regex.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 1999 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 1999 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/util/Timer.cc
+++ b/jlib/util/Timer.cc
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 1999 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 1999 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/util/Timer.hh
+++ b/jlib/util/Timer.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 1999 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 1999 Joey Yandle <xoloki@gmail.com>
  * 
  */
 

--- a/jlib/util/URL.cc
+++ b/jlib/util/URL.cc
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 2001 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 2001 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/util/URL.hh
+++ b/jlib/util/URL.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 2001 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 2001 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/util/json.cc
+++ b/jlib/util/json.cc
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4  -*-
  * 
- * Copyright (c) 2010 Joe Yandle <xoloki@gmail.com>
+ * Copyright (c) 2010 Joey Yandle <xoloki@gmail.com>
  * 
  */
 

--- a/jlib/util/json.hh
+++ b/jlib/util/json.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4  -*-
  * 
- * Copyright (c) 2010 Joe Yandle <xoloki@gmail.com>
+ * Copyright (c) 2010 Joey Yandle <xoloki@gmail.com>
  * 
  */
 

--- a/jlib/util/util.cc
+++ b/jlib/util/util.cc
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 1999 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 1999 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/util/util.hh
+++ b/jlib/util/util.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 1999 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 1999 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/x/Display.cc
+++ b/jlib/x/Display.cc
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 1999 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 1999 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/x/Display.hh
+++ b/jlib/x/Display.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 1999 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 1999 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/x/Plot.hh
+++ b/jlib/x/Plot.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 1999 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 1999 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/x/Window.cc
+++ b/jlib/x/Window.cc
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 1999 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 1999 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/jlib/x/Window.hh
+++ b/jlib/x/Window.hh
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 1999 Joe Yandle <jwy@divisionbyzero.com>
+ * Copyright (c) 1999 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/tests/crypt_curve_test.cc
+++ b/tests/crypt_curve_test.cc
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 1999 Joey Yandle <dragon@dancingdragon.net>
+ * Copyright (c) 1999 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/tests/crypt_groth_test.cc
+++ b/tests/crypt_groth_test.cc
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 1999 Joey Yandle <dragon@dancingdragon.net>
+ * Copyright (c) 1999 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/tests/crypt_schnorr_test.cc
+++ b/tests/crypt_schnorr_test.cc
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  * 
- * Copyright (c) 1999 Joey Yandle <dragon@dancingdragon.net>
+ * Copyright (c) 1999 Joey Yandle <xoloki@gmail.com>
  * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/tests/math_test.cc
+++ b/tests/math_test.cc
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  *
- * Copyright (c) 1999 Joe Yandle <joey@divisionbyzero.com>
+ * Copyright (c) 1999 Joey Yandle <xoloki@gmail.com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License

--- a/tests/tensor_test.cc
+++ b/tests/tensor_test.cc
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  *
- * Copyright (c) 1999 Joe Yandle <joey@divisionbyzero.com>
+ * Copyright (c) 1999 Joey Yandle <xoloki@gmail.com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License


### PR DESCRIPTION
Every copyright notice in the tree now names one author at one address.  No code
changes; the diff is 167 files of comment.

    macOS  36 tests, 36 pass, 0 skip
    Linux  37 tests, 36 pass, 1 skip

what was there

    Seven spellings of the same person across 195 notices, at three domains and
    under two names:

        121  Joe Yandle <jwy@divisionbyzero.com>
         42  Joe Yandle <joey@divisionbyzero.com>
         15  Joey Yandle <xoloki@gmail.com>        already right
         10  Joey Yandle <dragon@dancingdragon.net>
          3  Joe Yandle <dragon@dancingdragon.net>
          2  Joey Yandle <jwy@divisionbyzero.com>
          2  Joe Yandle <xoloki@gmail.com>

    plus two notices carrying a name and no address at all (PlayList.hh, .cc).

    The two dead domains are dead for different reasons, which is worth keeping
    straight.  divisionbyzero.com reaches the author only through a redirect he
    does not control, and could stop working without notice -- link rot on the
    one contact address a copyright notice exists to provide.  dancingdragon.net
    still works, but it belongs to LLCs rather than to personal software work,
    and a personal project should not carry a business identity in the line that
    says who owns it.

    AUTHORS and README carried the same old address and are updated too.

what was deliberately not touched

    The years.  They record when each file was written -- 1999, 2000, 2002 --
    and rewriting them would be a false claim about the work.  Only the name and
    the address changed.

    jlib/util/xml*.  Those six files are co-copyright Michael Fink, and his line
    is not the author's to edit.  They are due for removal in a later branch;
    until then they keep both notices exactly as they are, which is why a grep
    for the old name still finds six hits there.

    Test corpora.  tests/util_headers_*.cc and tests/net_email_*.cc contain real
    email messages from 2001 with divisionbyzero.com addresses in their headers.
    Those are the data under test, not attribution: rewriting them would change
    what the parser is being asked to parse.  A blanket search-and-replace over
    the tree would have quietly altered five test fixtures.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
