### PR TITLE
Read ABNF grammar text, bootstrapped from RFC 5234's own grammar

### DIFF
--- a/jlib/util/abnf.cc
+++ b/jlib/util/abnf.cc
@@ -1596,6 +1596,9 @@ public:
     std::map<std::string, std::shared_ptr<slot>, iless> slots;
     std::vector<std::string> order;
 
+    // Set by compile() only; see grammar::prose_rules().
+    std::vector<std::string> prose;
+
     std::shared_ptr<slot> cell(std::string_view name)
     {
         auto i = slots.find(name);
@@ -1681,7 +1684,38 @@ void grammar::define_alternative(std::string name, const rule& more)
     rule(std::make_shared<detail::reference>(i->second)).define_alternative(more);
 }
 
+void grammar::seed_core()
+{
+    struct seed { const char* name; const rule& (*get)(); };
+
+    static const seed cores[] = {
+        { "ALPHA",  core::ALPHA  }, { "BIT",    core::BIT    },
+        { "CHAR",   core::CHAR   }, { "CR",     core::CR     },
+        { "CRLF",   core::CRLF   }, { "CTL",    core::CTL    },
+        { "DIGIT",  core::DIGIT  }, { "DQUOTE", core::DQUOTE },
+        { "HEXDIG", core::HEXDIG }, { "HTAB",   core::HTAB   },
+        { "LF",     core::LF     }, { "LWSP",   core::LWSP   },
+        { "OCTET",  core::OCTET  }, { "SP",     core::SP     },
+        { "VCHAR",  core::VCHAR  }, { "WSP",    core::WSP    },
+    };
+
+    for(const seed& c : cores) {
+        std::shared_ptr<slot> s = m_impl->cell(c.name);
+
+        if(s->body) continue;
+
+        s->body = c.get().node();
+        s->seeded = true;
+    }
+
+    // Deliberately not added to m_impl->order: a core rule nothing referenced
+    // is not part of the grammar anyone wrote, and printing sixteen of them
+    // above every to_abnf() would bury it.
+}
+
 std::vector<std::string> grammar::rules() const { return m_impl->order; }
+
+std::vector<std::string> grammar::prose_rules() const { return m_impl->prose; }
 
 /** Everything reachable from e, following references into their bodies. */
 static void reachable(const expr* e,
@@ -1812,6 +1846,428 @@ std::string grammar::to_abnf() const
     }
 
     return o.str();
