### PR TITLE
Read Content-Type and split multipart bodies by MIME's grammar

### DIFF
--- a/jlib/net/Email.cc
+++ b/jlib/net/Email.cc
@@ -19,6 +19,7 @@
  */
 
 #include <jlib/net/net.hh>
+#include <jlib/net/content_type.hh>
 
 #include <jlib/sys/sys.hh>
 
@@ -109,88 +110,49 @@ namespace jlib {
                 std::cerr <<"jlib::net::Email::create(): Content-Type: "
                           << type << std::endl;
             }
-            if(jlib::util::icontains(type, "multipart")) {
-                std::vector<std::string> v = jlib::util::tokenize(type,";");
-                std::string bound;
-                std::vector<std::string>::iterator i = v.begin();
-                while(bound == "" && i != v.end()) {
-                    if(jlib::util::icontains(*i,"boundary")) {
-                        bound = *i;
-                    }
-                    i++;
-                }
-                bound = bound.substr(bound.find("=")+1);
-                bound = jlib::util::slice(bound, "\"", "\"");
-                //cout << "boundary='"<<bound<<"'"<<endl;
-                std::vector<long> attach_divide;
-                std::istringstream ihead(m_raw);
-                ihead.seekg(header_end);
-                parse_divide(ihead, attach_divide, "--"+bound);
-                for(unsigned int i=0;i<attach_divide.size();i++) {
-                    std::istringstream istr(m_raw);
-                    //cout << "seekg()'ing "<<attach_divide[i]<<endl;
-                    istr.seekg(attach_divide[i]);
-                    std::string buf;
-                    while(buf.find(bound) == buf.npos) {
-                        //cout << "istr.tellg() = " << istr.tellg() << endl;
-                        //cout << "istr.eof() = " << istr.eof() << endl;
-                        jlib::sys::getline(istr, buf);
-                        //cout << "read line: '"<<buf<<"'"<<endl;
-                    }
-                    if(buf.find("--"+bound+"-") != buf.npos) {
-                        // final boundary, ignore everything after this
-                        //cout << "final boundary, ignore everything after this"<<endl;
-                        i = attach_divide.size();
-                    }
-                    else {
-                        // intermediate boundary, go for it
-                        //cout << "intermediate boundary, go for it"<<endl;
+            // icontains(type, "multipart") used to be the test, so a
+            // Content-Type of text/plain; name="multipart.txt" was a multipart
+            // message.  is() compares the type, not the header.
+            net::content_type ctype;
 
-                        // tellg() returns a streampos, which this narrowed to
-                        // 32 bits -- wrong for any message past 4GB, and it
-                        // also swallows the -1 tellg() returns on a failed
-                        // stream, turning it into a huge offset that substr
-                        // then throws on.
-                        const std::istream::pos_type where = istr.tellg();
-
-                        if(where == std::istream::pos_type(-1)) {
-                            break;
-                        }
-
-                        const std::string::size_type pos =
-                            static_cast<std::string::size_type>(where);
-                        // last case, have to get jiggy
-                        if(i+1 == attach_divide.size()) {
-                            buf = m_raw.substr(pos);
-                        }
-                        else {
-                            buf = m_raw.substr(pos, attach_divide[i+1]-pos);
-                        }
-
-                        if(buf[buf.length()-1] == '\n') {
-                            buf = buf.substr(0,buf.length()-1);
-                            if(buf[buf.length()-1] == '\r') {
-                                buf = buf.substr(0,buf.length()-1);
-                            }
-                        }
-
-                        //std::istringstream icreate(buf);
-                        m_attach.push_back(Email(buf));
-                    }
+            try {
+                ctype = net::content_type::parse(type);
+            }
+            catch(net::content_type::exception& e) {
+                // An unreadable Content-Type is text/plain, which is what
+                // RFC 2045 5.2 says to do with one that is missing, and is
+                // what the sanitizing above already assumes.
+                if(getenv("JLIB_NET_EMAIL_DEBUG")) {
+                    std::cerr << "jlib::net::Email::create(): " << e.what()
+                              << std::endl;
                 }
             }
-            else if(jlib::util::icontains(type, "message")) {
-                std::string buf;
-                if(jlib::util::icontains(type, "message/digest")) {
-                    
+
+            const std::string bound = ctype.get("boundary");
+
+            if(ctype.is("multipart") && !bound.empty()) {
+                // The boundary used to be found by splitting the header on
+                // ";" -- which splits inside a quoted value, so boundary="a;b"
+                // came out as boundary="a -- and then asking util::slice for
+                // what lay between the quotes, which returns its whole input
+                // when there are none.  Neither failure was visible: the
+                // message simply did not split into its parts, so an
+                // attachment went missing or the body was shown as one.
+                //
+                // The split is RFC 2046 5.1.1 now, rather than parse_divide on
+                // "--" + bound.  It is the leading CRLF belonging to the
+                // delimiter that this gets right and the old loop did not.
+                for(std::string& part : net::split_multipart(m_raw.substr(header_end),
+                                                             bound)) {
+                    m_attach.push_back(Email(std::move(part)));
                 }
-                else if(jlib::util::icontains(type, "message/rfc822")) {
-                    buf = m_raw.substr(header_end);
-                    m_attach.push_back(Email(buf));
-                }
-                else {
-                    
-                }
+            }
+            else if(ctype.is("message", "rfc822")) {
+                // The two empty branches that used to sit beside this one
+                // tested for "message" and then for "message/digest", which is
+                // not a media type -- the digest is multipart/digest, and it
+                // is handled by the multipart branch above.
+                m_attach.push_back(Email(m_raw.substr(header_end)));
             }
             else {
                 std::string encoding = jlib::util::upper(find("CONTENT-TRANSFER-ENCODING"));
@@ -389,8 +351,23 @@ namespace jlib {
         }
 
         bool Email::is(const std::string& type) const {
-            std::string ctype = jlib::util::lower(find("CONTENT-TYPE"));
-            return (ctype.find(type) != std::string::npos);
+            // A whole-component comparison.  This used to be find() != npos
+            // over the entire lowercased header, so is("text") was true for
+            // application/x-latext, and true for any multipart whose boundary
+            // happened to contain the letters "text" -- which is to say, true
+            // for a message whose boundary the sender chose.
+            const std::string::size_type slash = type.find('/');
+
+            try {
+                const net::content_type c = net::content_type::parse(find("CONTENT-TYPE"));
+
+                if(slash == type.npos) return c.is(type);
+
+                return c.is(type.substr(0, slash), type.substr(slash + 1));
+            }
+            catch(net::content_type::exception&) {
+                return false;
+            }
         }
 
         void Email::parse_received() {
@@ -424,33 +401,39 @@ namespace jlib {
         }
 
         std::string Email::get_name() const {
-            std::vector<std::string> ctype = util::tokenize(find("content-type"), ";");
-            std::string name;
-
-            for(std::vector<std::string>::iterator i = ctype.begin(); i != ctype.end(); i++) {
-                std::string buf = util::trim(*i);
-                if(buf.find("name=") == 0) {
-                    name = buf.substr(buf.find("=")+1);
-                    return util::slice(name, "\"", "\"");
-                }
+            // The old version matched a piece that *began* with "name=", so a
+            // parameter written with a space before it was invisible, and it
+            // read the value with util::slice, which hands back its whole
+            // input when the quotes are not there.  RFC 2231's filename*= form
+            // -- which is how any name with a non-ASCII character in it
+            // arrives -- it did not know about at all.
+            try {
+                return net::content_type::parse(find("CONTENT-TYPE")).get("name");
             }
-
-            return "";
+            catch(net::content_type::exception&) {
+                return std::string();
+            }
         }
 
         std::string Email::get_filename() const {
-            std::vector<std::string> ctype = util::tokenize(find("content-disposition"), ";");
-            std::string name;
+            // Content-Disposition, RFC 2183, and the same grammar -- the
+            // disposition type is a token with the parameter syntax of
+            // RFC 2045 after it.
+            try {
+                const std::string name =
+                    net::content_type::parse_disposition(find("CONTENT-DISPOSITION"))
+                        .get("filename");
 
-            for(std::vector<std::string>::iterator i = ctype.begin(); i != ctype.end(); i++) {
-                std::string buf = util::trim(*i);
-                if(buf.find("filename=") == 0) {
-                    name = buf.substr(buf.find("=")+1);
-                    return util::slice(name, "\"", "\"");
-                }
+                if(!name.empty()) return name;
+            }
+            catch(net::content_type::exception&) {
             }
 
-            return "";
+            // Falling back to Content-Type's "name" is new.  Every mail client
+            // does it, because plenty of senders put the attachment's name
+            // there and nowhere else, and an attachment that displays with no
+            // name is the whole of what this function is for.
+            return get_name();
         }
 
         void Email::set_indx(int indx) {

--- a/jlib/net/Makefile.am
+++ b/jlib/net/Makefile.am
@@ -4,7 +4,7 @@ lib_LTLIBRARIES = libjnet.la
 libjnet_la_SOURCES = Email.cc MailBox.cc Imap4Box.cc Pop3.cc MBox.cc \
                      Imap4.cc Imap4Fetch.cc net.cc MFolder.cc Imap4Folder.cc \
                      MailFolder.cc ASMailBox.cc ASImapBox.cc ASMBox.cc \
-                     address.cc
+                     address.cc content_type.cc
 libjnet_la_LDFLAGS = -version-info $(LIBJ_SO_VERSION) -release $(JLIB_RELEASE) -no-undefined
 libjnet_la_LIBADD = $(top_builddir)/jlib/sys/libjsys.la \
                     $(top_builddir)/jlib/util/libjutil.la \
@@ -15,4 +15,5 @@ libjnetincludedir = $(includedir)/jlib-1.2/jlib/net
 libjnetinclude_HEADERS = Imap4Box.hh Pop3.hh MBox.hh Email.hh \
                          Imap4.hh Imap4Fetch.hh net.hh MFolder.hh \
                          Imap4Folder.hh MailBox.hh MailFetch.hh MailFolder.hh \
-                         ASMailBox.hh ASImapBox.hh ASMBox.hh address.hh rfc5322.hh
+                         ASMailBox.hh ASImapBox.hh ASMBox.hh address.hh rfc5322.hh \
+                         content_type.hh rfc2045.hh

--- a/jlib/net/address.cc
+++ b/jlib/net/address.cc
@@ -37,7 +37,9 @@ using util::abnf::options;
 
 grammar build(bool obsolete, bool lenient)
 {
-    std::string text = rfc5322::CORE;
+    std::string text = rfc5322::LEXICAL;
+
+    text += rfc5322::CORE;
 
     text += obsolete ? rfc5322::OBSOLETE : rfc5322::STRICT;
     if(lenient) text += rfc5322::LENIENT;

--- a/jlib/net/content_type.cc
+++ b/jlib/net/content_type.cc
@@ -1,0 +1,530 @@
+/* -*- mode: C++ c-basic-offset: 4  -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ *
+ */
+
+#include <jlib/net/content_type.hh>
+#include <jlib/net/rfc2045.hh>
+#include <jlib/net/rfc5322.hh>
+
+#include <jlib/util/abnf.hh>
+
+#include <algorithm>
+#include <map>
+#include <set>
+
+namespace jlib {
+namespace net {
+
+namespace {
+
+using util::abnf::grammar;
+using util::abnf::match;
+using util::abnf::options;
+
+/**
+ * The grammar, built on first use.
+ *
+ * Function-local for the reason at crypt/curve.hh:42, and read-only once
+ * check() has run -- see the same note in address.cc.
+ */
+const grammar& mime()
+{
+    static grammar g = [] {
+        grammar g = util::abnf::compile(std::string(rfc5322::LEXICAL) +
+                                        rfc2045::CONTENT);
+        g.check();
+
+        return g;
+    }();
+
+    return g;
+}
+
+options parse_options()
+{
+    options o;
+
+    o.captures = options::capture_policy::listed;
+    o.capture_only = { "mt-type", "mt-subtype", "disp-type",
+                       "parameter", "attribute", "section", "extended",
+                       "value", "token", "qs-body" };
+
+    return o;
+}
+
+std::string lower(std::string_view s)
+{
+    std::string out(s);
+
+    std::transform(out.begin(), out.end(), out.begin(),
+                   [](unsigned char c) { return std::tolower(c); });
+
+    return out;
+}
+
+/** RFC 5322 3.2.1 and 3.2.2: undo quoted-pair, and unfold. */
+std::string unescape(std::string_view s)
+{
+    std::string out;
+
+    out.reserve(s.size());
+
+    for(std::size_t i = 0; i < s.size(); ++i) {
+        if(s[i] == '\\' && i + 1 < s.size())      out += s[++i];
+        else if(s[i] != '\r' && s[i] != '\n')     out += s[i];
+    }
+
+    return out;
+}
+
+/** The text of a value, whether it was written as a token or quoted. */
+std::string value_of(const match& v)
+{
+    const match q = v.child("qs-body");
+
+    if(q) return unescape(q.text());
+
+    const match t = v.child("token");
+
+    return t ? t.str() : std::string();
+}
+
+int hex(char c)
+{
+    if(c >= '0' && c <= '9') return c - '0';
+    if(c >= 'a' && c <= 'f') return c - 'a' + 10;
+    if(c >= 'A' && c <= 'F') return c - 'A' + 10;
+
+    return -1;
+}
+
+/**
+ * RFC 2231 4's ext-octet: "%" 2HEXDIG.
+ *
+ * A stray "%" that is not followed by two hex digits is kept as a "%" rather
+ * than dropped.  The alternative is to lose a character out of a filename
+ * because a sender wrote "100%.txt" and forgot to escape it.
+ */
+std::string percent_decode(std::string_view s)
+{
+    std::string out;
+
+    out.reserve(s.size());
+
+    for(std::size_t i = 0; i < s.size(); ++i) {
+        if(s[i] == '%' && i + 2 < s.size() &&
+           hex(s[i + 1]) >= 0 && hex(s[i + 2]) >= 0) {
+            out += static_cast<char>(hex(s[i + 1]) * 16 + hex(s[i + 2]));
+            i += 2;
+        }
+        else {
+            out += s[i];
+        }
+    }
+
+    return out;
+}
+
+/** One parameter as the grammar matched it, before sections are joined. */
+struct raw {
+    std::string name;
+    long section = -1;      ///< -1 when the name carried no "*n"
+    bool extended = false;
+    std::string text;
+};
+
+/**
+ * RFC 2231 4: charset'language'value, on the first section only.
+ *
+ * The two apostrophes are mandatory in the initial segment and absent from
+ * every continuation, which is what makes a continuation distinguishable from
+ * a segment that happens to contain one.
+ */
+void split_extended(std::string_view s, std::string& charset, std::string& rest)
+{
+    const std::size_t a = s.find('\'');
+
+    if(a == s.npos) { rest = std::string(s); return; }
+
+    const std::size_t b = s.find('\'', a + 1);
+
+    if(b == s.npos) { rest = std::string(s); return; }
+
+    charset = lower(s.substr(0, a));
+    rest = std::string(s.substr(b + 1));   // the language tag is discarded
+}
+
+/** Join the sections of each name, decoding what is marked extended. */
+content_type::parameter_list assemble(const std::vector<raw>& in)
+{
+    content_type::parameter_list out;
+    std::map<std::string, std::size_t> at;
+
+    // Sections are joined in numeric order however they arrived, but the
+    // parameters themselves keep the order the header wrote them in.
+    std::map<std::string, std::map<long, const raw*>> parts;
+
+    for(const raw& r : in) {
+        if(!at.count(r.name)) {
+            at[r.name] = out.size();
+            out.push_back({ r.name, std::string(), std::string() });
+        }
+
+        // First wins.  RFC 2045 does not say what a repeated parameter means,
+        // and taking the last would let a second "charset" or "boundary"
+        // appended to a header override the first -- which is a parameter
+        // smuggling primitive, not a parse.
+        parts[r.name].emplace(r.section, &r);
+    }
+
+    for(const auto& p : parts) {
+        content_type::parameter& q = out[at[p.first]];
+        bool first = true;
+
+        for(const auto& s : p.second) {
+            const raw& r = *s.second;
+
+            if(!r.extended) {
+                q.value += r.text;
+            }
+            else if(first) {
+                std::string rest;
+
+                split_extended(r.text, q.charset, rest);
+                q.value += percent_decode(rest);
+            }
+            else {
+                q.value += percent_decode(r.text);
+            }
+
+            first = false;
+        }
+    }
+
+    return out;
+}
+
+}
+
+// -------------------------------------------------------------- the reader
+
+struct mime_reader {
+
+    static content_type read(const match& m, bool disposition)
+    {
+        content_type c;
+
+        if(disposition) {
+            c.m_type = lower(m.child("disp-type").text());
+        }
+        else {
+            c.m_type = lower(m.child("mt-type").text());
+            c.m_subtype = lower(m.child("mt-subtype").text());
+        }
+
+        std::vector<raw> params;
+
+        for(const match& p : m.all("parameter")) {
+            raw r;
+
+            r.name = lower(p.child("attribute").text());
+
+            const match s = p.child("section");
+
+            // "*0" -- the "*" is part of the match, so skip it.
+            if(s) r.section = std::stol(s.str().substr(1));
+
+            r.extended = static_cast<bool>(p.child("extended"));
+            r.text = value_of(p.child("value"));
+
+            params.push_back(std::move(r));
+        }
+
+        c.m_parameters = assemble(params);
+
+        return c;
+    }
+};
+
+// ---------------------------------------------------------------- exception
+
+content_type::exception::exception(const std::string& msg, std::string text,
+                                   std::size_t offset)
+    : std::runtime_error("jlib::net::content_type::exception: " + msg),
+      m_text(std::move(text)),
+      m_offset(offset)
+{
+}
+
+// -------------------------------------------------------------------- parse
+
+namespace {
+
+match run(const std::string& rule, std::string_view s)
+{
+    try {
+        return mime().at(rule).parse(s, parse_options());
+    }
+    catch(util::abnf::budget_exceeded& e) {
+        throw content_type::exception(std::string("gave up reading a header: ")
+                                      + e.what(), std::string(s), e.offset());
+    }
+    catch(util::abnf::error& e) {
+        // The expected set for this grammar is every tchar, which tells a
+        // caller nothing.  Where it stopped does.
+        throw content_type::exception("not a MIME header at column "
+                                      + std::to_string(e.column()) + "\n  "
+                                      + e.context_line() + "\n  "
+                                      + std::string(e.column() - 1, ' ') + "^",
+                                      std::string(s), e.offset());
+    }
+}
+
+}
+
+content_type content_type::parse(std::string_view s)
+{
+    return mime_reader::read(run("media-type", s), false);
+}
+
+content_type content_type::parse_disposition(std::string_view s)
+{
+    return mime_reader::read(run("disposition", s), true);
+}
+
+bool content_type::valid(std::string_view s)
+{
+    try {
+        parse(s);
+        return true;
+    }
+    catch(exception&) {
+        return false;
+    }
+}
+
+// ------------------------------------------------------------------ reading
+
+std::string content_type::essence() const
+{
+    return m_subtype.empty() ? m_type : m_type + "/" + m_subtype;
+}
+
+bool content_type::is(std::string_view type) const
+{
+    return m_type == lower(type);
+}
+
+bool content_type::is(std::string_view type, std::string_view subtype) const
+{
+    return m_type == lower(type) && m_subtype == lower(subtype);
+}
+
+bool content_type::has(std::string_view name) const
+{
+    const std::string n = lower(name);
+
+    for(const parameter& p : m_parameters) {
+        if(p.name == n) return true;
+    }
+
+    return false;
+}
+
+std::string content_type::get(std::string_view name,
+                              const std::string& fallback) const
+{
+    const std::string n = lower(name);
+
+    for(const parameter& p : m_parameters) {
+        if(p.name == n) return p.value;
+    }
+
+    return fallback;
+}
+
+std::string content_type::charset_of(std::string_view name) const
+{
+    const std::string n = lower(name);
+
+    for(const parameter& p : m_parameters) {
+        if(p.name == n) return p.charset;
+    }
+
+    return std::string();
+}
+
+// ------------------------------------------------------------------ writing
+
+void content_type::set(std::string name, std::string value)
+{
+    const std::string n = lower(name);
+
+    for(parameter& p : m_parameters) {
+        if(p.name == n) {
+            p.value = std::move(value);
+            p.charset.clear();
+
+            return;
+        }
+    }
+
+    m_parameters.push_back({ n, std::move(value), std::string() });
+}
+
+namespace {
+
+const std::string& tchar()
+{
+    static const std::string s =
+        "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+        "!#$%&'*+-.^_`{|}~";
+
+    return s;
+}
+
+std::string quote(std::string_view s)
+{
+    std::string out = "\"";
+
+    for(char c : s) {
+        if(c == '"' || c == '\\') out += '\\';
+        out += c;
+    }
+
+    return out + "\"";
+}
+
+}
+
+namespace {
+
+/**
+ * RFC 2231 4, for a value a quoted-string cannot hold.
+ *
+ * A parameter value is ASCII: qtext stops at %d126, so a filename with a
+ * non-ASCII octet in it written as "naïve.pdf" produces a header that this
+ * very parser refuses.  Anything with a high byte, or anything that arrived
+ * with a charset attached, goes back out the way it came in.
+ */
+std::string extended(const content_type::parameter& p)
+{
+    std::string out = p.name + "*=" + p.charset + "''";
+
+    for(unsigned char c : p.value) {
+        if(c >= 0x80 || tchar().find(static_cast<char>(c)) == std::string::npos) {
+            static const char* d = "0123456789ABCDEF";
+
+            out += '%';
+            out += d[c >> 4];
+            out += d[c & 0xF];
+        }
+        else {
+            out += static_cast<char>(c);
+        }
+    }
+
+    return out;
+}
+
+}
+
+std::string content_type::str() const
+{
+    std::string out = essence();
+
+    for(const parameter& p : m_parameters) {
+        bool plain = !p.value.empty();
+        bool ascii = true;
+
+        for(unsigned char c : p.value) {
+            if(c >= 0x80) ascii = false;
+            if(tchar().find(static_cast<char>(c)) == std::string::npos) plain = false;
+        }
+
+        if(!ascii || !p.charset.empty()) {
+            out += "; " + extended(p);
+        }
+        else {
+            out += "; " + p.name + "=" + (plain ? p.value : quote(p.value));
+        }
+    }
+
+    return out;
+}
+
+// --------------------------------------------------------------- multipart
+
+std::vector<std::string> split_multipart(std::string_view body,
+                                         std::string_view boundary)
+{
+    std::vector<std::string> out;
+
+    if(boundary.empty()) return out;
+
+    const std::string mark = "--" + std::string(boundary);
+
+    // Where the current part's content begins; npos until the first delimiter
+    // has been seen, because everything before that is the preamble.
+    std::size_t begin = std::string_view::npos;
+
+    for(std::size_t i = body.find(mark); i != body.npos;
+        i = body.find(mark, i + 1)) {
+
+        // RFC 2046 5.1.1: the delimiter is CRLF "--" boundary, so it has to
+        // start a line.  Without this, a boundary appearing inside a part's
+        // content would split the message.
+        std::size_t eol = 0;
+
+        if(i >= 2 && body.compare(i - 2, 2, "\r\n") == 0)      eol = 2;
+        else if(i >= 1 && body[i - 1] == '\n')                 eol = 1;
+        else if(i != 0)                                        continue;
+
+        std::size_t j = i + mark.size();
+        const bool last = body.compare(j, 2, "--") == 0;
+
+        if(last) j += 2;
+
+        // Transport padding, then the line break that ends the delimiter
+        // line.  Both belong to the delimiter, not to what follows.
+        while(j < body.size() && (body[j] == ' ' || body[j] == '\t')) j++;
+
+        if(body.compare(j, 2, "\r\n") == 0)          j += 2;
+        else if(j < body.size() && body[j] == '\n')  j += 1;
+        else if(j < body.size() && !last)            continue;
+
+        // The line break before this delimiter ended the previous part and is
+        // not part of it.
+        if(begin != std::string_view::npos) {
+            out.push_back(std::string(body.substr(begin, i - eol - begin)));
+        }
+
+        if(last) return out;
+
+        begin = j;
+    }
+
+    // No closing delimiter.  What has been collected is real; the unterminated
+    // last part is not, and a truncated message should not produce a part
+    // whose end nothing marked.
+    return out;
+}
+
+}
+}

--- a/jlib/net/content_type.hh
+++ b/jlib/net/content_type.hh
@@ -1,0 +1,192 @@
+/* -*- mode: C++ c-basic-offset: 4  -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ *
+ */
+
+#ifndef JLIB_NET_CONTENT_TYPE_HH
+#define JLIB_NET_CONTENT_TYPE_HH
+
+#include <cstddef>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace jlib {
+namespace net {
+
+/**
+ * A Content-Type or Content-Disposition, parsed against MIME's grammar.
+ *
+ * The grammar is RFC 2045 5.1 and RFC 2231, in jlib/net/rfc2045.hh, read by
+ * jlib::util::abnf::compile().  Nothing here scans by hand.
+ *
+ *     content_type c = content_type::parse(email.find("CONTENT-TYPE"));
+ *     c.is("multipart")        ->  true for multipart/mixed, and only for that
+ *     c.get("boundary")        ->  the boundary, unquoted
+ *
+ * ## Why a header this simple needs a grammar
+ *
+ *     Content-Type: multipart/mixed; boundary="a;b"
+ *
+ * That boundary is legal, and every parser that splits the header on ";" and
+ * takes what is between the first quote and the last gets it wrong -- which is
+ * what jlib did, and what gtkmail then did again on top of it.  The failure is
+ * not cosmetic: a wrong boundary means the message does not split into its
+ * parts, so an attachment is not found or half the body is shown as an
+ * attachment.
+ *
+ * The same header also has to survive a comment ("text/plain (why not)"),
+ * whitespace around the "=", a missing or repeated semicolon, and an unquoted
+ * value that the old code's util::slice would have handed back whole.
+ *
+ * ## RFC 2231
+ *
+ * Parameters may be split across numbered sections and may carry a charset:
+ *
+ *     Content-Disposition: attachment;
+ *       filename*0*=UTF-8''%E2%98%83;
+ *       filename*1=.txt
+ *
+ * The sections are joined in order, the percent-escapes decoded, and the
+ * charset kept:
+ *
+ *     c.get("filename")        ->  the octets of "☃.txt"
+ *     c.charset_of("filename") ->  "UTF-8"
+ *
+ * They are handed back as octets rather than converted, and the charset is
+ * exposed so a caller *can* convert.  jlib does not transcode, and silently
+ * returning bytes in an unnamed encoding is how the rest of this library's
+ * charset handling went wrong.
+ *
+ * ## Case
+ *
+ * Type, subtype and parameter names are lowercased on the way in, because
+ * RFC 2045 5.1 says they are case insensitive.  Parameter *values* are not:
+ * a boundary is case sensitive and so is a filename.
+ */
+class content_type {
+public:
+    /** What could not be read, and where it stopped making sense. */
+    class exception : public std::runtime_error {
+    public:
+        exception(const std::string& msg, std::string text, std::size_t offset);
+
+        const std::string& text() const { return m_text; }
+        std::size_t offset() const { return m_offset; }
+
+    protected:
+        std::string m_text;
+        std::size_t m_offset;
+    };
+
+    /**
+     * One parameter.
+     *
+     * A struct rather than a pair because charset is not optional information
+     * once RFC 2231 is in play -- it is the difference between a filename and
+     * a run of octets.
+     */
+    struct parameter {
+        std::string name;      ///< lowercased
+        std::string value;     ///< unquoted, unescaped, sections joined
+        std::string charset;   ///< "" unless RFC 2231 named one
+    };
+
+    typedef std::vector<parameter> parameter_list;
+
+    content_type() = default;
+
+    /** "type/subtype; a=b".  Throws content_type::exception. */
+    static content_type parse(std::string_view s);
+
+    /**
+     * "attachment; filename=x", RFC 2183.
+     *
+     * Same grammar with no subtype, because RFC 2183 2 says so: the
+     * disposition type uses "the parameter syntax of RFC 2045".  subtype() is
+     * empty for one of these.
+     */
+    static content_type parse_disposition(std::string_view s);
+
+    /** Would it parse?  The way to ask without catching. */
+    static bool valid(std::string_view s);
+
+    const std::string& type() const { return m_type; }
+    const std::string& subtype() const { return m_subtype; }
+
+    /** "text/plain", or just the disposition type when there is no subtype. */
+    std::string essence() const;
+
+    /**
+     * Is this that type?
+     *
+     * A whole-component comparison, not a substring search.  Email::is("text")
+     * used to be find() != npos over the entire header, so it was true for
+     * application/x-latext and true for any multipart whose boundary happened
+     * to contain the letters "text".
+     */
+    bool is(std::string_view type) const;
+    bool is(std::string_view type, std::string_view subtype) const;
+
+    bool has(std::string_view name) const;
+
+    /** The parameter's value, or fallback when it is not there. */
+    std::string get(std::string_view name,
+                    const std::string& fallback = std::string()) const;
+
+    /** What charset get(name) is in, or "" when nothing said. */
+    std::string charset_of(std::string_view name) const;
+
+    const parameter_list& parameters() const { return m_parameters; }
+
+    /** Set the parameter of this name, adding it if it is not there. */
+    void set(std::string name, std::string value);
+
+    /** Canonical, requoting any value that needs it. */
+    std::string str() const;
+
+protected:
+    std::string m_type;
+    std::string m_subtype;
+    parameter_list m_parameters;
+
+    friend struct mime_reader;
+};
+
+/**
+ * The parts of a multipart body, per RFC 2046 5.1.1.
+ *
+ * The delimiter is CRLF "--" boundary -- the line break belongs to the
+ * delimiter and not to the part before it, which is the detail that decides
+ * whether every part comes back with a stray blank line on the end.  Transport
+ * padding after the boundary is skipped, the preamble before the first
+ * delimiter and the epilogue after the closing "--" are discarded, and a body
+ * with no delimiter in it at all comes back empty rather than as one part.
+ *
+ * A bare LF is accepted where the RFC says CRLF, because a message that has
+ * been through a file, an mbox, or anything else that normalises line endings
+ * no longer has its CRLFs and is not thereby a different message.
+ */
+std::vector<std::string> split_multipart(std::string_view body,
+                                         std::string_view boundary);
+
+}
+}
+
+#endif // JLIB_NET_CONTENT_TYPE_HH

--- a/jlib/net/rfc2045.hh
+++ b/jlib/net/rfc2045.hh
@@ -1,0 +1,120 @@
+/* -*- mode: C++ c-basic-offset: 4  -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ *
+ */
+
+#ifndef JLIB_NET_RFC2045_HH
+#define JLIB_NET_RFC2045_HH
+
+namespace jlib {
+namespace net {
+
+/**
+ * MIME's Content-Type and Content-Disposition, as ABNF.
+ *
+ * Appended to jlib::net::rfc5322::LEXICAL, because RFC 2045 5.1 is explicit
+ * that it is not defining its own lexical layer: "comments are allowed in
+ * accordance with RFC 822", and quoted-string is that document's.  So the
+ * quoted-string a boundary parameter is written in is literally the same
+ * production as the one a display name is written in, and it is written once.
+ *
+ * See jlib/net/content_type.hh for what reads it.
+ *
+ * ## Where this departs from the published text
+ *
+ * Marked with "; jlib:" comments, as rfc5322.hh's are, and the same three
+ * kinds: names for spans the RFC leaves unnamed, alternatives reordered for
+ * ordered choice, and productions deliberately not carried.
+ *
+ * RFC 2045 writes its grammar in the RFC 822 style with ":= " and prose
+ * exclusions -- token is "any CHAR except SPACE, CTLs, or tspecials" -- which
+ * is not ABNF and cannot be pasted.  tchar below is that exclusion worked out
+ * as ranges, and it is the one place here where a reader has to take something
+ * on trust rather than compare it to the document.  The test spells out every
+ * excluded character.
+ *
+ * ## What this grammar is not
+ *
+ * Not a check that the type is registered.  "application/x-made-up" parses.
+ *
+ * Not RFC 2047.  An encoded word in a parameter value comes back as the
+ * literal "=?utf-8?q?...?=" it was written as -- which is also what RFC 2231
+ * exists to replace, and RFC 2231 *is* here.
+ *
+ * Not a transcoder.  An RFC 2231 extended value is decoded to octets and the
+ * charset it was tagged with is handed back beside them; converting them is
+ * somebody else's job and doing it silently would be worse than not doing it.
+ */
+namespace rfc2045 {
+
+/**
+ * Section 5.1, plus RFC 2183's Content-Disposition and RFC 2231's parameters.
+ *
+ * The two headers are one grammar because they are one shape -- a token, then
+ * a semicolon-separated list of attribute=value -- and RFC 2183 3 says so:
+ * "the disposition type ... using the parameter syntax of RFC 2045".
+ */
+inline const char* const CONTENT = R"ABNF(
+; RFC 2045 5.1.  The header field name and its colon are not here: a caller
+; has a Headers already and passes the value.
+media-type      =  [CFWS] mt-type "/" mt-subtype parameters [CFWS]
+mt-type         =  token
+mt-subtype      =  token
+
+; RFC 2183 2.  Same shape with no subtype.
+disposition     =  [CFWS] disp-type parameters [CFWS]
+disp-type       =  token
+
+; jlib: the RFC writes *(";" parameter).  A trailing or doubled semicolon with
+; nothing after it is not legal and is everywhere, and a parameter list is not
+; the place to be the only parser that minds.
+parameters      =  *( [CFWS] ";" [CFWS] [ parameter ] )
+
+; RFC 2045 5.1 as extended by RFC 2231 4 and 3: a name may carry a "*n"
+; section number, a trailing "*" marking the value as extended, or both.
+parameter       =  attribute [section] [extended] [CFWS] "=" [CFWS] value
+section         =  "*" 1*DIGIT
+extended        =  "*"
+
+; RFC 2231 7.  NOT token: "*" is what separates a parameter name from its
+; section number and its extension marker, and "%" and "'" are what an
+; extended value is punctuated with, so none of the three can be part of a
+; name.  token would match "filename*0*" whole and there would be nothing
+; left for [section] and [extended] to find.
+attribute       =  1*attribute-char
+attribute-char  =  %x21 / %x23-24 / %x26 / %x2B / %x2D-2E / %x30-39 /
+                   %x41-5A / %x5E-7E
+
+; jlib: quoted-string first.  It is RFC 5322's, so it carries [CFWS] on both
+; sides, and token would otherwise match the empty leading comment's worth of
+; nothing and commit.
+value           =  quoted-string / token
+
+; RFC 2045 5.1: any CHAR except SPACE, CTLs and tspecials, where tspecials is
+;     ( ) < > @ , ; : \ " / [ ] ? =
+; jlib: worked out as ranges, because the RFC states it as an exclusion.
+token           =  1*tchar
+tchar           =  %x21 / %x23-27 / %x2A-2B / %x2D-2E / %x30-39 /
+                   %x41-5A / %x5E-7E
+)ABNF";
+
+}
+}
+}
+
+#endif // JLIB_NET_RFC2045_HH

--- a/jlib/net/rfc5322.hh
+++ b/jlib/net/rfc5322.hh
@@ -31,10 +31,11 @@ namespace net {
  * RFC's own text rather than a transcription into find() and substr(), so what
  * jlib accepts can be checked against the document by reading it.
  *
- * Four pieces.  CORE is what every policy shares; STRICT and OBSOLETE are two
+ * Five pieces.  LEXICAL is section 3.2's tokens, which RFC 2045 borrows too;
+ * CORE is the rest of what every policy shares; STRICT and OBSOLETE are two
  * spellings of the six productions the RFC gives an obsolete form to, and
- * exactly one of them is appended to CORE; LENIENT is a further "=/" extension
- * for text that is not RFC 5322 at all.  See jlib/net/address.hh.
+ * exactly one of them is appended; LENIENT is a further "=/" extension for
+ * text that is not RFC 5322 at all.  See jlib/net/address.hh.
  *
  * ## Where this departs from the published text, and why
  *
@@ -81,10 +82,14 @@ namespace net {
 namespace rfc5322 {
 
 /**
- * Everything the policies share: 3.2 lexical tokens, 3.4.1 addr-spec, and the
- * 3.4 shapes whose obsolete form is elsewhere.
+ * Section 3.2's lexical tokens, which are not only an address's.
+ *
+ * Separate from CORE because RFC 2045 5.1 builds Content-Type out of these
+ * same pieces -- "comments are allowed in accordance with RFC 822" -- and a
+ * grammar for a media type should not have to drag addr-spec in behind it to
+ * get a quoted-string.  See jlib/net/rfc2045.hh, which appends to this.
  */
-inline const char* const CORE = R"ABNF(
+inline const char* const LEXICAL = R"ABNF(
 ; 3.2.1 quoted characters
 quoted-pair     =  "\" (VCHAR / WSP)
 
@@ -110,10 +115,21 @@ dot-atom-text   =  atom-text *("." atom-text) ; jlib: 1*atext respelled, so one
 ; 3.2.4 quoted strings
 qtext           =  %d33 / %d35-91 / %d93-126
 qcontent        =  qtext / quoted-pair
-quoted-string   =  [CFWS] DQUOTE qs-body [FWS] DQUOTE [CFWS]
-qs-body         =  *([FWS] qcontent)          ; jlib: names what is between the
-                                              ; quotes
+quoted-string   =  [CFWS] DQUOTE qs-body DQUOTE [CFWS]
+qs-body         =  *([FWS] qcontent) [FWS]    ; jlib: names what is between the
+                                              ; quotes, which 3.2.4 says is the
+                                              ; whole of the value -- so the
+                                              ; trailing FWS is inside it, or a
+                                              ; parameter written as "a long "
+                                              ; loses its last space
 
+)ABNF";
+
+/**
+ * Everything the address policies share: 3.2.5, 3.4.1's addr-spec, and the 3.4
+ * shapes whose obsolete form is elsewhere.  Appended to LEXICAL.
+ */
+inline const char* const CORE = R"ABNF(
 ; 3.2.5 miscellaneous tokens
 word            =  atom / quoted-string
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -54,6 +54,7 @@ TESTS = \
 	net_email_multipart_test \
 	net_mbox_crlf_test \
 	net_protocol_test \
+	net_mime_test \
 	net_same_address_test \
  \
 	sys_sync_test \
@@ -125,6 +126,9 @@ net_email_test_SOURCES          = net_email_test.cc
 net_email_test_LDADD            = $(JNET_LA)
 net_email_received_test_SOURCES = net_email_received_test.cc
 net_email_received_test_LDADD   = $(JNET_LA)
+net_mime_test_SOURCES           = net_mime_test.cc
+net_mime_test_LDADD             = $(JNET_LA) $(JUTIL_LA)
+
 net_protocol_test_SOURCES       = net_protocol_test.cc
 net_protocol_test_LDADD         = $(JNET_LA) $(JUTIL_LA)
 

--- a/tests/net_address_test.cc
+++ b/tests/net_address_test.cc
@@ -287,7 +287,8 @@ static void extending_the_grammar() {
     // RFC 6532 is written as one incremental alternative, and so is this.
     using namespace jlib::util::abnf;
 
-    grammar g = compile(std::string(jlib::net::rfc5322::CORE) +
+    grammar g = compile(std::string(jlib::net::rfc5322::LEXICAL) +
+                        jlib::net::rfc5322::CORE +
                         jlib::net::rfc5322::OBSOLETE + R"ABNF(
 atext           =/ UTF8-non-ascii
 UTF8-non-ascii  =  UTF8-2 / UTF8-3 / UTF8-4
@@ -360,7 +361,8 @@ static void the_grammar_itself() {
         std::string why;
 
         try {
-            grammar g = compile(std::string(jlib::net::rfc5322::CORE) + d);
+            grammar g = compile(std::string(jlib::net::rfc5322::LEXICAL) +
+                                jlib::net::rfc5322::CORE + d);
             g.check();
             built = true;
         }

--- a/tests/net_mime_test.cc
+++ b/tests/net_mime_test.cc
@@ -1,0 +1,488 @@
+/* -*- mode: C++ c-basic-offset: 4  -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ *
+ */
+
+// Content-Type, Content-Disposition, and where a multipart body divides.
+//
+// The last of the four headers jlib was reading by looking for a delimiter and
+// hoping.  This one is the worst of them, because getting it wrong is not a
+// parse error a caller can see -- the message simply does not come apart into
+// its pieces, and an attachment goes missing.
+
+#include <jlib/net/content_type.hh>
+#include <jlib/net/rfc2045.hh>
+#include <jlib/net/rfc5322.hh>
+#include <jlib/net/Email.hh>
+
+#include <jlib/util/abnf.hh>
+
+#include <iostream>
+#include <string>
+
+using jlib::net::content_type;
+using jlib::net::split_multipart;
+
+static int failures = 0;
+
+static void ok(const std::string& what, bool good, const std::string& detail = "") {
+    if(!good) ++failures;
+    std::cout << (good ? "  ok   " : "  FAIL ") << what;
+    if(!detail.empty()) std::cout << ": " << detail;
+    std::cout << "\n";
+}
+
+static std::string show(const std::string& s) {
+    std::string out;
+
+    for(char c : s) {
+        if(c == '\r')      out += "\\r";
+        else if(c == '\n') out += "\\n";
+        else               out += c;
+    }
+
+    return out;
+}
+
+/** get(name) or "<threw>", so a failure prints something. */
+static std::string param(const char* header, const char* name) {
+    try { return content_type::parse(header).get(name); }
+    catch(content_type::exception&) { return "<threw>"; }
+}
+
+static void reading_a_content_type() {
+    std::cout << "Content-Type:\n";
+
+    const content_type c = content_type::parse("text/plain; charset=us-ascii");
+
+    ok("type and subtype", c.type() == "text" && c.subtype() == "plain");
+    ok("essence",          c.essence() == "text/plain", c.essence());
+    ok("a parameter",      c.get("charset") == "us-ascii", c.get("charset"));
+    ok("and one that is not there", c.get("boundary", "none") == "none");
+    ok("has()",            c.has("charset") && !c.has("boundary"));
+
+    // RFC 2045 5.1: the type, subtype and parameter names are case
+    // insensitive.  The value of a parameter is not -- a boundary is case
+    // sensitive, and so is a filename.
+    const content_type u = content_type::parse("TEXT/PLAIN; CharSet=\"UTF-8\"");
+
+    ok("names fold case",  u.essence() == "text/plain" && u.has("CHARSET"));
+    ok("values do not",    u.get("charset") == "UTF-8", u.get("charset"));
+
+    // RFC 822 comments, which RFC 2045 5.1 says are allowed here.
+    ok("a comment is not part of anything",
+       content_type::parse("text/plain (why not); charset=utf-8").get("charset")
+       == "utf-8");
+
+    ok("whitespace around the equals",
+       param("text/plain; charset = utf-8", "charset") == "utf-8");
+
+    // Not legal, and everywhere.
+    ok("a trailing semicolon", content_type::valid("text/plain;"));
+    ok("a doubled one",        content_type::valid("text/plain; ; charset=x"));
+
+    for(const char* bad : { "text", "text/", "/plain", "text/plain; charset",
+                            "text plain", "" }) {
+        ok(std::string("\"") + bad + "\" is not a media type",
+           !content_type::valid(bad));
+    }
+}
+
+static void the_boundary_that_used_to_break_it() {
+    std::cout << "\nthe one that mattered:\n";
+
+    // Splitting the header on ";" cuts this in half, and the old code then
+    // asked util::slice for what lay between the first quote and the last.
+    // The boundary came out as "a" and the message did not divide.
+    ok("a semicolon inside a quoted boundary",
+       param("multipart/mixed; boundary=\"a;b\"", "boundary") == "a;b",
+       param("multipart/mixed; boundary=\"a;b\"", "boundary"));
+
+    // And the other half of that: slice returns its whole input when the
+    // delimiters are absent, so an unquoted boundary came back with its own
+    // name still attached.
+    ok("an unquoted boundary",
+       param("multipart/mixed; boundary=simple", "boundary") == "simple",
+       param("multipart/mixed; boundary=simple", "boundary"));
+
+    ok("one with an equals sign in it",
+       param("multipart/mixed; boundary=\"----=_Part_0_1234\"", "boundary")
+       == "----=_Part_0_1234");
+
+    ok("and an escaped quote in a value",
+       param("application/x; name=\"say \\\" hi\"", "name") == "say \" hi",
+       param("application/x; name=\"say \\\" hi\"", "name"));
+}
+
+static void repeated_parameters() {
+    std::cout << "\na parameter given twice:\n";
+
+    // RFC 2045 does not say what this means.  The first wins, because taking
+    // the last would let a second boundary or charset appended to a header
+    // override the first -- that is a way to smuggle a parameter past
+    // something that read the header before this did, not a parse.
+    ok("the first wins", param("application/x; a=1; a=2", "a") == "1",
+       param("application/x; a=1; a=2", "a"));
+
+    ok("including a second boundary",
+       param("multipart/mixed; boundary=real; boundary=fake", "boundary")
+       == "real");
+}
+
+static void rfc2231() {
+    std::cout << "\nRFC 2231, which is how a filename with an accent arrives:\n";
+
+    {
+        const content_type c =
+            content_type::parse("application/pdf; filename*=UTF-8''na%C3%AFve.pdf");
+
+        ok("an extended value is decoded",
+           c.get("filename") == "na\xc3\xafve.pdf", c.get("filename"));
+        ok("and the charset comes with it",
+           c.charset_of("filename") == "utf-8", c.charset_of("filename"));
+    }
+
+    {
+        // Outlook splits long parameters across numbered sections.
+        const content_type c =
+            content_type::parse("application/pdf; filename*0=\"a long \"; "
+                                "filename*1=\"name.pdf\"");
+
+        ok("sections are joined", c.get("filename") == "a long name.pdf",
+           c.get("filename"));
+    }
+
+    {
+        // And both at once, which is the form that actually turns up.
+        const content_type c =
+            content_type::parse("application/pdf; filename*0*=UTF-8''%E2%98%83; "
+                                "filename*1=.txt");
+
+        ok("an extended first section and a plain second",
+           c.get("filename") == "\xe2\x98\x83.txt", c.get("filename"));
+        ok("with the charset from the first",
+           c.charset_of("filename") == "utf-8");
+    }
+
+    {
+        // Out of order in the header, in order in the value.
+        const content_type c =
+            content_type::parse("application/pdf; filename*1=b; filename*0=a");
+
+        ok("sections join in numeric order, not header order",
+           c.get("filename") == "ab", c.get("filename"));
+    }
+
+    // A "%" that is not an escape is a "%".  Dropping it would lose a
+    // character out of a filename because a sender wrote "100%.txt".
+    ok("a stray percent survives",
+       param("text/plain; name=100%.txt", "name") == "100%.txt",
+       param("text/plain; name=100%.txt", "name"));
+
+    ok("a plain parameter has no charset",
+       content_type::parse("text/plain; charset=utf-8").charset_of("charset").empty());
+}
+
+static void writing_it_back_out() {
+    std::cout << "\nround trip:\n";
+
+    for(const char* s : { "text/plain",
+                          "text/plain; charset=utf-8",
+                          "multipart/mixed; boundary=\"a;b\"",
+                          "application/x; name=\"say \\\" hi\"",
+                          "application/pdf; filename*=UTF-8''na%C3%AFve.pdf" }) {
+        const content_type a = content_type::parse(s);
+        std::string why;
+        bool same = false;
+
+        try {
+            const content_type b = content_type::parse(a.str());
+
+            same = b.essence() == a.essence() &&
+                   b.parameters().size() == a.parameters().size();
+
+            for(std::size_t i = 0; same && i < a.parameters().size(); i++) {
+                same = b.parameters()[i].name    == a.parameters()[i].name &&
+                       b.parameters()[i].value   == a.parameters()[i].value &&
+                       b.parameters()[i].charset == a.parameters()[i].charset;
+            }
+        }
+        catch(content_type::exception& e) { why = e.what(); }
+
+        ok(s, same, why.empty() ? a.str() : why);
+    }
+
+    // The reason the last of those needs RFC 2231 on the way out as well as
+    // on the way in: a parameter value is ASCII.  qtext stops at %d126, so a
+    // filename written back as "naïve.pdf" produces a header this very parser
+    // refuses, and the round trip above is what catches that.
+    ok("a non-ASCII value goes back out extended",
+       content_type::parse("application/pdf; filename*=UTF-8''na%C3%AFve.pdf")
+           .str().find("filename*=") != std::string::npos);
+}
+
+static void disposition() {
+    std::cout << "\nContent-Disposition, RFC 2183:\n";
+
+    const content_type d =
+        content_type::parse_disposition("attachment; filename=\"a b.txt\"");
+
+    ok("the disposition type", d.type() == "attachment");
+    ok("and no subtype",       d.subtype().empty());
+    ok("essence is just the type", d.essence() == "attachment", d.essence());
+    ok("the filename",         d.get("filename") == "a b.txt", d.get("filename"));
+
+    ok("inline with no parameters",
+       content_type::parse_disposition("inline").type() == "inline");
+
+    // The same grammar, so the same things work.
+    ok("and RFC 2231 applies here too",
+       content_type::parse_disposition("attachment; filename*=UTF-8''%E2%98%83")
+           .get("filename") == "\xe2\x98\x83");
+}
+
+static void is_compares_components() {
+    std::cout << "\nis():\n";
+
+    const content_type c = content_type::parse("text/plain; charset=utf-8");
+
+    ok("the type",            c.is("text"));
+    ok("type and subtype",    c.is("text", "plain"));
+    ok("case insensitively",  c.is("TEXT", "Plain"));
+    ok("and not a near miss", !c.is("tex") && !c.is("text", "html"));
+
+    // Email::is() was find() != npos over the whole lowercased header.
+    jlib::net::Email latex("Content-Type: application/x-latext\r\n\r\nbody\r\n");
+
+    ok("application/x-latext is not text", !latex.is("text"));
+
+    // And this one is the reason it matters: the boundary is chosen by the
+    // sender, so the old test could be made to say anything.
+    jlib::net::Email tricky(
+        "Content-Type: multipart/mixed; boundary=\"text/html\"\r\n\r\nbody\r\n");
+
+    ok("a boundary containing a type does not make it that type",
+       !tricky.is("text") && !tricky.is("text/html"));
+    ok("and it is still multipart", tricky.is("multipart"));
+}
+
+static void splitting_a_body() {
+    std::cout << "\nsplit_multipart, RFC 2046 5.1.1:\n";
+
+    {
+        const std::string body =
+            "preamble, which is discarded\r\n"
+            "--B\r\n"
+            "one\r\n"
+            "--B\r\n"
+            "two\r\n"
+            "--B--\r\n"
+            "epilogue, also discarded";
+
+        const std::vector<std::string> p = split_multipart(body, "B");
+
+        ok("two parts", p.size() == 2, std::to_string(p.size()));
+
+        if(p.size() == 2) {
+            // The CRLF before a delimiter belongs to the delimiter, so a part
+            // does not come back with a blank line stuck on the end.
+            ok("without the delimiter's line break",
+               p[0] == "one" && p[1] == "two",
+               show(p[0]) + " | " + show(p[1]));
+        }
+    }
+
+    {
+        // A boundary only counts at the start of a line.
+        const std::vector<std::string> p =
+            split_multipart("--B\r\nsay --B please\r\n--B--\r\n", "B");
+
+        ok("a boundary inside a line is content", p.size() == 1 &&
+           p[0] == "say --B please", p.empty() ? "" : show(p[0]));
+    }
+
+    {
+        // Transport padding, RFC 2046 5.1.1.
+        const std::vector<std::string> p =
+            split_multipart("--B  \r\none\r\n--B--  \r\n", "B");
+
+        ok("whitespace after a boundary is skipped",
+           p.size() == 1 && p[0] == "one", p.empty() ? "" : show(p[0]));
+    }
+
+    {
+        // A message that has been through a file no longer has its CRLFs and
+        // is not thereby a different message.
+        const std::vector<std::string> p = split_multipart("--B\none\n--B--\n", "B");
+
+        ok("bare LF works too", p.size() == 1 && p[0] == "one",
+           p.empty() ? "" : show(p[0]));
+    }
+
+    {
+        const std::vector<std::string> p =
+            split_multipart("--B\r\none\r\n--B\r\ntruncated", "B");
+
+        ok("a truncated body yields the parts that were terminated",
+           p.size() == 1 && p[0] == "one", std::to_string(p.size()));
+    }
+
+    ok("no boundary in the body at all",
+       split_multipart("just a body\r\n", "B").empty());
+    ok("and an empty boundary is refused rather than matching everything",
+       split_multipart("--\r\na\r\n----\r\n", "").empty());
+
+    {
+        // An empty part is a part.  A message whose first section is empty is
+        // unusual and legal.
+        const std::vector<std::string> p =
+            split_multipart("--B\r\n\r\n--B\r\nsecond\r\n--B--\r\n", "B");
+
+        ok("an empty part still counts", p.size() == 2 && p[0].empty(),
+           std::to_string(p.size()));
+    }
+}
+
+static void a_whole_message() {
+    std::cout << "\nend to end:\n";
+
+    // The boundary has a semicolon in it, which is what made this worth
+    // writing: every step below used to go wrong at the first one.
+    const std::string raw =
+        "From: Joe <joe@x.com>\r\n"
+        "Content-Type: multipart/mixed; boundary=\"a;b\"\r\n"
+        "\r\n"
+        "--a;b\r\n"
+        "Content-Type: text/plain; charset=utf-8\r\n"
+        "\r\n"
+        "hello\r\n"
+        "--a;b\r\n"
+        "Content-Type: application/pdf; name=\"report.pdf\"\r\n"
+        "Content-Disposition: attachment; filename*=UTF-8''na%C3%AFve.pdf\r\n"
+        "\r\n"
+        "%PDF-1.4\r\n"
+        "--a;b--\r\n";
+
+    jlib::net::Email e(raw);
+
+    ok("it is multipart",   e.is("multipart/mixed"));
+    ok("with two parts",    e.attach().size() == 2,
+       std::to_string(e.attach().size()));
+
+    if(e.attach().size() == 2) {
+        ok("the first is text",  e.attach()[0].is("text/plain"));
+        ok("the second is a PDF", e.attach()[1].is("application/pdf"));
+
+        // Content-Type's name and Content-Disposition's filename are two
+        // different parameters in two different headers, and a client wants
+        // whichever it can get.
+        ok("its Content-Type name",
+           e.attach()[1].get_name() == "report.pdf",
+           e.attach()[1].get_name());
+        ok("and its RFC 2231 filename",
+           e.attach()[1].get_filename() == "na\xc3\xafve.pdf",
+           e.attach()[1].get_filename());
+    }
+
+    // get_filename() falls back to Content-Type's name, which is new: plenty
+    // of senders put the name there and nowhere else, and an attachment shown
+    // with no name is the whole of what the function is for.
+    jlib::net::Email named(
+        "Content-Type: application/pdf; name=\"only-here.pdf\"\r\n\r\nx\r\n");
+
+    ok("get_filename falls back to the Content-Type name",
+       named.get_filename() == "only-here.pdf", named.get_filename());
+}
+
+static void the_grammar_itself() {
+    std::cout << "\nthe grammar:\n";
+
+    using namespace jlib::util::abnf;
+
+    bool built = false;
+    std::string why;
+
+    try {
+        grammar g = compile(std::string(jlib::net::rfc5322::LEXICAL) +
+                            jlib::net::rfc2045::CONTENT);
+        g.check();
+        built = true;
+    }
+    catch(exception& e) { why = e.what(); }
+
+    ok("it compiles and checks", built, why);
+
+    // tchar is the one place in rfc2045.hh where the RFC states an exclusion
+    // in prose and the grammar states ranges, so a reader cannot check it by
+    // comparing.  Every excluded character, spelled out: SPACE, and RFC 2045
+    // 5.1's tspecials.
+    for(char c : std::string(" ()<>@,;:\\\"/[]?=")) {
+        const std::string s = std::string("text/pl") + c + "ain";
+
+        ok(std::string("tchar excludes '") + c + "'", !content_type::valid(s));
+    }
+
+    // And a sample of what it does allow, which is everything else printable.
+    ok("and allows the rest",
+       content_type::valid("application/x!#$%&'*+-.^_`{|}~123ABCabc"));
+}
+
+int main() {
+    std::cout << std::unitbuf;
+
+    reading_a_content_type();
+    the_boundary_that_used_to_break_it();
+    repeated_parameters();
+    rfc2231();
+    writing_it_back_out();
+    disposition();
+    is_compares_components();
+    splitting_a_body();
+    a_whole_message();
+    the_grammar_itself();
+
+    // What a green run does NOT establish.
+    //
+    // Not MIME conformance.  It establishes that the grammar as transcribed in
+    // rfc2045.hh accepts and rejects this corpus.  RFC 2045 writes its grammar
+    // in the RFC 822 style with prose exclusions rather than in ABNF, so
+    // tchar had to be worked out by hand; the section above checks it
+    // character by character, which is the best that can be done short of
+    // checking it against the document by eye.
+    //
+    // Not RFC 2047.  An encoded word in a parameter comes back as the literal
+    // "=?utf-8?q?...?=" -- RFC 2231 is what replaced that for parameters and
+    // RFC 2231 is here, but a sender using the older form gets no help.
+    //
+    // Not transcoding.  charset_of() names the encoding an RFC 2231 value is
+    // in and get() hands back the octets; nothing converts them, and a caller
+    // that ignores the charset and assumes UTF-8 will be right almost always
+    // and silently wrong the rest of the time.
+    //
+    // Not the rest of Email.  Content-Transfer-Encoding is still matched with
+    // find("BASE64") != npos over an uppercased header, so a message declaring
+    // "x-not-base64" is decoded as base64.  Same bug class, and it is small
+    // enough that it belongs with whatever touches that path next rather than
+    // here.
+    //
+    // Not boundary validity.  RFC 2046 5.1.1 bounds a boundary to 70
+    // characters from a restricted set and forbids a trailing space; nothing
+    // here checks that, because a sender who breaks the rule still means the
+    // string they wrote and refusing the message would help nobody.
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
The fourth and worst of the headers jlib was reading by looking for a delimiter
and hoping.  Worst because getting it wrong is not a parse error anyone sees --
the message simply does not come apart into its pieces, and an attachment goes
missing.

    macOS  39 tests, 39 pass, 0 skip
    Linux  40 tests, 39 pass, 1 skip

    jlib/net/rfc2045.hh          new -- the grammar
    jlib/net/content_type.hh     new
    jlib/net/content_type.cc     new
    tests/net_mime_test.cc       new

the header that motivates all of it

    Content-Type: multipart/mixed; boundary="a;b"

    That is legal, and it defeats every parser that splits on ";" and takes
    what lies between the first quote and the last.  Which is what Email.cc
    did:

        std::vector<std::string> v = util::tokenize(type, ";");
        bound = util::slice(bound, "\"", "\"");

    tokenize cut the boundary in half; slice, on an unquoted boundary, handed
    back its whole input with the parameter name still attached.  Neither
    failure was visible.  gtkmail then hand-rolled the same parsing again on
    top of it, in the UI layer, with the same two bugs.

the grammar borrows RFC 5322's lexical layer, because RFC 2045 says to

    RFC 2045 5.1 is explicit that it defines no lexical layer of its own:
    comments are allowed "in accordance with RFC 822", and quoted-string is
    that document's production.  So rfc5322.hh's CORE is split into LEXICAL --
    3.2's tokens -- and the rest, and rfc2045.hh appends to LEXICAL.  The
    quoted-string a boundary is written in is now literally the same rule as
    the one a display name is written in, written once.

    That split immediately found a bug in it.  qs-body was
    *([FWS] qcontent), leaving the trailing FWS to quoted-string, so a value
    written as "a long " came back as "a long".  RFC 5322 3.2.4 says the
    quoted-string *is* what is contained between the quote characters, so the
    trailing whitespace is part of it.  Fixed in LEXICAL, which means addresses
    get it too.

RFC 2231, which is how a filename with an accent arrives

        Content-Disposition: attachment;
          filename*0*=UTF-8''%E2%98%83;
          filename*1=.txt

    Sections joined in numeric order, percent-escapes decoded, charset kept:

        c.get("filename")        ->  the octets of "snowman.txt"
        c.charset_of("filename") ->  "UTF-8"

    The octets are handed back rather than converted, and the charset is
    exposed so a caller can convert.  jlib does not transcode, and returning
    bytes in an unnamed encoding is how the rest of this library's charset
    handling went wrong.

    str() writes the extended form back out when it has to, which the round
    trip test is what caught: a parameter value is ASCII -- qtext stops at
    %d126 -- so a filename written back as "naive.pdf" with a real i-diaeresis
    in it produces a header this very parser refuses.

three more things Email was wrong about

    is() was find() != npos over the whole lowercased header.  So is("text")
    was true for application/x-latext, and true for any multipart whose
    boundary contained the letters "text" -- and the boundary is chosen by the
    sender, so the predicate could be made to say anything.  It compares
    components now.

    get_name() matched a piece that *began* with "name=", so a parameter with
    a space before it was invisible, and read the value with util::slice.
    get_filename() did the same to Content-Disposition.  Both go through the
    grammar, and get_filename() now falls back to Content-Type's name --
    plenty of senders put it there and nowhere else, and an attachment shown
    with no name is the whole of what the function is for.

    The message branch tested for "message/digest", which is not a media type.
    The digest is multipart/digest and the multipart branch handles it.  Two
    empty if-branches went with it.

split_multipart is RFC 2046 5.1.1, not parse_divide on "--" + bound

    The delimiter is CRLF "--" boundary: the line break belongs to the
    delimiter, not to the part before it, which is what decides whether every
    part comes back with a stray blank line on the end.  Transport padding is
    skipped, preamble and epilogue discarded, a boundary appearing mid-line is
    content, and a bare LF is accepted because a message that has been through
    a file no longer has its CRLFs and is not thereby a different message.

    An empty boundary parameter yields no parts rather than splitting on every
    line beginning with "--", which is what the old code did when the boundary
    was missing.

a repeated parameter takes the first, not the last

    RFC 2045 does not say what a repeated parameter means.  Taking the last
    would let a second boundary or charset appended to a header override the
    first, which is a way to smuggle a parameter past something that read the
    header earlier -- not a parse.

    backref() was in the plan for this branch and is not used.  It would have
    been, if the boundary had to be matched against something captured from
    the same input; it does not -- the boundary is known from the header before
    the body is scanned, so the honest tool is a literal and a scan.

what a green run does not establish

    Written down in the test.  Not MIME conformance.  RFC 2045 writes its
    grammar in the RFC 822 style with prose exclusions rather than in ABNF --
    token is "any CHAR except SPACE, CTLs, or tspecials" -- so tchar had to be
    worked out as ranges by hand.  It is the one place in rfc2045.hh a reader
    cannot check by comparing against the document, so the test checks it
    character by character instead.

    Not RFC 2047: an encoded word in a parameter comes back as its literal
    text.  Not transcoding.  Not boundary validity -- RFC 2046 bounds a
    boundary to 70 characters from a restricted set, and a sender who breaks
    that still means the string they wrote.

    Not the rest of Email.  Content-Transfer-Encoding is still matched with
    find("BASE64") != npos over an uppercased header, so a message declaring
    "x-not-base64" is decoded as base64.  Same bug class, small enough to go
    with whatever touches that path next.
