### PR TITLE
Add the ABNF combinator core: rules, grammars, captures, counted and backref

### DIFF
--- a/jlib/util/Makefile.am
+++ b/jlib/util/Makefile.am
@@ -1,11 +1,11 @@
 AM_CPPFLAGS = -I$(top_srcdir) $(JSONC_CFLAGS)
 
 lib_LTLIBRARIES = libjutil.la
-libjutil_la_SOURCES = Regex.cc MimeType.cc util.cc Date.cc xml.cc xmlparser.cc \
+libjutil_la_SOURCES = abnf.cc Regex.cc MimeType.cc util.cc Date.cc xml.cc xmlparser.cc \
                       xmltokenizer.cc URL.cc Headers.cc Timer.cc json.cc
 libjutil_la_LDFLAGS = -version-info $(LIBJ_SO_VERSION) -release $(JLIB_RELEASE) -no-undefined
 libjutil_la_LIBADD = $(top_builddir)/jlib/sys/libjsys.la $(JSONC_LIBS)
 
 libjutilincludedir = $(includedir)/jlib-1.2/jlib/util
-libjutilinclude_HEADERS = Regex.hh MimeType.hh util.hh Date.hh xml.hh xmlparser.hh \
+libjutilinclude_HEADERS = abnf.hh Regex.hh MimeType.hh util.hh Date.hh xml.hh xmlparser.hh \
                           xmltokenizer.hh URL.hh Headers.hh Timer.hh json.hh