+}
+
+
+// ------------------------------------------------------------- the ABNF text
+
+std::string dedent(std::string_view text)
+{
+    std::size_t common = std::string::npos;
+    std::size_t i = 0;
+
+    while(i <= text.size()) {
+        std::size_t eol = text.find('\n', i);
+        if(eol == std::string_view::npos) eol = text.size();
+
+        std::size_t j = i;
+        while(j < eol && (text[j] == ' ' || text[j] == '\t')) j++;
+
+        // Blank lines say nothing about the common indent.
+        if(j < eol && (common == std::string::npos || j - i < common)) {
+            common = j - i;
+        }
+
+        if(eol == text.size()) break;
+        i = eol + 1;
+    }
+
+    if(common == std::string::npos || common == 0) {
+        return std::string(text);
+    }
+
+    std::string out;
+    i = 0;
+
+    while(i <= text.size()) {
+        std::size_t eol = text.find('\n', i);
+        const bool last = (eol == std::string_view::npos);
+        if(last) eol = text.size();
+
+        std::size_t skip = 0;
+        while(skip < common && i + skip < eol &&
+              (text[i + skip] == ' ' || text[i + skip] == '\t')) {
+            skip++;
+        }
+
+        out.append(text.substr(i + skip, eol - (i + skip)));
+
+        if(last) break;
+
+        out += '\n';
+        i = eol + 1;
+    }
+
+    return out;
+}
+
+namespace {
+
+/**
+ * RFC 5234 section 4, written in the combinators of section... this file.
+ *
+ * The bootstrap: ABNF's own grammar, by hand, once -- and everything after it
+ * is read rather than written.  It is also the strongest test available, since
+ * the result can be asked to parse the text it was built from.
+ *
+ * Two deliberate departures from the RFC's own text, both noted where they
+ * occur: repeat's alternatives are reordered, because ordered choice would
+ * commit to the wrong one, and c-nl may be a bare LF, because grammar text
+ * pasted out of a browser is not CRLF.
+ */
+class abnf_grammar {
+public:
+    explicit abnf_grammar(bool bare_lf)
+    {
+        const rule ALPHA = core::ALPHA();
+        const rule DIGIT = core::DIGIT();
+        const rule HEXDIG = core::HEXDIG();
+        const rule WSP = core::WSP();
+        const rule VCHAR = core::VCHAR();
+        const rule DQUOTE = core::DQUOTE();
+
+        // RFC 5234 says CRLF.  Text pasted from a browser or an RFC .txt file
+        // has bare LFs, and refusing it would defeat the point of reading ABNF
+        // text at all.
+        const rule nl = bare_lf
+            ? (core::CRLF() | core::LF() | core::CR())
+            : core::CRLF();
+
+        const rule comment = lit(";") >> *(WSP | VCHAR) >> nl;
+        const rule c_nl = comment | nl;
+        const rule c_wsp = WSP | (c_nl >> WSP);
+
+        const rule rulename = ALPHA >> *(ALPHA | DIGIT | lit("-"));
+
+        // char-val, with RFC 7405's %s and %i.  Case insensitive by default,
+        // per 5234 2.3 -- which is the opposite of lit() and is why the two
+        // layers differ there.
+        const rule quoted =
+            DQUOTE >> as("cv-text", *(rng(0x20, 0x21) | rng(0x23, 0x7E)))
+                   >> DQUOTE;
+
+        const rule char_val = as("char-val",
+            (as("cv-sensitive", ilit("%s")) >> quoted) |
+            (-ilit("%i") >> quoted));
+
+        // The body is taken whole and read in C++: splitting 1*BIT from
+        // 1*DIGIT from 1*HEXDIG in the grammar buys nothing when the value has
+        // to be converted anyway, and the base is right there.
+        const rule num_val = as("num-val",
+            lit("%") >> as("nv-base", anyof("bdxBDX"))
+                     >> as("nv-body", +(HEXDIG | anyof(".-"))));
+
+        const rule prose_val = as("prose-val",
+            lit("<") >> as("prose-text", *(rng(0x20, 0x3D) | rng(0x3F, 0x7E)))
+                     >> lit(">"));
+
+        m_grammar.define("element",
+            as("ref", rulename)
+          | as("group",  lit("(") >> *c_wsp >> m_grammar["alternation"]
+                                  >> *c_wsp >> lit(")"))
+          | as("option", lit("[") >> *c_wsp >> m_grammar["alternation"]
+                                  >> *c_wsp >> lit("]"))
+          | char_val | num_val | prose_val);
+
+        // RFC 5234 writes this as
+        //
+        //     repeat = 1*DIGIT / (*DIGIT "*" *DIGIT)
+        //
+        // which cannot work under ordered choice: against "3*5" the first
+        // alternative takes the 3 and the enclosing rule then fails on the
+        // "*", with the choice already committed.  Longest first.
+        m_grammar.define("repetition",
+            as("repetition",
+               -as("repeat", (*DIGIT >> lit("*") >> *DIGIT) | +DIGIT)
+               >> m_grammar["element"]));
+
+        m_grammar.define("concatenation",
+            as("concatenation",
+               m_grammar["repetition"] >> *(+c_wsp >> m_grammar["repetition"])));
+
+        m_grammar.define("alternation",
+            as("alternation",
+               m_grammar["concatenation"]
+               >> *(*c_wsp >> lit("/") >> *c_wsp >> m_grammar["concatenation"])));
+
+        // "=/" before "=", or the choice commits to "=" and leaves a stray "/".
+        m_grammar.define("rule",
+            as("rule",
+               as("defined-name", rulename) >> *c_wsp
+               >> as("op", lit("=/") | lit("=")) >> *c_wsp
+               >> m_grammar["alternation"] >> *c_wsp >> c_nl));
+
+        m_grammar.define("rulelist",
+            +( m_grammar["rule"] | (*c_wsp >> c_nl) ));
+
+        m_grammar.check();
+    }
+
+    rule rulelist() const { return m_grammar.at("rulelist"); }
+
+protected:
+    mutable grammar m_grammar;
+};
+
+const abnf_grammar& bootstrap(bool bare_lf)
+{
+    static const abnf_grammar strict(false);
+    static const abnf_grammar loose(true);
+
+    return bare_lf ? loose : strict;
+}
+
+// ------------------------------------------------------ reading the tree back
+
+rule build_alternation(const match& m, grammar& g, const compile_options& o);
+
+unsigned long digits_of(std::string_view s, int base)
+{
+    unsigned long v = 0;
+
+    for(char c : s) {
+        int d;
+
+        if(c >= '0' && c <= '9')      d = c - '0';
+        else if(c >= 'a' && c <= 'f') d = c - 'a' + 10;
+        else if(c >= 'A' && c <= 'F') d = c - 'A' + 10;
+        else throw grammar_error(std::string("\"") + c +
+                                 "\" is not a digit in that base");
+
+        if(d >= base) {
+            throw grammar_error(std::string("\"") + c +
+                                "\" is not a digit in base " +
+                                std::to_string(base));
+        }
+
+        v = v * static_cast<unsigned long>(base) + static_cast<unsigned long>(d);
+
+        if(v > 0xFF && base != 0) {
+            // Checked as it accumulates, so a long run of digits cannot wrap.
+            // ABNF is octet based; a value that does not fit in one is a
+            // mistake in the grammar rather than something to truncate.
+            throw grammar_error("numeric value above %xFF; ABNF is octets");
+        }
+    }
+
+    return v;
+}
+
+rule build_num_val(const match& m)
+{
+    const std::string base_text = m.child("nv-base").str();
+    const std::string body = m.child("nv-body").str();
+
+    const char b = static_cast<char>(std::tolower(
+        static_cast<unsigned char>(base_text[0])));
+
+    const int base = (b == 'b') ? 2 : (b == 'd') ? 10 : 16;
+
+    const std::size_t dash = body.find('-');
+
+    if(dash != std::string::npos) {
+        const unsigned long lo = digits_of(body.substr(0, dash), base);
+        const unsigned long hi = digits_of(body.substr(dash + 1), base);
+
+        return rng(static_cast<unsigned char>(lo), static_cast<unsigned char>(hi));
+    }
+
+    // A dotted run is a sequence of octets, and never case folded.
+    std::string bytes_out;
+    std::size_t at = 0;
+
+    while(at <= body.size()) {
+        std::size_t dot = body.find('.', at);
+        if(dot == std::string::npos) dot = body.size();
+
+        bytes_out += static_cast<char>(digits_of(body.substr(at, dot - at), base));
+
+        if(dot == body.size()) break;
+        at = dot + 1;
+    }
+
+    if(bytes_out.size() == 1) {
+        return chr(static_cast<unsigned char>(bytes_out[0]));
+    }
+
+    return lit(bytes_out);
+}
+
+rule build_element(const match& m, grammar& g, const compile_options& o)
+{
+    const std::string k = m.name();
+
+    if(k == "ref") {
+        return g[m.str()];
+    }
+
+    if(k == "group") {
+        return build_alternation(m.child("alternation"), g, o);
+    }
+
+    if(k == "option") {
+        return opt(build_alternation(m.child("alternation"), g, o));
+    }
+
+    if(k == "char-val") {
+        const match t = m.child("cv-text");
+        const std::string text = t ? t.str() : std::string();
+
+        // RFC 5234 2.3: a quoted string is case insensitive.  RFC 7405's %s
+        // is the way to ask for the other thing.
+        return m.child("cv-sensitive") ? lit(text) : ilit(text);
+    }
+
+    if(k == "num-val") {
+        return build_num_val(m);
+    }
+
+    if(k == "prose-val") {
+        const match t = m.child("prose-text");
+        const std::string text = t ? t.str() : std::string();
+
+        if(o.prose) {
+            return o.prose(text);
+        }
+
+        // Compiles; fails when reached.  Refusing to compile a grammar because
+        // one obsolete production is prose would defeat the purpose of being
+        // able to paste one in.
+        return where("prose <" + text + ">",
+                     [text](std::string_view, std::size_t&) -> bool {
+                         throw grammar_error("prose-val <" + text + "> has no "
+                                             "implementation; supply one with "
+                                             "compile_options::prose");
+                     });
+    }
+
+    throw grammar_error("unrecognised element \"" + k + "\" in the grammar text");
+}
+
+rule build_repetition(const match& m, grammar& g, const compile_options& o)
+{
+    match repeat, element;
+
+    for(const match& c : m.children()) {
+        if(c.name() == "repeat") repeat = c;
+        else                     element = c;
+    }
+
+    if(!element) {
+        throw grammar_error("a repetition with nothing to repeat");
+    }
+
+    rule e = build_element(element, g, o);
+
+    if(!repeat) {
+        return e;
+    }
+
+    const std::string r = repeat.str();
+    const std::size_t star = r.find('*');
+
+    if(star == std::string::npos) {
+        const unsigned long n = digits_of(r, 10);
+
+        return rep(e, n, n);
+    }
+
+    const std::string lo = r.substr(0, star);
+    const std::string hi = r.substr(star + 1);
+
+    return rep(e,
+               lo.empty() ? 0 : digits_of(lo, 10),
+               hi.empty() ? rule::unbounded : digits_of(hi, 10));
+}
+
+rule build_concatenation(const match& m, grammar& g, const compile_options& o)
+{
+    rule out;
+    bool first = true;
+
+    for(const match& c : m.children()) {
+        if(c.name() != "repetition") continue;
+
+        rule r = build_repetition(c, g, o);
+
+        out = first ? r : (out >> r);
+        first = false;
+    }
+
+    return first ? empty() : out;
+}
+
+rule build_alternation(const match& m, grammar& g, const compile_options& o)
+{
+    rule out;
+    bool first = true;
+
+    for(const match& c : m.children()) {
+        if(c.name() != "concatenation") continue;
+
+        rule r = build_concatenation(c, g, o);
+
+        out = first ? r : (out | r);
+        first = false;
+    }
+
+    return first ? empty() : out;
+}
+
+}  // namespace
+
+grammar compile(std::string_view text)
+{
+    return compile(text, compile_options());
+}
+
+grammar compile(std::string_view text, const compile_options& o)
+{
+    std::string src = o.dedent ? dedent(text) : std::string(text);
+
+    // rulelist ends every rule with a c-nl, and grammar text routinely does
+    // not end with a newline.  Supplying one is kinder than making every
+    // caller remember.
+    if(src.empty() || (src.back() != '\n' && src.back() != '\r')) {
+        src += "\r\n";
+    }
+
+    grammar g;
+
+    if(o.seed_core_rules) {
+        g.seed_core();
+    }
+
+    options po;
+    po.captures = options::capture_policy::named;
+
+    const parse_result r = bootstrap(o.allow_bare_lf).rulelist().try_parse(src, po);
+
+    if(!r) {
+        const error& e = r.why();
+
+        throw grammar_error("the grammar text does not parse at line " +
+                            std::to_string(e.line()) + ", column " +
+                            std::to_string(e.column()) + ": " + e.context_line());
+    }
+
+    for(const match& rl : r.root().all("rule")) {
+        const std::string name = rl.child("defined-name").str();
+        const std::string op = rl.child("op").str();
+
+        rule body = build_alternation(rl.child("alternation"), g, o);
+
+        if(op == "=/") g.define_alternative(name, body);
+        else           g.define(name, body);
+
+        // Recorded rather than derived: once a prose-val has been lowered to a
+        // rule there is nothing left in the tree that says it was one.
+        if(!o.prose && !rl.all("prose-val").empty()) {
+            g.m_impl->prose.push_back(name);
+        }
+    }
+
+    return g;
 }
 
 // ----------------------------------------------------------------- core rules

