### PR TITLE
Fix base64, quoted-printable and percent-encoding

### DIFF
--- a/jlib/net/net.cc
+++ b/jlib/net/net.cc
@@ -231,14 +231,20 @@ namespace jlib {
                     //cout << "data = "<< email.data() << endl;
                 }
                 else if(util::icontains(encoding, "quoted-printable")) {
-                    //cout << "QP encoding"<<endl;
-                    data += email.data();
-                    //cout << "data = "<< email.data() << endl;
+                    // This used to append the body unencoded while the header
+                    // said quoted-printable, so a message with a high byte in
+                    // it was declared to be one thing and sent as another.
+                    // qp::encode was an empty stub at the time, which is why.
+                    data += util::qp::encode(email.data());
                 }
                 else if(util::icontains(encoding, "base64")) {
-                    //cout << "base64 encoding"<<endl;
-                    data += util::base64::encode(email.data());
-                    //cout << "data = "<< email.data() << endl;
+                    // RFC 2045 6.8: base64 in a MIME body is broken into
+                    // lines of at most 76 characters.  base64::encode no
+                    // longer wraps by default, because the other two callers
+                    // -- an SMTP AUTH token and an RFC 2047 encoded word --
+                    // are both broken by a line break in the middle.  This one
+                    // wants it, so it asks.
+                    data += util::base64::encode(email.data(), 76);
                 }
                 else {
                     throw exception("error in net::build_mime(): unknown content-transfer-encoding '"+encoding+"'");

--- a/jlib/util/util.cc
+++ b/jlib/util/util.cc
@@ -368,208 +368,351 @@ namespace jlib {
             return ( upper(s) == upper(t) );
         }        
 
+        // ------------------------------------------------------------ base64
+
         namespace base64 {
-            
-            static char decode_table[] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 62, 0, 0, 0, 63, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 0, 0, 0, 0, 0, 0, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51  };
-            
-            int decode(const char* in, char* out) {
-                if(in[2] == '=') {
-                    out[0] = ((decode_table[in[0]] << 2 ) | (0x03)) & ((0xfc) | (decode_table[in[1]] >> 4));
-                    return 1;
-                }
-                else if(in[3] == '=') {
-                    out[0] = ((decode_table[in[0]] << 2 ) | (0x03)) & ((0xfc) | (decode_table[in[1]] >> 4));
-                    out[1] = ((decode_table[in[1]] << 4 ) | (0x0f)) & ((0xf0) | (decode_table[in[2]] >> 2));
-                    return 2;
-                }
-                else {
-                    out[0] = ((decode_table[in[0]] << 2 ) | (0x03)) & ((0xfc) | (decode_table[in[1]] >> 4));
-                    out[1] = ((decode_table[in[1]] << 4 ) | (0x0f)) & ((0xf0) | (decode_table[in[2]] >> 2));
-                    out[2] = ((decode_table[in[2]] << 6 ) | (0x3f)) & ((0xc0) | (decode_table[in[3]] >> 0));
-                    return 3;
-                }
-            }
-            
 
-            std::string decode(const std::string& s) {
-                char* out = new char[s.length()];
-                const char* in = s.data();
-                
-                int j=0;
-                for(unsigned int i=0; i<s.length(); i+=4) {
-                    while(i<s.length() && s[i] < 0x20) {
-                        i++;
+            static const char* const ALPHABET =
+                "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+            /**
+             * 256 entries, indexed through unsigned char.
+             *
+             * The old table had 123 and was indexed with a plain char, so
+             * every byte over 0x7F was a negative index and "{|}~" ran off
+             * the end.  Both are out-of-bounds reads on input that arrives
+             * from the network -- ASan caught the second one on
+             * decode("~~~~").
+             */
+            static const signed char* table()
+            {
+                static signed char t[256];
+                static const bool built = [] {
+                    for(int i = 0; i < 256; i++) t[i] = -1;
+                    for(int i = 0; i < 64; i++) {
+                        t[static_cast<unsigned char>(ALPHABET[i])] =
+                            static_cast<signed char>(i);
                     }
-                    if(i<s.length()) {
-                        j += decode(in+i, out+j);
+
+                    return true;
+                }();
+
+                (void)built;
+
+                return t;
+            }
+
+            std::string decode(const std::string& s, bool& clean)
+            {
+                std::string out;
+
+                out.reserve(s.size() / 4 * 3);
+                clean = true;
+
+                // Three decoded bytes per four symbols, accumulated six bits
+                // at a time.  The old version stepped four bytes at a time and
+                // read in[2] and in[3] unconditionally, so a final group of
+                // one to three symbols -- which is what a truncated message
+                // or a stripped line break leaves -- read past the end of the
+                // string and appended whatever was there.
+                unsigned int bits = 0;
+                int have = 0;
+                bool padded = false;
+
+                for(unsigned char c : s) {
+                    if(c == '=') { padded = true; continue; }
+
+                    const signed char v = table()[c];
+
+                    if(v < 0) {
+                        // RFC 2045 6.8: characters outside the alphabet are
+                        // ignored in base64-encoded data.  That rule is what
+                        // makes the line breaks in a MIME body work, so it is
+                        // not optional -- but anything other than whitespace
+                        // being skipped means the input was not what it said.
+                        if(c != '\r' && c != '\n' && c != ' ' && c != '\t') {
+                            clean = false;
+                        }
+
+                        continue;
+                    }
+
+                    // Padding means the data ended.  Whatever follows it is
+                    // not part of this value, and decoding it anyway is how
+                    // "Zg==Zg==" produced a byte that neither half encodes.
+                    if(padded) { clean = false; break; }
+
+                    bits = (bits << 6) | static_cast<unsigned int>(v);
+                    have += 6;
+
+                    if(have >= 8) {
+                        have -= 8;
+                        out += static_cast<char>((bits >> have) & 0xFF);
                     }
                 }
 
-                std::string ret(out,j);
-                delete [] out;
-                return ret;
-            }
-          
+                // Six leftover bits cannot be a byte.  They are dropped rather
+                // than rounded up into one: inventing a byte is how the old
+                // version turned "aGk" into "hi" plus a stray character.
+                if(have >= 6) clean = false;
 
-            static unsigned char encode_table[] = { 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '+', '/' };
+                return out;
+            }
 
-            int encode(const char* in, char* out, int sz) {
-                if(sz < 1) {
-                    return 0;
-                }
-                else if(sz == 1) {
-                    out[0] = encode_table[(in[0] >> 2) & (0x3f)];
-                    out[1] = encode_table[(((in[0] << 4) & (0x3f)) | 0x0f) & ((0xf0))];
-                    return 2;
-                }
-                else if(sz == 2) {
-                    out[0] = encode_table[(in[0] >> 2) & (0x3f)];
-                    out[1] = encode_table[(((in[0] << 4) & (0x3f)) | 0x0f) & ((0xf0) | (in[1] >> 4))];
-                    out[2] = encode_table[(((in[1] << 2) & (0x3f)) | 0x03) & ((0xfc))];
-                    return 3;
-                }
-                else if(sz == 3) {
-                    out[0] = encode_table[(in[0] >> 2) & (0x3f)];
-                    out[1] = encode_table[(((in[0] << 4) & (0x3f)) | 0x0f) & ((0xf0) | (in[1] >> 4))];
-                    out[2] = encode_table[(((in[1] << 2) & (0x3f)) | 0x03) & ((0xfc) | (in[2] >> 6))];
-                    out[3] = encode_table[(in[2]) & (0x3f)];
-                    return 4;
-                }
-                else {
-                    return 0;
-                }
+            std::string decode(const std::string& s)
+            {
+                bool clean;
+
+                return decode(s, clean);
             }
-            
-            std::string encode(const std::string& s) {
-                char* outbuf = new char[2*s.length()];
-                int sz = 0;
-                u_int j = 0;
-                const char* inbuf = s.data();
-                
-                bool first = true;
-                
-                while(j < s.length()) {
-                    u_int num = 3;
-                    if((s.length() - j) < num) {
-                        num = s.length() - j;
+
+            std::string encode(const std::string& s, std::size_t wrap)
+            {
+                std::string out;
+
+                out.reserve((s.size() + 2) / 3 * 4 + (wrap ? s.size() / wrap : 0));
+
+                std::size_t column = 0;
+
+                for(std::size_t i = 0; i < s.size(); i += 3) {
+                    const std::size_t n = std::min<std::size_t>(3, s.size() - i);
+
+                    unsigned int bits = 0;
+
+                    for(std::size_t k = 0; k < 3; k++) {
+                        bits = (bits << 8) |
+                               (k < n ? static_cast<unsigned char>(s[i + k]) : 0);
                     }
-                    sz += encode(inbuf+j, outbuf+sz, num);
-                    j += 3;
-                    if( (first && (sz % 64) == 0) || (!first && ((sz+1) % 65) == 0) ) {
-                        outbuf[sz++] = '\n';
+
+                    char quad[4];
+
+                    for(int k = 0; k < 4; k++) {
+                        quad[k] = ALPHABET[(bits >> (18 - 6 * k)) & 0x3F];
                     }
-                    if(sz >= 64) {
-                        first = false;
+
+                    // One padding character per byte the last group was short.
+                    for(std::size_t k = n + 1; k < 4; k++) quad[k] = '=';
+
+                    if(wrap && column + 4 > wrap) {
+                        out += "\r\n";
+                        column = 0;
                     }
+
+                    out.append(quad, 4);
+                    column += 4;
                 }
-                int numeq = 0;
-                switch(s.length() % 3) {
-                case 1:
-                    numeq = 2;
-                    break;
-                case 2:
-                    numeq = 1;
-                    break;
-                default:
-                    break;
-                    
-                }
-                for(int i = 0; i<numeq; i++) {
-                    outbuf[sz++] = '=';
-                }
-            
-                //outbuf[sz] = 0;
-                std::string ret(outbuf,sz);
-                delete [] outbuf;
-                return ret;                
+
+                return out;
             }
-            
+
+            std::string encode(const std::string& s)
+            {
+                // No wrapping by default, which is a change.  The old version
+                // put a newline in after every 64 characters, unconditionally
+                // -- including in the middle of an SMTP AUTH token, which
+                // breaks the command, and in the middle of an RFC 2047
+                // encoded word, which may not contain whitespace at all.  The
+                // callers that want a wrapped MIME body ask for one.
+                return encode(s, 0);
+            }
+
         }
-        
+
+        // -------------------------------------------------- quoted-printable
+
         namespace qp {
-            
-            std::string decode(const std::string& s) {
-                std::string ret;
-                
-                int i=0;
-                int j=i;
-                
-                while((unsigned int)i<s.length() && (j=s.find("=", i)) != -1) {
-                    ret += s.substr(i,j-i);
-                    if(s[j+1] == '\n') {
-                        i = j+2;
+
+            static int hex(unsigned char c)
+            {
+                if(c >= '0' && c <= '9') return c - '0';
+                if(c >= 'a' && c <= 'f') return c - 'a' + 10;
+                if(c >= 'A' && c <= 'F') return c - 'A' + 10;
+
+                return -1;
+            }
+
+            std::string decode(const std::string& s, bool& clean)
+            {
+                std::string out;
+
+                out.reserve(s.size());
+                clean = true;
+
+                for(std::string::size_type i = 0; i < s.size(); i++) {
+                    if(s[i] != '=') { out += s[i]; continue; }
+
+                    // A soft line break, RFC 2045 6.7 rule 5.
+                    if(i + 2 < s.size() && s[i + 1] == '\r' && s[i + 2] == '\n') {
+                        i += 2;
+                        continue;
                     }
-                    else if(s[j+1] == '\r' && s[j+2] == '\n') {
-                        i = j+3;
+
+                    if(i + 1 < s.size() && s[i + 1] == '\n') {
+                        i += 1;
+                        continue;
+                    }
+
+                    const int hi = i + 1 < s.size() ? hex(s[i + 1]) : -1;
+                    const int lo = i + 2 < s.size() ? hex(s[i + 2]) : -1;
+
+                    // An escape that is not one.  Passed through as written
+                    // rather than decoded: strtol used to accept "=ZZ", stop
+                    // at the first character it could not read, and return
+                    // zero, so a stray equals sign became a NUL byte in the
+                    // middle of the message.
+                    if(hi < 0 || lo < 0) {
+                        clean = false;
+                        out += s[i];
+                        continue;
+                    }
+
+                    out += static_cast<char>(hi * 16 + lo);
+                    i += 2;
+                }
+
+                return out;
+            }
+
+            std::string decode(const std::string& s)
+            {
+                bool clean;
+
+                return decode(s, clean);
+            }
+
+            std::string encode(const std::string& s)
+            {
+                // RFC 2045 6.7, the body form.  This was an empty function
+                // returning the empty string, with a TODO where the body
+                // should be.
+                //
+                // Not RFC 2047's "Q" encoding, which is a different rule set
+                // on the same idea -- it writes a space as "_" and must escape
+                // anything a header field may not contain.  That belongs with
+                // Headers::encode.
+                static const char* const HEX = "0123456789ABCDEF";
+
+                std::string out;
+                std::size_t column = 0;
+
+                for(std::string::size_type i = 0; i < s.size(); i++) {
+                    const unsigned char c = static_cast<unsigned char>(s[i]);
+
+                    if(c == '\n') {
+                        out += '\n';
+                        column = 0;
+                        continue;
+                    }
+
+                    // Rule 3: whitespace may stand for itself, but not at the
+                    // end of a line, where transport would strip it.
+                    const bool trailing = (c == ' ' || c == '\t') &&
+                        (i + 1 == s.size() || s[i + 1] == '\n' || s[i + 1] == '\r');
+
+                    const bool literal = c >= 33 && c <= 126 && c != '=';
+                    const std::size_t width = (literal || (!trailing &&
+                                              (c == ' ' || c == '\t'))) ? 1 : 3;
+
+                    // Rule 5: at most 76 characters, and the "=" of a soft
+                    // break needs a column of its own.
+                    if(column + width > 75) {
+                        out += "=\r\n";
+                        column = 0;
+                    }
+
+                    if(width == 1) {
+                        out += static_cast<char>(c);
+                    }
+                    else if(c == '\r') {
+                        // A bare CR, since CRLF was handled above.
+                        out += "=0D";
                     }
                     else {
-                        std::string ch = s.substr(j+1,2);
-                        char val = std::strtol(ch.c_str(), NULL, 16);
-                        ret.append(1,val);
-                        i = j+3;
+                        out += '=';
+                        out += HEX[c >> 4];
+                        out += HEX[c & 0x0F];
                     }
-                }
-                ret += s.substr(i);
-                return ret;
-            }
 
-            std::string encode(const std::string& s) {
-                std::string ret;
-                
-                //TODO: write qp::encode()
-                
-                return ret;
+                    column += width;
+                }
+
+                return out;
             }
 
         }
 
+        // --------------------------------------------------------------- uri
 
         namespace uri {
 
-            const std::string reserved = ";/?:@&=+$,%";
-
-	    std::string hex_value(unsigned char c, bool upper) {
-		const unsigned int size=16;
-		char buffer[size];
-
-		snprintf(buffer, size-1, "%02x", c);
-
-		std::string ret(buffer);
-
-		if(upper) {
-		    for (unsigned int i = 0; i < ret.size(); i++) {
-			ret[i] = toupper(ret[i]);
-		    }
-		    return ret;
-		}
-		else {
-		    return ret;
-		}
-
-	    }
-
-
-            std::string encode(const std::string& s) {
-                std::string::size_type i, j=0;
-                std::string ret = s;
-                while( (i=ret.find_first_of(reserved,j)) != std::string::npos ) {
-                    std::string tmp = "%" + hex_value(ret[i], false);
-                    ret.replace(i,1,tmp);
-                    j = i+tmp.length();
-                }
-                return ret;
+            /**
+             * RFC 3986 2.3.  Everything else is escaped.
+             *
+             * The old list went the other way round -- it named eleven
+             * characters to escape and left the rest alone -- so a space, a
+             * quote and every byte over 0x7F went into a URI untouched.
+             */
+            static bool unreserved(unsigned char c)
+            {
+                return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') ||
+                       (c >= '0' && c <= '9') ||
+                       c == '-' || c == '.' || c == '_' || c == '~';
             }
 
-            std::string decode(const std::string& s) {
-                std::string ret = s;
-                std::string::size_type i;
-                while( (i=ret.find("%")) != ret.npos ) {
-                    std::string hex = ret.substr(i+1,2);
-                    char c = strtol(hex.c_str(), NULL, 16);
-                    ret.replace(i,3,1,c);
+            std::string encode(const std::string& s)
+            {
+                static const char* const HEX = "0123456789ABCDEF";
+
+                std::string out;
+
+                out.reserve(s.size());
+
+                for(unsigned char c : s) {
+                    if(unreserved(c)) {
+                        out += static_cast<char>(c);
+                    }
+                    else {
+                        // 2.1: uppercase hex digits are the canonical form.
+                        out += '%';
+                        out += HEX[c >> 4];
+                        out += HEX[c & 0x0F];
+                    }
                 }
 
-                return ret;
+                return out;
+            }
+
+            std::string decode(const std::string& s, bool& clean)
+            {
+                std::string out;
+
+                out.reserve(s.size());
+                clean = true;
+
+                for(std::string::size_type i = 0; i < s.size(); i++) {
+                    if(s[i] != '%') { out += s[i]; continue; }
+
+                    const int hi = i + 1 < s.size() ? qp::hex(s[i + 1]) : -1;
+                    const int lo = i + 2 < s.size() ? qp::hex(s[i + 2]) : -1;
+
+                    if(hi < 0 || lo < 0) {
+                        clean = false;
+                        out += s[i];
+                        continue;
+                    }
+
+                    out += static_cast<char>(hi * 16 + lo);
+                    i += 2;
+                }
+
+                return out;
+            }
+
+            std::string decode(const std::string& s)
+            {
+                bool clean;
+
+                return decode(s, clean);
             }
 
         }

--- a/jlib/util/util.hh
+++ b/jlib/util/util.hh
@@ -23,6 +23,7 @@
 
 #include <sys/stat.h>
 
+#include <cstddef>
 #include <cstdio>
 #include <cstring>
 #include <cctype>
@@ -290,55 +291,101 @@ namespace jlib {
         void store(std::ostream& os, std::map<std::string,std::string>& m);
 
         /**
-         * namespace base64 contains functions that encode and decode base64 encryption
+         * base64, RFC 4648 section 4 as MIME uses it.
+         *
+         * ## Decoding is lenient, and says when it had to be
+         *
+         * RFC 2045 6.8 requires that characters outside the alphabet be
+         * ignored in base64-encoded data -- that rule is what makes the line
+         * breaks in a MIME body work, so it is not optional.  But "ignored"
+         * covers both a CRLF, which is expected, and a byte of corruption,
+         * which is not, so the two-argument form says which happened:
+         *
+         *     bool clean;
+         *     std::string data = base64::decode(part, clean);
+         *     if(!clean) { ... }   // something was skipped, or the tail was
+         *                          // short, or there was data after the "="
+         *
+         * A final group of one symbol carries six bits, which is not a byte.
+         * It is dropped and clean goes false, rather than being rounded up
+         * into a byte that the sender never wrote.
          */
         namespace base64 {
-            
-            /**
-             * Decode the std::string into a blob.
-             *
-             * @param s std::string to parse data from
-             * @return decoded data
-             */
+
+            /** Decoded bytes.  See the note above on what is skipped. */
             std::string decode(const std::string& s);
-            
+
+            /** As decode(s), and clears clean if anything was not as declared. */
+            std::string decode(const std::string& s, bool& clean);
+
             /**
-             * Encode the blob into a string.
+             * Encoded, on one line.
              *
-             * @param s std::string to parse data from
-             * @return encoded data
+             * No line breaks: an SMTP AUTH token and an RFC 2047 encoded word
+             * both go through here and neither may contain whitespace.  Ask
+             * for wrapping where a MIME body wants it.
              */
             std::string encode(const std::string& s);
 
+            /** Encoded, broken with CRLF every wrap columns.  0 means never. */
+            std::string encode(const std::string& s, std::size_t wrap);
+
         }
-        
+
+        /**
+         * Quoted-printable, RFC 2045 section 6.7.
+         *
+         * Not RFC 2047's "Q" encoding, which is a different rule set on the
+         * same idea and belongs with Headers.
+         */
         namespace qp {
-            
+
             /**
-             * Decode the std::string into a blob.
+             * Decoded bytes.
              *
-             * @param s std::string to parse data from
-             * @return decoded data
+             * An "=" that does not begin a valid escape is passed through as
+             * written and clears clean.  It used to be run through strtol,
+             * which stops at the first character it cannot read and returns
+             * zero, so "=ZZ" became a NUL byte in the middle of the message.
              */
             std::string decode(const std::string& s);
-            
-            /**
-             * Encode the blob into a string.
-             *
-             * @param s std::string to parse data from
-             * @return encoded data
-             */
+            std::string decode(const std::string& s, bool& clean);
+
+            /** Encoded, with soft line breaks at 76 columns. */
             std::string encode(const std::string& s);
 
         }
 
-
+        /**
+         * Percent-encoding, RFC 3986 sections 2.1 and 2.3.
+         */
         namespace uri {
+
+            /**
+             * Everything outside unreserved -- ALPHA DIGIT "-" "." "_" "~" --
+             * is escaped.
+             *
+             * This used to name eleven characters to escape and leave the
+             * rest, so a space, a quote and every byte over 0x7F went into a
+             * URI untouched.
+             */
             std::string encode(const std::string& s);
+
+            /**
+             * Decoded bytes.
+             *
+             * A "%" that does not begin a valid escape is passed through and
+             * clears clean.  The old version restarted its search from the
+             * front of the string after every replacement, so a "%" that came
+             * out of one escape was decoded again -- "%2525" came back as a
+             * NUL rather than as "%25".
+             */
             std::string decode(const std::string& s);
+            std::string decode(const std::string& s, bool& clean);
+
         }
-       
-        
+
+
         namespace xml {
             std::string encode(const std::string& s);
             std::string decode(const std::string& s);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -60,6 +60,7 @@ TESTS = \
 	sys_sync_test \
  \
 	util_test \
+	util_codec_test \
 	util_headers_test \
 	util_headers_manual_test \
 	util_headers_fold_test \
@@ -146,6 +147,9 @@ sys_sync_test_LDADD   = $(JSYS_LA)
 
 util_test_SOURCES = util_test.cc
 util_test_LDADD   = $(JUTIL_LA)
+util_codec_test_SOURCES         = util_codec_test.cc
+util_codec_test_LDADD           = $(JUTIL_LA)
+
 util_headers_test_SOURCES = util_headers_test.cc
 util_headers_test_LDADD   = $(JUTIL_LA)
 util_headers_manual_test_SOURCES = util_headers_manual_test.cc

--- a/tests/util_codec_test.cc
+++ b/tests/util_codec_test.cc
@@ -1,0 +1,334 @@
+/* -*- mode: C++ c-basic-offset: 4 -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// base64, quoted-printable and percent-encoding.
+//
+// These three sit under every MIME body and every encoded header, so they read
+// bytes a stranger chose.  Two of the three were reading out of bounds while
+// doing it, and all three answered a malformed escape with a NUL byte.
+
+#include <jlib/util/util.hh>
+
+#include <iostream>
+#include <string>
+
+using namespace jlib::util;
+
+static int failures = 0;
+
+static void ok(const std::string& what, bool good, const std::string& detail = "") {
+    if(!good) ++failures;
+    std::cout << (good ? "  ok   " : "  FAIL ") << what;
+    if(!detail.empty()) std::cout << ": " << detail;
+    std::cout << "\n";
+}
+
+static std::string show(const std::string& s) {
+    std::string out;
+
+    for(unsigned char c : s) {
+        if(c == '\\')                       out += "\\\\";
+        else if(c == '\r')                  out += "\\r";
+        else if(c == '\n')                  out += "\\n";
+        else if(c >= 0x20 && c < 0x7f)      out += static_cast<char>(c);
+        else {
+            static const char* h = "0123456789abcdef";
+            out += "\\x";
+            out += h[c >> 4];
+            out += h[c & 0xF];
+        }
+    }
+
+    return out;
+}
+
+/** Every byte value, so nothing can be right by accident on ASCII alone. */
+static std::string all_octets() {
+    std::string s;
+
+    for(int i = 0; i < 256; i++) s += static_cast<char>(i);
+
+    return s;
+}
+
+static void base64_round_trips() {
+    std::cout << "base64, RFC 4648 4:\n";
+
+    // RFC 4648 section 10's vectors, which is the point of having them.
+    struct { const char* in; const char* out; } v[] = {
+        { "",       ""         },
+        { "f",      "Zg=="     },
+        { "fo",     "Zm8="     },
+        { "foo",    "Zm9v"     },
+        { "foob",   "Zm9vYg==" },
+        { "fooba",  "Zm9vYmE=" },
+        { "foobar", "Zm9vYmFy" },
+    };
+
+    for(const auto& t : v) {
+        ok(std::string("encode(\"") + t.in + "\")",
+           base64::encode(t.in) == t.out, base64::encode(t.in));
+        ok(std::string("decode(\"") + t.out + "\")",
+           base64::decode(t.out) == t.in, show(base64::decode(t.out)));
+    }
+
+    // And every byte, at every alignment, so a sign-extension bug in the
+    // encoder cannot hide in the bytes ASCII does not reach.
+    for(int off = 0; off < 3; off++) {
+        const std::string in = std::string(off, 'x') + all_octets();
+
+        ok("all 256 octets round trip at offset " + std::to_string(off),
+           base64::decode(base64::encode(in)) == in);
+    }
+}
+
+static void base64_reads_within_its_input() {
+    std::cout << "\nbase64 on input from a stranger:\n";
+
+    // The decode table had 123 entries and was indexed with a plain char, so
+    // "{|}~" ran off the end of it and every byte over 0x7F was a negative
+    // index.  ASan caught this one; the test is here so it stays caught.
+    bool clean = true;
+
+    ok("\"~~~~\" does not read past the table",
+       base64::decode("~~~~", clean).empty());
+    ok("  and says the input was not base64", !clean);
+
+    ok("a byte over 0x7F is skipped, not indexed",
+       base64::decode("\xff\xfe\xfd\xfc", clean).empty() && !clean);
+
+    // The old decoder stepped four at a time and read in[2] and in[3]
+    // unconditionally, so a final group of one to three symbols read past the
+    // end of the string and appended whatever was there.  That is what a
+    // truncated message looks like.
+    ok("a two-symbol tail decodes to one byte",
+       base64::decode("aGk") == "hi", show(base64::decode("aGk")));
+
+    ok("and a long one does not pick up a neighbour",
+       base64::decode("aGVsbG8gdGhlcmUgd29ybGQhIQ") == "hello there world!!",
+       show(base64::decode("aGVsbG8gdGhlcmUgd29ybGQhIQ")));
+
+    // Two symbols legitimately encode one byte -- 12 bits, of which 8 are
+    // used -- so a short tail is not by itself wrong.
+    ok("a two-symbol tail is a byte", base64::decode("Zm9vYg") == "foob",
+       show(base64::decode("Zm9vYg")));
+
+    // One symbol is six bits, which is not a byte at any alignment.
+    ok("a one-symbol tail is dropped, not rounded up",
+       base64::decode("Zm9vY", clean) == "foo" && !clean,
+       show(base64::decode("Zm9vY")));
+}
+
+static void base64_is_lenient_and_says_so() {
+    std::cout << "\nbase64, what was skipped:\n";
+
+    bool clean = false;
+
+    // RFC 2045 6.8 requires this: it is what makes a wrapped MIME body work.
+    ok("line breaks are ignored",
+       base64::decode("Zm9v\r\nYmFy", clean) == "foobar");
+    ok("  and that is not a complaint", clean);
+
+    ok("but a character that is not whitespace is",
+       base64::decode("Zm9v!YmFy", clean) == "foobar" && !clean);
+
+    // Padding means the data ended.  Decoding on past it produced a byte
+    // that neither half of "Zg==Zg==" encodes.
+    ok("decoding stops at the padding",
+       base64::decode("Zg==Zg==", clean) == "f" && !clean,
+       show(base64::decode("Zg==Zg==")));
+}
+
+static void base64_line_wrapping() {
+    std::cout << "\nbase64 line breaks:\n";
+
+    const std::string long_input(200, 'x');
+
+    // The old encoder wrapped at 64 unconditionally.  Two of the three callers
+    // are broken by that: an SMTP AUTH token with a newline in it is not a
+    // valid command, and RFC 2047 2 says an encoded word may contain no
+    // whitespace at all.  A credential over 48 bytes was long enough to hit it.
+    const std::string plain = base64::encode(long_input);
+
+    ok("encode() does not wrap",
+       plain.find('\n') == std::string::npos && plain.find('\r') == std::string::npos);
+
+    ok("an SMTP AUTH token stays on one line",
+       base64::encode(std::string(1, '\0') + std::string(40, 'u') +
+                      std::string(1, '\0') + std::string(40, 'p'))
+           .find('\n') == std::string::npos);
+
+    const std::string wrapped = base64::encode(long_input, 76);
+
+    ok("encode(s, 76) does wrap", wrapped.find("\r\n") != std::string::npos);
+
+    for(std::string::size_type i = 0, n; i < wrapped.size(); i = n + 2) {
+        n = wrapped.find("\r\n", i);
+        const std::string line = wrapped.substr(i, n == wrapped.npos ? n : n - i);
+
+        if(line.size() > 76) {
+            ok("no line over 76 characters", false, std::to_string(line.size()));
+            break;
+        }
+
+        if(n == wrapped.npos) break;
+    }
+
+    ok("no line over 76 characters", true);
+    ok("and it still decodes to the same bytes",
+       base64::decode(wrapped) == long_input);
+}
+
+static void quoted_printable() {
+    std::cout << "\nquoted-printable, RFC 2045 6.7:\n";
+
+    ok("a plain string is itself", qp::decode("hello") == "hello");
+    ok("an escape",                qp::decode("a=3Db") == "a=b");
+    ok("lowercase hex too",        qp::decode("=e2=98=83") == "\xe2\x98\x83");
+    ok("a soft line break",        qp::decode("abc=\r\ndef") == "abcdef");
+    ok("and a bare LF one",        qp::decode("abc=\ndef") == "abcdef");
+
+    bool clean = true;
+
+    // strtol stops at the first character it cannot read and returns zero, so
+    // every one of these used to come back as a NUL byte in the middle of the
+    // message.
+    struct { const char* in; const char* out; } bad[] = {
+        { "=ZZ", "=ZZ" },
+        { "a=",  "a="  },
+        { "=1",  "=1"  },
+        { "= 1", "= 1" },
+        { "=+1", "=+1" },
+    };
+
+    for(const auto& b : bad) {
+        clean = true;
+        const std::string got = qp::decode(b.in, clean);
+
+        ok(std::string("\"") + b.in + "\" is passed through, not zeroed",
+           got == b.out && !clean, show(got));
+    }
+
+    // encode() was an empty function returning "".
+    ok("encode is not a stub any more", qp::encode("hello") == "hello");
+    ok("an equals sign is escaped",     qp::encode("a=b") == "a=3Db");
+    ok("and a high byte",               qp::encode("\xe2\x98\x83") == "=E2=98=83",
+       qp::encode("\xe2\x98\x83"));
+
+    // Rule 3: whitespace may stand for itself, but not where a transport would
+    // strip it.
+    ok("a space in the middle stays a space", qp::encode("a b") == "a b");
+    ok("a trailing one is escaped",           qp::encode("a ") == "a=20",
+       qp::encode("a "));
+
+    for(int off = 0; off < 3; off++) {
+        const std::string in = std::string(off, 'x') + all_octets();
+
+        ok("all 256 octets round trip at offset " + std::to_string(off),
+           qp::decode(qp::encode(in)) == in);
+    }
+
+    // Rule 5.
+    const std::string wrapped = qp::encode(std::string(300, 'x'));
+
+    bool fits = true;
+
+    for(std::string::size_type i = 0, n; i < wrapped.size(); i = n + 2) {
+        n = wrapped.find("\r\n", i);
+        if(n == wrapped.npos) break;
+        if(n - i > 76) fits = false;
+    }
+
+    ok("no encoded line runs past 76 characters", fits);
+}
+
+static void percent_encoding() {
+    std::cout << "\npercent-encoding, RFC 3986 2.1 and 2.3:\n";
+
+    // The decoder restarted its search from the front of the string after
+    // every replacement, so a "%" that came out of one escape was decoded
+    // again -- and once there was nothing left to read, strtol returned zero.
+    ok("a percent that decodes to a percent stops there",
+       uri::decode("%2525") == "%25", show(uri::decode("%2525")));
+
+    bool clean = true;
+
+    ok("a truncated escape is passed through",
+       uri::decode("a%", clean) == "a%" && !clean, show(uri::decode("a%")));
+    ok("and one that is not hex",
+       uri::decode("%zz", clean) == "%zz" && !clean, show(uri::decode("%zz")));
+
+    ok("a good one is not a complaint",
+       uri::decode("a%20b", clean) == "a b" && clean);
+
+    // encode used to name eleven characters to escape and leave everything
+    // else, so a space went into a URI as a space.
+    ok("a space is escaped",   uri::encode("a b") == "a%20b", uri::encode("a b"));
+    ok("a quote is escaped",   uri::encode("\"") == "%22");
+    ok("a high byte is too",   uri::encode("\xe2\x98\x83") == "%E2%98%83",
+       uri::encode("\xe2\x98\x83"));
+
+    // RFC 3986 2.3: these six and only these six stand for themselves.
+    ok("unreserved characters are left alone",
+       uri::encode("aZ09-._~") == "aZ09-._~", uri::encode("aZ09-._~"));
+
+    ok("uppercase hex, which 2.1 calls canonical",
+       uri::encode("\xff") == "%FF", uri::encode("\xff"));
+
+    for(int off = 0; off < 3; off++) {
+        const std::string in = std::string(off, 'x') + all_octets();
+
+        ok("all 256 octets round trip at offset " + std::to_string(off),
+           uri::decode(uri::encode(in)) == in);
+    }
+}
+
+int main() {
+    std::cout << std::unitbuf;
+
+    base64_round_trips();
+    base64_reads_within_its_input();
+    base64_is_lenient_and_says_so();
+    base64_line_wrapping();
+    quoted_printable();
+    percent_encoding();
+
+    // What a green run does NOT establish.
+    //
+    // Not memory safety.  A test can show that a decoder returns the right
+    // bytes; it cannot show that it read only its own.  The out-of-bounds
+    // reads these tests are named for were found by AddressSanitizer, not by
+    // assertions, and nothing in `make check` runs under it -- so a future
+    // regression of the same kind would produce the right answer here and
+    // still be a bug.  Build with -fsanitize=address to check that part.
+    //
+    // Not RFC 2047's "Q" encoding.  qp::encode is the body form of
+    // quoted-printable; the header form writes a space as "_" and must escape
+    // everything a field may not contain.  Headers::encode still only ever
+    // emits "?B?", which is why nobody noticed qp::encode was an empty stub.
+    //
+    // Not the base64 alphabet variants.  RFC 4648 section 5's URL-safe
+    // alphabet, which uses "-" and "_" for 62 and 63, is not accepted and
+    // decodes to nothing with clean set false.  Nothing in jlib needs it.
+    //
+    // Not canonical-form checking.  RFC 4648 section 3.5 allows an
+    // implementation to reject a final group whose unused bits are not zero;
+    // this one accepts it silently, because real mail contains it.
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
Closes #88 and closes #89.  base64, quoted-printable and percent-encoding sit under
every MIME body and every encoded header, so they read bytes a stranger chose.
Two of the three were reading out of bounds while doing it, and all three
answered a malformed escape with a NUL byte.

    macOS  40 tests, 40 pass, 0 skip
    Linux  41 tests, 40 pass, 1 skip

    jlib/util/util.cc            the three namespaces, rewritten
    jlib/util/util.hh            declarations and what they promise
    jlib/net/net.cc              two callers that were asking for the wrong thing
    tests/util_codec_test.cc     new

base64 was reading out of bounds, twice

    The decode table had 123 entries and was indexed with a plain `char`.  So
    "{|}~" ran off the end of it, and every byte over 0x7F was a *negative*
    index.  AddressSanitizer, on decode("~~~~"):

        ==82159==ERROR: AddressSanitizer: global-buffer-overflow
        READ of size 1 ... util.cc:386
        0x...247e is located 34 bytes before global variable
            'jlib::util::base64::encode_table' ... of size 64

    Separately, the four-byte inner decode read in[2] and in[3]
    unconditionally, while the loop that called it stepped four at a time and
    could stop within three bytes of the end.  That is what a truncated message
    or a stripped line break looks like, and it corrupted the output even where
    the allocation happened to have slack:

        decode("aGVsbG8gdGhlcmUgd29ybGQhIQ")  ->  "hello there world!!  "
                                                                     ^^

    The table is 256 entries indexed through `unsigned char` now, with -1 for
    "not base64", and decoding accumulates six bits at a time instead of
    stepping in quads.  The test rounds all 256 octet values through, at three
    alignments, so a sign-extension bug cannot hide in the bytes ASCII does not
    reach.

all three turned a bad escape into a NUL

        uri::decode("%2525")  = |\x00|   want |%25|
        uri::decode("a%")     = |a\x00|  want |a%|
        uri::decode("%zz")    = |\x00|   want |%zz|
        qp::decode("=ZZ")     = |\x00|   want |=ZZ|

    Two causes.  `uri::decode` restarted `find("%")` from position 0 after
    every replacement, so a "%" that came *out* of an escape was decoded again
    -- the same bug as the infinite loop already fixed in `util::recode`, which
    is: resume after what you wrote.  And both decoders read their hex with
    `strtol`, which accepts leading whitespace and a sign, stops at the first
    character it cannot read, and returns 0 -- so "=ZZ", "= 1" and "%+1" all
    "succeeded" with a zero byte.

    A malformed escape is passed through as written now, and there is a
    two-argument form that says so:

        bool clean;
        std::string data = base64::decode(part, clean);

    Lenient by default because RFC 2045 6.8 *requires* it -- ignoring
    characters outside the alphabet is what makes the line breaks in a MIME
    body work -- but "ignored" covers both a CRLF, which is expected, and a
    byte of corruption, which is not, and a caller should be able to tell them
    apart.

encode() no longer wraps, and two callers were wrong about it

    The old base64::encode put a newline in after every 64 characters,
    unconditionally.  Of its three callers, two are broken by that:

      net.cc:712   an SMTP AUTH token -- a newline ends the command
      Headers.cc:420  an RFC 2047 encoded word -- RFC 2047 2 says it may
                      contain no whitespace at all

    48 bytes of credentials was enough to trip the first.  encode(s) is one
    line now, and the third caller -- a MIME body in build_mime, which does
    want wrapping -- asks for encode(s, 76).

    While there: build_mime declared quoted-printable and then appended the
    body unencoded, so a message with a high byte in it was labelled one thing
    and sent as another.  It did that because qp::encode was an empty function
    with a TODO where the body should be.  It is RFC 2045 6.7 now, soft line
    breaks and all.

uri::encode was escaping the wrong set

    It named eleven characters to escape and left everything else, so a space
    went into a URI as a space.  RFC 3986 2.3 defines it the other way round:
    ALPHA, DIGIT, "-", ".", "_", "~" stand for themselves and everything else
    is escaped.  Nothing in the tree called it, so nothing depended on the old
    behaviour.

a decision worth flagging

    decode() now stops at the padding rather than reading past it.
    "Zg==Zg==" used to produce a byte that neither half encodes, because the
    bits after the "=" were accumulated onto the leftovers from before it.
    Padding means the data ended; what follows is not part of this value.

what a green run does not establish

    Not memory safety.  A test can show a decoder returns the right bytes; it
    cannot show it read only its own.  The two out-of-bounds reads this branch
    is named for were found by AddressSanitizer, not by an assertion, and
    nothing in `make check` runs under it -- so a regression of the same kind
    would produce the right answers here and still be a bug.  The test says
    this, and the suite was run under -fsanitize=address,undefined by hand
    before this landed.

    Not RFC 2047's "Q" encoding -- qp::encode is the body form.  The header
    form writes a space as "_" and has its own escaping rules; that is #90.
