### PR TITLE
Fix the npos truncations, the missing virtual destructor, and two predicates that said yes too readily

### DIFF
--- a/jlib/net/Email.cc
+++ b/jlib/net/Email.cc
@@ -146,7 +146,19 @@ namespace jlib {
                         // intermediate boundary, go for it
                         //cout << "intermediate boundary, go for it"<<endl;
 
-                        unsigned int pos = istr.tellg();
+                        // tellg() returns a streampos, which this narrowed to
+                        // 32 bits -- wrong for any message past 4GB, and it
+                        // also swallows the -1 tellg() returns on a failed
+                        // stream, turning it into a huge offset that substr
+                        // then throws on.
+                        const std::istream::pos_type where = istr.tellg();
+
+                        if(where == std::istream::pos_type(-1)) {
+                            break;
+                        }
+
+                        const std::string::size_type pos =
+                            static_cast<std::string::size_type>(where);
                         // last case, have to get jiggy
                         if(i+1 == attach_divide.size()) {
                             buf = m_raw.substr(pos);

--- a/jlib/net/Imap4.cc
+++ b/jlib/net/Imap4.cc
@@ -46,12 +46,33 @@ namespace jlib {
 
         ListItem::ListItem() {}
         ListItem::ListItem(const std::string& line) {
-            unsigned int i,j;
+            // These were unsigned int, which truncates npos to 0xFFFFFFFF: a
+            // reply with no "(" left i as that, i+1 wrapped to 0, and the
+            // find(")") that followed searched from the start of the line.
+            // line.substr(j+1) then threw, or returned a slice of something
+            // unrelated.  This is the same bug class already fixed and
+            // regression-tested in net::extract_address.
+            std::string::size_type i, j;
+
             i = line.find("(");
-            j = line.find(")",i+1);
-            
+            j = (i == line.npos) ? line.npos : line.find(")", i+1);
+
+            if(i == line.npos || j == line.npos) {
+                return;
+            }
+
             std::string ending = line.substr(j+1);
             std::vector<std::string> etokens = util::tokenize(ending," ",false);
+
+            // A truncated reply used to index etokens[0] and etokens[1] with
+            // no size check.  Leaving the item as it is means the caller sees
+            // a nameless non-folder and skips it, which is the same outcome as
+            // a mailbox it cannot select -- rather than a crash from the
+            // network.  Reading LIST properly needs the grammar, not more
+            // guards; that is a later branch.
+            if(etokens.empty() || etokens[0].empty()) {
+                return;
+            }
             if(getenv("JLIB_NET_IMAP4_DEBUG")) {
                 std::cout << "ending = '"<<ending<<"'"<<std::endl;
                 for(unsigned int i=0;i<etokens.size();i++) {
@@ -73,6 +94,9 @@ namespace jlib {
             }
             else {
                 m_delim = etokens[0];
+                if(etokens.size() < 2 || etokens[1].empty()) {
+                    return;
+                }
                 if(etokens[1][0] == '"') {
                     std::string b = ending;
                     b = b.substr(b.find(m_delim)+m_delim.length()+1);

--- a/jlib/net/Imap4.hh
+++ b/jlib/net/Imap4.hh
@@ -49,8 +49,13 @@ namespace jlib {
             std::vector<std::string> m_attr;
             std::string m_delim;
             std::string m_name;
-            bool m_is_folder;
-            bool m_is_parent;
+
+            // Initialized here because ListItem() is an empty body: a
+            // default-constructed item reported whatever was on the stack for
+            // both of these, and one of them decides whether a mailbox is
+            // shown at all.
+            bool m_is_folder = false;
+            bool m_is_parent = false;
         };
 
         /**

--- a/jlib/net/MFolder.cc
+++ b/jlib/net/MFolder.cc
@@ -188,10 +188,22 @@ namespace jlib {
 
                 u_int size = buf.length();
 
-                // don't try to parse the whole email, just grab the headers
-                unsigned int p = buf.find("\n\n");
+                // Don't try to parse the whole email, just grab the headers.
+                //
+                // Two faults here, and they compounded.  p was an unsigned
+                // int, so npos truncated to 0xFFFFFFFF and the "did we find
+                // it" guard could never fire -- buf.erase(0xFFFFFFFF) then
+                // threw out_of_range.  And the separator searched for was
+                // "\n\n", which does not occur in a CRLF mailbox at all: the
+                // bytes there are "\r\n\r\n".  So every CRLF mbox took the
+                // path that throws.
+                std::string::size_type p = buf.find("\r\n\r\n");
+
+                if(p == buf.npos) {
+                    p = buf.find("\n\n");
+                }
+
                 if(p != buf.npos) {
-                    //buf.erase(p+2);
                     buf.erase(p);
                 }
 

--- a/jlib/net/MailFolder.hh
+++ b/jlib/net/MailFolder.hh
@@ -38,7 +38,28 @@ namespace jlib {
 
         class FolderBuffer {
         public:
-            
+            /**
+             * Needed, and it was missing.
+             *
+             * MailFolder holds its buffer as a shared_ptr<FolderBuffer> and
+             * init() takes a FolderBuffer*, so the deleter the shared_ptr
+             * stores is typed to this class.  Destroying an MFolder therefore
+             * deleted an MFolderBuffer through a base pointer with no virtual
+             * destructor -- undefined behaviour, which libc++ turns into a
+             * trap, so every mbox folder crashed on the way out.  Declaring
+             * ~MFolderBuffer virtual in the derived class did not help: what
+             * matters is the static type at the delete.
+             *
+             * The other four are defaulted because declaring this one
+             * suppresses the implicit moves.
+             */
+            FolderBuffer() = default;
+            FolderBuffer(const FolderBuffer&) = default;
+            FolderBuffer(FolderBuffer&&) = default;
+            FolderBuffer& operator=(const FolderBuffer&) = default;
+            FolderBuffer& operator=(FolderBuffer&&) = default;
+            virtual ~FolderBuffer() = default;
+
             typedef std::vector<Email> rep_type;
 
             typedef rep_type::pointer pointer;

--- a/jlib/net/net.cc
+++ b/jlib/net/net.cc
@@ -204,7 +204,17 @@ namespace jlib {
                 }
                 
                 count += buf.length();
-                newline_tail = (buf[buf.length()-2] == '\n');
+
+                // The *last* byte of this chunk, so the next one can tell
+                // whether a divider at its position 0 was preceded by a
+                // newline.  This read length()-2, which is the byte before
+                // that, and read out of range entirely whenever a chunk came
+                // back shorter than two bytes -- including the zero-length
+                // read at end of file.  A "From " landing exactly on a 16K
+                // chunk boundary was therefore either missed or accepted when
+                // it should not have been, depending on what happened to be
+                // in memory.
+                newline_tail = (!buf.empty() && buf[buf.length()-1] == '\n');
             }
 
             if(getenv("JLIB_NET_DEBUG")) {
@@ -277,17 +287,28 @@ namespace jlib {
         }
 
         bool same_address(const std::string& p_addr1, const std::string& p_addr2) {
-            std::string addr1, addr2;
-            
-            try {
-                addr1 = util::upper(extract_address(p_addr1));
-                addr2 = util::upper(extract_address(p_addr2));
-            }
-            catch(exception& e) {
+            const std::string addr1 = extract_address(p_addr1);
+            const std::string addr2 = extract_address(p_addr2);
+
+            // An address that could not be read is not the same as anything,
+            // and that includes another address that could not be read.
+            //
+            // This used to uppercase both results and compare them.
+            // extract_address returns "" for anything with no @ in it, so both
+            // sides came back empty and equal: same_address("Joe Yandle",
+            // "Bob Smith") was true, and so was same_address("", "garbage").
+            // A function whose whole job is "is this the same person" answered
+            // yes for two different people whenever it failed to read either
+            // one of them, silently, which in a mail client is a misfiled
+            // message or a reply to the wrong recipient.
+            if(addr1.empty() || addr2.empty()) {
                 return false;
             }
-            
-            return (addr1 == addr2);
+
+            // Case folding is left as it was for now -- see the note on
+            // RFC 5321 2.4 in net.hh.  The catch(exception&) that used to wrap
+            // this is gone with it: extract_address does not throw.
+            return util::iequals(addr1, addr2);
         }
         
         std::string extract_address(const std::string& p_addr) {
@@ -458,11 +479,55 @@ namespace jlib {
         }
 
         bool is_addr(const std::string& s) {
-            for(std::string::size_type i=0;i<s.length();i++) {
-                if(!isdigit(s[i]) && s[i] != '.')
+            // Four decimal octets separated by dots, and nothing else.
+            //
+            // This used to accept any string of digits and dots, which meant
+            // it could only ever return false and never true by mistake -- so
+            // "" and "...." were both addresses, the loop having nothing to
+            // reject.  get_host calls it to decide whether to attempt a
+            // reverse lookup.
+            int octets = 0;
+            std::string::size_type i = 0;
+
+            while(i < s.length()) {
+                std::string::size_type digits = 0;
+                int value = 0;
+
+                // isdigit takes an int that must be representable as unsigned
+                // char; a plain char is signed here, so a high-bit byte would
+                // be undefined behaviour.
+                while(i < s.length() &&
+                      isdigit(static_cast<unsigned char>(s[i]))) {
+                    value = value * 10 + (s[i] - '0');
+                    digits++;
+                    i++;
+                }
+
+                if(digits == 0 || digits > 3 || value > 255) {
                     return false;
+                }
+
+                octets++;
+
+                if(i == s.length()) {
+                    break;
+                }
+
+                if(s[i] != '.') {
+                    return false;
+                }
+
+                i++;
+
+                // A dot has to be followed by another octet.  Without this,
+                // "1.2.3.4." consumed the trailing dot, fell out of the loop
+                // with four octets counted, and was accepted.
+                if(i == s.length()) {
+                    return false;
+                }
             }
-            return true;
+
+            return (octets == 4);
         }
 
         std::pair< std::string, std::vector<std::string> > get_host(const std::string& s) {

--- a/jlib/util/util.cc
+++ b/jlib/util/util.cc
@@ -99,9 +99,14 @@ namespace jlib {
 
         std::string excise(const std::string& s, const std::string& d1, const std::string& d2) {
             std::string ret = s;
-            int i,j=0;
-            
-            while( (i=ret.find(d1,j)) != -1 && (j=ret.find(d2,i+1)) != -1 ) {
+
+            // These were ints compared against -1.  find() returns a
+            // size_type, so npos survived only as an implementation-defined
+            // narrowing that happens to give -1 -- and stops doing so the
+            // moment the string is longer than INT_MAX.
+            std::string::size_type i, j = 0;
+
+            while( (i=ret.find(d1,j)) != ret.npos && (j=ret.find(d2,i+1)) != ret.npos ) {
                 ret.erase(i,j+1-i);
                 j = i;
                 //cout << "Excising '" << ret.c_str() << "' between '" << d1.c_str() << "' and '" << d2.c_str() << "' = '" << ret.c_str() << "'\n";
@@ -347,7 +352,8 @@ namespace jlib {
         }
         
         bool icontains(const std::string& s, const std::string& t) {
-            return (s.size() >= t.size() && (int)upper(s).find(upper(t)) != -1);
+            // The cast to int truncated npos; see excise() above.
+            return (s.size() >= t.size() && upper(s).find(upper(t)) != std::string::npos);
         }
         
         bool ibegins(const std::string& s, const std::string& t) {

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -55,6 +55,8 @@ TESTS = \
 	net_email_test \
 	net_email_received_test \
 	net_email_multipart_test \
+	net_mbox_crlf_test \
+	net_same_address_test \
  \
 	sys_sync_test \
  \
@@ -128,6 +130,12 @@ net_email_test_SOURCES          = net_email_test.cc
 net_email_test_LDADD            = $(JNET_LA)
 net_email_received_test_SOURCES = net_email_received_test.cc
 net_email_received_test_LDADD   = $(JNET_LA)
+net_mbox_crlf_test_SOURCES      = net_mbox_crlf_test.cc
+net_mbox_crlf_test_LDADD        = $(JNET_LA)
+
+net_same_address_test_SOURCES   = net_same_address_test.cc
+net_same_address_test_LDADD     = $(JNET_LA)
+
 net_email_multipart_test_SOURCES = net_email_multipart_test.cc
 net_email_multipart_test_LDADD   = $(JNET_LA)
 

--- a/tests/net_mbox_crlf_test.cc
+++ b/tests/net_mbox_crlf_test.cc
@@ -1,0 +1,109 @@
+/* -*- mode: C++ c-basic-offset: 4  -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ *
+ */
+
+// An mbox whose lines end CRLF.
+//
+// MFolderBuffer::scan_headers looked for "\n\n" to find where a message's
+// headers stopped.  A CRLF mailbox has "\r\n\r\n" there and no "\n\n"
+// anywhere, so the search always failed -- and the "did we find it" guard was
+// written against an `unsigned int`, which truncates npos to 0xFFFFFFFF and is
+// therefore never equal to the real npos.  The guard could not fire, and
+// buf.erase(0xFFFFFFFF) threw out_of_range.  Every CRLF mbox threw.
+//
+// gtkmail opens mbox:// accounts through this path, so it was reachable by
+// pointing the client at a mailbox written by anything that speaks CRLF.
+
+#include <jlib/net/MFolder.hh>
+
+#include <cstdio>
+#include <fstream>
+#include <iostream>
+#include <string>
+
+static int failures = 0;
+
+static void ok(const std::string& what, bool good, const std::string& detail = "") {
+    if(!good) ++failures;
+    std::cout << (good ? "  ok   " : "  FAIL ") << what;
+    if(!detail.empty()) std::cout << ": " << detail;
+    std::cout << "\n";
+}
+
+/** Two messages, with the line endings given. */
+static void write_mbox(const std::string& path, const std::string& eol) {
+    std::ofstream out(path.c_str(), std::ios::binary);
+
+    out << "From joey@dbzero.com Mon Dec  3 15:01:45 2001" << eol
+        << "From: joey@dbzero.com" << eol
+        << "To: someone@example.com" << eol
+        << "Subject: the first one" << eol
+        << eol
+        << "body of the first message" << eol
+        << eol
+        << "From joey@dbzero.com Tue Dec  4 09:12:00 2001" << eol
+        << "From: joey@dbzero.com" << eol
+        << "To: someone@example.com" << eol
+        << "Subject: the second one" << eol
+        << eol
+        << "body of the second message" << eol;
+}
+
+static void scans(const std::string& what, const std::string& eol) {
+    const std::string path = "mbox_crlf_test.mbox";
+
+    write_mbox(path, eol);
+
+    bool threw = false;
+    std::string why;
+    std::size_t found = 0;
+
+    try {
+        jlib::net::MFolder folder(path);
+        folder.scan();
+        found = folder.size();
+    }
+    catch(std::exception& e) {
+        threw = true;
+        why = e.what();
+    }
+
+    ok(what + ": scanning does not throw", !threw, why);
+    ok(what + ": both messages are found", found == 2, std::to_string(found));
+
+    std::remove(path.c_str());
+}
+
+int main() {
+    std::cout << std::unitbuf;
+
+    std::cout << "an mbox, by line ending:\n";
+
+    // LF has always worked; it is here so a regression in the shared path
+    // cannot hide behind the CRLF fix.
+    scans("LF  ", "\n");
+    scans("CRLF", "\r\n");
+
+    // What this does not establish: that CRLF mailboxes are handled correctly
+    // throughout, only that scanning one no longer throws and finds the right
+    // number of messages.  net::parse_divide still splits on any body line
+    // beginning with "From ", and nothing here writes a mailbox, so the
+    // >From-escaping that jlib does not do is untested and still absent.
+    return failures ? 1 : 0;
+}

--- a/tests/net_same_address_test.cc
+++ b/tests/net_same_address_test.cc
@@ -1,0 +1,116 @@
+/* -*- mode: C++ c-basic-offset: 4  -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ *
+ */
+
+// same_address and is_addr: two predicates that used to say yes too readily.
+//
+// same_address extracted both addresses, uppercased, and compared.
+// extract_address returns "" for anything with no @ in it, so two unparseable
+// strings both became "" and compared equal: same_address("Joe Yandle",
+// "Bob Smith") was true.  A function whose whole job is "is this the same
+// person" answered yes for two different people whenever it could not read
+// either one of them.
+//
+// is_addr looped over the string returning false for anything that was not a
+// digit or a dot -- so it could only ever reject, never accept by mistake, and
+// "" and "...." were both addresses.
+
+#include <jlib/net/net.hh>
+
+#include <iostream>
+#include <string>
+
+static int failures = 0;
+
+static void ok(const std::string& what, bool good, const std::string& detail = "") {
+    if(!good) ++failures;
+    std::cout << (good ? "  ok   " : "  FAIL ") << what;
+    if(!detail.empty()) std::cout << ": " << detail;
+    std::cout << "\n";
+}
+
+static void an_address_it_cannot_read_matches_nothing() {
+    std::cout << "same_address:\n";
+
+    // The regression.  Both of these extract to "", and used to compare equal.
+    ok("two different names are not the same person",
+       !jlib::net::same_address("Joe Yandle", "Bob Smith"));
+
+    ok("nor are an empty string and some garbage",
+       !jlib::net::same_address("", "garbage"));
+
+    ok("nor are two empty strings",
+       !jlib::net::same_address("", ""));
+
+    ok("nor is a name the same as a real address",
+       !jlib::net::same_address("Joe Yandle", "joey@dbzero.com"));
+
+    // and it still says yes when it should
+    ok("the same address is the same address",
+       jlib::net::same_address("joey@dbzero.com", "joey@dbzero.com"));
+
+    ok("through a display name",
+       jlib::net::same_address("Joey Yandle <joey@dbzero.com>", "joey@dbzero.com"));
+
+    ok("and case does not matter",
+       jlib::net::same_address("JOEY@DBZERO.COM", "joey@dbzero.com"));
+}
+
+static void only_a_dotted_quad_is_an_address() {
+    std::cout << "\nis_addr:\n";
+
+    // The regression: neither of these has any digits in it at all.
+    ok("an empty string is not an address", !jlib::net::is_addr(""));
+    ok("nor is a row of dots",              !jlib::net::is_addr("...."));
+
+    ok("a dotted quad is",                   jlib::net::is_addr("192.168.0.1"));
+    ok("and the edges of one",               jlib::net::is_addr("0.0.0.0"));
+    ok("and the other edge",                 jlib::net::is_addr("255.255.255.255"));
+
+    ok("three octets is not enough",        !jlib::net::is_addr("1.2.3"));
+    ok("five is too many",                  !jlib::net::is_addr("1.2.3.4.5"));
+    ok("an octet over 255 is not one",      !jlib::net::is_addr("1.2.3.256"));
+    ok("nor is a four digit octet",         !jlib::net::is_addr("1.2.3.0001"));
+    ok("a trailing dot is not an address",  !jlib::net::is_addr("1.2.3.4."));
+    ok("nor a leading one",                 !jlib::net::is_addr(".1.2.3.4"));
+    ok("a hostname is not an address",      !jlib::net::is_addr("dbzero.com"));
+    ok("nor is a hostname of digits",       !jlib::net::is_addr("1.2.3.four"));
+}
+
+int main() {
+    std::cout << std::unitbuf;
+
+    an_address_it_cannot_read_matches_nothing();
+    only_a_dotted_quad_is_an_address();
+
+    // What this does not establish.
+    //
+    // same_address still folds case across the whole address, including the
+    // local part, which RFC 5321 2.4 says is case sensitive.  That is a
+    // deliberate hold rather than an oversight -- the requirement binds
+    // relays, jlib is a user agent, and every large provider folds -- and it
+    // is due to become a policy flag when the RFC 5322 parser lands.  Nothing
+    // here tests the quoted local part ("Joe"@x.com vs "joe"@x.com), which is
+    // the case where 5321 is unambiguous and folding is simply wrong.
+    //
+    // is_addr only knows IPv4.  is_addr("::1") is false, and get_host will
+    // therefore not attempt a reverse lookup on an IPv6 literal.  That is
+    // unchanged behaviour, not something this fix addresses.
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
Live bugs, none of which need the parser.  Doing them first means the parser
branches land on a base whose behaviour is understood.

    macOS  38 tests, 38 pass, 0 skip
    Linux  39 tests, 38 pass, 1 skip

two predicates that said yes too readily

    same_address extracted both addresses, uppercased them, and compared.
    extract_address returns "" for anything with no @ in it, so two unreadable
    strings both became "" and compared equal:

        same_address("Joe Yandle", "Bob Smith")  ->  true

    A function whose entire job is "is this the same person" answered yes for
    two different people whenever it failed to read either one of them, and did
    it silently.  In a mail client that is a misfiled message or a reply to the
    wrong recipient.  An address that could not be read is now the same as
    nothing, including another address that could not be read.

    The catch(exception&) around it went too; extract_address does not throw,
    so it was dead, and a dead catch around a rewritten body is how the next
    reader gets misled.

    is_addr looped over the string returning false for anything that was not a
    digit or a dot -- so it could only ever reject and never wrongly accept,
    which meant "" and "...." were both addresses.  It now wants four decimal
    octets and nothing else.  get_host calls it to decide whether to attempt a
    reverse lookup.

    Case folding in same_address is deliberately left as it was for now.  It
    folds the whole address including the local part, which RFC 5321 2.4 says
    is case sensitive -- but that requirement binds relays, jlib is a user
    agent, and gtkmail already lowercases before calling.  It becomes a policy
    flag when the 5322 parser lands.

the npos truncation, five more times

    The bug class already fixed and regression-tested in extract_address was
    still live in five places: a find() result stored in an unsigned int or an
    int, so npos truncated and the "did we find it" guard could never fire.

        MFolder.cc:192   headers/body split -- see below
        Imap4.cc:49      LIST response, "(" and ")"
        Email.cc:149     tellg() narrowed to 32 bits
        util.cc:104      excise(), int compared against -1
        util.cc:350      icontains(), (int)find() compared against -1

    Imap4's was the worst of the four: a LIST reply with no "(" left i as
    0xFFFFFFFF, i+1 wrapped to 0, and the find(")") that followed searched from
    the start of the line, after which substr threw or returned a slice of
    something unrelated.  That reply comes from the network.  The unchecked
    etokens[0] and etokens[1] next to it are guarded now as well -- reading
    LIST properly needs a grammar, not more guards, and that is a later branch.

    ListItem's two bools were never initialized, either.  ListItem() is an
    empty body, so a default-constructed item reported whatever was on the
    stack for m_is_folder -- which decides whether a mailbox is shown at all.

every CRLF mbox threw, and a test that proves it

    MFolderBuffer::scan_headers looked for "\n\n" to find where a message's
    headers stopped.  A CRLF mailbox has "\r\n\r\n" there and no "\n\n"
    anywhere in it, so the search always failed -- and the guard was written
    against an unsigned int, so it could not fire.  buf.erase(0xFFFFFFFF) threw
    out_of_range.  Every CRLF mbox, every time.

    gtkmail opens mbox:// accounts through this path (MainWin.cc:791), so it
    was reachable by pointing the client at a mailbox written by anything that
    speaks CRLF.

    tests/net_mbox_crlf_test.cc writes the same two messages with each line
    ending and scans both.  Checked that it has teeth by reverting the fix:
    LF passes and CRLF throws, which is the shape the bug had.

and the crash that found

    Writing that test turned up something worse, and it was not on the list.
    Every MFolder destruction was undefined behaviour.

    MailFolder holds its buffer as a shared_ptr<FolderBuffer>, and init() takes
    a FolderBuffer*, so the deleter the shared_ptr stores is typed to the base
    -- which had no virtual destructor.  Declaring ~MFolderBuffer virtual in
    the derived class does not help: what matters is the static type at the
    delete.  libc++ turns it into a trap, so the test crashed after passing its
    assertions, on the way out of scope.

    FolderBuffer has one now, with the other four defaulted, since declaring a
    destructor suppresses the implicit moves.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