--- a/jlib/util/abnf.hh
+++ b/jlib/util/abnf.hh
@@ -39,10 +39,17 @@ namespace util {
  * Grammars, and the machinery to run them against input.
  *
  * This is the layer the RFCs are eventually written in.  Two of them, in fact:
- * these combinators, and -- built on top, in a later branch -- a reader for
- * ABNF grammar text, so an RFC's own grammar can be pasted in as it stands.
- * Both are public, because ABNF cannot express everything the RFCs need.
- * RFC 3501 says
+ * these combinators, and -- built on top, see compile() -- a reader for ABNF
+ * grammar text, so an RFC's own grammar can be pasted in as it stands:
+ *
+ *     grammar g = abnf::compile(
+ *         "addr-spec  = local-part \"@\" domain\r\n"
+ *         "local-part = 1*atext\r\n"
+ *         "domain     = 1*atext *(\".\" 1*atext)\r\n"
+ *         "atext      = ALPHA / DIGIT / \"+\" / \"-\" / \"_\"\r\n");
+ *
+ * Both layers are public, because ABNF cannot express everything the RFCs
+ * need.  RFC 3501 says
  *
  *     literal = "{" number "}" CRLF *CHAR8
  *             ; Number represents the number of CHAR8s
@@ -476,6 +483,8 @@ rule where_pure(std::string description,
  * Rules declared outside a grammar and made recursive by hand will leak, and
  * that is the reason to keep them in one of these.
  */
+struct compile_options;
+
 class grammar {
 public:
     grammar();
@@ -497,8 +506,31 @@ public:
     void define(std::string name, const rule& body);
     void define_alternative(std::string name, const rule& more);
 
+    /**
+     * Predefine RFC 5234 Appendix B.
+     *
+     * Marked so that a grammar may redefine one with "=" without that being
+     * the redefinition error it would otherwise be -- RFC 3501 defines its own
+     * CHAR8, and grammars do reach for a core name and mean something slightly
+     * different by it.  A seeded rule that nothing uses does not appear in
+     * rules() or to_abnf().
+     */
+    void seed_core();
+
     /** Defined rules, in the order they were defined. */
     std::vector<std::string> rules() const;
+
+    /**
+     * Rules whose definition contains a prose-val with no implementation.
+     *
+     * A grammar read from an RFC often has one or two productions the RFC
+     * describes in words rather than in ABNF, and compile() lets those through
+     * so that the other two hundred rules are usable.  This is how to find out
+     * which they are before relying on the result, rather than when a parse
+     * reaches one.  Empty for a grammar built in combinators, and for one
+     * whose prose was all supplied through compile_options::prose.
+     */
+    std::vector<std::string> prose_rules() const;
 
     /** Referenced and never defined. */
     std::vector<std::string> undefined() const;
@@ -517,9 +549,102 @@ public:
 protected:
     friend class rule;
 
+    // The one thing outside this class that reaches into impl: compile() has
+    // to record which rules it left as unimplemented prose, and a public
+    // setter for that would be a wart on an API nobody else should call.
+    friend grammar compile(std::string_view, const compile_options&);
+
     class impl;
     std::unique_ptr<impl> m_impl;
 };
+
+// ------------------------------------------------------------- the ABNF text
+
+/**
+ * Strip the indentation an RFC prints its grammar with.
+ *
+ * RFC 5234's rulelist wants a rulename at column zero, and grammars in an RFC
+ * are indented three spaces.  Removing the *common* prefix rather than
+ * trimming every line is what keeps line folding working: a continuation is a
+ * line that begins with more whitespace than the rule it continues, and that
+ * relationship has to survive.
+ *
+ * Exposed because it is worth being able to test on its own.
+ */
+std::string dedent(std::string_view text);
+
+/** How to read grammar text. */
+struct compile_options {
+    /** Remove the common leading indent first.  See dedent(). */
+    bool dedent = true;
+
+    /** Predefine RFC 5234 Appendix B.  A grammar may still redefine them. */
+    bool seed_core_rules = true;
+
+    /**
+     * Accept a bare LF where the grammar says CRLF.
+     *
+     * RFC 5234 is written in terms of CRLF, and grammar text pasted out of a
+     * browser or an RFC has bare LFs in it.  Refusing that would defeat the
+     * entire purpose of reading ABNF text.
+     */
+    bool allow_bare_lf = true;
+
+    /**
+     * What to do with a prose-val -- the <...> that means "described in
+     * words, elsewhere".
+     *
+     * Null means: compile it, and fail at *parse* time with a position saying
+     * which prose rule has no implementation.  Refusing to compile a
+     * two-hundred rule grammar because one obsolete production is prose would
+     * defeat the purpose; failing when it is actually reached does not.
+     *
+     * Supplying one is the seam this layer exists to provide: the RFC's own
+     * words, implemented in combinators.
+     */
+    std::function<rule(std::string_view)> prose;
+};
+
+/**
+ * Read RFC 5234 ABNF, and return the grammar it describes.
+ *
+ * Paste it out of the RFC:
+ *
+ *     grammar g = abnf::compile(
+ *         "addr-spec   = local-part \"@\" domain\r\n"
+ *         "local-part  = dot-atom / quoted-string\r\n");
+ *
+ * Throws grammar_error, with a position in the grammar text, for ABNF that
+ * does not parse.  Rules referenced and never defined are *not* an error here
+ * -- a grammar is often built from several calls -- but grammar::check() and
+ * the first parse will both refuse them.
+ *
+ * ## A compiled grammar is still this engine's
+ *
+ * The text is RFC 5234's; what runs it is ordered choice and possessive
+ * repetition, as described at the top of this header.  So a pasted grammar
+ * means what *this* reads it as, which is not always what the RFC intended --
+ * and RFC 5234's own section 4 is an example.  Written as published, its
+ *
+ *     defined-as = *c-wsp ("=" / "=/") *c-wsp
+ *     repeat     = 1*DIGIT / (*DIGIT "*" *DIGIT)
+ *
+ * both commit to the wrong branch here: "=" matches the first character of
+ * "=/" and wins, and 1*DIGIT eats the "3" of "3*5" and wins.  Swapping the two
+ * alternatives in each makes them behave as the RFC means them to, and that is
+ * the form the bootstrap uses.  Grammars needing this are uncommon, and the
+ * symptom is always the same -- a longer alternative that a shorter prefix of
+ * it shadows.
+ *
+ * ## Case
+ *
+ * A quoted string in ABNF is case *insensitive* (RFC 5234 2.3), so "HELO"
+ * here compiles to ilit(), not lit(); RFC 7405's %s asks for the other thing.
+ * That is the reverse of what a handwritten lit() does, and deliberately so at
+ * both ends -- see the note on lit().
+ */
+grammar compile(std::string_view abnf_text);
+grammar compile(std::string_view abnf_text, const compile_options& o);
 
 // ----------------------------------------------------------------- core rules
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -67,6 +67,7 @@ TESTS = \
 	util_headers_angie_test \
 	util_xml_test \
 	util_abnf_test \
+	util_abnf_compile_test \
  \
 	$(X_TESTS) \
 	$(MEDIA_TESTS) \
@@ -155,6 +156,9 @@ util_headers_angie_test_SOURCES = util_headers_angie_test.cc
 util_headers_angie_test_LDADD   = $(JUTIL_LA)
 util_abnf_test_SOURCES = util_abnf_test.cc
 util_abnf_test_LDADD   = $(JUTIL_LA)
+
+util_abnf_compile_test_SOURCES = util_abnf_compile_test.cc
+util_abnf_compile_test_LDADD   = $(JUTIL_LA)
 
 util_xml_test_SOURCES = util_xml_test.cc
 util_xml_test_LDADD   = $(JUTIL_LA)

--- a/tests/util_abnf_compile_test.cc
+++ b/tests/util_abnf_compile_test.cc
@@ -1,0 +1,406 @@
+/* -*- mode: C++ c-basic-offset: 4  -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ *
+ */
+
+// Reading ABNF text, which is the point of the whole exercise: the grammars
+// in the RFCs stop being something to transcribe and become something to
+// paste.
+//
+// The last section is the one worth reading.  The reader is bootstrapped --
+// RFC 5234's own grammar, written once by hand in combinators -- so it can be
+// handed the text of RFC 5234 section 4 and asked to produce a reader for
+// ABNF.  That result then parses the same text, parses its own serialization,
+// and compiles to a fixed point.
+
+#include <jlib/util/abnf.hh>
+
+#include <iostream>
+#include <string>
+
+using namespace jlib::util::abnf;
+
+static int failures = 0;
+
+static void ok(const std::string& what, bool good, const std::string& detail = "") {
+    if(!good) ++failures;
+    std::cout << (good ? "  ok   " : "  FAIL ") << what;
+    if(!detail.empty()) std::cout << ": " << detail;
+    std::cout << "\n";
+}
+
+/** Does the named rule of this grammar match the whole of s? */
+static bool matches(grammar& g, const std::string& name, const std::string& s) {
+    options o;
+    o.captures = options::capture_policy::none;
+
+    return static_cast<bool>(g.at(name).try_parse(s, o));
+}
+
+static void a_grammar_read_from_text_does_what_the_text_says() {
+    std::cout << "reading a grammar:\n";
+
+    grammar g = compile(
+        "addr-spec  = local-part \"@\" domain\r\n"
+        "local-part = 1*atext\r\n"
+        "domain     = 1*atext *(\".\" 1*atext)\r\n"
+        "atext      = ALPHA / DIGIT / %x2B / %x2D / %x5F\r\n");
+
+    ok("the rules are there, in order",
+       g.rules().size() == 4 && g.rules()[0] == "addr-spec" &&
+       g.rules()[3] == "atext");
+
+    ok("and it parses",       matches(g, "addr-spec", "joe@example.com"));
+    ok("including a plus",    matches(g, "addr-spec", "joe+tag@example.com"));
+    ok("a subdomain",         matches(g, "addr-spec", "a@b.c.d"));
+    ok("no local part",      !matches(g, "addr-spec", "@example.com"));
+    ok("no domain",          !matches(g, "addr-spec", "joe@"));
+    ok("a space",            !matches(g, "addr-spec", "a b@c"));
+
+    // Core rules are predefined, which is why ALPHA and DIGIT above needed no
+    // declaration -- and they do not clutter the grammar afterwards.
+    ok("core rules do not show up as the grammar's own",
+       g.rules().size() == 4);
+}
+
+static void the_pieces_of_the_notation() {
+    std::cout << "\nthe notation:\n";
+
+    {
+        // RFC 5234 2.3: a quoted string is case INsensitive.  That is the
+        // opposite of lit(), and the divergence is deliberate -- a pasted
+        // grammar has to mean what the RFC says it means.
+        grammar g = compile("greeting = \"HELO\"\r\n");
+
+        ok("a quoted string is case insensitive",
+           matches(g, "greeting", "helo") && matches(g, "greeting", "HeLo"));
+    }
+
+    {
+        // RFC 7405 is how to ask for the other thing.
+        grammar g = compile("greeting = %s\"HELO\"\r\n");
+
+        ok("%s makes it case sensitive",
+           matches(g, "greeting", "HELO") && !matches(g, "greeting", "helo"));
+
+        grammar h = compile("greeting = %i\"HELO\"\r\n");
+        ok("and %i says so explicitly",  matches(h, "greeting", "helo"));
+    }
+
+    {
+        grammar g = compile(
+            "a = %x41\r\n"        // one octet, hex
+            "b = %d66\r\n"        // decimal
+            "c = %b1000011\r\n"   // binary
+            "d = %x44-46\r\n"     // a range
+            "e = %x47.48\r\n");   // a sequence
+
+        ok("hex",      matches(g, "a", "A") && !matches(g, "a", "B"));
+        ok("decimal",  matches(g, "b", "B"));
+        ok("binary",   matches(g, "c", "C"));
+        ok("a range",  matches(g, "d", "D") && matches(g, "d", "F") &&
+                      !matches(g, "d", "G"));
+        ok("a sequence of octets", matches(g, "e", "GH"));
+    }
+
+    {
+        grammar g = compile(
+            "a = 3\"x\"\r\n"
+            "b = *\"x\"\r\n"
+            "c = 1*\"x\"\r\n"
+            "d = 2*4\"x\"\r\n"
+            "e = *3\"x\"\r\n");
+
+        ok("exactly n", matches(g, "a", "xxx") && !matches(g, "a", "xx"));
+        ok("zero or more", matches(g, "b", "") && matches(g, "b", "xxxx"));
+        ok("one or more", !matches(g, "c", "") && matches(g, "c", "x"));
+        ok("between n and m",
+           !matches(g, "d", "x") && matches(g, "d", "xx") &&
+            matches(g, "d", "xxxx") && !matches(g, "d", "xxxxx"));
+        ok("at most m", matches(g, "e", "") && !matches(g, "e", "xxxx"));
+    }
+
+    {
+        grammar g = compile(
+            "a = (\"x\" / \"y\") \"z\"\r\n"
+            "b = [\"x\"] \"z\"\r\n");
+
+        ok("a group",  matches(g, "a", "xz") && matches(g, "a", "yz") &&
+                      !matches(g, "a", "z"));
+        ok("an option", matches(g, "b", "xz") && matches(g, "b", "z"));
+    }
+
+    {
+        grammar g = compile(
+            "; a comment on its own line\r\n"
+            "a = \"x\"   ; and one after a rule\r\n"
+            "\r\n"
+            "b = \"y\"\r\n");
+
+        ok("comments and blank lines are skipped",
+           g.rules().size() == 2 && matches(g, "a", "x") && matches(g, "b", "y"));
+    }
+
+    {
+        // A rule continues on the next line when that line is indented --
+        // c-wsp being WSP or (c-nl WSP).
+        grammar g = compile(
+            "a = \"x\"\r\n"
+            "    \"y\"\r\n"
+            "    \"z\"\r\n");
+
+        ok("a rule folded over three lines", matches(g, "a", "xyz"));
+    }
+}
+
+static void incremental_alternatives() {
+    std::cout << "\nABNF's \"=/\":\n";
+
+    grammar g = compile(
+        "atext = ALPHA / DIGIT\r\n"
+        "atext =/ \"+\"\r\n"
+        "atext =/ \"-\"\r\n");
+
+    ok("the original alternatives",  matches(g, "atext", "q"));
+    ok("and each addition",          matches(g, "atext", "+") &&
+                                     matches(g, "atext", "-"));
+    ok("and nothing else",          !matches(g, "atext", "@"));
+
+    // "=/" before "=" in the bootstrap, or ordered choice takes the "=" and
+    // leaves a stray "/" for the alternation to choke on.
+    ok("it is one rule, not three", g.rules().size() == 1);
+}
+
+static void indentation_and_line_endings() {
+    std::cout << "\npasting from an RFC:\n";
+
+    // An RFC prints its grammar indented, and rulelist wants a rulename at
+    // column zero.
+    grammar g = compile(
+        "   a = \"x\" b\r\n"
+        "   b = \"y\"\r\n");
+
+    ok("indented text compiles", matches(g, "a", "xy"));
+
+    ok("dedent keeps relative indentation",
+       dedent("   a = \"x\"\n       \"y\"\n") == "a = \"x\"\n    \"y\"\n");
+
+    ok("and does nothing when there is none",
+       dedent("a = \"x\"\n") == "a = \"x\"\n");
+
+    // Text pasted from a browser has bare LFs where the RFC says CRLF.
+    grammar lf = compile("a = \"x\"\n");
+    ok("bare LF is accepted", matches(lf, "a", "x"));
+
+    {
+        compile_options o;
+        o.allow_bare_lf = false;
+
+        bool threw = false;
+        try { compile("a = \"x\"\n", o); }
+        catch(grammar_error&) { threw = true; }
+
+        ok("unless asked to be strict about it", threw);
+    }
+}
+
+static void prose_is_not_a_grammar() {
+    std::cout << "\nprose-val:\n";
+
+    // <...> means "described in words, elsewhere".  A grammar containing one
+    // still compiles, because refusing two hundred rules over one obsolete
+    // production would defeat the purpose of pasting them in at all.
+    grammar g = compile(
+        "a = \"x\" / b\r\n"
+        "b = <a mailbox, as RFC 822 defines one>\r\n");
+
+    ok("a grammar with prose in it compiles", g.rules().size() == 2);
+    ok("and the part that is not prose works", matches(g, "a", "x"));
+
+    ok("and it says up front which rules are only prose",
+       g.prose_rules().size() == 1 && g.prose_rules()[0] == "b");
+
+    bool threw = false;
+    std::string msg;
+    try { matches(g, "b", "anything"); }
+    catch(grammar_error& e) { threw = true; msg = e.what(); }
+
+    ok("reaching the prose is what fails", threw);
+    ok("and it says which prose",
+       msg.find("mailbox") != std::string::npos, msg);
+
+    // And the hook, which is the seam this layer exists to provide.
+    {
+        compile_options o;
+        o.prose = [](std::string_view) { return +core::DIGIT(); };
+
+        grammar h = compile("a = <a number, in words>\r\n", o);
+
+        ok("supplying an implementation makes it work",
+           matches(h, "a", "1234"));
+
+        ok("and then nothing is left as prose", h.prose_rules().empty());
+    }
+}
+
+static void grammar_text_that_does_not_parse() {
+    std::cout << "\nbad grammar text:\n";
+
+    struct { const char* what; const char* text; } bad[] = {
+        { "no equals",        "a \"x\"\r\n" },
+        { "nothing after =",  "a =\r\n" },
+        { "an unclosed group","a = (\"x\"\r\n" },
+        { "an unclosed quote","a = \"x\r\n" },
+        { "a stray slash",    "a = / \"x\"\r\n" },
+        { "=/ with nothing to extend", "a =/ \"x\"\r\n" },
+        { "an octet past FF", "a = %x100\r\n" },
+        { "a bad digit",      "a = %b1002\r\n" },
+    };
+
+    for(const auto& b : bad) {
+        bool threw = false;
+        try { compile(b.text); }
+        catch(grammar_error&) { threw = true; }
+
+        ok(b.what, threw);
+    }
+
+    // A reference to something never defined is NOT an error at compile time:
+    // a grammar is often assembled from several calls.  check() is where it
+    // becomes one.
+    bool compiled = false;
+    grammar g;
+    try { g = compile("a = b\r\n"); compiled = true; }
+    catch(grammar_error&) { }
+
+    ok("an undefined reference compiles", compiled);
+
+    bool threw = false;
+    try { g.check(); }
+    catch(grammar_error&) { threw = true; }
+
+    ok("and check() is what refuses it", threw);
+}
+
+// RFC 5234 section 4, verbatim but for two reorderings, each marked.
+static const char* ABNF_OF_ABNF =
+"rulelist       =  1*( rule / (*c-wsp c-nl) )\r\n"
+"rule           =  rulename defined-as elements c-nl\r\n"
+"rulename       =  ALPHA *(ALPHA / DIGIT / \"-\")\r\n"
+"defined-as     =  *c-wsp (\"=/\" / \"=\") *c-wsp\r\n"
+"elements       =  alternation *c-wsp\r\n"
+"c-wsp          =  WSP / (c-nl WSP)\r\n"
+"c-nl           =  comment / CRLF\r\n"
+"comment        =  \";\" *(WSP / VCHAR) CRLF\r\n"
+"alternation    =  concatenation *(*c-wsp \"/\" *c-wsp concatenation)\r\n"
+"concatenation  =  repetition *(1*c-wsp repetition)\r\n"
+"repetition     =  [repeat] element\r\n"
+"repeat         =  (*DIGIT \"*\" *DIGIT) / 1*DIGIT\r\n"
+"element        =  rulename / group / option / char-val / num-val / prose-val\r\n"
+"group          =  \"(\" *c-wsp alternation *c-wsp \")\"\r\n"
+"option         =  \"[\" *c-wsp alternation *c-wsp \"]\"\r\n"
+"char-val       =  DQUOTE *(%x20-21 / %x23-7E) DQUOTE\r\n"
+"num-val        =  \"%\" (bin-val / dec-val / hex-val)\r\n"
+"bin-val        =  \"b\" 1*BIT [ 1*(\".\" 1*BIT) / (\"-\" 1*BIT) ]\r\n"
+"dec-val        =  \"d\" 1*DIGIT [ 1*(\".\" 1*DIGIT) / (\"-\" 1*DIGIT) ]\r\n"
+"hex-val        =  \"x\" 1*HEXDIG [ 1*(\".\" 1*HEXDIG) / (\"-\" 1*HEXDIG) ]\r\n"
+"prose-val      =  \"<\" *(%x20-3D / %x3F-7E) \">\"\r\n";
+
+static void it_reads_its_own_grammar() {
+    std::cout << "\nthe fixed point:\n";
+
+    grammar G = compile(ABNF_OF_ABNF);
+
+    ok("RFC 5234 section 4 compiles", G.rules().size() == 21,
+       std::to_string(G.rules().size()) + " rules");
+
+    options o;
+    o.captures = options::capture_policy::none;
+
+    // The reader that was written by hand read this text; the reader the text
+    // describes now reads it back.
+    ok("and the result parses the text it came from",
+       static_cast<bool>(G.at("rulelist").try_parse(ABNF_OF_ABNF, o)));
+
+    const std::string once = G.to_abnf();
+
+    ok("and its own serialization",
+       static_cast<bool>(G.at("rulelist").try_parse(once, o)));
+
+    grammar G2 = compile(once);
+
+    ok("which compiles to the same thing again", G2.to_abnf() == once);
+
+    // Every rule individually, which is what catches a precedence bug in
+    // write(): an alternation nested in a concatenation that loses its
+    // brackets still round trips as a whole if the error is symmetric.
+    std::size_t differ = 0;
+
+    for(const std::string& n : G.rules()) {
+        if(G.at(n).to_abnf() != G2.at(n).to_abnf()) differ++;
+    }
+
+    ok("rule by rule as well", differ == 0,
+       differ ? (std::to_string(differ) + " differ") : "");
+
+    // The two reorderings above are not cosmetic.  As RFC 5234 writes them,
+    // ordered choice takes the wrong branch -- and the grammar this produces
+    // is exactly what the text says, so it inherits whatever the text did.
+    {
+        grammar bad = compile(
+            "defined-as = *c-wsp (\"=\" / \"=/\") *c-wsp\r\n"
+            "c-wsp      = WSP\r\n");
+
+        ok("as the RFC writes defined-as, =/ cannot match",
+           !matches(bad, "defined-as", "=/"));
+    }
+}
+
+int main() {
+    std::cout << std::unitbuf;
+
+    a_grammar_read_from_text_does_what_the_text_says();
+    the_pieces_of_the_notation();
+    incremental_alternatives();
+    indentation_and_line_endings();
+    prose_is_not_a_grammar();
+    grammar_text_that_does_not_parse();
+    it_reads_its_own_grammar();
+
+    // What a green run does NOT establish.
+    //
+    // Not that a grammar compiled from text behaves as RFC 5234 says it
+    // should.  The engine underneath is ordered choice with possessive
+    // repetition, and a compiled grammar inherits that -- which is why two of
+    // RFC 5234's own productions had to be reordered above before its grammar
+    // would work.  A pasted grammar means what this engine makes of it, not
+    // what a different one would.
+    //
+    // Not that the ABNF-of-ABNF here is byte-for-byte the RFC's.  It is the
+    // RFC's text with those two reorderings, and nothing checks it against the
+    // published document.
+    //
+    // Not the external-repetition and incremental-alternative rules of RFC
+    // 7405 beyond %s and %i, and not RFC 5234's own "incremental alternatives
+    // must not change a rule's meaning" advice, which is guidance to a grammar
+    // author and not something a reader can enforce.
+    //
+    // Not performance.  compile() parses with captures on and walks the tree;
+    // nothing here measures either, and a grammar is compiled once.
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
The point of the whole exercise.  The grammars in the RFCs stop being something
to transcribe by hand and become something to paste:

    grammar g = abnf::compile(
        "addr-spec  = local-part \"@\" domain\r\n"
        "local-part = 1*atext\r\n"
        "domain     = 1*atext *(\".\" 1*atext)\r\n"
        "atext      = ALPHA / DIGIT / \"+\" / \"-\" / \"_\"\r\n");

    macOS  40 tests, 40 pass, 0 skip
    Linux  41 tests, 40 pass, 1 skip

    jlib/util/abnf.hh                  +133
    jlib/util/abnf.cc                  +456
    tests/util_abnf_compile_test.cc     406   new

bootstrapped, not hand-written

    RFC 5234 section 4 is ABNF's own grammar, written in ABNF.  So the reader
    is that grammar, written once in the combinators branch 1 shipped -- about
    ninety lines -- and then a tree walk lowering what it matches back into
    combinators.  There is no hand-rolled scanner anywhere in it.

    That is less code than a hand-written ABNF parser would have been, and it
    is also the hardest test layer 1 could be given: a grammar with recursion
    three levels deep, an alternation of six element kinds, back-to-back
    optionals, and line folding, all running against real text.

the fixed point

    The last section of the test is the one worth reading.

      - The hand-written bootstrap parses the text of RFC 5234 section 4, and
        produces a grammar G.
      - G parses that same text.
      - G parses its own to_abnf() serialization.
      - compile(G.to_abnf()) is a grammar G', and G'.to_abnf() == G.to_abnf(),
        rule by rule as well as whole.

    Each step is checkable on its own and none of them is trivially true.  The
    per-rule comparison is what catches a precedence bug in the serializer: an
    alternation nested inside a concatenation that loses its brackets still
    round trips as a whole, because the error is symmetric, and only shows up
    when the rules are compared individually.

two productions had to be reordered, and that is the interesting part

    RFC 5234 writes

        defined-as = *c-wsp ("=" / "=/") *c-wsp
        repeat     = 1*DIGIT / (*DIGIT "*" *DIGIT)

    and neither works here.  This engine is PEG ordered choice, so "=" matches
    the first character of "=/" and wins, and 1*DIGIT eats the "3" of "3*5" and
    wins.  Swap the alternatives in each and both behave as the RFC means them
    to.

    This is not a defect discovered late.  Branch 1's test already asserted
    that ordered choice is not RFC 5234's unordered alternation, and used
    exactly this repeat production as its illustration; branch 3 is where it
    stopped being an illustration and became something the code had to handle.
    It is now written up in the header at compile(), with the symptom named --
    a longer alternative shadowed by a shorter prefix of itself -- because a
    caller pasting a grammar will eventually hit it and should recognise it.

what "paste verbatim" required

    Three things, each small and each load-bearing.

    dedent(), on by default.  rulelist wants a rulename at column zero and an
    RFC indents its grammar three spaces.  It strips the *common* prefix rather
    than trimming each line, because a continuation line is one indented more
    than the rule it continues, and folding has to survive.  Exposed on its own
    so it is testable without a grammar.

    Bare LF.  RFC 5234 says CRLF; text pasted out of a browser has LFs.  The
    bootstrap accepts either, under compile_options::allow_bare_lf.  Note that
    the grammar it *produces* from RFC 5234's text is RFC 5234's, whose c-nl is
    CRLF -- so G accepts its own source in CRLF and refuses it in LF.  That
    asymmetry is correct: leniency belongs to the reader, not to the grammars
    it reads.

    prose-val.  <...> means "described in words, elsewhere", and there are
    still RFCs with one or two.  Refusing to compile two hundred rules over one
    obsolete production would defeat the purpose, so it compiles and fails at
    parse time with a message naming the prose.  compile_options::prose is the
    seam for supplying an implementation, and grammar::prose_rules() says up
    front which rules are only prose, so a caller can find out before relying
    on the result rather than when a parse reaches one.

case, which ABNF and C++ disagree about

    A quoted string in ABNF is case *insensitive* (RFC 5234 2.3), so char-val
    compiles to ilit().  That is the reverse of lit(), which branch 1 made case
    sensitive on the grounds that lit("HELO") silently matching "helo" in
    handwritten code is a footgun.  Both are right for their layer -- pasted
    text has to mean what the RFC says, handwritten code has to mean what it
    says -- and both are documented at the point of use.  RFC 7405's %s and %i
    are how to be explicit.

what the test does not establish

    Written down in the test, as the ringbuffer habit requires:

      - Not RFC 5234 conformance.  A compiled grammar inherits ordered choice
        and possessive repetition from the engine, which is why the two
        reorderings above were needed at all.  A pasted grammar means what this
        makes of it, not what a different engine would.
      - Not that the ABNF-of-ABNF in the test is byte-for-byte the RFC's.  It
        is the RFC's text with those two reorderings, and nothing checks it
        against the published document.
      - Not RFC 7405 beyond %s and %i.
      - Not performance.  compile() parses with captures on and walks the tree;
        a grammar is compiled once and nothing here measures it.

one thing reaches into grammar

    compile() is a friend of grammar, so it can record which rules it left as
    unimplemented prose.  The alternative was a public setter for a field only
    compile() should ever write.