--- a/jlib/util/abnf.cc
+++ b/jlib/util/abnf.cc
@@ -1,0 +1,1889 @@
+/* -*- mode: C++ c-basic-offset: 4  -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ *
+ */
+
+#include <jlib/util/abnf.hh>
+
+#include <algorithm>
+#include <cctype>
+#include <ostream>
+#include <sstream>
+
+namespace jlib {
+namespace util {
+namespace abnf {
+
+static const std::size_t NONE = static_cast<std::size_t>(-1);
+
+namespace detail {
+
+// ------------------------------------------------------------------ the tape
+
+struct capture_record {
+    std::string name;
+    std::size_t begin;
+    std::size_t end;
+    std::size_t parent;
+};
+
+struct arena {
+    std::string input;
+    std::vector<capture_record> records;
+};
+
+/** Where a node that something back-references last matched. */
+struct tracked_record {
+    const expr* source;
+    std::size_t begin;
+    std::size_t end;
+};
+
+/**
+ * One rulename's cell.
+ *
+ * A reference points here rather than at a body, which is what makes forward
+ * declaration, recursion and "=/" all the same mechanism: replacing the body
+ * is seen by every reference at once.
+ */
+class slot {
+public:
+    std::string name;
+    std::shared_ptr<const expr> body;
+    bool seeded = false;
+};
+
+/**
+ * Everything one parse needs, and nothing that outlives it.
+ *
+ * Deliberately not on the grammar: a frozen grammar is read-only, so the same
+ * one can be parsed against from several threads at once.  Anything cached
+ * here rather than there keeps that true.
+ */
+class context {
+public:
+    std::string_view input;
+
+    const options* opt = 0;
+    std::size_t steps = 0;
+    std::size_t budget = 0;
+    std::size_t depth = 0;
+    std::size_t max_depth = 0;
+
+    std::vector<capture_record> captures;
+    std::vector<tracked_record> tracked;
+    std::size_t parent = NONE;
+
+    /** Furthest position anything reached, and what it wanted there. */
+    std::size_t furthest = 0;
+    std::vector<std::string> expected;
+    std::vector<std::string> stack;
+    std::vector<std::string> furthest_stack;
+
+    struct mark {
+        std::size_t captures;
+        std::size_t tracked;
+    };
+
+    mark save() const { return mark{captures.size(), tracked.size()}; }
+
+    void restore(const mark& m)
+    {
+        captures.resize(m.captures);
+        tracked.resize(m.tracked);
+    }
+
+    bool keeping(const std::string& name) const
+    {
+        switch(opt->captures) {
+        case options::capture_policy::none:
+            return false;
+        case options::capture_policy::named:
+            return true;
+        case options::capture_policy::listed:
+            return opt->capture_only.count(name) != 0;
+        }
+
+        return false;
+    }
+
+    /** Note that something wanted `what` at `pos` and did not get it. */
+    void want(std::size_t pos, const std::string& what)
+    {
+        if(pos > furthest) {
+            furthest = pos;
+            expected.clear();
+            furthest_stack = stack;
+        }
+
+        if(pos == furthest &&
+           std::find(expected.begin(), expected.end(), what) == expected.end()) {
+            expected.push_back(what);
+        }
+    }
+};
+
+// ------------------------------------------------------------------ the node
+
+class expr {
+public:
+    typedef std::shared_ptr<const expr> ptr;
+
+    expr() = default;
+    expr(const expr&) = default;
+    expr(expr&&) = default;
+    expr& operator=(const expr&) = default;
+    expr& operator=(expr&&) = default;
+    virtual ~expr() = default;
+
+    virtual bool parse(context& ctx, std::size_t& pos) const = 0;
+
+    /** Serialize, parenthesizing when the context binds tighter than we do. */
+    virtual void write(std::ostream& os, int prec) const = 0;
+
+    /** Direct children, for the analysis passes. */
+    virtual void kids(std::vector<const expr*>& out) const { (void)out; }
+
+    /** Can this match the empty string?  visiting breaks reference cycles. */
+    virtual bool nullable(std::set<const slot*>& visiting) const = 0;
+
+    /** Slots reachable without consuming anything.  For left recursion. */
+    virtual void leftmost(std::set<const slot*>& out,
+                          std::set<const slot*>& visiting) const = 0;
+
+    /**
+     * True unless the subtree's answer can depend on more than the input at
+     * a position -- which counted, backref and an impure predicate all make
+     * it.  Nothing reads it yet; a memo table would, and a memo keyed on
+     * (rule, position) is a lie for exactly those nodes.  Computing it here
+     * while the shape is fresh is cheaper than retrofitting it under a
+     * memoizer later and discovering IMAP literals were being cached.
+     */
+    virtual bool pure() const { return true; }
+
+    /** Some counted() or backref() names this node as its source. */
+    mutable bool m_tracked = false;
+};
+
+/**
+ * Every internal call goes through here rather than calling parse() directly.
+ *
+ * One place to count steps, and one place to record the extent of a node
+ * something else back-references.
+ */
+static bool run(const expr* e, context& ctx, std::size_t& pos);
+
+// ------------------------------------------------------------------ terminals
+
+class charclass : public expr {
+public:
+    charclass(std::bitset<256> set, std::string label)
+        : m_set(set), m_label(std::move(label)) {}
+
+    virtual bool parse(context& ctx, std::size_t& pos) const
+    {
+        if(pos < ctx.input.size() &&
+           m_set.test(static_cast<unsigned char>(ctx.input[pos]))) {
+            pos++;
+            return true;
+        }
+
+        ctx.want(pos, m_label);
+        return false;
+    }
+
+    virtual void write(std::ostream& os, int) const { os << m_label; }
+
+    virtual bool nullable(std::set<const slot*>&) const { return false; }
+    virtual void leftmost(std::set<const slot*>&, std::set<const slot*>&) const {}
+
+protected:
+    std::bitset<256> m_set;
+    std::string m_label;
+};
+
+class literal : public expr {
+public:
+    literal(std::string s, bool fold)
+        : m_text(std::move(s)), m_fold(fold) {}
+
+    virtual bool parse(context& ctx, std::size_t& pos) const
+    {
+        if(pos + m_text.size() > ctx.input.size()) {
+            ctx.want(pos, label());
+            return false;
+        }
+
+        for(std::size_t i = 0; i < m_text.size(); i++) {
+            char a = ctx.input[pos + i];
+            char b = m_text[i];
+
+            if(m_fold) {
+                a = static_cast<char>(std::tolower(static_cast<unsigned char>(a)));
+                b = static_cast<char>(std::tolower(static_cast<unsigned char>(b)));
+            }
+
+            if(a != b) {
+                ctx.want(pos, label());
+                return false;
+            }
+        }
+
+        pos += m_text.size();
+        return true;
+    }
+
+    virtual void write(std::ostream& os, int) const { os << label(); }
+
+    virtual bool nullable(std::set<const slot*>&) const { return m_text.empty(); }
+    virtual void leftmost(std::set<const slot*>&, std::set<const slot*>&) const {}
+
+protected:
+    std::string label() const
+    {
+        return (m_fold ? "\"" : "%s\"") + m_text + "\"";
+    }
+
+    std::string m_text;
+    bool m_fold;
+};
+
+class nothing : public expr {
+public:
+    explicit nothing(bool succeed) : m_succeed(succeed) {}
+
+    virtual bool parse(context& ctx, std::size_t& pos) const
+    {
+        (void)pos;
+        if(!m_succeed) {
+            ctx.want(pos, "<nothing>");
+        }
+        return m_succeed;
+    }
+
+    virtual void write(std::ostream& os, int) const
+    {
+        os << (m_succeed ? "\"\"" : "<never>");
+    }
+
+    virtual bool nullable(std::set<const slot*>&) const { return m_succeed; }
+    virtual void leftmost(std::set<const slot*>&, std::set<const slot*>&) const {}
+
+protected:
+    bool m_succeed;
+};
+
+// ---------------------------------------------------------------- structural
+
+/** Precedence for write(): alternation loosest, then concatenation. */
+enum { PREC_ALT = 1, PREC_CAT = 2, PREC_REP = 3, PREC_ATOM = 4 };
+
+class concat : public expr {
+public:
+    explicit concat(std::vector<ptr> parts) : m_parts(std::move(parts)) {}
+
+    virtual bool parse(context& ctx, std::size_t& pos) const
+    {
+        const context::mark m = ctx.save();
+        const std::size_t start = pos;
+
+        for(const ptr& p : m_parts) {
+            if(!run(p.get(), ctx, pos)) {
+                pos = start;
+                ctx.restore(m);
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    virtual void write(std::ostream& os, int prec) const
+    {
+        const bool paren = prec > PREC_CAT;
+        if(paren) os << "(";
+
+        for(std::size_t i = 0; i < m_parts.size(); i++) {
+            if(i) os << " ";
+            m_parts[i]->write(os, PREC_CAT);
+        }
+
+        if(paren) os << ")";
+    }
+
+    virtual void kids(std::vector<const expr*>& out) const
+    {
+        for(const ptr& p : m_parts) out.push_back(p.get());
+    }
+
+    virtual bool nullable(std::set<const slot*>& v) const
+    {
+        for(const ptr& p : m_parts)
+            if(!p->nullable(v)) return false;
+
+        return true;
+    }
+
+    virtual void leftmost(std::set<const slot*>& out,
+                          std::set<const slot*>& visiting) const
+    {
+        // Leftmost reaches past anything that can match nothing.
+        for(const ptr& p : m_parts) {
+            p->leftmost(out, visiting);
+
+            std::set<const slot*> fresh;
+            if(!p->nullable(fresh)) break;
+        }
+    }
+
+    virtual bool pure() const
+    {
+        for(const ptr& p : m_parts)
+            if(!p->pure()) return false;
+
+        return true;
+    }
+
+    const std::vector<ptr>& parts() const { return m_parts; }
+
+protected:
+    std::vector<ptr> m_parts;
+};
+
+class alternation : public expr {
+public:
+    explicit alternation(std::vector<ptr> branches)
+        : m_branches(std::move(branches)) {}
+
+    virtual bool parse(context& ctx, std::size_t& pos) const
+    {
+        const context::mark m = ctx.save();
+        const std::size_t start = pos;
+
+        for(const ptr& b : m_branches) {
+            if(run(b.get(), ctx, pos)) {
+                return true;
+            }
+
+            // Everything the branch did is undone before the next is tried.
+            // This is what "full backtracking" means here, and it is what lets
+            // mailbox = name-addr / addr-spec run a display name across a bare
+            // address, fail at the @, and rescan from the beginning.
+            pos = start;
+            ctx.restore(m);
+        }
+
+        return false;
+    }
+
+    virtual void write(std::ostream& os, int prec) const
+    {
+        const bool paren = prec > PREC_ALT;
+        if(paren) os << "(";
+
+        for(std::size_t i = 0; i < m_branches.size(); i++) {
+            if(i) os << " / ";
+            m_branches[i]->write(os, PREC_ALT);
+        }
+
+        if(paren) os << ")";
+    }
+
+    virtual void kids(std::vector<const expr*>& out) const
+    {
+        for(const ptr& b : m_branches) out.push_back(b.get());
+    }
+
+    virtual bool nullable(std::set<const slot*>& v) const
+    {
+        for(const ptr& b : m_branches)
+            if(b->nullable(v)) return true;
+
+        return false;
+    }
+
+    virtual void leftmost(std::set<const slot*>& out,
+                          std::set<const slot*>& visiting) const
+    {
+        for(const ptr& b : m_branches) b->leftmost(out, visiting);
+    }
+
+    virtual bool pure() const
+    {
+        for(const ptr& b : m_branches)
+            if(!b->pure()) return false;
+
+        return true;
+    }
+
+    const std::vector<ptr>& branches() const { return m_branches; }
+
+protected:
+    std::vector<ptr> m_branches;
+};
+
+class repeat : public expr {
+public:
+    repeat(ptr body, std::size_t min, std::size_t max)
+        : m_body(std::move(body)), m_min(min), m_max(max) {}
+
+    virtual bool parse(context& ctx, std::size_t& pos) const
+    {
+        const context::mark m = ctx.save();
+        const std::size_t start = pos;
+
+        std::size_t n = 0;
+
+        while(n < m_max) {
+            std::size_t at = pos;
+
+            if(!run(m_body.get(), ctx, at)) {
+                break;
+            }
+
+            // A body that matched without consuming would spin forever.  The
+            // grammar check rejects that shape up front for an unbounded
+            // repetition; this is the belt to its braces, and it also covers
+            // a bounded one, where the check lets it through.
+            if(at == pos) {
+                break;
+            }
+
+            pos = at;
+            n++;
+        }
+
+        if(n < m_min) {
+            pos = start;
+            ctx.restore(m);
+            return false;
+        }
+
+        return true;
+    }
+
+    virtual void write(std::ostream& os, int prec) const
+    {
+        const bool paren = prec > PREC_REP;
+        if(paren) os << "(";
+
+        if(m_min == 0 && m_max == 1) {
+            os << "[";
+            m_body->write(os, PREC_ALT);
+            os << "]";
+
+            if(paren) os << ")";
+            return;
+        }
+
+        if(m_min != 0) os << m_min;
+        os << "*";
+        if(m_max != rule::unbounded) os << m_max;
+
+        m_body->write(os, PREC_REP + 1);
+
+        if(paren) os << ")";
+    }
+
+    virtual void kids(std::vector<const expr*>& out) const
+    {
+        out.push_back(m_body.get());
+    }
+
+    virtual bool nullable(std::set<const slot*>& v) const
+    {
+        return m_min == 0 || m_body->nullable(v);
+    }
+
+    virtual void leftmost(std::set<const slot*>& out,
+                          std::set<const slot*>& visiting) const
+    {
+        m_body->leftmost(out, visiting);
+    }
+
+    virtual bool pure() const { return m_body->pure(); }
+
+    const ptr& body() const { return m_body; }
+    std::size_t min() const { return m_min; }
+    std::size_t max() const { return m_max; }
+
+protected:
+    ptr m_body;
+    std::size_t m_min;
+    std::size_t m_max;
+};
+
+// ------------------------------------------------------------------ reference
+
+class reference : public expr {
+public:
+    explicit reference(std::shared_ptr<slot> s) : m_slot(std::move(s)) {}
+
+    virtual bool parse(context& ctx, std::size_t& pos) const
+    {
+        if(!m_slot->body) {
+            throw grammar_error("rule \"" + m_slot->name +
+                                "\" is referenced but never defined");
+        }
+
+        if(ctx.depth >= ctx.max_depth) {
+            throw budget_exceeded(
+                "recursion passed " + std::to_string(ctx.max_depth) +
+                " while parsing \"" + m_slot->name + "\"",
+                std::string(ctx.input), pos);
+        }
+
+        ctx.depth++;
+        ctx.stack.push_back(m_slot->name);
+
+        const bool ok = run(m_slot->body.get(), ctx, pos);
+
+        ctx.stack.pop_back();
+        ctx.depth--;
+
+        if(!ok) {
+            ctx.want(pos, m_slot->name);
+        }
+
+        return ok;
+    }
+
+    virtual void write(std::ostream& os, int) const { os << m_slot->name; }
+
+    virtual bool nullable(std::set<const slot*>& v) const
+    {
+        if(!m_slot->body || v.count(m_slot.get())) {
+            return false;
+        }
+
+        v.insert(m_slot.get());
+        const bool n = m_slot->body->nullable(v);
+        v.erase(m_slot.get());
+
+        return n;
+    }
+
+    virtual void leftmost(std::set<const slot*>& out,
+                          std::set<const slot*>& visiting) const
+    {
+        out.insert(m_slot.get());
+
+        if(!m_slot->body || visiting.count(m_slot.get())) {
+            return;
+        }
+
+        visiting.insert(m_slot.get());
+        m_slot->body->leftmost(out, visiting);
+        visiting.erase(m_slot.get());
+    }
+
+    virtual bool pure() const
+    {
+        // Not followed through the slot: the body may not be defined yet, and
+        // a cycle would not terminate.  Assuming a reference impure would
+        // disable memoization everywhere; assuming it pure is safe only
+        // because nothing memoizes yet, and the check moves into freeze()
+        // when something does.
+        return true;
+    }
+
+    const std::shared_ptr<slot>& cell() const { return m_slot; }
+
+protected:
+    std::shared_ptr<slot> m_slot;
+};
+
+// -------------------------------------------------------------------- capture
+
+class capture : public expr {
+public:
+    capture(std::string name, ptr body)
+        : m_name(std::move(name)), m_body(std::move(body)) {}
+
+    virtual bool parse(context& ctx, std::size_t& pos) const
+    {
+        const bool keep = ctx.keeping(m_name);
+
+        std::size_t index = NONE;
+        const std::size_t start = pos;
+        const std::size_t was = ctx.parent;
+
+        if(keep) {
+            index = ctx.captures.size();
+            ctx.captures.push_back(capture_record{m_name, start, start, was});
+            ctx.parent = index;
+        }
+
+        const bool ok = run(m_body.get(), ctx, pos);
+
+        ctx.parent = was;
+
+        if(keep) {
+            if(ok) {
+                ctx.captures[index].end = pos;
+            }
+            else {
+                ctx.captures.resize(index);
+            }
+        }
+
+        return ok;
+    }
+
+    virtual void write(std::ostream& os, int prec) const
+    {
+        m_body->write(os, prec);
+    }
+
+    virtual void kids(std::vector<const expr*>& out) const
+    {
+        out.push_back(m_body.get());
+    }
+
+    virtual bool nullable(std::set<const slot*>& v) const
+    {
+        return m_body->nullable(v);
+    }
+
+    virtual void leftmost(std::set<const slot*>& out,
+                          std::set<const slot*>& visiting) const
+    {
+        m_body->leftmost(out, visiting);
+    }
+
+    virtual bool pure() const { return m_body->pure(); }
+
+    const std::string& name() const { return m_name; }
+
+protected:
+    std::string m_name;
+    ptr m_body;
+};
+
+// ------------------------------------------------------- context sensitivity
+
+/** The most recent extent of source that has not been backtracked away. */
+static const tracked_record* last(const context& ctx, const expr* source)
+{
+    for(std::size_t i = ctx.tracked.size(); i > 0; i--) {
+        if(ctx.tracked[i-1].source == source) {
+            return &ctx.tracked[i-1];
+        }
+    }
+
+    return 0;
+}
+
+class counted_node : public expr {
+public:
+    counted_node(ptr source, ptr element,
+                 std::function<std::size_t(std::string_view)> adapt)
+        : m_source(std::move(source)),
+          m_element(std::move(element)),
+          m_adapt(std::move(adapt))
+    {
+        m_source->m_tracked = true;
+    }
+
+    virtual bool parse(context& ctx, std::size_t& pos) const
+    {
+        const tracked_record* r = last(ctx, m_source.get());
+
+        if(!r) {
+            throw error("jlib::util::abnf::error: counted() has no prior match "
+                        "of its source rule",
+                        std::string(ctx.input), pos, {}, ctx.stack);
+        }
+
+        const std::size_t n =
+            m_adapt(ctx.input.substr(r->begin, r->end - r->begin));
+
+        if(!m_element) {
+            if(pos + n > ctx.input.size()) {
+                ctx.want(pos, std::to_string(n) + " octets");
+                return false;
+            }
+
+            pos += n;
+            return true;
+        }
+
+        const context::mark m = ctx.save();
+        const std::size_t start = pos;
+
+        for(std::size_t i = 0; i < n; i++) {
+            if(!run(m_element.get(), ctx, pos)) {
+                pos = start;
+                ctx.restore(m);
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    virtual void write(std::ostream& os, int) const
+    {
+        os << "<counted>";
+    }
+
+    virtual bool nullable(std::set<const slot*>&) const
+    {
+        // Depends on a runtime count, so it might match nothing.  Saying yes
+        // is the safe answer: it makes *counted(...) a grammar error rather
+        // than a possible infinite loop.
+        return true;
+    }
+
+    virtual void leftmost(std::set<const slot*>&, std::set<const slot*>&) const {}
+    virtual bool pure() const { return false; }
+
+protected:
+    ptr m_source;
+    ptr m_element;
+    std::function<std::size_t(std::string_view)> m_adapt;
+};
+
+class backref_node : public expr {
+public:
+    backref_node(ptr source, bool fold)
+        : m_source(std::move(source)), m_fold(fold)
+    {
+        m_source->m_tracked = true;
+    }
+
+    virtual bool parse(context& ctx, std::size_t& pos) const
+    {
+        const tracked_record* r = last(ctx, m_source.get());
+
+        if(!r) {
+            throw error("jlib::util::abnf::error: backref() has no prior match "
+                        "of its source rule",
+                        std::string(ctx.input), pos, {}, ctx.stack);
+        }
+
+        const std::string_view want = ctx.input.substr(r->begin, r->end - r->begin);
+
+        if(pos + want.size() > ctx.input.size()) {
+            ctx.want(pos, "the earlier \"" + std::string(want) + "\"");
+            return false;
+        }
+
+        for(std::size_t i = 0; i < want.size(); i++) {
+            char a = ctx.input[pos + i];
+            char b = want[i];
+
+            if(m_fold) {
+                a = static_cast<char>(std::tolower(static_cast<unsigned char>(a)));
+                b = static_cast<char>(std::tolower(static_cast<unsigned char>(b)));
+            }
+
+            if(a != b) {
+                ctx.want(pos, "the earlier \"" + std::string(want) + "\"");
+                return false;
+            }
+        }
+
+        pos += want.size();
+        return true;
+    }
+
+    virtual void write(std::ostream& os, int) const { os << "<backref>"; }
+
+    virtual bool nullable(std::set<const slot*>&) const { return true; }
+    virtual void leftmost(std::set<const slot*>&, std::set<const slot*>&) const {}
+    virtual bool pure() const { return false; }
+
+protected:
+    ptr m_source;
+    bool m_fold;
+};
+
+class until_node : public expr {
+public:
+    explicit until_node(ptr terminator) : m_term(std::move(terminator)) {}
+
+    virtual bool parse(context& ctx, std::size_t& pos) const
+    {
+        while(pos <= ctx.input.size()) {
+            std::size_t at = pos;
+            const context::mark m = ctx.save();
+
+            if(run(m_term.get(), ctx, at)) {
+                ctx.restore(m);
+                return true;
+            }
+
+            ctx.restore(m);
+
+            if(pos == ctx.input.size()) {
+                break;
+            }
+
+            pos++;
+        }
+
+        ctx.want(pos, "something the terminator follows");
+        return false;
+    }
+
+    virtual void write(std::ostream& os, int) const { os << "<until>"; }
+
+    virtual bool nullable(std::set<const slot*>&) const { return true; }
+    virtual void leftmost(std::set<const slot*>&, std::set<const slot*>&) const {}
+    virtual bool pure() const { return m_term->pure(); }
+
+protected:
+    ptr m_term;
+};
+
+class predicate : public expr {
+public:
+    predicate(std::string desc,
+              std::function<bool(std::string_view, std::size_t&)> f, bool pure)
+        : m_desc(std::move(desc)), m_fn(std::move(f)), m_pure(pure) {}
+
+    virtual bool parse(context& ctx, std::size_t& pos) const
+    {
+        if(m_fn(ctx.input, pos)) {
+            return true;
+        }
+
+        ctx.want(pos, m_desc);
+        return false;
+    }
+
+    virtual void write(std::ostream& os, int) const { os << "<" << m_desc << ">"; }
+
+    virtual bool nullable(std::set<const slot*>&) const { return true; }
+    virtual void leftmost(std::set<const slot*>&, std::set<const slot*>&) const {}
+    virtual bool pure() const { return m_pure; }
+
+protected:
+    std::string m_desc;
+    std::function<bool(std::string_view, std::size_t&)> m_fn;
+    bool m_pure;
+};
+
+// ---------------------------------------------------------------------- run
+
+static bool run(const expr* e, context& ctx, std::size_t& pos)
+{
+    ctx.steps++;
+
+    if(ctx.steps > ctx.budget) {
+        throw budget_exceeded(
+            "gave up after " + std::to_string(ctx.steps) + " steps",
+            std::string(ctx.input), ctx.furthest);
+    }
+
+    const std::size_t start = pos;
+    const bool ok = e->parse(ctx, pos);
+
+    if(ok && e->m_tracked) {
+        ctx.tracked.push_back(tracked_record{e, start, pos});
+    }
+
+    return ok;
+}
+
+
+}  // namespace detail
+
+using detail::expr;
+using detail::slot;
+using detail::context;
+using detail::arena;
+using detail::capture_record;
+
+// ------------------------------------------------------------------- errors
+
+error::error(const std::string& msg, std::string input, std::size_t offset,
+             std::vector<std::string> expected, std::vector<std::string> stack)
+    : exception(msg),
+      m_input(std::move(input)),
+      m_offset(offset),
+      m_expected(std::move(expected)),
+      m_stack(std::move(stack))
+{
+}
+
+std::size_t error::line() const
+{
+    std::size_t n = 1;
+
+    for(std::size_t i = 0; i < m_offset && i < m_input.size(); i++) {
+        if(m_input[i] == '\n') n++;
+    }
+
+    return n;
+}
+
+std::size_t error::column() const
+{
+    std::size_t start = 0;
+
+    for(std::size_t i = 0; i < m_offset && i < m_input.size(); i++) {
+        if(m_input[i] == '\n') start = i + 1;
+    }
+
+    return m_offset - start + 1;
+}
+
+std::string error::context_line() const
+{
+    std::size_t start = 0;
+
+    for(std::size_t i = 0; i < m_offset && i < m_input.size(); i++) {
+        if(m_input[i] == '\n') start = i + 1;
+    }
+
+    std::size_t stop = m_input.find('\n', start);
+    if(stop == std::string::npos) stop = m_input.size();
+
+    return m_input.substr(start, stop - start);
+}
+
+std::string error::report() const
+{
+    std::ostringstream o;
+
+    o << what();
+
+    if(!m_expected.empty()) {
+        o << ": expected ";
+
+        for(std::size_t i = 0; i < m_expected.size(); i++) {
+            if(i) o << (i + 1 == m_expected.size() ? " or " : ", ");
+            o << m_expected[i];
+        }
+    }
+
+    o << " at line " << line() << ", column " << column() << "\n";
+    o << "  " << context_line() << "\n";
+    o << "  " << std::string(column() - 1, ' ') << "^";
+
+    if(!m_stack.empty()) {
+        o << "\n  while parsing:";
+
+        for(std::size_t i = 0; i < m_stack.size(); i++) {
+            o << (i ? " -> " : " ") << m_stack[i];
+        }
+    }
+
+    return o.str();
+}
+
+budget_exceeded::budget_exceeded(const std::string& msg, std::string input,
+                                 std::size_t offset)
+    : error("jlib::util::abnf::budget_exceeded: " + msg, std::move(input),
+            offset, {}, {})
+{
+}
+
+// -------------------------------------------------------------------- match
+
+match::match() : m_index(NONE) {}
+
+match::match(std::shared_ptr<const arena> a, std::size_t i)
+    : m_arena(std::move(a)), m_index(i) {}
+
+match::operator bool() const { return m_arena && m_index != NONE; }
+
+std::string match::name() const
+{
+    if(!*this || m_index >= m_arena->records.size()) return std::string();
+
+    return m_arena->records[m_index].name;
+}
+
+std::size_t match::begin() const
+{
+    if(!m_arena) return 0;
+    if(m_index >= m_arena->records.size()) return 0;
+
+    return m_arena->records[m_index].begin;
+}
+
+std::size_t match::end() const
+{
+    if(!m_arena) return 0;
+    if(m_index >= m_arena->records.size()) return m_arena->input.size();
+
+    return m_arena->records[m_index].end;
+}
+
+std::string_view match::text() const
+{
+    if(!m_arena) return std::string_view();
+
+    const std::size_t b = begin(), e = end();
+
+    return std::string_view(m_arena->input).substr(b, e - b);
+}
+
+/** Depth-first over the records, which are already in document order. */
+static bool descends(const std::vector<capture_record>& rs,
+                     std::size_t child, std::size_t ancestor)
+{
+    if(ancestor == NONE) return true;
+
+    for(std::size_t at = rs[child].parent; at != NONE; at = rs[at].parent) {
+        if(at == ancestor) return true;
+    }
+
+    return false;
+}
+
+match match::operator[](std::string_view name) const
+{
+    if(!m_arena) return match();
+
+    for(std::size_t i = 0; i < m_arena->records.size(); i++) {
+        if(m_arena->records[i].name == name &&
+           descends(m_arena->records, i, m_index)) {
+            return match(m_arena, i);
+        }
+    }
+
+    return match();
+}
+
+match match::child(std::string_view name) const
+{
+    if(!m_arena) return match();
+
+    for(std::size_t i = 0; i < m_arena->records.size(); i++) {
+        if(m_arena->records[i].name == name &&
+           m_arena->records[i].parent == m_index) {
+            return match(m_arena, i);
+        }
+    }
+
+    return match();
+}
+
+bool match::has(std::string_view name) const
+{
+    return static_cast<bool>((*this)[name]);
+}
+
+match::list match::all(std::string_view name) const
+{
+    list out;
+
+    if(!m_arena) return out;
+
+    for(std::size_t i = 0; i < m_arena->records.size(); i++) {
+        if(m_arena->records[i].name == name &&
+           descends(m_arena->records, i, m_index)) {
+            out.push_back(match(m_arena, i));
+        }
+    }
+
+    return out;
+}
+
+match::list match::children() const
+{
+    list out;
+
+    if(!m_arena) return out;
+
+    for(std::size_t i = 0; i < m_arena->records.size(); i++) {
+        if(m_arena->records[i].parent == m_index) {
+            out.push_back(match(m_arena, i));
+        }
+    }
+
+    return out;
+}
+
+// -------------------------------------------------------------- parse_result
+
+parse_result::parse_result() : m_ok(false), m_consumed(0) {}
+
+match parse_result::root() const
+{
+    if(!m_ok) throw *m_why;
+
+    return m_root;
+}
+
+const error& parse_result::why() const
+{
+    if(m_ok) {
+        throw exception("jlib::util::abnf::exception: why() on a parse that "
+                        "succeeded");
+    }
+
+    return *m_why;
+}
+
+// --------------------------------------------------------------------- rule
+
+static expr::ptr node_of(const rule& r) { return r.node(); }
+
+rule::rule() : m_expr(std::make_shared<detail::nothing>(true)) {}
+rule::rule(ptr e) : m_expr(std::move(e)) {}
+
+rule rule::declare(std::string name)
+{
+    std::shared_ptr<slot> s = std::make_shared<slot>();
+    s->name = std::move(name);
+
+    return rule(std::make_shared<detail::reference>(s));
+}
+
+static const detail::reference* as_reference(const expr::ptr& e)
+{
+    return dynamic_cast<const detail::reference*>(e.get());
+}
+
+bool rule::declared() const { return as_reference(m_expr) != 0; }
+
+bool rule::defined() const
+{
+    const detail::reference* r = as_reference(m_expr);
+
+    return r && r->cell()->body;
+}
+
+std::string rule::name() const
+{
+    const detail::reference* r = as_reference(m_expr);
+
+    return r ? r->cell()->name : std::string();
+}
+
+void rule::define(const rule& body)
+{
+    const detail::reference* r = as_reference(m_expr);
+
+    if(!r) {
+        throw grammar_error("define() on a rule that was not declared");
+    }
+
+    if(r->cell()->body && !r->cell()->seeded) {
+        throw grammar_error("rule \"" + r->cell()->name +
+                            "\" is already defined; use define_alternative()"
+                            " for ABNF's \"=/\"");
+    }
+
+    r->cell()->seeded = false;
+    r->cell()->body = body.node();
+}
+
+void rule::define_alternative(const rule& more)
+{
+    const detail::reference* r = as_reference(m_expr);
+
+    if(!r) {
+        throw grammar_error("define_alternative() on a rule that was not "
+                            "declared");
+    }
+
+    if(!r->cell()->body) {
+        throw grammar_error("rule \"" + r->cell()->name + "\" has no definition"
+                            " to add an alternative to");
+    }
+
+    std::vector<expr::ptr> branches;
+
+    // Flatten, so a rule extended five times is one alternation and not five.
+    const detail::alternation* a =
+        dynamic_cast<const detail::alternation*>(r->cell()->body.get());
+
+    if(a) {
+        branches = a->branches();
+    }
+    else {
+        branches.push_back(r->cell()->body);
+    }
+
+    branches.push_back(more.node());
+
+    r->cell()->body = std::make_shared<detail::alternation>(std::move(branches));
+}
+
+std::string rule::to_abnf() const
+{
+    std::ostringstream o;
+    m_expr->write(o, detail::PREC_ALT);
+
+    return o.str();
+}
+
+std::ostream& operator<<(std::ostream& os, const rule& r)
+{
+    return os << r.to_abnf();
+}
+
+parse_result rule::try_parse(std::string_view in) const
+{
+    return try_parse(in, options());
+}
+
+parse_result rule::try_parse(std::string_view in, const options& o) const
+{
+    parse_result out;
+
+    context ctx;
+    ctx.input = in;
+    ctx.opt = &o;
+    ctx.budget = o.step_budget ? o.step_budget : (1000 * in.size() + 100000);
+    ctx.max_depth = o.max_depth;
+
+    std::size_t pos = 0;
+    bool ok = false;
+
+    try {
+        ok = detail::run(m_expr.get(), ctx, pos);
+    }
+    catch(budget_exceeded& e) {
+        out.m_why = std::make_shared<budget_exceeded>(e);
+        return out;
+    }
+
+    if(ok && pos != in.size()) {
+        ctx.want(pos, "end of input");
+        ok = false;
+    }
+
+    out.m_consumed = pos;
+
+    if(!ok) {
+        out.m_why = std::make_shared<error>(
+            "jlib::util::abnf::error", std::string(in), ctx.furthest,
+            ctx.expected, ctx.furthest_stack);
+
+        return out;
+    }
+
+    std::shared_ptr<arena> a = std::make_shared<arena>();
+    a->input = std::string(in);
+    a->records = std::move(ctx.captures);
+
+    out.m_ok = true;
+    out.m_root = match(a, NONE);
+
+    return out;
+}
+
+match rule::parse(std::string_view in) const
+{
+    return parse(in, options());
+}
+
+match rule::parse(std::string_view in, const options& o) const
+{
+    parse_result r = try_parse(in, o);
+
+    if(!r) throw r.why();
+
+    return r.root();
+}
+
+// ----------------------------------------------------------------- terminals
+
+static std::bitset<256> one(unsigned char c)
+{
+    std::bitset<256> b;
+    b.set(c);
+
+    return b;
+}
+
+static std::string hex(unsigned char c)
+{
+    static const char* digits = "0123456789ABCDEF";
+
+    std::string s = "%x";
+    s += digits[(c >> 4) & 0xf];
+    s += digits[c & 0xf];
+
+    return s;
+}
+
+rule lit(std::string s)
+{
+    if(s.empty()) return empty();
+
+    return rule(std::make_shared<detail::literal>(std::move(s), false));
+}
+
+rule ilit(std::string s)
+{
+    if(s.empty()) return empty();
+
+    return rule(std::make_shared<detail::literal>(std::move(s), true));
+}
+
+rule chr(unsigned char c)
+{
+    return rule(std::make_shared<detail::charclass>(one(c), hex(c)));
+}
+
+rule rng(unsigned char lo, unsigned char hi)
+{
+    if(lo > hi) {
+        throw grammar_error("rng(): " + hex(lo) + " is above " + hex(hi));
+    }
+
+    std::bitset<256> b;
+    for(unsigned int c = lo; c <= hi; c++) b.set(c);
+
+    return rule(std::make_shared<detail::charclass>(
+                    b, hex(lo) + "-" + hex(hi).substr(2)));
+}
+
+rule bytes(std::initializer_list<unsigned char> b)
+{
+    std::string s;
+    for(unsigned char c : b) s += static_cast<char>(c);
+
+    return rule(std::make_shared<detail::literal>(std::move(s), false));
+}
+
+rule anyof(std::string_view chars)
+{
+    std::bitset<256> b;
+    std::string label = "<any of \"";
+
+    for(char c : chars) {
+        b.set(static_cast<unsigned char>(c));
+        label += c;
+    }
+
+    label += "\">";
+
+    return rule(std::make_shared<detail::charclass>(b, label));
+}
+
+rule none() { return rule(std::make_shared<detail::nothing>(false)); }
+rule empty() { return rule(std::make_shared<detail::nothing>(true)); }
+
+// --------------------------------------------------------------- combinators
+
+rule operator>>(const rule& a, const rule& b)
+{
+    std::vector<expr::ptr> parts;
+
+    // Flatten, so a >> b >> c is one node rather than two nested ones.  It
+    // makes to_abnf() read the way it was written, and it keeps the step count
+    // proportional to the grammar rather than to how it was parenthesized.
+    const detail::concat* ca = dynamic_cast<const detail::concat*>(a.node().get());
+    const detail::concat* cb = dynamic_cast<const detail::concat*>(b.node().get());
+
+    if(ca) parts = ca->parts();
+    else   parts.push_back(a.node());
+
+    if(cb) {
+        for(const expr::ptr& p : cb->parts()) parts.push_back(p);
+    }
+    else {
+        parts.push_back(b.node());
+    }
+
+    return rule(std::make_shared<detail::concat>(std::move(parts)));
+}
+
+rule operator|(const rule& a, const rule& b)
+{
+    std::vector<expr::ptr> branches;
+
+    const detail::alternation* aa =
+        dynamic_cast<const detail::alternation*>(a.node().get());
+    const detail::alternation* ab =
+        dynamic_cast<const detail::alternation*>(b.node().get());
+
+    if(aa) branches = aa->branches();
+    else   branches.push_back(a.node());
+
+    if(ab) {
+        for(const expr::ptr& p : ab->branches()) branches.push_back(p);
+    }
+    else {
+        branches.push_back(b.node());
+    }
+
+    return rule(std::make_shared<detail::alternation>(std::move(branches)));
+}
+
+rule operator*(const rule& a) { return rep(a, 0, rule::unbounded); }
+rule operator+(const rule& a) { return rep(a, 1, rule::unbounded); }
+rule operator-(const rule& a) { return rep(a, 0, 1); }
+rule opt(const rule& a) { return rep(a, 0, 1); }
+
+rule rep(const rule& a, std::size_t n) { return rep(a, n, n); }
+
+rule rep(const rule& a, std::size_t min, std::size_t max)
+{
+    if(min > max) {
+        throw grammar_error("rep(): minimum " + std::to_string(min) +
+                            " is above maximum " + std::to_string(max));
+    }
+
+    return rule(std::make_shared<detail::repeat>(a.node(), min, max));
+}
+
+rule seq(std::initializer_list<rule> rs)
+{
+    std::vector<expr::ptr> parts;
+    for(const rule& r : rs) parts.push_back(r.node());
+
+    return rule(std::make_shared<detail::concat>(std::move(parts)));
+}
+
+rule alt(std::initializer_list<rule> rs)
+{
+    std::vector<expr::ptr> branches;
+    for(const rule& r : rs) branches.push_back(r.node());
+
+    return rule(std::make_shared<detail::alternation>(std::move(branches)));
+}
+
+rule as(std::string name, const rule& a)
+{
+    return rule(std::make_shared<detail::capture>(std::move(name), a.node()));
+}
+
+// ------------------------------------------------- context sensitive pieces
+
+static std::size_t decimal(std::string_view s)
+{
+    std::size_t n = 0;
+
+    for(char c : s) {
+        if(c < '0' || c > '9') break;
+        n = n * 10 + static_cast<std::size_t>(c - '0');
+    }
+
+    return n;
+}
+
+rule counted(const rule& source)
+{
+    return counted(source, decimal);
+}
+
+rule counted(const rule& source, const rule& element)
+{
+    return counted(source, element, decimal);
+}
+
+rule counted(const rule& source, std::function<std::size_t(std::string_view)> adapt)
+{
+    return rule(std::make_shared<detail::counted_node>(
+                    source.node(), expr::ptr(), std::move(adapt)));
+}
+
+rule counted(const rule& source, const rule& element,
+             std::function<std::size_t(std::string_view)> adapt)
+{
+    return rule(std::make_shared<detail::counted_node>(
+                    source.node(), element.node(), std::move(adapt)));
+}
+
+rule backref(const rule& source) { return backref(source, false); }
+
+rule backref(const rule& source, bool fold)
+{
+    return rule(std::make_shared<detail::backref_node>(source.node(), fold));
+}
+
+rule until(const rule& terminator)
+{
+    return rule(std::make_shared<detail::until_node>(terminator.node()));
+}
+
+rule where(std::string description,
+           std::function<bool(std::string_view, std::size_t&)> f)
+{
+    return rule(std::make_shared<detail::predicate>(
+                    std::move(description), std::move(f), false));
+}
+
+rule where_pure(std::string description,
+                std::function<bool(std::string_view, std::size_t&)> f)
+{
+    return rule(std::make_shared<detail::predicate>(
+                    std::move(description), std::move(f), true));
+}
+
+
+// ------------------------------------------------------------------- grammar
+
+/**
+ * ABNF rulenames are case-insensitive (RFC 5234 2.1).
+ *
+ * Deliberately not util::iequals, which upper-cases both arguments into
+ * temporaries: this runs once per reference resolved and once per lookup, and
+ * two allocations per comparison is not what it should cost.
+ */
+struct iless {
+    typedef void is_transparent;
+
+    bool operator()(std::string_view a, std::string_view b) const
+    {
+        const std::size_t n = std::min(a.size(), b.size());
+
+        for(std::size_t i = 0; i < n; i++) {
+            const unsigned char x =
+                static_cast<unsigned char>(std::tolower(static_cast<unsigned char>(a[i])));
+            const unsigned char y =
+                static_cast<unsigned char>(std::tolower(static_cast<unsigned char>(b[i])));
+
+            if(x != y) return x < y;
+        }
+
+        return a.size() < b.size();
+    }
+};
+
+class grammar::impl {
+public:
+    std::map<std::string, std::shared_ptr<slot>, iless> slots;
+    std::vector<std::string> order;
+
+    std::shared_ptr<slot> cell(std::string_view name)
+    {
+        auto i = slots.find(name);
+        if(i != slots.end()) return i->second;
+
+        std::shared_ptr<slot> s = std::make_shared<slot>();
+        s->name = std::string(name);
+        slots.emplace(s->name, s);
+
+        return s;
+    }
+};
+
+grammar::grammar() : m_impl(new impl) {}
+
+grammar::grammar(grammar&&) noexcept = default;
+grammar& grammar::operator=(grammar&&) noexcept = default;
+
+grammar::~grammar()
+{
+    if(!m_impl) return;
+
+    // Break the cycles before letting go.
+    //
+    // A recursive rule is a slot holding a body that holds a reference that
+    // holds the slot.  Reference counting cannot see round that, so every
+    // recursive grammar would leak its whole rule tree.  Clearing the bodies
+    // cuts each cycle exactly once.
+    for(auto& kv : m_impl->slots) {
+        kv.second->body.reset();
+    }
+}
+
+rule grammar::operator[](std::string_view name)
+{
+    return rule(std::make_shared<detail::reference>(m_impl->cell(name)));
+}
+
+rule grammar::at(std::string_view name) const
+{
+    auto i = m_impl->slots.find(name);
+
+    if(i == m_impl->slots.end()) {
+        throw grammar_error("no rule named \"" + std::string(name) + "\"");
+    }
+
+    return rule(std::make_shared<detail::reference>(i->second));
+}
+
+bool grammar::has(std::string_view name) const
+{
+    auto i = m_impl->slots.find(name);
+
+    return i != m_impl->slots.end() && i->second->body;
+}
+
+void grammar::define(std::string name, const rule& body)
+{
+    std::shared_ptr<slot> s = m_impl->cell(name);
+
+    if(s->body && !s->seeded) {
+        throw grammar_error("rule \"" + s->name + "\" is already defined; use"
+                            " define_alternative() for ABNF's \"=/\"");
+    }
+
+    if(!s->body) {
+        m_impl->order.push_back(s->name);
+    }
+
+    s->seeded = false;
+    s->body = body.node();
+}
+
+void grammar::define_alternative(std::string name, const rule& more)
+{
+    auto i = m_impl->slots.find(name);
+
+    if(i == m_impl->slots.end() || !i->second->body) {
+        throw grammar_error("rule \"" + std::string(name) + "\" has no"
+                            " definition to add an alternative to");
+    }
+
+    rule(std::make_shared<detail::reference>(i->second)).define_alternative(more);
+}
+
+std::vector<std::string> grammar::rules() const { return m_impl->order; }
+
+/** Everything reachable from e, following references into their bodies. */
+static void reachable(const expr* e,
+                      std::set<const expr*>& nodes,
+                      std::set<const slot*>& cells,
+                      std::vector<const expr*>& out)
+{
+    if(!e || nodes.count(e)) return;
+
+    nodes.insert(e);
+    out.push_back(e);
+
+    const detail::reference* r = dynamic_cast<const detail::reference*>(e);
+
+    if(r) {
+        if(cells.count(r->cell().get())) return;
+
+        cells.insert(r->cell().get());
+
+        if(r->cell()->body) {
+            reachable(r->cell()->body.get(), nodes, cells, out);
+        }
+
+        return;
+    }
+
+    std::vector<const expr*> kids;
+    e->kids(kids);
+
+    for(const expr* k : kids) reachable(k, nodes, cells, out);
+}
+
+std::vector<std::string> grammar::undefined() const
+{
+    std::set<const expr*> nodes;
+    std::set<const slot*> cells;
+    std::vector<const expr*> all;
+
+    for(const std::string& n : m_impl->order) {
+        auto i = m_impl->slots.find(n);
+        if(i != m_impl->slots.end() && i->second->body) {
+            reachable(i->second->body.get(), nodes, cells, all);
+        }
+    }
+
+    std::vector<std::string> out;
+
+    for(const expr* e : all) {
+        const detail::reference* r = dynamic_cast<const detail::reference*>(e);
+
+        if(r && !r->cell()->body) {
+            if(std::find(out.begin(), out.end(), r->cell()->name) == out.end()) {
+                out.push_back(r->cell()->name);
+            }
+        }
+    }
+
+    return out;
+}
+
+void grammar::check() const
+{
+    // Every undefined rule at once.  A grammar pasted out of an RFC is usually
+    // missing several, and reporting them one run at a time is miserable.
+    const std::vector<std::string> missing = undefined();
+
+    if(!missing.empty()) {
+        std::string m = "referenced but never defined:";
+
+        for(const std::string& n : missing) m += " " + n;
+
+        throw grammar_error(m);
+    }
+
+    // Left recursion.  A rule that can reach itself without consuming anything
+    // recurses forever; the depth guard would eventually stop it, but with a
+    // message about depth rather than about the grammar.
+    for(const std::string& n : m_impl->order) {
+        auto i = m_impl->slots.find(n);
+        if(i == m_impl->slots.end() || !i->second->body) continue;
+
+        std::set<const slot*> out, visiting;
+        visiting.insert(i->second.get());
+        i->second->body->leftmost(out, visiting);
+
+        if(out.count(i->second.get())) {
+            throw grammar_error("left recursion through rule \"" + n + "\"");
+        }
+    }
+
+    // A repetition of something that can match nothing never terminates.
+    std::set<const expr*> nodes;
+    std::set<const slot*> cells;
+    std::vector<const expr*> all;
+
+    for(const std::string& n : m_impl->order) {
+        auto i = m_impl->slots.find(n);
+        if(i != m_impl->slots.end() && i->second->body) {
+            reachable(i->second->body.get(), nodes, cells, all);
+        }
+    }
+
+    for(const expr* e : all) {
+        const detail::repeat* r = dynamic_cast<const detail::repeat*>(e);
+
+        if(!r || r->max() != rule::unbounded) continue;
+
+        std::set<const slot*> v;
+
+        if(r->body()->nullable(v)) {
+            throw grammar_error("unbounded repetition of something that can"
+                                " match the empty string");
+        }
+    }
+}
+
+std::string grammar::to_abnf() const
+{
+    std::ostringstream o;
+
+    for(const std::string& n : m_impl->order) {
+        auto i = m_impl->slots.find(n);
+        if(i == m_impl->slots.end() || !i->second->body) continue;
+
+        o << n << " = ";
+        i->second->body->write(o, detail::PREC_ALT);
+        o << "\r\n";
+    }
+
+    return o.str();
+}
+
+// ----------------------------------------------------------------- core rules
+
+namespace core {
+
+const rule& ALPHA()
+{
+    static const rule r = rng(0x41, 0x5A) | rng(0x61, 0x7A);
+    return r;
+}
+
+const rule& BIT()
+{
+    static const rule r = lit("0") | lit("1");
+    return r;
+}
+
+const rule& CHAR()
+{
+    static const rule r = rng(0x01, 0x7F);
+    return r;
+}
+
+const rule& CR()
+{
+    static const rule r = chr(0x0D);
+    return r;
+}
+
+const rule& CRLF()
+{
+    static const rule r = CR() >> LF();
+    return r;
+}
+
+const rule& CTL()
+{
+    static const rule r = rng(0x00, 0x1F) | chr(0x7F);
+    return r;
+}
+
+const rule& DIGIT()
+{
+    static const rule r = rng(0x30, 0x39);
+    return r;
+}
+
+const rule& DQUOTE()
+{
+    static const rule r = chr(0x22);
+    return r;
+}
+
+const rule& HEXDIG()
+{
+    static const rule r = DIGIT() | anyof("ABCDEFabcdef");
+    return r;
+}
+
+const rule& HTAB()
+{
+    static const rule r = chr(0x09);
+    return r;
+}
+
+const rule& LF()
+{
+    static const rule r = chr(0x0A);
+    return r;
+}
+
+const rule& LWSP()
+{
+    // Included because Appendix B defines it, with the warning the appendix
+    // itself carries: this accepts a bare CRLF with nothing after it, which is
+    // almost never what a grammar wants.  Prefer WSP.
+    static const rule r = *(WSP() | (CRLF() >> WSP()));
+    return r;
+}
+
+const rule& OCTET()
+{
+    static const rule r = rng(0x00, 0xFF);
+    return r;
+}
+
+const rule& SP()
+{
+    static const rule r = chr(0x20);
+    return r;
+}
+
+const rule& VCHAR()
+{
+    static const rule r = rng(0x21, 0x7E);
+    return r;
+}
+
+const rule& WSP()
+{
+    static const rule r = SP() | HTAB();
+    return r;
+}
+
+}  // namespace core
+
+}
+}
+}

--- a/jlib/util/abnf.hh
+++ b/jlib/util/abnf.hh
@@ -1,0 +1,563 @@
+/* -*- mode: C++ c-basic-offset: 4  -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ *
+ */
+
+#ifndef JLIB_UTIL_ABNF_HH
+#define JLIB_UTIL_ABNF_HH
+
+#include <bitset>
+#include <cstddef>
+#include <functional>
+#include <map>
+#include <memory>
+#include <set>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace jlib {
+namespace util {
+
+/**
+ * Grammars, and the machinery to run them against input.
+ *
+ * This is the layer the RFCs are eventually written in.  Two of them, in fact:
+ * these combinators, and -- built on top, in a later branch -- a reader for
+ * ABNF grammar text, so an RFC's own grammar can be pasted in as it stands.
+ * Both are public, because ABNF cannot express everything the RFCs need.
+ * RFC 3501 says
+ *
+ *     literal = "{" number "}" CRLF *CHAR8
+ *             ; Number represents the number of CHAR8s
+ *
+ * with the actual constraint in a *comment*, because there is no way to write
+ * it.  counted() is that constraint, and it is why the combinators have to
+ * stay reachable rather than being an implementation detail of the text
+ * front end.
+ *
+ * ## What this is not
+ *
+ * **It is not RFC 5234 semantics.** Alternation here is PEG ordered choice:
+ * the first branch that matches wins, and the others are not tried unless it
+ * fails.  RFC 5234's `/` is unordered.  The difference is observable, and
+ * RFC 5234's own grammar contains an instance of it -- see the note on
+ * operator| below.
+ *
+ * **Repetition is possessive.** `*a` matches as much as it can and never gives
+ * any of it back, so `*CHAR "@"` does not parse `a@b`: the repetition eats the
+ * `@` and the concatenation then has nothing to match.  until(), counted() and
+ * backref() are the ways round it.
+ *
+ * Both are deliberate, both are tested, and both are stated here rather than
+ * discovered.
+ */
+namespace abnf {
+
+namespace detail {
+class expr;
+class slot;
+class context;
+struct arena;
+struct capture_record;
+}
+
+class match;
+class parse_result;
+class rule;
+struct options;
+
+// ---------------------------------------------------------------- exceptions
+
+/**
+ * Base for everything this throws.
+ *
+ * A departure from the convention of a nested exception per class: the same
+ * three failures arise from rule, grammar and match alike, and three nested
+ * types for one failure mode would be worse than one hierarchy.  What the
+ * convention actually buys -- an identifiable prefixed message, and a single
+ * catch that works -- is preserved: every what() begins with the qualified
+ * name of the type that threw.
+ */
+class exception : public std::runtime_error {
+public:
+    explicit exception(const std::string& msg)
+        : std::runtime_error(msg) {}
+};
+
+/** The input did not match.  Expected at runtime, and carries a position. */
+class error : public exception {
+public:
+    error(const std::string& msg, std::string input, std::size_t offset,
+          std::vector<std::string> expected, std::vector<std::string> stack);
+
+    std::size_t offset() const { return m_offset; }
+
+    /** 1-based, computed on demand -- the success path pays nothing. */
+    std::size_t line() const;
+    std::size_t column() const;
+
+    /** The line the failure is on, without its terminator. */
+    std::string context_line() const;
+
+    /** Terminals and rules that could have continued at offset(). */
+    const std::vector<std::string>& expected() const { return m_expected; }
+
+    /** The named rules that were open when the furthest failure happened. */
+    const std::vector<std::string>& rule_stack() const { return m_stack; }
+
+    /** Several lines, with a caret under the offending column. */
+    std::string report() const;
+
+protected:
+    std::string m_input;
+    std::size_t m_offset;
+    std::vector<std::string> m_expected;
+    std::vector<std::string> m_stack;
+};
+
+/**
+ * The grammar itself is broken.
+ *
+ * Left recursion, a rulename referenced and never defined, a repetition of
+ * something that can match nothing, or -- once the text front end exists --
+ * ABNF that does not parse.
+ */
+class grammar_error : public exception {
+public:
+    explicit grammar_error(const std::string& msg)
+        : exception("jlib::util::abnf::grammar_error: " + msg) {}
+};
+
+/**
+ * The parse ran too long or too deep.
+ *
+ * Not a failure of the input so much as a refusal to keep going.  Ordered
+ * choice over a grammar with shared prefixes can be exponential, and recursive
+ * descent over deeply nested input can exhaust the stack -- and both are
+ * reachable from the network, where the input is chosen by somebody else.
+ * This turns a hang or a SIGSEGV into something with a position on it.
+ */
+class budget_exceeded : public error {
+public:
+    budget_exceeded(const std::string& msg, std::string input,
+                    std::size_t offset);
+};
+
+// ------------------------------------------------------------------- options
+
+/**
+ * What to keep, and what to refuse.
+ */
+struct options {
+    /**
+     * Which matches are recorded.
+     *
+     * none keeps nothing and is the cheapest way to ask "does this parse".
+     * named keeps every rule built with as(); for a grammar the size of
+     * RFC 5322 that is still hundreds of records per address.  listed keeps
+     * only the names asked for, which is usually what a caller wants:
+     *
+     *     r.parse(text, { .captures = options::capture_policy::listed,
+     *                     .capture_only = {"local-part", "domain"} });
+     */
+    enum class capture_policy { none, named, listed };
+
+    capture_policy captures = capture_policy::named;
+    std::set<std::string> capture_only;
+
+    /** 0 means 1000 * input.size() + 100000. */
+    std::size_t step_budget = 0;
+
+    /** Nested rule invocations before budget_exceeded. */
+    std::size_t max_depth = 1000;
+};
+
+// --------------------------------------------------------------------- match
+
+/**
+ * A matched span, and a cursor over the ones inside it.
+ *
+ * Sixteen bytes: everything is held in one arena that the whole result shares,
+ * and this is an index into it.  Copying a match is free.
+ *
+ * The arena owns a copy of the input, so a match cannot outlive its text the
+ * way a string_view into the caller's buffer would.
+ */
+class match {
+public:
+    typedef std::vector<match> list;
+    typedef list::value_type value_type;
+    typedef list::size_type size_type;
+    typedef list::const_iterator const_iterator;
+
+    match();
+
+    /** "" for the root, which is anonymous. */
+    std::string name() const;
+
+    std::string_view text() const;
+    std::string str() const { return std::string(text()); }
+
+    std::size_t begin() const;
+    std::size_t end() const;
+
+    bool has(std::string_view name) const;
+
+    /**
+     * The first descendant with that name, at any depth.
+     *
+     * Descendant rather than child on purpose: a caller asking for
+     * "local-part" should not have to know it sits under addr-spec under
+     * mailbox.  Where a name occurs at more than one depth this returns the
+     * shallowest, then the earliest; child() is the strict version.
+     */
+    match operator[](std::string_view name) const;
+    match child(std::string_view name) const;
+
+    /** Every descendant with that name, in document order. */
+    list all(std::string_view name) const;
+    list children() const;
+
+    /** False for the match returned when a name was not found. */
+    explicit operator bool() const;
+
+protected:
+    friend class rule;
+    match(std::shared_ptr<const detail::arena> a, std::size_t i);
+
+    std::shared_ptr<const detail::arena> m_arena;
+    std::size_t m_index;
+};
+
+/**
+ * The outcome of a parse that was allowed to fail.
+ *
+ * The library throws rather than returns, as the rest of jlib does, so
+ * rule::parse() is the documented path.  This exists for the caller in a loop
+ * over input that is expected to be malformed -- extracting addresses from a
+ * mailbox, say -- where a throw per line is the wrong shape.
+ */
+class parse_result {
+public:
+    parse_result();
+
+    explicit operator bool() const { return m_ok; }
+
+    /** Throws if the parse failed. */
+    match root() const;
+
+    /** Valid only when the parse failed. */
+    const error& why() const;
+
+    /** Bytes consumed.  Less than the input for a deliberate partial parse. */
+    std::size_t consumed() const { return m_consumed; }
+
+protected:
+    friend class rule;
+
+    bool m_ok;
+    std::size_t m_consumed;
+    match m_root;
+    std::shared_ptr<error> m_why;
+};
+
+// ---------------------------------------------------------------------- rule
+
+/**
+ * A grammar rule: a value handle over an immutable expression.
+ *
+ * Copying is a reference count; sharing one rule between several grammars is
+ * free and is the normal case.  Rules are immutable once built, with one
+ * exception -- a rule from declare() owns a cell that define() fills in later,
+ * which is how forward references and recursion work.
+ */
+class rule {
+public:
+    typedef std::shared_ptr<const detail::expr> ptr;
+
+    /** For the max of rep(): as many as there are. */
+    static const std::size_t unbounded = static_cast<std::size_t>(-1);
+
+    /** Matches the empty string. */
+    rule();
+    explicit rule(ptr e);
+
+    /**
+     * A named rule with no body yet.
+     *
+     * RFC grammars are not written in dependency order, so a rule routinely
+     * mentions one defined further down.  This is also how a rule refers to
+     * itself.  Parsing one that was never defined is a grammar_error.
+     */
+    static rule declare(std::string name);
+
+    /** Fill in a declared rule.  Throws if it was not declared, or is done. */
+    void define(const rule& body);
+
+    /**
+     * Add an alternative to a rule already defined -- ABNF's "=/".
+     *
+     * Every reference to the rule sees this, because they all point at the
+     * cell rather than at the body.
+     */
+    void define_alternative(const rule& more);
+
+    bool declared() const;
+    bool defined() const;
+
+    /** "" when the rule is anonymous. */
+    std::string name() const;
+
+    /** Parse the whole input.  Throws error if it does not match. */
+    match parse(std::string_view in) const;
+    match parse(std::string_view in, const options& o) const;
+
+    /** As parse(), but a mismatch is a return value rather than a throw. */
+    parse_result try_parse(std::string_view in) const;
+    parse_result try_parse(std::string_view in, const options& o) const;
+
+    /** Canonical ABNF for this rule.  A serialization, not the source text. */
+    std::string to_abnf() const;
+
+    ptr node() const { return m_expr; }
+
+protected:
+    ptr m_expr;
+};
+
+std::ostream& operator<<(std::ostream& os, const rule& r);
+
+// ----------------------------------------------------------------- terminals
+
+/**
+ * A literal string, matched case-SENSITIVELY.
+ *
+ * Note the divergence, because it is deliberate and it is the opposite way
+ * round from ABNF.  RFC 5234 2.3 makes a quoted string in a grammar
+ * case-insensitive, so the text front end compiles char-val to ilit() -- a
+ * pasted grammar must behave as the RFC says.  But in handwritten C++,
+ * lit("HELO") quietly also matching "helo" is a trap with nothing to
+ * recommend it, so here the plain spelling is the literal one.
+ */
+rule lit(std::string s);
+
+/** A literal string, matched without regard to ASCII case. */
+rule ilit(std::string s);
+
+rule chr(unsigned char c);
+rule rng(unsigned char lo, unsigned char hi);
+
+/** An exact sequence of octets, never case-folded.  ABNF's %x0D.0A. */
+rule bytes(std::initializer_list<unsigned char> b);
+
+/** Any one of these octets. */
+rule anyof(std::string_view chars);
+
+/** Matches nothing at all, and never succeeds. */
+rule none();
+
+/** Succeeds without consuming anything. */
+rule empty();
+
+// --------------------------------------------------------------- combinators
+
+rule operator>>(const rule& a, const rule& b);
+
+/**
+ * Ordered choice: a, and only if that fails, b.
+ *
+ * C++ precedence happens to be exactly right -- >> is tighter than | -- so
+ * `a >> b | c >> d` groups as `(a >> b) | (c >> d)`, which is what RFC 5234
+ * 3.10 specifies for concatenation against alternation.  No parentheses
+ * needed, and none should be added for fear of it.
+ *
+ * What is *not* right is the RFC's claim that `/` is unordered.  Here the
+ * first match wins, so alternatives that share a prefix must be written
+ * longest-first.  RFC 5234's own grammar has an instance:
+ *
+ *     repeat = 1*DIGIT / (*DIGIT "*" *DIGIT)
+ *
+ * Against "3*5" the first alternative matches "3", the enclosing rule then
+ * fails on "*", and the choice has already committed.  Written the other way
+ * round it parses.  See tests/util_abnf_test.cc, which asserts both.
+ */
+rule operator|(const rule& a, const rule& b);
+
+/** Zero or more, possessively. */
+rule operator*(const rule& a);
+
+/** One or more, possessively. */
+rule operator+(const rule& a);
+
+/** Zero or one -- ABNF's [a]. */
+rule operator-(const rule& a);
+rule opt(const rule& a);
+
+rule rep(const rule& a, std::size_t n);
+rule rep(const rule& a, std::size_t min, std::size_t max);
+
+rule seq(std::initializer_list<rule> rs);
+rule alt(std::initializer_list<rule> rs);
+
+/** Record what this matches, under a name, for match::operator[]. */
+rule as(std::string name, const rule& a);
+
+// -------------------------------------------------- context sensitive pieces
+
+/**
+ * A run of octets whose length was matched earlier.
+ *
+ * The IMAP literal, and the reason the combinator layer is public.  source is
+ * the rule whose most recent match holds the count; the default adapter reads
+ * it as decimal.
+ *
+ *     rule number  = +core::DIGIT();
+ *     rule literal = lit("{") >> number >> lit("}") >> core::CRLF()
+ *                  >> counted(number);
+ *
+ * A count from a branch that was later abandoned is not visible: the record of
+ * it is dropped when the branch is.
+ */
+rule counted(const rule& source);
+rule counted(const rule& source, const rule& element);
+rule counted(const rule& source, std::function<std::size_t(std::string_view)> adapt);
+rule counted(const rule& source, const rule& element,
+             std::function<std::size_t(std::string_view)> adapt);
+
+/**
+ * The same text some earlier rule matched.
+ *
+ * A MIME multipart boundary is a back-reference: the delimiter is whatever the
+ * Content-Type header said it was.  So is an XML end tag.
+ */
+rule backref(const rule& source);
+rule backref(const rule& source, bool fold);
+
+/** Everything up to, but not including, the next match of terminator. */
+rule until(const rule& terminator);
+
+/**
+ * An escape hatch: match by running this.
+ *
+ * Assumed to depend on things the engine cannot see, so a subtree containing
+ * one is never memoized.  where_pure() is for a predicate that genuinely
+ * depends on nothing but the input at that position.
+ */
+rule where(std::string description,
+           std::function<bool(std::string_view, std::size_t&)> f);
+rule where_pure(std::string description,
+                std::function<bool(std::string_view, std::size_t&)> f);
+
+// ------------------------------------------------------------------- grammar
+
+/**
+ * A set of named rules.
+ *
+ * Also the owner that breaks their reference cycles: a rule that mentions
+ * itself holds a cell that holds a body that holds the cell, which no
+ * reference count will ever free.  This clears every body on the way out.
+ * Rules declared outside a grammar and made recursive by hand will leak, and
+ * that is the reason to keep them in one of these.
+ */
+class grammar {
+public:
+    grammar();
+    ~grammar();
+
+    grammar(const grammar&) = delete;
+    grammar& operator=(const grammar&) = delete;
+    grammar(grammar&&) noexcept;
+    grammar& operator=(grammar&&) noexcept;
+
+    /** The named rule.  Declares it if it is not there yet. */
+    rule operator[](std::string_view name);
+
+    /** The named rule, or throws.  Does not declare. */
+    rule at(std::string_view name) const;
+
+    bool has(std::string_view name) const;
+
+    void define(std::string name, const rule& body);
+    void define_alternative(std::string name, const rule& more);
+
+    /** Defined rules, in the order they were defined. */
+    std::vector<std::string> rules() const;
+
+    /** Referenced and never defined. */
+    std::vector<std::string> undefined() const;
+
+    /**
+     * Run the checks a grammar has to pass before it can parse anything.
+     *
+     * Undefined rules, left recursion, and repetition of something that can
+     * match the empty string -- which would loop forever.  Called by the first
+     * parse; here so a caller can ask without parsing.
+     */
+    void check() const;
+
+    std::string to_abnf() const;
+
+protected:
+    friend class rule;
+
+    class impl;
+    std::unique_ptr<impl> m_impl;
+};
+
+// ----------------------------------------------------------------- core rules
+
+/**
+ * RFC 5234 Appendix B.
+ *
+ * Functions rather than objects, and the reason is written down in
+ * crypt/curve.hh: Commitment::G() and H() were namespace-scope objects, so
+ * they were constructed while the shared library loaded -- before main() could
+ * call sodium_init() -- and on Linux that allocated until the process was
+ * killed, with no output.  These have the same shape, since CRLF() is built
+ * from CR() and LF(): at namespace scope their correctness would depend on
+ * initialization order, which is guaranteed only within a translation unit.
+ * Function-local statics are built on first use and are thread-safe.
+ */
+namespace core {
+
+const rule& ALPHA();     ///< %x41-5A / %x61-7A
+const rule& BIT();       ///< "0" / "1"
+const rule& CHAR();      ///< %x01-7F -- note this excludes NUL
+const rule& CR();        ///< %x0D
+const rule& CRLF();      ///< CR LF
+const rule& CTL();       ///< %x00-1F / %x7F
+const rule& DIGIT();     ///< %x30-39
+const rule& DQUOTE();    ///< %x22
+const rule& HEXDIG();    ///< DIGIT / "A" / "B" / "C" / "D" / "E" / "F"
+const rule& HTAB();      ///< %x09
+const rule& LF();        ///< %x0A
+const rule& LWSP();      ///< *(WSP / CRLF WSP) -- see the warning in the source
+const rule& OCTET();     ///< %x00-FF -- and this one includes it
+const rule& SP();        ///< %x20
+const rule& VCHAR();     ///< %x21-7E
+const rule& WSP();       ///< SP / HTAB
+
+}
+
+}
+}
+}
+
+#endif // JLIB_UTIL_ABNF_HH

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -66,6 +66,7 @@ TESTS = \
 	util_headers_fold_test \
 	util_headers_angie_test \
 	util_xml_test \
+	util_abnf_test \
  \
 	$(X_TESTS) \
 	$(MEDIA_TESTS) \
@@ -152,6 +153,9 @@ util_headers_fold_test_SOURCES = util_headers_fold_test.cc
 util_headers_fold_test_LDADD   = $(JUTIL_LA)
 util_headers_angie_test_SOURCES = util_headers_angie_test.cc
 util_headers_angie_test_LDADD   = $(JUTIL_LA)
+util_abnf_test_SOURCES = util_abnf_test.cc
+util_abnf_test_LDADD   = $(JUTIL_LA)
+
 util_xml_test_SOURCES = util_xml_test.cc
 util_xml_test_LDADD   = $(JUTIL_LA)
 

--- a/tests/util_abnf_test.cc
+++ b/tests/util_abnf_test.cc
@@ -1,0 +1,597 @@
+/* -*- mode: C++ c-basic-offset: 4  -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ *
+ */
+
+// The combinator layer.
+//
+// Several sections here assert that something does NOT work.  They are the
+// most important ones in the file: this is a PEG engine wearing ABNF's
+// notation, and the two differ in ways that are easy to trip over and
+// impossible to notice from the grammar text alone.  Each such section says
+// what the limitation is and what to use instead, and asserts the failure, so
+// a future change to the semantics breaks a test loudly rather than silently
+// changing what a grammar means.
+
+#include <jlib/util/abnf.hh>
+
+#include <cmath>
+#include <iomanip>
+#include <iostream>
+#include <string>
+#include <vector>
+
+using namespace jlib::util::abnf;
+
+static int failures = 0;
+
+static void ok(const std::string& what, bool good, const std::string& detail = "") {
+    if(!good) ++failures;
+    std::cout << (good ? "  ok   " : "  FAIL ") << what;
+    if(!detail.empty()) std::cout << ": " << detail;
+    std::cout << "\n";
+}
+
+/** Does r match the whole of s? */
+static bool matches(const rule& r, const std::string& s) {
+    return static_cast<bool>(r.try_parse(s));
+}
+
+static void terminals_match_exactly_what_they_say() {
+    std::cout << "terminals:\n";
+
+    ok("a literal is case sensitive",
+       matches(lit("HELO"), "HELO") && !matches(lit("HELO"), "helo"));
+
+    ok("and ilit is not",
+       matches(ilit("HELO"), "helo") && matches(ilit("HELO"), "HeLo"));
+
+    ok("a single octet", matches(chr('a'), "a") && !matches(chr('a'), "b"));
+
+    ok("a range", matches(rng('0','9'), "5") && !matches(rng('0','9'), "x"));
+
+    ok("a byte sequence is never folded",
+       matches(bytes({0x0D, 0x0A}), "\r\n"));
+
+    ok("anyof takes any of them",
+       matches(anyof("+-*/"), "*") && !matches(anyof("+-*/"), "x"));
+
+    ok("empty matches nothing at all", matches(empty(), ""));
+    ok("and none matches nothing ever", !matches(none(), "") && !matches(none(), "a"));
+
+    // A literal of no characters is the empty match, not a literal that can
+    // never fire.
+    ok("an empty literal is the empty match", matches(lit(""), ""));
+}
+
+static void concatenation_binds_tighter_than_alternation() {
+    std::cout << "\nprecedence:\n";
+
+    // If >> did not bind tighter than |, this would parse as a >> (b|c) >> d.
+    const rule r = lit("a") >> lit("b") | lit("c") >> lit("d");
+
+    ok("ab matches",  matches(r, "ab"));
+    ok("cd matches",  matches(r, "cd"));
+    ok("ad does not", !matches(r, "ad"));
+    ok("cb does not", !matches(r, "cb"));
+
+    // Unary binds tighter than either.
+    const rule s = *lit("a") >> lit("b");
+    ok("*a >> b groups as (*a) >> b", matches(s, "aaab") && matches(s, "b"));
+}
+
+static void ordered_choice_is_not_unordered_alternation() {
+    std::cout << "\nordered choice, which RFC 5234 alternation is not:\n";
+
+    // The classic shape.  "ab" is tried first, matches "a"... no: on input
+    // "ac" the first branch fails outright, so the second is tried and this
+    // one works.  The failing case is the other way round.
+    const rule shadowed = (lit("a") | lit("ab")) >> lit("c");
+
+    ok("a shorter alternative first shadows the longer one",
+       !matches(shadowed, "abc"),
+       "(\"a\" / \"ab\") \"c\" cannot match abc");
+
+    ok("written longest first it parses",
+       matches((lit("ab") | lit("a")) >> lit("c"), "abc"));
+
+    // And the one that matters, because it is in RFC 5234's own grammar.
+    //
+    //     repeat = 1*DIGIT / (*DIGIT "*" *DIGIT)
+    //
+    // Against "3*5" the first branch takes the 3, the enclosing rule then
+    // wants end-of-input and does not get it, and the choice has committed.
+    const rule as_written =
+        +core::DIGIT() | (*core::DIGIT() >> lit("*") >> *core::DIGIT());
+    const rule reordered =
+        (*core::DIGIT() >> lit("*") >> *core::DIGIT()) | +core::DIGIT();
+
+    ok("RFC 5234's own repeat rule fails as written", !matches(as_written, "3*5"));
+    ok("and parses when reordered",                    matches(reordered, "3*5"));
+    ok("the reordering still accepts a bare count",    matches(reordered, "3"));
+}
+
+static void repetition_is_possessive() {
+    std::cout << "\npossessive repetition, and the way round it:\n";
+
+    // *CHAR eats the @ and never gives it back.
+    ok("*CHAR \"@\" cannot parse a@b",
+       !matches(*core::CHAR() >> lit("@"), "a@b"));
+
+    ok("until() is what that wants",
+       matches(until(lit("@")) >> lit("@") >> *core::CHAR(), "a@b"));
+
+    // It is not that repetition is broken -- a self-delimiting body is fine,
+    // which is why most ABNF in the wild does not notice.
+    ok("a body that cannot match the delimiter is fine",
+       matches(*rng('a','z') >> lit("@") >> *rng('a','z'), "abc@def"));
+}
+
+static void recursion_and_forward_references() {
+    std::cout << "\nrecursion:\n";
+
+    grammar g;
+
+    // parens = "(" *parens ")" -- mentions itself, and is used before the
+    // line that defines it.
+    g.define("parens", lit("(") >> *g["parens"] >> lit(")"));
+
+    const rule p = g.at("parens");
+
+    ok("balanced",           matches(p, "()"));
+    ok("nested",             matches(p, "((()))"));
+    ok("siblings",           matches(p, "(()())"));
+    ok("unbalanced fails",   !matches(p, "(()"));
+
+    // Forward reference: b is used by a before b exists.
+    grammar f;
+    f.define("a", lit("x") >> f["b"]);
+    f.define("b", lit("y"));
+
+    ok("a rule may be used before it is defined", matches(f.at("a"), "xy"));
+}
+
+static void a_broken_grammar_says_which_rule_is_broken() {
+    std::cout << "\ngrammars that cannot work:\n";
+
+    {
+        grammar g;
+        g.define("a", g["b"] >> lit("x"));
+
+        std::string msg;
+        try { g.check(); } catch(grammar_error& e) { msg = e.what(); }
+
+        ok("an undefined rule is named", msg.find("\"b\"") != std::string::npos ||
+                                         msg.find(" b") != std::string::npos, msg);
+    }
+
+    {
+        // Every missing rule at once, not one run at a time.
+        grammar g;
+        g.define("a", g["b"] >> g["c"] >> g["d"]);
+
+        std::string msg;
+        try { g.check(); } catch(grammar_error& e) { msg = e.what(); }
+
+        ok("and so is every other one",
+           msg.find("b") != std::string::npos &&
+           msg.find("c") != std::string::npos &&
+           msg.find("d") != std::string::npos, msg);
+    }
+
+    {
+        grammar g;
+        g.define("e", g["e"] >> lit("+"));
+
+        std::string msg;
+        try { g.check(); } catch(grammar_error& e) { msg = e.what(); }
+
+        ok("left recursion is caught rather than run",
+           msg.find("left recursion") != std::string::npos, msg);
+    }
+
+    {
+        // *( "" ) would spin forever.
+        grammar g;
+        g.define("z", *opt(lit("a")));
+
+        std::string msg;
+        try { g.check(); } catch(grammar_error& e) { msg = e.what(); }
+
+        ok("so is repeating something that can match nothing",
+           msg.find("empty string") != std::string::npos, msg);
+    }
+
+    {
+        grammar g;
+        g.define("a", lit("x"));
+
+        std::string msg;
+        try { g.define("a", lit("y")); } catch(grammar_error& e) { msg = e.what(); }
+
+        ok("redefining a rule is an error, and says what to use instead",
+           msg.find("define_alternative") != std::string::npos, msg);
+    }
+}
+
+static void incremental_alternatives() {
+    std::cout << "\nABNF's \"=/\":\n";
+
+    grammar g;
+    g.define("atext", rng('a','z'));
+
+    const rule a = g.at("atext");
+    ok("before", matches(a, "q") && !matches(a, "+"));
+
+    g.define_alternative("atext", lit("+"));
+
+    ok("after, the new alternative is accepted", matches(a, "+"));
+    ok("and the old one still is",               matches(a, "q"));
+
+    // The point of the cell: a rule handed out *before* the extension sees it.
+    ok("a reference taken earlier sees the change too", matches(a, "+"));
+}
+
+static void captures_retain_only_what_was_asked_for() {
+    std::cout << "\ncaptures:\n";
+
+    grammar g;
+    g.define("local", as("local", +rng('a','z')));
+    g.define("domain", as("domain", +anyof("abcdefghijklmnopqrstuvwxyz.")));
+    g.define("addr", as("addr", g["local"] >> lit("@") >> g["domain"]));
+
+    const rule r = g.at("addr");
+    const std::string in = "joey@dbzero.com";
+
+    {
+        const match m = r.parse(in);
+        ok("named: the parts come back",
+           m["local"].str() == "joey" && m["domain"].str() == "dbzero.com",
+           m["local"].str() + " / " + m["domain"].str());
+
+        ok("and the whole", m["addr"].str() == in, m["addr"].str());
+    }
+
+    {
+        options o;
+        o.captures = options::capture_policy::listed;
+        o.capture_only = {"local"};
+
+        const match m = r.parse(in, o);
+
+        ok("listed: what was asked for is there", m["local"].str() == "joey");
+        ok("and what was not, is not",            !m.has("domain"));
+        ok("exactly one record kept",             m.all("local").size() == 1);
+    }
+
+    {
+        options o;
+        o.captures = options::capture_policy::none;
+
+        const match m = r.parse(in, o);
+
+        ok("none: it still parses",  m.text() == in);
+        ok("and keeps nothing",      !m.has("local") && !m.has("domain"));
+    }
+
+    // A capture inside a branch that loses is not visible.
+    {
+        grammar h;
+        h.define("pick", (as("first", lit("ab")) >> lit("!")) |
+                          as("second", lit("ab")));
+
+        const match m = h.at("pick").parse("ab");
+
+        ok("a capture from an abandoned branch is dropped",
+           !m.has("first") && m.has("second"));
+    }
+}
+
+static void errors_carry_a_position_and_a_rule_stack() {
+    std::cout << "\nerrors:\n";
+
+    grammar g;
+    g.define("digits", +core::DIGIT());
+    g.define("pair", g["digits"] >> lit(".") >> g["digits"]);
+
+    bool threw = false;
+    std::string report;
+    std::size_t at = 0;
+
+    try {
+        g.at("pair").parse("12.x4");
+    }
+    catch(error& e) {
+        threw = true;
+        report = e.report();
+        at = e.offset();
+    }
+
+    ok("a mismatch throws", threw);
+    ok("at the offending byte", at == 3, std::to_string(at));
+    ok("with a line and column",
+       report.find("line 1") != std::string::npos &&
+       report.find("column 4") != std::string::npos);
+    ok("and says which rule it was in",
+       report.find("pair") != std::string::npos, report);
+
+    std::cout << "     the report reads:\n";
+    std::cout << "       " << report << "\n";
+}
+
+static void a_length_prefixed_field_reads_its_length_from_earlier() {
+    std::cout << "\ncounted(), which is why the combinators are public:\n";
+
+    // The IMAP literal, near enough:  "{" number "}" CRLF <number octets>
+    const rule number = as("number", +core::DIGIT());
+    const rule lit_rule = lit("{") >> number >> lit("}") >> core::CRLF()
+                        >> as("body", counted(number));
+
+    {
+        const match m = lit_rule.parse("{5}\r\nhello");
+        ok("the body is exactly as long as the count said",
+           m["body"].str() == "hello", m["body"].str());
+    }
+
+    {
+        const match m = lit_rule.parse("{0}\r\n");
+        ok("a count of zero takes nothing", m["body"].str().empty());
+    }
+
+    ok("a body shorter than the count fails",
+       !matches(lit_rule, "{9}\r\nhello"));
+
+    // The count is octets, so it does not care what is in them.
+    {
+        const match m = lit_rule.parse("{3}\r\n} \r");
+        ok("and it does not care what the octets are", m["body"].str() == "} \r");
+    }
+}
+
+static void a_back_reference_matches_what_came_before() {
+    std::cout << "\nbackref(), which is how an end tag knows its own name:\n";
+
+    const rule name = as("name", +rng('a','z'));
+    const rule element = lit("<") >> name >> lit(">")
+                       >> as("content", *rng('a','z'))
+                       >> lit("</") >> backref(name) >> lit(">");
+
+    const match m = element.parse("<b>hello</b>");
+    ok("matching tags parse", m["content"].str() == "hello", m["content"].str());
+
+    ok("mismatched tags do not", !matches(element, "<b>hello</i>"));
+}
+
+static void the_depth_guard_fires_instead_of_the_stack() {
+    std::cout << "\nrunaway input:\n";
+
+    grammar g;
+    g.define("parens", lit("(") >> *g["parens"] >> lit(")"));
+
+    const rule p = g.at("parens");
+
+    auto nest = [](std::size_t n) {
+        return std::string(n, '(') + std::string(n, ')');
+    };
+
+    // The guard counts nested rule invocations, and each level of nesting is
+    // one, so the default of 1000 is reached at about 1000 parens -- not at
+    // some much larger number.  Worth pinning, because "deep enough" is
+    // exactly the sort of thing that gets assumed.
+    ok("five hundred deep parses with the defaults", matches(p, nest(500)));
+
+    {
+        const parse_result r = p.try_parse(nest(2000));
+        ok("two thousand does not", !r);
+    }
+
+    {
+        options o;
+        o.max_depth = 8000;
+
+        const parse_result r = p.try_parse(nest(2000), o);
+        ok("and does once the limit is raised", static_cast<bool>(r));
+    }
+
+    // Deep enough to exhaust a default stack if nothing stopped it.  The
+    // assertion is that we reach the next line at all.
+    {
+        const parse_result r = p.try_parse(std::string(200000, '('));
+        ok("two hundred thousand fails rather than crashing", !r);
+    }
+
+    // The step budget, which is a different guard from the depth one.
+    //
+    // Written first against a left-recursive grammar, which was wrong: that
+    // recurses without consuming, so the *depth* guard caught it and the
+    // budget was never reached.  A plain grammar with a budget too small to
+    // finish is what actually exercises it.
+    {
+        options o;
+        o.step_budget = 50;
+
+        const parse_result r = (*rng('a','z')).try_parse(std::string(500, 'a'), o);
+
+        ok("a step budget stops a parse that would otherwise finish", !r);
+        ok("and says which guard fired",
+           std::string(r.why().what()).find("steps") != std::string::npos,
+           std::string(r.why().what()).substr(0, 70));
+    }
+
+    // And the depth guard names itself differently, so the two are told apart.
+    {
+        const parse_result r = p.try_parse(nest(2000));
+
+        ok("the depth guard says depth, not steps",
+           std::string(r.why().what()).find("recursion") != std::string::npos,
+           std::string(r.why().what()).substr(0, 70));
+    }
+}
+
+static void a_grammar_serializes_to_abnf() {
+    std::cout << "\nto_abnf():\n";
+
+    ok("a concatenation",  (lit("a") >> lit("b")).to_abnf() == "%s\"a\" %s\"b\"",
+       (lit("a") >> lit("b")).to_abnf());
+
+    ok("an alternation",   (lit("a") | lit("b")).to_abnf() == "%s\"a\" / %s\"b\"",
+       (lit("a") | lit("b")).to_abnf());
+
+    // The parenthesization is the part that is easy to get wrong: an
+    // alternation inside a concatenation needs brackets or it means something
+    // else entirely.
+    ok("an alternation inside a concatenation keeps its brackets",
+       ((lit("a") | lit("b")) >> lit("c")).to_abnf() == "(%s\"a\" / %s\"b\") %s\"c\"",
+       ((lit("a") | lit("b")) >> lit("c")).to_abnf());
+
+    ok("a concatenation inside an alternation does not need them",
+       ((lit("a") >> lit("b")) | lit("c")).to_abnf() == "%s\"a\" %s\"b\" / %s\"c\"",
+       ((lit("a") >> lit("b")) | lit("c")).to_abnf());
+
+    ok("optional",  opt(lit("a")).to_abnf() == "[%s\"a\"]", opt(lit("a")).to_abnf());
+    ok("star",      (*lit("a")).to_abnf() == "*%s\"a\"",    (*lit("a")).to_abnf());
+    ok("plus",      (+lit("a")).to_abnf() == "1*%s\"a\"",   (+lit("a")).to_abnf());
+    ok("a range",   rng('0','9').to_abnf() == "%x30-39",    rng('0','9').to_abnf());
+}
+
+static void the_core_rules_are_the_ones_in_appendix_b() {
+    std::cout << "\nRFC 5234 appendix B:\n";
+
+    ok("ALPHA",  matches(core::ALPHA(), "Q") && !matches(core::ALPHA(), "0"));
+    ok("BIT",    matches(core::BIT(), "1")   && !matches(core::BIT(), "2"));
+    ok("DIGIT",  matches(core::DIGIT(), "7") && !matches(core::DIGIT(), "a"));
+    ok("HEXDIG", matches(core::HEXDIG(), "f") && !matches(core::HEXDIG(), "g"));
+    ok("SP",     matches(core::SP(), " ")    && !matches(core::SP(), "\t"));
+    ok("HTAB",   matches(core::HTAB(), "\t"));
+    ok("WSP",    matches(core::WSP(), " ")   && matches(core::WSP(), "\t"));
+    ok("CRLF",   matches(core::CRLF(), "\r\n") && !matches(core::CRLF(), "\n"));
+    ok("DQUOTE", matches(core::DQUOTE(), "\""));
+
+    // The boundaries, which are where CHAR and OCTET differ and where grammars
+    // routinely reach for the wrong one.
+    ok("CHAR excludes NUL",  !matches(core::CHAR(), std::string(1, '\0')));
+    ok("OCTET includes it",   matches(core::OCTET(), std::string(1, '\0')));
+    ok("VCHAR excludes SP",  !matches(core::VCHAR(), " "));
+    ok("VCHAR excludes DEL", !matches(core::VCHAR(), std::string(1, '\x7f')));
+    ok("CTL includes DEL",    matches(core::CTL(), std::string(1, '\x7f')));
+}
+
+static void what_a_parse_costs() {
+    std::cout << "\nwhat it costs:\n";
+
+    // A grammar with the shape that matters: alternatives sharing a prefix,
+    // nested repetition, and a rule that has to be re-scanned when the first
+    // branch fails -- the mailbox = name-addr / addr-spec shape.
+    grammar g;
+    g.define("atom", +anyof("abcdefghijklmnopqrstuvwxyz0123456789"));
+    g.define("word", g["atom"] | (lit("\"") >> *anyof("abc ") >> lit("\"")));
+    g.define("phrase", g["word"] >> *(lit(" ") >> g["word"]));
+    g.define("addr", g["atom"] >> lit("@") >> g["atom"]);
+    g.define("mailbox", (g["phrase"] >> lit(" <") >> g["addr"] >> lit(">")) |
+                         g["addr"]);
+
+    const rule m = g.at("mailbox");
+
+    struct { const char* what; std::string in; } cases[] = {
+        { "a bare address",      "joey@dbzero" },
+        { "a display name",      "joey yandle <joey@dbzero>" },
+        { "a long bare address", std::string(200, 'a') + "@dbzero" },
+        { "a long non-match",    std::string(200, 'a') },
+    };
+
+    for(const auto& c : cases) {
+        options o;
+        o.captures = options::capture_policy::none;
+
+        const parse_result r = m.try_parse(c.in, o);
+
+        // Steps are not exposed, so this measures what can be measured from
+        // outside: that it terminates, and how big the input was.  The real
+        // number belongs in a profile, and the ceiling below is the guard.
+        std::cout << "     " << std::setw(20) << std::left << c.what
+                  << " " << std::setw(5) << c.in.size() << " bytes  "
+                  << (r ? "parsed" : "rejected") << "\n";
+    }
+
+    // The regression guard: a grammar of this shape on 400 bytes must not need
+    // an exponential number of steps.  The budget is the only thing that can
+    // observe it, so ask for a generous one and require it not to fire.
+    options o;
+    o.captures = options::capture_policy::none;
+    o.step_budget = 4000000;
+
+    bool blew = false;
+    try {
+        m.try_parse(std::string(400, 'a'), o);
+    }
+    catch(budget_exceeded&) {
+        blew = true;
+    }
+
+    ok("400 bytes of near-miss stays inside four million steps", !blew);
+}
+
+int main() {
+    std::cout << std::unitbuf;
+
+    terminals_match_exactly_what_they_say();
+    concatenation_binds_tighter_than_alternation();
+    ordered_choice_is_not_unordered_alternation();
+    repetition_is_possessive();
+    recursion_and_forward_references();
+    a_broken_grammar_says_which_rule_is_broken();
+    incremental_alternatives();
+    captures_retain_only_what_was_asked_for();
+    errors_carry_a_position_and_a_rule_stack();
+    a_length_prefixed_field_reads_its_length_from_earlier();
+    a_back_reference_matches_what_came_before();
+    the_depth_guard_fires_instead_of_the_stack();
+    a_grammar_serializes_to_abnf();
+    the_core_rules_are_the_ones_in_appendix_b();
+    what_a_parse_costs();
+
+    // What a green run here does NOT establish.
+    //
+    // Not RFC 5234 conformance.  Alternation is PEG ordered choice and
+    // repetition is possessive; two sections above assert the difference, one
+    // of them using a production from RFC 5234's own grammar.  A grammar that
+    // relies on unordered alternation will fail, and it will fail as a clean
+    // parse error rather than a wrong answer -- which is the better of the two
+    // but is still a difference.
+    //
+    // Not that the step counts are reasonable.  There is no memoization, and
+    // what_a_parse_costs() asserts only that one shape on 400 bytes stays
+    // under a ceiling.  Whether packrat is needed is a measurement that has to
+    // be taken against a real grammar, which does not exist yet.
+    //
+    // Not thread safety.  A grammar is read-only once defined and every piece
+    // of parse state lives on a per-call context, so parsing one grammar from
+    // several threads is *intended* to work and is not tested here.  If a memo
+    // table is ever added it must stay on the context; move it to the grammar
+    // for a cache-hit win and that property is gone, silently.
+    //
+    // Not the absence of leaks in general.  grammar's destructor breaks the
+    // slot cycles it owns, and nothing here counts allocations to prove it.
+    // A rule made recursive by hand with rule::declare(), outside any grammar,
+    // still leaks its cycle -- that is documented, not fixed.
+    //
+    // Not the depth limit as a guarantee.  It is a count of nested rule
+    // invocations, not of stack bytes, and the relationship between them
+    // depends on the compiler and the platform.
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
Layer one of the parser: rules built from C++ objects, a grammar to hold them,
and the two escapes ABNF itself cannot express.  No ABNF *text* yet -- that is
the next branch, and it is written in these.

    macOS  39 tests, 39 pass, 0 skip
    Linux  40 tests, 39 pass, 1 skip

    jlib/util/abnf.hh        563 lines
    jlib/util/abnf.cc       1889
    tests/util_abnf_test.cc  597

it is a PEG wearing ABNF's notation, and that is written down

    Alternation is ordered choice: the first branch that matches wins.  RFC
    5234 says `/` is unordered.  The difference is observable and the test
    asserts it using a production from RFC 5234's own grammar:

        repeat = 1*DIGIT / (*DIGIT "*" *DIGIT)

    Against "3*5" the first branch takes the 3, the enclosing rule then wants
    end of input, and the choice has already committed.  Written the other way
    round it parses.  Both are asserted, so a future move to unordered
    semantics breaks a test rather than quietly changing what every grammar
    means.

    Repetition is possessive: *CHAR "@" cannot parse a@b, because the
    repetition eats the @ and will not give it back.  until(), counted() and
    backref() are the ways round it, and the test demonstrates the failure
    next to the fix rather than only the fix.

    Neither is a defect to be corrected later.  They are what makes the engine
    a plain recursive walk instead of a continuation-passing one, and the cost
    is paid in grammars that must be written longest-alternative-first.

one mechanism for three things

    A rulename is a cell; a reference points at the cell rather than at a body.
    That single indirection is forward references, recursion, and ABNF's "=/"
    all at once -- replacing a cell's body is seen by every reference that
    already exists, which the test checks by extending a rule after taking a
    reference to it.

    It also leaks.  A recursive rule is a cell holding a body holding a
    reference holding the cell, and no reference count sees round that.
    grammar's destructor clears every body it owns, which cuts each cycle
    exactly once.  A rule made recursive by hand outside a grammar still leaks,
    and that is documented rather than fixed.

captures are a flat tape, and backtracking is truncation

    Records go in a vector on the parse context; abandoning a branch is
    resize().  No node allocation per match, no shared_ptr unwinding, and a
    capture from a branch that lost is unreachable by construction rather than
    by bookkeeping -- asserted.

    Three retention policies, because "every named rule" is hundreds of records
    for a grammar the size of RFC 5322 and usually two of them are wanted:

        o.captures = options::capture_policy::listed;
        o.capture_only = {"local-part", "domain"};

what the RFCs cannot say

    counted(number) matches as many octets as an earlier rule's match says.
    That is RFC 3501's literal -- whose own grammar puts the constraint in a
    comment, because ABNF has no way to write it -- and it is the whole reason
    the combinator layer is public rather than an implementation detail of the
    text front end.

    backref(name) matches the text an earlier rule matched: a MIME boundary, or
    an XML end tag.  The test parses <b>hello</b> and rejects <b>hello</i>.

    Both mark their subtree impure, so that a memo table -- if measurement ever
    justifies one -- cannot cache them.  A memo keyed on (rule, position) is a
    lie when the answer also depends on what matched earlier.

guards, because the input comes from strangers

    A depth guard and a step budget, both on by default.  Recursive comment
    inside CFWS is reachable from any mail header, so unbounded nesting is a
    remote crash; ordered choice over shared prefixes can be exponential, so a
    mangled header is a hang.  Both now produce an exception with a position on
    it.

    Writing the tests for them found two of my own mistakes.  The first
    asserted "a thousand deep is fine" against a default depth of 1000 -- off
    by exactly the boundary, and it failed.  The second exercised the step
    budget with a left-recursive grammar, so the *depth* guard fired first and
    the budget was never reached; the assertion passed while testing the wrong
    thing.  Both now pin which guard fires, by its message.

    Two assertions were ok(..., true, ...) -- decoration that cannot fail.
    They assert results now.

errors say where

    Furthest-failure position, the expected set at that position, and the rules
    that were open when it happened.  The XML parser this eventually replaces
    reports an enum with no location at all; the bar was low and is cleared:

        jlib::util::abnf::error: expected %x30-39 or digits at line 1, column 4
          12.x4
             ^
          while parsing: pair -> digits

a grammar can be read back

    to_abnf() serializes, with parenthesization driven by precedence -- an
    alternation inside a concatenation keeps its brackets, a concatenation
    inside an alternation does not need them.  Asserted both ways, because
    getting it wrong changes what the grammar means and nothing else would
    notice.  It is also half of the strongest test available in the next
    branch, where the ABNF-of-ABNF parses its own serialization.

what a green run does not establish

    Not RFC 5234 conformance -- see above.  Not that the step counts are
    reasonable: there is no memoization, and whether it is needed is a
    measurement that needs a real grammar, which arrives two branches from now.
    Not thread safety, which is intended (a grammar is read-only, all parse
    state is per-call) and untested.  Not the absence of leaks in general.  And
    the depth limit counts rule invocations rather than stack bytes, so it is a
    guard rather than a guarantee.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
