### PR TITLE
Frame SMTP, POP3 and IMAP bodies by the RFC rather than by guesswork

### DIFF
--- a/jlib/net/Imap4.cc
+++ b/jlib/net/Imap4.cc
@@ -21,6 +21,8 @@
 #include <jlib/net/net.hh>
 #include <jlib/net/Imap4.hh>
 
+#include <jlib/util/abnf.hh>
+
 #include <jlib/sys/sys.hh>
 #include <jlib/sys/sslstream.hh>
 #include <jlib/sys/sslproxystream.hh>
@@ -143,6 +145,72 @@ namespace jlib {
         }
 
 
+
+        namespace {
+
+            /**
+             * RFC 3501's literal introducer, and RFC 7888's.
+             *
+             * Two productions, so this is a small thing to reach for a grammar
+             * over -- but it is the RFC's own two productions, which is the
+             * point: what is accepted here can be checked by reading 4.3
+             * rather than by reading this.  Built once, on first use, for the
+             * reason in crypt/curve.hh:42.
+             */
+            const util::abnf::grammar& imap_literal() {
+                static util::abnf::grammar g = [] {
+                    util::abnf::grammar g = util::abnf::compile(
+                        "literal-introducer = \"{\" number [\"+\"] \"}\"\r\n"
+                        "number             = 1*DIGIT\r\n");
+                    g.check();
+
+                    return g;
+                }();
+
+                return g;
+            }
+
+        }
+
+        bool Imap4::literal_size(const std::string& line, std::size_t& n) {
+            // The introducer is the last thing on the line, so this is where
+            // it has to start if it is anywhere.
+            const std::string::size_type b = line.rfind('{');
+
+            if(b == line.npos) return false;
+
+            util::abnf::options o;
+            o.captures = util::abnf::options::capture_policy::listed;
+            o.capture_only = { "number" };
+
+            const util::abnf::parse_result r =
+                imap_literal().at("literal-introducer").try_parse(line.substr(b), o);
+
+            // A whole-input match, so "{12} more words" is not a literal and
+            // neither is "{}", "{-1}" or "{12x}".
+            if(!r) return false;
+
+            const std::string digits = r.root()["number"].str();
+
+            // A count from the network decides how many octets to read, so it
+            // is refused rather than clamped when it is absurd.  Two gigabytes
+            // is past anything a mail server will send in one literal and is
+            // also where the long this used to be held in would have gone
+            // negative.
+            try {
+                const unsigned long long v = std::stoull(digits);
+
+                if(v > 0x7FFFFFFFull) return false;
+
+                n = static_cast<std::size_t>(v);
+            }
+            catch(std::exception&) {
+                return false;
+            }
+
+            return true;
+        }
+
         Imap4::Imap4(util::URL url) 
             : m_url(url)
         {
@@ -258,8 +326,13 @@ namespace jlib {
             if(getenv("JLIB_NET_IMAP4_DEBUG")) 
                 std::cout << "Parse header size from token" << info.back() << std::endl;
 
-            //header_size = util::int_value(util::slice(info[info.size()-1], "{", "}"));
-            header_size = util::int_value(util::slice(info.back(), "{", "}"));
+            std::size_t literal = 0;
+
+            if(!literal_size(buf, literal)) {
+                throw exception("expected a literal at the end of: " + buf);
+            }
+
+            header_size = static_cast<long>(literal);
             if(getenv("JLIB_NET_IMAP4_DEBUG")) 
                 std::cout << "Header size:" << header_size << std::endl;
             
@@ -368,7 +441,13 @@ namespace jlib {
                 size = 0;
             }
 
-            long n = util::intValue(util::slice(bufvec[bufvec.size()-1], "{", "}"));
+            std::size_t literal = 0;
+
+            if(!literal_size(buf, literal)) {
+                throw exception("expected a literal at the end of: " + buf);
+            }
+
+            const long n = static_cast<long>(literal);
             
             if(getenv("JLIB_NET_IMAP4_DEBUG")) std::cout << "DEBUG: reading " << n << " bytes from server...\n";            
             std::string ret;
@@ -415,7 +494,13 @@ namespace jlib {
                 throw exception(buf.substr(tag().length()+1));
             }
             std::vector<std::string> bufvec = util::tokenize(buf);
-            long n = util::intValue(util::slice(bufvec[bufvec.size()-1], "{", "}"));
+            std::size_t literal = 0;
+
+            if(!literal_size(buf, literal)) {
+                throw exception("expected a literal at the end of: " + buf);
+            }
+
+            const long n = static_cast<long>(literal);
             
             if(getenv("JLIB_NET_IMAP4_DEBUG")) std::cout << "DEBUG: reading " << n << " bytes from server...\n";            
             std::string ret;
@@ -818,12 +903,7 @@ namespace jlib {
             handshake(sock,"EXPUNGE");
         }
 
-        std::vector<std::string> Imap4::search(sys::socketstream& sock, const std::string& criteria, const std::string& spec) {
-            std::vector<std::string> ret = handshake(sock,"");
-            return ret;
-        }
-
-        std::vector<std::string> Imap4::fetch(sys::socketstream& sock, std::pair<unsigned int,unsigned int> set, std::vector<std::string> n) {
+                std::vector<std::string> Imap4::fetch(sys::socketstream& sock, std::pair<unsigned int,unsigned int> set, std::vector<std::string> n) {
             std::ostringstream cmd;
             cmd << "FETCH "<<set.first<<":"<<set.second<<" (";
             for(unsigned int i=0;i<n.size();i++) {
@@ -837,12 +917,7 @@ namespace jlib {
             return ret;
         }
 
-        std::vector<std::string> Imap4::partial(sys::socketstream& sock, std::pair<unsigned int,unsigned int> set, std::vector<std::string> n,unsigned int p, unsigned int o) {
-            std::vector<std::string> ret = handshake(sock,"");
-            return ret;            
-        }
-
-        std::vector<std::string> Imap4::store(sys::socketstream& sock, std::pair<unsigned int,unsigned int> set, const std::string& key, std::vector<std::string> val) {
+                std::vector<std::string> Imap4::store(sys::socketstream& sock, std::pair<unsigned int,unsigned int> set, const std::string& key, std::vector<std::string> val) {
             std::ostringstream cmd;
             cmd << "STORE "<<set.first<<":"<<set.second<<" "<<key<<" (";
             for(unsigned int i=0;i<val.size();i++) {
@@ -864,10 +939,6 @@ namespace jlib {
             std::vector<std::string> ret = handshake(sock,cmd.str());
         }
         
-        std::vector<std::string> Imap4::uid(sys::socketstream& sock, const std::string& cmd, std::vector<std::string> arg) {
-            std::vector<std::string> ret = handshake(sock,"");
-            return ret;
-        }
-       
+               
     }
 }

--- a/jlib/net/Imap4.hh
+++ b/jlib/net/Imap4.hh
@@ -26,6 +26,7 @@
 #include <jlib/util/URL.hh>
 #include <jlib/net/Email.hh>
 
+#include <cstddef>
 #include <vector>
 #include <mutex>
 #include <map>
@@ -345,20 +346,28 @@ namespace jlib {
              */
             void expunge(jlib::sys::socketstream& sock);
 
-            /**
-             * The SEARCH command searches the mailbox for messages that match
-             * the given searching criteria.  Searching criteria consist of one
-             * or more search keys.  The untagged SEARCH response from the server
-             * contains a listing of message sequence numbers corresponding to
-             * those messages that match the searching criteria.
-             * 
-             * @param criteria searching criteria
-             * @param spec optional character set specification
-             *
-             * @return vector with server response
-             */
-            std::vector<std::string> search(jlib::sys::socketstream& sock, const std::string& criteria, const std::string& spec="");
             
+            /**
+             * The octet count of the literal a response line ends with.
+             *
+             * RFC 3501 4.3: a literal is "{" number "}" CRLF followed by that
+             * many octets, and RFC 7888 adds the non-synchronising "{n+}".
+             * The count is the only way to know where the literal ends, so
+             * getting it wrong desynchronises the connection for good.
+             *
+             * Returns false when the line does not end in a literal, which is
+             * the case the old code got wrong: it took the last token of the
+             * line and asked util::slice for what was between "{" and "}",
+             * and slice returns its whole input when the delimiters are not
+             * there.  int_value of that is 0, so a response with no literal --
+             * an error, a NIL, a server that answered something else -- read
+             * zero octets and then consumed the message body as though it were
+             * protocol.
+             *
+             * Static and public because it is worth testing without a server.
+             */
+            static bool literal_size(const std::string& line, std::size_t& n);
+
             /**
              * The FETCH command retrieves data associated with a message in the
              * mailbox.  The data items to be fetched may be either a single atom
@@ -372,23 +381,6 @@ namespace jlib {
              */
             std::vector<std::string> fetch(jlib::sys::socketstream& sock, std::pair<unsigned int,unsigned int> set, std::vector<std::string> n);
             
-            /**
-             * The PARTIAL command is equivalent to the associated FETCH command,
-             * with the added functionality that only the specified number of
-             * octets, beginning at the specified starting octet, are returned.
-             * Only a single message can be fetched at a time.  The first octet
-             * of a message, and hence the minimum for the starting octet, is
-             * octet 1.
-             * 
-             * @param set message set
-             * @param n vector of message data item names
-             * @param p position of first octet
-             * @param o number of octets
-             * 
-             * @return vector containing sever response
-             */
-            std::vector<std::string> partial(jlib::sys::socketstream& sock, std::pair<unsigned int,unsigned int> set, std::vector<std::string> n, 
-                                   unsigned int p, unsigned int o);
             
             /**
              * The STORE command alters data associated with a message in the
@@ -416,66 +408,6 @@ namespace jlib {
              */
             void copy(jlib::sys::socketstream& sock, std::pair<unsigned int,unsigned int> set, const std::string& box);
 
-            /**
-             * The UID command has two forms.  In the first form, it takes as its
-             * arguments a COPY, FETCH, or STORE command with arguments
-             * appropriate for the associated command.  However, the numbers in
-             * the message set argument are unique identifiers instead of message
-             * sequence numbers.
-             * 
-             * In the second form, the UID command takes a SEARCH command with
-             * SEARCH command arguments.  The interpretation of the arguments is
-             * the same as with SEARCH; however, the numbers returned in a SEARCH
-             * response for a UID SEARCH command are unique identifiers instead
-             * of message sequence numbers.  For example, the command UID SEARCH
-             * 1:100 UID 443:557 returns the unique identifiers corresponding to
-             * the intersection of the message sequence number set 1:100 and the
-             * UID set 443:557.
-             * 
-             * A unique identifier of a message is a number, and is guaranteed
-             * not to refer to any other message in the mailbox.  Unique
-             * identifiers are assigned in a strictly ascending fashion for each
-             * message added to the mailbox.  Unlike message sequence numbers,
-             * unique identifiers persist across sessions.  This permits a client
-             * to resynchronize its state from a previous session with the server
-             * (e.g.  disconnected or offline access clients); this is discussed
-             * further in [IMAP-DISC].
-             * 
-             * Associated with every mailbox is a unique identifier validity
-             * value, which is sent in an UIDVALIDITY response code in an OK
-             * untagged response at message selection time.  If unique
-             * identifiers from an earlier session fail to persist to this
-             * session, the unique identifier validity value MUST be greater than
-             * in the earlier session.
-             * 
-             * Note: An example of a good value to use for the unique
-             * identifier validity value would be a 32-bit
-             * representation of the creation date/time of the mailbox.
-             * It is alright to use a constant such as 1, but only if
-             * it guaranteed that unique identifers will never be
-             * reused, even in the case of a mailbox being deleted and
-             * a new mailbox by the same name created at some future
-             * time.
-             * 
-             * 
-             * Message set ranges are permitted; however, there is no guarantee
-             * that unique identifiers be contiguous.  A non-existent unique
-             * identifier within a message set range is ignored without any error
-             * message generated.
-             * 
-             * The number after the "*" in an untagged FETCH response is always a
-             * message sequence number, not a unique identifier, even for a UID
-             * command response.  However, server implementations MUST implicitly
-             * include the UID message data item as part of any FETCH response
-             * caused by a UID command, regardless of whether UID was specified
-             * as a message data item to the FETCH.
-             * 
-             * @param cmd command
-             * @param arg args to cmd
-             * 
-             * @return result of cmd
-             */
-            std::vector<std::string> uid(jlib::sys::socketstream& sock, const std::string& cmd, std::vector<std::string> arg);
 
             /**
              * Any command prefixed with an X is an experimental command.

--- a/jlib/net/Pop3.cc
+++ b/jlib/net/Pop3.cc
@@ -19,6 +19,7 @@
  */
 
 #include <jlib/net/Pop3.hh>
+#include <jlib/net/net.hh>
 
 #include <jlib/sys/sys.hh>
 #include <jlib/sys/sslstream.hh>
@@ -62,12 +63,44 @@ namespace jlib {
             return buf;
         }
 
+        std::string Pop3::read_body(std::istream& is) {
+            std::string body, line;
+
+            for(;;) {
+                if(!std::getline(is, line)) {
+                    throw exception("connection ended before the \".\" that ends "
+                                    "a multi-line response");
+                }
+
+                // Exactly one CRLF comes off, not every trailing CR.
+                // sys::getline() erases all of them, which is right for a
+                // command response and wrong for message content: a body line
+                // that genuinely ends in CR would come back a byte short and
+                // the message would no longer be what was sent.
+                if(!line.empty() && line.back() == '\r') line.pop_back();
+
+                if(line == ".") return dot_unstuff(std::move(body));
+
+                body += line;
+                body += "\r\n";
+            }
+        }
+
         std::string Pop3::retrieve(jlib::sys::socketstream& sock, unsigned int which) {
-            std::string buf = handshake(sock,"RETR "+jlib::util::string_value(which), OK);
-            std::vector<std::string> bufvec = jlib::util::tokenize(buf);
-            int n = jlib::util::int_value(bufvec[1]);
-            jlib::sys::getstring(sock, buf, n);
-            return buf;
+            // Read to the terminating ".", not to the octet count in the +OK.
+            //
+            // This used to tokenize the "+OK 1234 octets" line and read
+            // exactly 1234 bytes.  That count is optional in RFC 1939 -- the
+            // response is "+OK message follows" and the size is a courtesy --
+            // and where it is sent it is a maildrop size that counts CRLF as
+            // one octet on some servers and two on others.  Reading the wrong
+            // number leaves the rest of the message sitting in the socket, and
+            // every command after it reads somebody else's mail as its
+            // response.  On a server that omits the number entirely,
+            // bufvec[1] was out of range.
+            handshake(sock, "RETR " + jlib::util::string_value(which), OK);
+
+            return read_body(sock);
         }
         
         jlib::sys::socketstream* Pop3::connect() {

--- a/jlib/net/Pop3.hh
+++ b/jlib/net/Pop3.hh
@@ -57,7 +57,23 @@ namespace jlib {
              * Retrieve all email
              */
             std::list<std::string> retrieve();
-            
+
+            /**
+             * Read a multi-line response body, up to the "." that ends it.
+             *
+             * RFC 1939 3: a multi-line response ends with CRLF "." CRLF, and
+             * nothing else terminates it.  The dot transparency is undone on
+             * the way past, so what comes back is the message as it was sent.
+             *
+             * Public and static because it is the whole of what is worth
+             * testing here, and a std::istringstream is a POP3 server for the
+             * purpose.
+             *
+             * Throws Pop3::exception if the stream ends before the "." does --
+             * a truncated message is not a short message.
+             */
+            static std::string read_body(std::istream& is);
+
         protected:
             std::string retrieve(jlib::sys::socketstream& sock, unsigned int which);
             

--- a/jlib/net/net.cc
+++ b/jlib/net/net.cc
@@ -57,124 +57,6 @@ namespace jlib {
 
         long parse_size = 16384;
 
-        void parse_headers(std::istream& is, std::map<std::string,std::string>& m, bool uppercase) {
-            std::string buf, key, val;
-            bool bunny = true;
-            while(bunny && !is.eof()) {
-                sys::getline(is,buf);
-                if(buf == "") {
-                    bunny = false;
-                }
-                else {
-                    if(isspace(buf[0])) {
-                        if(key != "" && val != "") {
-                            m[key] = m[key]+" "+util::trim(buf);
-                        }
-                    }
-                    else {
-                        /* do decoding of previous header */
-                        if(key != "") {
-                            std::string buffer = m[key];
-                            if(buffer.find("=") != std::string::npos) {
-                                static util::Regex reg("(.*)=\\?(.+)\\?([QqBb])\\?(.+)\\?=(.*)");
-                                util::Regex::Match match(reg.match(buffer));
-                                if(match.size() > 0) {
-                                    std::string enc = match[4];
-                                    std::string dec;
-                                    if(util::upper(match[3]) == "B") {
-                                        dec = util::base64::decode(enc);
-                                    }
-                                    else if(util::upper(match[3]) == "Q") {
-                                        dec = util::qp::decode(enc);
-                                    }
-
-                                    m[key] = match[1]+dec+match[5];
-                                }
-                            }
-                        }
-
-                        std::string::size_type j;
-                        if( (j=buf.find(":")) != buf.npos ) {
-                            key = buf.substr(0,j);
-                            if(uppercase)
-                                key = util::upper(key);
-                            val = buf.substr(j+1);
-                            if(key.find("FROM ") == 0) {
-                                key = "";
-                            }
-                            else {
-                                //cerr << "setting m[\""<<key<<"\"] = "<<val<<endl;
-                                m[key] = util::trim(val);
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        std::vector<std::string> parse_header(std::istream& stream, const std::string& header) {
-            std::vector<std::string> ret;
-            std::string buf, key, val;
-            std::vector<std::string>::iterator current = ret.end();
-            bool bunny = true;
-            while(bunny && !stream.eof()) {
-                sys::getline(stream,buf);
-                if(buf == "") {
-                    bunny = false;
-                }
-                else {
-                    /* wrapped header */
-                    if(isspace(buf[0])) {
-                        if(current != ret.end()) {
-                            val += util::trim(buf);
-                            *current = val;
-                        }
-                    }
-                    else {
-                        /* do decoding of previous header */
-                        if(current != ret.end()) {
-                            std::string buffer = *current;
-                            if(buffer.find("=") != std::string::npos) {
-                                static util::Regex reg("(.*)=\\?(.+)\\?([QqBb])\\?(.+)\\?=(.*)");
-                                util::Regex::Match match(reg.match(buffer));
-                                if(match.size() > 0) {
-                                    std::string enc = match[4];
-                                    std::string dec;
-                                    if(util::upper(match[3]) == "B") {
-                                        dec = util::base64::decode(enc);
-                                    }
-                                    else if(util::upper(match[3]) == "Q") {
-                                        dec = util::qp::decode(enc);
-                                    }
-
-                                    *current = match[1]+dec+match[5];
-                                }
-                            }
-                        }
-
-                        key = "";
-                        val = "";
-                        current = ret.end();
-                        std::string::size_type j;
-                        if( (j=buf.find(":")) != buf.npos ) {
-                            key = buf.substr(0,j);
-                            if(util::upper(key) == util::upper(header)) {
-                                val = util::trim(buf.substr(j+1));
-                                ret.push_back(val);
-                                current = (ret.end()-1);
-                            }
-                            else {
-                                key = "";
-                                val = "";
-                            }
-                        }
-                    }
-                }
-            }
-
-            return ret;
-        }
-        
         void parse_divide(std::istream& is, std::vector<long>& divide, const std::string& div) {
             if(getenv("JLIB_NET_DEBUG")) {
                 std::cerr <<"net::parse_divide(is,divide,\""<<div<<"\"): entering"<<std::endl;
@@ -226,65 +108,51 @@ namespace jlib {
         // Returns size_type rather than long so that npos survives the round
         // trip.  Callers used to store the result in a u_int, which truncates
         // npos (SIZE_MAX) to 0xFFFFFFFF and so never compares equal to it.
-        std::string::size_type find_end(const std::string& s, const std::vector<std::string>& e) {
-            std::string::size_type ret = s.npos;
-            std::string::size_type p;
-            for(std::string::size_type i=0;i<e.size();i++) {
-                if( (p=s.find(e[i])) != s.npos ) {
-                    if(ret == s.npos) {
-                        ret = p;
-                    }
-                    else {
-                        if(p < ret)
-                            ret = p;
-                    }
+        std::string dot_stuff(std::string data) {
+            // RFC 5321 4.5.2.  Every line that begins with "." gets another,
+            // including the first, because "the first line of the body" is
+            // still a line.
+            //
+            // This used to do something else entirely: it searched the body
+            // for the terminator "\r\n.\r\n" and rewrote it as "\r\n. \r\n",
+            // inserting a *space* into the message.  That is transparency
+            // backwards -- it silently altered the sender's content, and it
+            // did nothing at all for a line like ".signature" that does not
+            // happen to be a lone dot, which is the case the mechanism exists
+            // for.  Such a line ended the DATA command early and the rest of
+            // the message was fed to the server as SMTP commands.
+            std::string::size_type p = 0;
+
+            while(p < data.size()) {
+                if(data[p] == '.') {
+                    data.insert(p, 1, '.');
+                    p++;
                 }
+
+                const std::string::size_type nl = data.find("\r\n", p);
+                if(nl == data.npos) break;
+
+                p = nl + 2;
             }
-            return ret;
+
+            return data;
         }
 
-        std::string parse_end(const std::string& s, const std::vector<std::string>& ends) {
-            if(ends.size() == 0) {
-                return s;
-            }
-            
-            std::string::size_type p = find_end(s,ends);
-            if(p != s.npos) {
-                return s.substr(0,p);
-            }
-            else {
-                return s;
-            }
-            
-        }
+        std::string dot_unstuff(std::string data) {
+            std::string::size_type p = 0;
 
-        void parse_end(std::istream& is, std::vector<std::string> ends, std::string& raw) {
-            // if we don't have any ends, just grab it all
-            if(ends.size() == 0) {
-                sys::getstring(is,raw);
-                return;
-            }
-            long beg = is.tellg();
-            std::string buf;
-            std::string tmp;
-            int count=0;
-            std::string::size_type p, q;
-            while(!is.eof()) {
-                sys::getstring(is, buf, parse_size);
-                
-                p=0;q=0;
-                if( (p=find_end(buf,ends)) != buf.npos  ) {
-                    tmp += buf.substr(0,p);
-                    is.seekg(beg+count+p, std::ios_base::beg);
-                    raw = tmp;
-                    return;
+            while(p < data.size()) {
+                if(data[p] == '.') {
+                    data.erase(p, 1);
                 }
-                else {
-                    tmp += buf;
-                    count += buf.length();
-                }
+
+                const std::string::size_type nl = data.find("\r\n", p);
+                if(nl == data.npos) break;
+
+                p = nl + 2;
             }
-            raw = tmp;
+
+            return data;
         }
 
         bool same_address(const std::string& p_addr1, const std::string& p_addr2) {
@@ -896,17 +764,20 @@ namespace jlib {
                 }
                
                 // On a local: this rewrote its own parameter, first to
-                // canonical line endings and then to escape any end-of-message
-                // sequence in the body.
-                std::string body = convert_to_crlf(data);
-                std::string eom = "\r\n.\r\n";
-                std::string neom = "\r\n. \r\n";
-                while(body.find(eom) != body.npos) {
-                    body.replace(body.find(eom), eom.length(), neom);
+                // canonical line endings and then to make the body safe to
+                // send inside a dot-terminated stream.
+                std::string body = dot_stuff(convert_to_crlf(data));
+
+                // The terminator is CRLF "." CRLF, and the leading CRLF is the
+                // one that ends the last line of the body -- so a body that
+                // already ends in CRLF must not get another, or the message
+                // gains a blank line every time it is sent.
+                if(body.size() < 2 || body.compare(body.size() - 2, 2, "\r\n") != 0) {
+                    body += "\r\n";
                 }
-                
+
                 handshake(stream, "DATA", "354");
-                handshake(stream, body+eom, "250");
+                handshake(stream, body + ".\r\n", "250");
                 
                 stream.close();
             }

--- a/jlib/net/net.hh
+++ b/jlib/net/net.hh
@@ -51,27 +51,32 @@ namespace jlib {
         };
         
         
-        void parse_headers(std::istream& is, std::multimap<std::string,std::string>& m, bool uppercase=true);
-
-        /**
-         * get a vector of the headers whose key is header
-         */
-        std::vector<std::string> parse_header(std::istream& stream, const std::string& header);
-
         void parse_divide(std::istream& is, std::vector<long>& divide, const std::string& div);
 
         /**
-         * parse through s, looking for the first occurance of something in ends
-         * when it's found, return the std::string up to that point
+         * Make a body safe to send inside a dot-terminated stream.
+         *
+         * RFC 5321 4.5.2, and RFC 1939 3 says the same thing from the other
+         * end: a line beginning with "." gets a second "." in front of it, so
+         * that the "." on a line by itself which ends the body can only ever
+         * be the end of the body.  Both protocols call it transparency and
+         * both mean this; it is one function because it is one mechanism.
+         *
+         * Expects CRLF line endings -- run convert_to_crlf() first.
+         *
+         * By value deliberately: data is modified and returned.
          */
-        std::string parse_end(const std::string& s, const std::vector<std::string>& ends);
+        std::string dot_stuff(std::string data);
 
         /**
-         * parse through is, looking for the first occurance of something in ends
-         * when it's found, copy the std::string up to that point into raw, then set 
-         * the streampos to the end (actually, the beginning of the next line)
+         * Undo dot_stuff() on a body just received.
+         *
+         * The terminating "." is not part of the body and is not expected
+         * here; Pop3::read_body() takes it off.
+         *
+         * By value deliberately: data is modified and returned.
          */
-        void parse_end(std::istream& is, std::vector<std::string> ends, std::string& raw);
+        std::string dot_unstuff(std::string data);
 
         /**
          * Are these two the same person?

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -53,6 +53,7 @@ TESTS = \
 	net_email_received_test \
 	net_email_multipart_test \
 	net_mbox_crlf_test \
+	net_protocol_test \
 	net_same_address_test \
  \
 	sys_sync_test \
@@ -124,6 +125,9 @@ net_email_test_SOURCES          = net_email_test.cc
 net_email_test_LDADD            = $(JNET_LA)
 net_email_received_test_SOURCES = net_email_received_test.cc
 net_email_received_test_LDADD   = $(JNET_LA)
+net_protocol_test_SOURCES       = net_protocol_test.cc
+net_protocol_test_LDADD         = $(JNET_LA) $(JUTIL_LA)
+
 net_mbox_crlf_test_SOURCES      = net_mbox_crlf_test.cc
 net_mbox_crlf_test_LDADD        = $(JNET_LA)
 

--- a/tests/net_protocol_test.cc
+++ b/tests/net_protocol_test.cc
@@ -1,0 +1,255 @@
+/* -*- mode: C++ c-basic-offset: 4  -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ *
+ */
+
+// Framing: where a message ends, and how a byte that looks like the end is
+// kept from being mistaken for one.
+//
+// SMTP and POP3 both terminate a body with a "." on a line by itself and both
+// call the escaping that makes that safe "transparency"; IMAP does not, and
+// counts octets instead.  All three were wrong here in the same way -- each
+// trusted something that is not the framing to tell it where the framing was.
+
+#include <jlib/net/net.hh>
+#include <jlib/net/Pop3.hh>
+#include <jlib/net/Imap4.hh>
+
+#include <iostream>
+#include <sstream>
+#include <string>
+
+using jlib::net::dot_stuff;
+using jlib::net::dot_unstuff;
+using jlib::net::Pop3;
+using jlib::net::Imap4;
+
+static int failures = 0;
+
+static void ok(const std::string& what, bool good, const std::string& detail = "") {
+    if(!good) ++failures;
+    std::cout << (good ? "  ok   " : "  FAIL ") << what;
+    if(!detail.empty()) std::cout << ": " << detail;
+    std::cout << "\n";
+}
+
+/** CRLF and the escapes made visible, so a failure says what it got. */
+static std::string show(const std::string& s) {
+    std::string out;
+
+    for(char c : s) {
+        if(c == '\r')      out += "\\r";
+        else if(c == '\n') out += "\\n";
+        else               out += c;
+    }
+
+    return out;
+}
+
+static void smtp_transparency() {
+    std::cout << "dot-stuffing, RFC 5321 4.5.2:\n";
+
+    // The case the whole mechanism exists for, and the one the old code did
+    // nothing about.  ".signature" is a line that starts with a dot and is not
+    // a lone dot; unstuffed, the server sees ".signature" mid-body, which is
+    // not the terminator, so this one is only *half* the story --
+    ok("a line beginning with a dot gets another",
+       dot_stuff("hello\r\n.signature\r\n") == "hello\r\n..signature\r\n",
+       show(dot_stuff("hello\r\n.signature\r\n")));
+
+    // -- and this is the other half.  A lone "." inside the body ends the
+    // DATA command where it stands, and everything after it is read by the
+    // server as SMTP commands.
+    ok("and so does a line that is only a dot",
+       dot_stuff("hello\r\n.\r\nworld\r\n") == "hello\r\n..\r\nworld\r\n",
+       show(dot_stuff("hello\r\n.\r\nworld\r\n")));
+
+    // The first line is a line.
+    ok("including the first line",
+       dot_stuff(".hello\r\nworld\r\n") == "..hello\r\nworld\r\n",
+       show(dot_stuff(".hello\r\nworld\r\n")));
+
+    // And a line with no dot is left exactly alone -- this is what the old
+    // code got wrong in the other direction, rewriting "\r\n.\r\n" as
+    // "\r\n. \r\n" and putting a space into the sender's message.
+    ok("a body with no leading dots is untouched",
+       dot_stuff("hello\r\nworld. and more\r\n") == "hello\r\nworld. and more\r\n");
+
+    ok("an empty body is untouched", dot_stuff("").empty());
+
+    ok("and a final line with no CRLF still counts",
+       dot_stuff("a\r\n.b") == "a\r\n..b", show(dot_stuff("a\r\n.b")));
+
+    // The two are inverses, which is the property that matters: what the
+    // receiver reconstructs is what the sender wrote.
+    for(const char* s : { "hello\r\n.signature\r\n", ".\r\n", "..\r\n...\r\n",
+                          "a\r\n\r\n.\r\nb\r\n", "", ".", "no dots here\r\n" }) {
+        ok(std::string("round trip: \"") + show(s) + "\"",
+           dot_unstuff(dot_stuff(s)) == s, show(dot_unstuff(dot_stuff(s))));
+    }
+}
+
+static void pop3_framing() {
+    std::cout << "\nPOP3 multi-line responses, RFC 1939 3:\n";
+
+    {
+        std::istringstream is("From: a@b\r\n\r\nhello\r\n.\r\n+OK next command\r\n");
+
+        const std::string body = Pop3::read_body(is);
+
+        ok("the body ends at the dot",
+           body == "From: a@b\r\n\r\nhello\r\n", show(body));
+    }
+
+    {
+        // And the stream is left where the next command's response starts.
+        // This is the failure the old code caused: it read the octet count out
+        // of the "+OK 1234 octets" line, and where that count was absent,
+        // approximate, or counting CRLF as one octet rather than two, the rest
+        // of the message stayed in the socket and the next command read it as
+        // its own response.
+        std::istringstream is("hello\r\n.\r\n+OK 3 messages\r\n");
+        Pop3::read_body(is);
+
+        std::string next;
+        std::getline(is, next);
+
+        ok("and the stream is left at the next response",
+           next == "+OK 3 messages\r", show(next));
+    }
+
+    {
+        std::istringstream is("a\r\n..\r\n...b\r\n.\r\n");
+
+        const std::string body = Pop3::read_body(is);
+
+        ok("dots are unstuffed on the way past",
+           body == "a\r\n.\r\n..b\r\n", show(body));
+    }
+
+    {
+        // sys::getline erases *every* trailing CR, which is right for a
+        // command response and wrong for message content.  read_body takes
+        // exactly one CRLF off, so a body line that genuinely ends in CR
+        // survives.
+        std::istringstream is("ends in a cr\r\r\n.\r\n");
+
+        const std::string body = Pop3::read_body(is);
+
+        ok("a body line ending in CR keeps it",
+           body == "ends in a cr\r\r\n", show(body));
+    }
+
+    {
+        std::istringstream is(".\r\n");
+
+        ok("an empty body is empty", Pop3::read_body(is).empty());
+    }
+
+    {
+        // A truncated message is not a short message.  Returning what arrived
+        // would hand a caller half an email with no indication of it.
+        std::istringstream is("hello\r\nworld\r\n");
+
+        bool threw = false;
+        try { Pop3::read_body(is); }
+        catch(Pop3::exception&) { threw = true; }
+
+        ok("a connection that drops mid-body throws", threw);
+    }
+}
+
+static void imap_literals() {
+    std::cout << "\nIMAP literals, RFC 3501 4.3:\n";
+
+    struct { const char* line; bool found; std::size_t n; } cases[] = {
+        { "* 1 FETCH (FLAGS (\\Seen) RFC822.SIZE 4242 RFC822 {1234}", true, 1234 },
+        { "* 1 FETCH (RFC822.HEADER {0}",                             true, 0 },
+
+        // RFC 7888's non-synchronising literal.
+        { "* 1 FETCH (RFC822 {1234+}",                                true, 1234 },
+
+        // No literal at all.  This is the one that mattered: util::slice
+        // returns its whole input when the delimiters are absent, so
+        // int_value of it was 0, the code read zero octets, and then read the
+        // message body as protocol lines.
+        { "* 1 FETCH (FLAGS (\\Seen))",                               false, 0 },
+        { "a001 OK FETCH completed",                                  false, 0 },
+        { "",                                                         false, 0 },
+        { "* 1 FETCH (RFC822 NIL)",                                   false, 0 },
+
+        // Nearly a literal.
+        { "* 1 FETCH {}",                                             false, 0 },
+        { "* 1 FETCH {abc}",                                          false, 0 },
+        { "* 1 FETCH {12x}",                                          false, 0 },
+        { "* 1 FETCH {-1}",                                           false, 0 },
+        { "* 1 FETCH {12",                                            false, 0 },
+
+        // The introducer has to be the last thing on the line.
+        { "* 1 FETCH {12} and then some",                             false, 0 },
+
+        // A count that decides how many octets to read, from the network.
+        { "* 1 FETCH {99999999999999999999}",                         false, 0 },
+        { "* 1 FETCH {2147483648}",                                   false, 0 },
+        { "* 1 FETCH {2147483647}",                                   true, 2147483647u },
+    };
+
+    for(const auto& c : cases) {
+        std::size_t n = 12345;
+        const bool got = Imap4::literal_size(c.line, n);
+
+        ok(std::string("\"") + c.line + "\"",
+           got == c.found && (!c.found || n == c.n),
+           got ? std::to_string(n) : "no literal");
+    }
+}
+
+int main() {
+    std::cout << std::unitbuf;
+
+    smtp_transparency();
+    pop3_framing();
+    imap_literals();
+
+    // What a green run does NOT establish.
+    //
+    // Not that jlib speaks SMTP, POP3 or IMAP correctly.  Every one of these
+    // is a pure function over a buffer, tested against a std::istringstream;
+    // no server was involved and none of the connect, authenticate or command
+    // sequencing around them is exercised here.  What is established is that
+    // the framing decisions -- where a body ends, and which bytes are content
+    // rather than protocol -- are now made by the rule the RFC states.
+    //
+    // Not the rest of Imap4.  literal_size() reads the introducer; the code
+    // that finds RFC822.SIZE in a response is still util::tokenize and a
+    // linear search, and a FETCH response is not really a whitespace-separated
+    // list of tokens.  That wants RFC 3501's grammar the way addresses got RFC
+    // 5322's, and it is not this branch.
+    //
+    // Not MIME.  Email.cc still finds a multipart boundary by splitting the
+    // Content-Type on ";" -- which splits inside a quoted parameter value --
+    // and then asking util::slice for what is between the quotes, which
+    // returns the whole input when the value is unquoted.  Same bug class,
+    // different RFC, next branch.
+    //
+    // Not the "+OK n octets" count.  read_body ignores it entirely rather than
+    // checking the body against it.  That is deliberate: RFC 1939 makes the
+    // number optional and servers disagree about whether it counts CRLF as one
+    // octet or two, so it is not something to validate against.
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
Three protocols, one mistake each, all the same mistake: every one of them
trusted something that is not the framing to say where the framing was.

    macOS  38 tests, 38 pass, 0 skip
    Linux  39 tests, 38 pass, 1 skip

    tests/net_protocol_test.cc    new
    jlib/net/net.cc              -180 net, mostly deletion
    jlib/net/Imap4.hh            -108
    jlib/net/{Pop3,Imap4}.{hh,cc} the three fixes

SMTP was doing transparency backwards

    RFC 5321 4.5.2 says a line of the body beginning with "." is sent with a
    second "." in front of it, so that the "." on a line by itself which ends
    the DATA command can only ever be the end of the body.

    smtp::finish did something else.  It searched the body for the terminator
    "\r\n.\r\n" and rewrote it as "\r\n. \r\n" -- inserting a space into the
    sender's message, silently, and only when the dot was already alone on its
    line.  For the case the mechanism actually exists for, a line like
    ".signature", it did nothing at all.

    dot_stuff() and dot_unstuff() are the fix, and they live in namespace net
    rather than in smtp because RFC 1939 3 describes the same mechanism for
    POP3 in the same words.  The test asserts they are inverses over a corpus,
    which is the property that matters: what the receiver reconstructs is what
    the sender wrote.

    Also fixed while there: the body used to get "\r\n.\r\n" appended
    unconditionally, so a body already ending in CRLF gained a blank line
    every time it was sent.

POP3 was reading an octet count that servers do not promise

    Pop3::retrieve tokenized the "+OK 1234 octets" line and read exactly 1234
    bytes.  RFC 1939 makes that number optional -- the response is "+OK message
    follows" and the size is a courtesy -- and where it is sent it is a maildrop
    size that some servers compute with CRLF as one octet and some as two.

    Read the wrong number and the rest of the message stays in the socket, so
    every command after it reads part of an email as its response.  On a server
    that omits the number, bufvec[1] was out of range.

    Pop3::read_body() scans for CRLF "." CRLF, unstuffs on the way past, and
    throws if the connection ends first -- a truncated message is not a short
    message.  It takes an istream and is public and static, so a
    std::istringstream is a POP3 server for testing purposes.

    It reads lines itself rather than through sys::getline, which erases
    *every* trailing CR.  That is right for a command response and wrong for
    message content: a body line genuinely ending in CR would come back a byte
    short.

IMAP was reading a literal that might not be there

    Three sites did util::int_value(util::slice(last_token, "{", "}")).
    util::slice returns its whole input when the delimiters are absent, so a
    response with no literal -- an error, a NIL, a server that answered
    something else -- gave 0, read zero octets, and then read the message body
    as protocol lines.

    Imap4::literal_size() is RFC 3501 4.3's two productions, in ABNF, plus RFC
    7888's "{n+}".  Two productions is a small thing to reach a grammar for,
    and that is rather the point: what is accepted can be checked by reading
    4.3.  It requires a whole-input match from the last "{", so "{}", "{12x}"
    and "{12} and then some" are not literals, and it refuses a count over
    2^31-1 -- that number comes from the network and decides how many octets to
    read.  A response with no literal is now an exception rather than a
    desynchronised connection.

dead code that was worse than absent

    Imap4::search, ::partial and ::uid each sent a bare tag with no command
    and returned whatever the server said about it, which is BAD.  A caller
    got a plausible-looking vector<string> back.

    net::parse_headers and net::parse_header were declared returning multimap
    and map respectively, so neither had ever linked; net::parse_end and
    net::find_end had no callers outside each other.  All five are gone.

what a green run does not establish

    Written down in the test.  Not that jlib speaks any of these protocols
    correctly -- these are pure functions over buffers, no server was involved,
    and none of the connect, authenticate or command sequencing is exercised.
    What it establishes is that the framing decisions are made by the rule the
    RFC states.

    Not the rest of Imap4: a FETCH response is still read with util::tokenize
    and a linear search, and it is not really a whitespace-separated list of
    tokens.  That wants RFC 3501's grammar the way addresses got RFC 5322's.

    Not MIME.  Email.cc still finds a multipart boundary by splitting
    Content-Type on ";" -- which splits inside a quoted parameter value -- and
    then asking util::slice for what is between the quotes, which returns the
    whole input when the value is unquoted.  Same bug class, different RFC,
    next branch.
