### PR TITLE
Read RFC 2047 encoded words with a grammar, and move MIME into util

### DIFF
--- a/jlib/net/Email.cc
+++ b/jlib/net/Email.cc
@@ -19,7 +19,7 @@
  */
 
 #include <jlib/net/net.hh>
-#include <jlib/net/content_type.hh>
+#include <jlib/util/content_type.hh>
 
 #include <jlib/sys/sys.hh>
 
@@ -113,12 +113,12 @@ namespace jlib {
             // icontains(type, "multipart") used to be the test, so a
             // Content-Type of text/plain; name="multipart.txt" was a multipart
             // message.  is() compares the type, not the header.
-            net::content_type ctype;
+            util::content_type ctype;
 
             try {
-                ctype = net::content_type::parse(type);
+                ctype = util::content_type::parse(type);
             }
-            catch(net::content_type::exception& e) {
+            catch(util::content_type::exception& e) {
                 // An unreadable Content-Type is text/plain, which is what
                 // RFC 2045 5.2 says to do with one that is missing, and is
                 // what the sanitizing above already assumes.
@@ -142,7 +142,7 @@ namespace jlib {
                 // The split is RFC 2046 5.1.1 now, rather than parse_divide on
                 // "--" + bound.  It is the leading CRLF belonging to the
                 // delimiter that this gets right and the old loop did not.
-                for(std::string& part : net::split_multipart(m_raw.substr(header_end),
+                for(std::string& part : util::split_multipart(m_raw.substr(header_end),
                                                              bound)) {
                     m_attach.push_back(Email(std::move(part)));
                 }
@@ -359,13 +359,13 @@ namespace jlib {
             const std::string::size_type slash = type.find('/');
 
             try {
-                const net::content_type c = net::content_type::parse(find("CONTENT-TYPE"));
+                const util::content_type c = util::content_type::parse(find("CONTENT-TYPE"));
 
                 if(slash == type.npos) return c.is(type);
 
                 return c.is(type.substr(0, slash), type.substr(slash + 1));
             }
-            catch(net::content_type::exception&) {
+            catch(util::content_type::exception&) {
                 return false;
             }
         }
@@ -408,9 +408,9 @@ namespace jlib {
             // -- which is how any name with a non-ASCII character in it
             // arrives -- it did not know about at all.
             try {
-                return net::content_type::parse(find("CONTENT-TYPE")).get("name");
+                return util::content_type::parse(find("CONTENT-TYPE")).get("name");
             }
-            catch(net::content_type::exception&) {
+            catch(util::content_type::exception&) {
                 return std::string();
             }
         }
@@ -421,12 +421,12 @@ namespace jlib {
             // RFC 2045 after it.
             try {
                 const std::string name =
-                    net::content_type::parse_disposition(find("CONTENT-DISPOSITION"))
+                    util::content_type::parse_disposition(find("CONTENT-DISPOSITION"))
                         .get("filename");
 
                 if(!name.empty()) return name;
             }
-            catch(net::content_type::exception&) {
+            catch(util::content_type::exception&) {
             }
 
             // Falling back to Content-Type's "name" is new.  Every mail client

--- a/jlib/net/Makefile.am
+++ b/jlib/net/Makefile.am
@@ -4,7 +4,7 @@ lib_LTLIBRARIES = libjnet.la
 libjnet_la_SOURCES = Email.cc MailBox.cc Imap4Box.cc Pop3.cc MBox.cc \
                      Imap4.cc Imap4Fetch.cc net.cc MFolder.cc Imap4Folder.cc \
                      MailFolder.cc ASMailBox.cc ASImapBox.cc ASMBox.cc \
-                     address.cc content_type.cc
+                     address.cc
 libjnet_la_LDFLAGS = -version-info $(LIBJ_SO_VERSION) -release $(JLIB_RELEASE) -no-undefined
 libjnet_la_LIBADD = $(top_builddir)/jlib/sys/libjsys.la \
                     $(top_builddir)/jlib/util/libjutil.la \
@@ -15,5 +15,4 @@ libjnetincludedir = $(includedir)/jlib-1.2/jlib/net
 libjnetinclude_HEADERS = Imap4Box.hh Pop3.hh MBox.hh Email.hh \
                          Imap4.hh Imap4Fetch.hh net.hh MFolder.hh \
                          Imap4Folder.hh MailBox.hh MailFetch.hh MailFolder.hh \
-                         ASMailBox.hh ASImapBox.hh ASMBox.hh address.hh rfc5322.hh \
-                         content_type.hh rfc2045.hh
+                         ASMailBox.hh ASImapBox.hh ASMBox.hh address.hh rfc5322.hh

--- a/jlib/net/address.cc
+++ b/jlib/net/address.cc
@@ -37,7 +37,7 @@ using util::abnf::options;
 
 grammar build(bool obsolete, bool lenient)
 {
-    std::string text = rfc5322::LEXICAL;
+    std::string text = util::rfc5322::LEXICAL;
 
     text += rfc5322::CORE;
 

--- a/jlib/net/rfc5322.hh
+++ b/jlib/net/rfc5322.hh
@@ -21,6 +21,8 @@
 #ifndef JLIB_NET_RFC5322_HH
 #define JLIB_NET_RFC5322_HH
 
+#include <jlib/util/rfc5322.hh>
+
 namespace jlib {
 namespace net {
 
@@ -31,7 +33,8 @@ namespace net {
  * RFC's own text rather than a transcription into find() and substr(), so what
  * jlib accepts can be checked against the document by reading it.
  *
- * Five pieces.  LEXICAL is section 3.2's tokens, which RFC 2045 borrows too;
+ * Four pieces, appended to jlib::util::rfc5322::LEXICAL -- section 3.2's
+ * tokens, which live in util because RFC 2045 and RFC 2047 borrow them too.
  * CORE is the rest of what every policy shares; STRICT and OBSOLETE are two
  * spellings of the six productions the RFC gives an obsolete form to, and
  * exactly one of them is appended; LENIENT is a further "=/" extension for
@@ -81,49 +84,6 @@ namespace net {
  */
 namespace rfc5322 {
 
-/**
- * Section 3.2's lexical tokens, which are not only an address's.
- *
- * Separate from CORE because RFC 2045 5.1 builds Content-Type out of these
- * same pieces -- "comments are allowed in accordance with RFC 822" -- and a
- * grammar for a media type should not have to drag addr-spec in behind it to
- * get a quoted-string.  See jlib/net/rfc2045.hh, which appends to this.
- */
-inline const char* const LEXICAL = R"ABNF(
-; 3.2.1 quoted characters
-quoted-pair     =  "\" (VCHAR / WSP)
-
-; 3.2.2 folding white space and comments
-FWS             =  [*WSP CRLF] 1*WSP
-ctext           =  %d33-39 / %d42-91 / %d93-126
-ccontent        =  ctext / quoted-pair / comment
-comment         =  "(" *([FWS] ccontent) [FWS] ")"
-CFWS            =  (1*([FWS] comment) [FWS]) / FWS
-
-; 3.2.3 atom
-atext           =  ALPHA / DIGIT / "!" / "#" / "$" / "%" / "&" / "'" /
-                   "*" / "+" / "-" / "/" / "=" / "?" / "^" / "_" / "`" /
-                   "{" / "|" / "}" / "~"
-atom            =  [CFWS] atom-text [CFWS]
-atom-text       =  1*atext                    ; jlib: names the value inside
-                                              ; the CFWS, which the span
-                                              ; otherwise includes
-dot-atom        =  [CFWS] dot-atom-text [CFWS]
-dot-atom-text   =  atom-text *("." atom-text) ; jlib: 1*atext respelled, so one
-                                              ; extractor serves both policies
-
-; 3.2.4 quoted strings
-qtext           =  %d33 / %d35-91 / %d93-126
-qcontent        =  qtext / quoted-pair
-quoted-string   =  [CFWS] DQUOTE qs-body DQUOTE [CFWS]
-qs-body         =  *([FWS] qcontent) [FWS]    ; jlib: names what is between the
-                                              ; quotes, which 3.2.4 says is the
-                                              ; whole of the value -- so the
-                                              ; trailing FWS is inside it, or a
-                                              ; parameter written as "a long "
-                                              ; loses its last space
-
-)ABNF";
 
 /**
  * Everything the address policies share: 3.2.5, 3.4.1's addr-spec, and the 3.4

--- a/jlib/util/Headers.cc
+++ b/jlib/util/Headers.cc
@@ -22,6 +22,8 @@
 
 #include <jlib/util/util.hh>
 #include <jlib/util/Headers.hh>
+#include <jlib/util/content_type.hh>
+#include <jlib/util/encoded_word.hh>
 
 #include <utility>
 
@@ -235,14 +237,26 @@ namespace jlib {
             m_length = current_length;
 
             if(find("content-type") != end()) {
-                std::string cs = "charset=";
-                std::string ctype = get("content-type");
-                std::vector<std::string> ctypev = tokenize(ctype, ";");
-                for(std::vector<std::string>::iterator x = ctypev.begin(); x != ctypev.end(); x++) {
-                    if(x->find(cs) != std::string::npos) {
-                        m_charset = trim(x->substr(x->find(cs)+cs.length()));
-                        break;
-                    }
+                // The fourth hand-rolled copy of MIME parameter parsing in the
+                // tree, and it had every bug the other three had: tokenize on
+                // ";" splits inside a quoted value, so boundary="a;b" was cut
+                // in half; find("charset=") anywhere rather than a whole-name
+                // comparison, so a boundary containing those letters won; and
+                // the value kept its quotes, so m_charset came back as
+                // "utf-8" with the quotation marks still on it and never
+                // matched a charset name anywhere else.
+                //
+                // content_type is in util now precisely so this could go --
+                // it used to be in jlib/net, which util cannot depend on.
+                try {
+                    m_charset = content_type::parse(get("content-type")).get("charset");
+                }
+                catch(content_type::exception&) {
+                    // A Content-Type that will not parse has no charset in it
+                    // to find.  RFC 2045 5.2 says to treat an unreadable one
+                    // as text/plain, which carries us-ascii by default, and
+                    // "" is what this reported for that case before.
+                    m_charset.clear();
                 }
             }
 
@@ -347,100 +361,28 @@ namespace jlib {
          * By value deliberately: val is the working buffer, decoded in place
          * and returned.
          */
-        std::string Headers::decode(std::string val, std::string& charset) {
-            //static jlib::util::Regex reg("(.*)=\\?(.+)\\?([QqBb])\\?(.+)\\?=(.*)");
-            static const std::string BEGIN = "=?", END = "?=";
-            if(getenv("JLIB_UTIL_HEADERS_DEBUG")) {
-                std::cerr <<"enter jlib::util::Headers::decode()"<<std::endl;
-            }
-            //jlib::util::Regex::Match m;
-            if(getenv("JLIB_UTIL_HEADERS_DEBUG")) {
-                std::cerr <<"\tparsing for RFC1522 header"<<std::endl;
-            }
-            
-            std::string::size_type i,j=0,k,m,n, z;
-            std::string enc, dec;
+        std::string Headers::decode(const std::string& val, std::string& charset) {
+            // This used to be forty lines of find() and substr(), with the two
+            // bug classes this repository has spent the year on.
+            //
+            // "m = val.find(\"?\", z)" was never checked against npos, so a
+            // value with an unbalanced "=?" in it read val[1] and took the
+            // whole rest of the string as the charset.  And after
+            // "val.replace(i, k + 2 - i, dec)" it resumed from k -- an index
+            // into the string as it had been *before* the replacement, which
+            // is shorter now -- so a header with two encoded words could lose
+            // the second.  The same shape as the util::recode loop.
+            std::vector<std::string> charsets;
+            const std::string out = rfc2047::decode(val, charsets);
 
-            while( (i=val.find(BEGIN,j)) != val.npos ) {
-            //while( (m=reg(val)) ) {
-                if(getenv("JLIB_UTIL_HEADERS_DEBUG")) {
-                    std::cerr <<"\tfound BEGIN"<<std::endl;
-                }
+            charset = charsets.empty() ? std::string() : charsets.front();
 
-                z = i+BEGIN.length();
-
-                if( (k=val.find(END,z)) != val.npos ) {
-                    if(getenv("JLIB_UTIL_HEADERS_DEBUG")) {
-                        std::cerr <<"\tfound END"<<std::endl;
-                        std::cerr <<"\t" << val.substr(z, k-z) <<std::endl;
-                    }
-                    m = val.find("?", z);
-                    if(val[m+2] == '?') {
-                        charset = val.substr(z, m-z);
-                        if(getenv("JLIB_UTIL_HEADERS_DEBUG")) {
-                            std::cerr <<"\tfound charset: "<< charset << std::endl;
-                        }
-                        enc = val.substr(m+3, k-m-3);
-                        dec = enc;
-
-                        if(std::toupper(val[m+1]) == 'B') {
-                            dec = base64::decode(enc);
-                        }
-                        else if(std::toupper(val[m+1]) == 'Q') {
-                            dec = qp::decode(enc);
-                        }
-                        
-                        if(getenv("JLIB_UTIL_HEADERS_DEBUG")) {
-                            std::cerr <<"\tdecoded "<<enc << " into " << dec << std::endl;
-                        }
-                        val.replace(i, k+END.length()-i, dec);
-                    }
-                }
-                
-                j = k;
-            }
-
-            
-
-            if(getenv("JLIB_UTIL_HEADERS_DEBUG")) {
-                std::cerr <<"leave jlib::util::Headers::decode()"<<std::endl;
-            }
-            return val;
+            return out;
         }
 
         std::string Headers::encode(const std::string& val, const std::string& charset) {
-            bool high = false;
-            std::string::size_type i = 0, p, x;
-            std::string ret;
-
-            while((p = find_high(val, i)) != std::string::npos) {
-                ret += val.substr(i, (p-i));
-                x = val.find(" ", p);
-                if(x != std::string::npos) {
-                    ret += ("=?" + charset + "?B?" + base64::encode(val.substr(p, (x-p))) + "?=");
-                } else {
-                    ret += ("=?" + charset + "?B?" + base64::encode(val.substr(p)) + "?=");
-                }
-
-                i = x;
-            }
-
-            if(i != std::string::npos)
-                ret += val.substr(i);
-
-            return ret;
+            return rfc2047::encode(val, charset);
         }
-
-        std::string::size_type Headers::find_high(const std::string& val, std::string::size_type p) {
-            for(; p < val.length(); p++) {
-                if(static_cast<u_char>(val[p]) > 127) {
-                    return p;
-                }
-            }
-            
-            return std::string::npos;
-        }
-
 
         u_int Headers::get_length() const {
             return m_length;

--- a/jlib/util/Headers.hh
+++ b/jlib/util/Headers.hh
@@ -115,9 +115,18 @@ namespace jlib {
 
             void clear(const std::string& key);
 
-            static std::string decode(std::string val, std::string& charset);
+            /**
+             * RFC 2047, as jlib::util::rfc2047 does it.
+             *
+             * Kept as the spelling a header caller reaches for; both are one
+             * line over jlib/util/encoded_word.hh now.  charset gets the first
+             * one seen, which is all a single out-parameter can say -- a
+             * header mixing two charsets decodes to a string that no one name
+             * describes, and rfc2047::decode's other form hands back all of
+             * them.
+             */
+            static std::string decode(const std::string& val, std::string& charset);
             static std::string encode(const std::string& val, const std::string& charset);
-            static std::string::size_type find_high(const std::string& val, std::string::size_type p);
 
             /**
              * this is from the 'content-type' header

--- a/jlib/util/Makefile.am
+++ b/jlib/util/Makefile.am
@@ -2,10 +2,13 @@ AM_CPPFLAGS = -I$(top_srcdir) $(JSONC_CFLAGS)
 
 lib_LTLIBRARIES = libjutil.la
 libjutil_la_SOURCES = abnf.cc Regex.cc MimeType.cc util.cc Date.cc xml.cc \
-                      URL.cc Headers.cc Timer.cc json.cc
+                      URL.cc Headers.cc Timer.cc json.cc content_type.cc \
+                      encoded_word.cc
 libjutil_la_LDFLAGS = -version-info $(LIBJ_SO_VERSION) -release $(JLIB_RELEASE) -no-undefined
 libjutil_la_LIBADD = $(top_builddir)/jlib/sys/libjsys.la $(JSONC_LIBS)
 
 libjutilincludedir = $(includedir)/jlib-1.2/jlib/util
 libjutilinclude_HEADERS = abnf.hh Regex.hh MimeType.hh util.hh Date.hh xml.hh \
-                          URL.hh Headers.hh Timer.hh json.hh
+                          URL.hh Headers.hh Timer.hh json.hh \
+                          content_type.hh rfc2045.hh rfc5322.hh \
+                          encoded_word.hh rfc2047.hh

--- a/jlib/util/content_type.cc
+++ b/jlib/util/content_type.cc
@@ -18,9 +18,9 @@
  *
  */
 
-#include <jlib/net/content_type.hh>
-#include <jlib/net/rfc2045.hh>
-#include <jlib/net/rfc5322.hh>
+#include <jlib/util/content_type.hh>
+#include <jlib/util/rfc2045.hh>
+#include <jlib/util/rfc5322.hh>
 
 #include <jlib/util/abnf.hh>
 
@@ -29,13 +29,13 @@
 #include <set>
 
 namespace jlib {
-namespace net {
+namespace util {
 
 namespace {
 
-using util::abnf::grammar;
-using util::abnf::match;
-using util::abnf::options;
+using abnf::grammar;
+using abnf::match;
+using abnf::options;
 
 /**
  * The grammar, built on first use.
@@ -46,7 +46,7 @@ using util::abnf::options;
 const grammar& mime()
 {
     static grammar g = [] {
-        grammar g = util::abnf::compile(std::string(rfc5322::LEXICAL) +
+        grammar g = abnf::compile(std::string(rfc5322::LEXICAL) +
                                         rfc2045::CONTENT);
         g.check();
 
@@ -266,7 +266,7 @@ struct mime_reader {
 
 content_type::exception::exception(const std::string& msg, std::string text,
                                    std::size_t offset)
-    : std::runtime_error("jlib::net::content_type::exception: " + msg),
+    : std::runtime_error("jlib::util::content_type::exception: " + msg),
       m_text(std::move(text)),
       m_offset(offset)
 {
@@ -281,11 +281,11 @@ match run(const std::string& rule, std::string_view s)
     try {
         return mime().at(rule).parse(s, parse_options());
     }
-    catch(util::abnf::budget_exceeded& e) {
+    catch(abnf::budget_exceeded& e) {
         throw content_type::exception(std::string("gave up reading a header: ")
                                       + e.what(), std::string(s), e.offset());
     }
-    catch(util::abnf::error& e) {
+    catch(abnf::error& e) {
         // The expected set for this grammar is every tchar, which tells a
         // caller nothing.  Where it stopped does.
         throw content_type::exception("not a MIME header at column "

--- a/jlib/util/content_type.hh
+++ b/jlib/util/content_type.hh
@@ -18,8 +18,8 @@
  *
  */
 
-#ifndef JLIB_NET_CONTENT_TYPE_HH
-#define JLIB_NET_CONTENT_TYPE_HH
+#ifndef JLIB_UTIL_CONTENT_TYPE_HH
+#define JLIB_UTIL_CONTENT_TYPE_HH
 
 #include <cstddef>
 #include <stdexcept>
@@ -28,12 +28,12 @@
 #include <vector>
 
 namespace jlib {
-namespace net {
+namespace util {
 
 /**
  * A Content-Type or Content-Disposition, parsed against MIME's grammar.
  *
- * The grammar is RFC 2045 5.1 and RFC 2231, in jlib/net/rfc2045.hh, read by
+ * The grammar is RFC 2045 5.1 and RFC 2231, in jlib/util/rfc2045.hh, read by
  * jlib::util::abnf::compile().  Nothing here scans by hand.
  *
  *     content_type c = content_type::parse(email.find("CONTENT-TYPE"));
@@ -189,4 +189,4 @@ std::vector<std::string> split_multipart(std::string_view body,
 }
 }
 
-#endif // JLIB_NET_CONTENT_TYPE_HH
+#endif // JLIB_UTIL_CONTENT_TYPE_HH

--- a/jlib/util/encoded_word.cc
+++ b/jlib/util/encoded_word.cc
@@ -1,0 +1,279 @@
+/* -*- mode: C++ c-basic-offset: 4 -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <jlib/util/encoded_word.hh>
+#include <jlib/util/rfc2047.hh>
+#include <jlib/util/util.hh>
+
+#include <jlib/util/abnf.hh>
+
+#include <algorithm>
+
+namespace jlib {
+namespace util {
+namespace rfc2047 {
+
+namespace {
+
+using abnf::grammar;
+using abnf::match;
+using abnf::options;
+
+/** Built on first use, for the reason at crypt/curve.hh:42. */
+const grammar& words()
+{
+    static grammar g = [] {
+        grammar g = abnf::compile(ENCODED_WORD);
+        g.check();
+
+        return g;
+    }();
+
+    return g;
+}
+
+options parse_options()
+{
+    options o;
+
+    o.captures = options::capture_policy::listed;
+    o.capture_only = { "charset", "encoding", "encoded-text" };
+
+    return o;
+}
+
+bool is_wsp(char c) { return c == ' ' || c == '\t' || c == '\r' || c == '\n'; }
+
+/**
+ * RFC 2047 4.2: like quoted-printable, but "_" is a space.
+ *
+ * The underscore rule exists because a space would end the encoded word, and
+ * "=20" everywhere is unreadable.  qp::decode does the escapes; this only has
+ * to put the spaces back first.
+ */
+std::string q_decode(std::string_view s, bool& clean)
+{
+    std::string t(s);
+
+    std::replace(t.begin(), t.end(), '_', ' ');
+
+    return qp::decode(t, clean);
+}
+
+/**
+ * The one encoded word beginning at i, or an empty span.
+ *
+ * encoded-text excludes "?" and so do charset and encoding, so the first "?="
+ * at or after i+2 is the end of the word and there is nothing to search for.
+ * Returns the offset just past it, or npos.
+ */
+std::size_t word_end(std::string_view s, std::size_t i)
+{
+    const std::size_t j = s.find("?=", i + 2);
+
+    return j == s.npos ? s.npos : j + 2;
+}
+
+/**
+ * RFC 2047 5: a word has to be delimited.
+ *
+ * Whitespace on either side, or the start or end of the field, or the
+ * parentheses of a comment.  Without this, "=?" inside an ordinary token --
+ * a URL with a query string in it, most often -- starts a decode.
+ */
+bool delimited(std::string_view s, std::size_t begin, std::size_t end)
+{
+    // Either bracket on either side: an encoded word may abut the start or
+    // the end of a comment, and being stricter than that means real headers
+    // come out as their own markup, which is the failure a user actually sees.
+    if(begin > 0 && !is_wsp(s[begin - 1]) &&
+       s[begin - 1] != '(' && s[begin - 1] != ')') return false;
+
+    if(end < s.size() && !is_wsp(s[end]) &&
+       s[end] != ')' && s[end] != '(') return false;
+
+    return true;
+}
+
+}
+
+std::string decode(std::string_view s, std::vector<std::string>& charsets)
+{
+    std::string out;
+    std::string pending;          // whitespace not yet committed to out
+    bool after_word = false;      // the last thing written was an encoded word
+
+    charsets.clear();
+    out.reserve(s.size());
+
+    for(std::size_t i = 0; i < s.size(); ) {
+        if(s[i] == '=' && i + 1 < s.size() && s[i + 1] == '?') {
+            const std::size_t end = word_end(s, i);
+
+            if(end != s.npos && delimited(s, i, end)) {
+                const std::string_view span = s.substr(i, end - i);
+                const abnf::parse_result r =
+                    words().at("encoded-word").try_parse(span, parse_options());
+
+                if(r) {
+                    const std::string enc =
+                        upper(r.root()["encoding"].str());
+                    const match text = r.root()["encoded-text"];
+
+                    bool known = true;
+                    bool clean = true;
+                    std::string dec;
+
+                    if(enc == "B")      dec = base64::decode(text.str(), clean);
+                    else if(enc == "Q") dec = q_decode(text.text(), clean);
+                    else                known = false;
+
+                    if(known) {
+                        // RFC 2047 6.2: whitespace between two adjacent
+                        // encoded words is not part of the text.  It is held
+                        // back rather than written, so that a name folded
+                        // across two words comes back without a gap in it.
+                        if(!after_word) out += pending;
+
+                        pending.clear();
+                        out += dec;
+                        charsets.push_back(lower(r.root()["charset"].str()));
+                        after_word = true;
+                        i = end;
+
+                        continue;
+                    }
+                }
+            }
+        }
+
+        // Not an encoded word.  Whitespace is held until something that is not
+        // whitespace decides whether it survives.
+        if(is_wsp(s[i])) {
+            pending += s[i];
+        }
+        else {
+            out += pending;
+            pending.clear();
+            out += s[i];
+            after_word = false;
+        }
+
+        i++;
+    }
+
+    out += pending;
+
+    return out;
+}
+
+std::string decode(std::string_view s)
+{
+    std::vector<std::string> charsets;
+
+    return decode(s, charsets);
+}
+
+namespace {
+
+/** Everything RFC 2047 4.2 lets a Q-encoded word carry unescaped. */
+bool q_literal(unsigned char c)
+{
+    return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') ||
+           (c >= '0' && c <= '9') ||
+           c == '!' || c == '*' || c == '+' || c == '-' || c == '/';
+}
+
+bool ascii(std::string_view s)
+{
+    for(unsigned char c : s) {
+        if(c >= 0x80) return false;
+    }
+
+    return true;
+}
+
+}
+
+std::string encode(std::string_view s, const std::string& charset)
+{
+    // "=?" + charset + "?B?" + text + "?=" must come to 75 or fewer.
+    const std::size_t overhead = charset.size() + 7;
+    const std::size_t room = overhead >= 75 ? 4 : 75 - overhead;
+
+    // base64 carries three octets in four characters, so this many octets fit.
+    const std::size_t chunk = std::max<std::size_t>(3, room / 4 * 3);
+
+    std::string out;
+    std::string held;   // source text waiting to go into an encoded word
+
+    // Chunks of one run, joined with a space that 6.2 takes back out.
+    const auto flush = [&] {
+        for(std::size_t k = 0; k < held.size(); k += chunk) {
+            if(k) out += " ";
+
+            out += "=?" + charset + "?B?" +
+                   base64::encode(held.substr(k, chunk)) + "?=";
+        }
+
+        held.clear();
+    };
+
+    for(std::size_t i = 0; i < s.size(); ) {
+        const std::size_t gap_at = i;
+
+        while(i < s.size() && is_wsp(s[i])) i++;
+
+        const std::string_view gap = s.substr(gap_at, i - gap_at);
+        const std::size_t word_at = i;
+
+        while(i < s.size() && !is_wsp(s[i])) i++;
+
+        const std::string_view word = s.substr(word_at, i - word_at);
+
+        if(ascii(word)) {
+            flush();
+            out += gap;
+            out += word;
+
+            continue;
+        }
+
+        // A whole word at a time.  This used to start the encoded word at the
+        // first byte over 0x7F, which produced "Jose N=?utf-8?B?...?=" -- an
+        // encoded word with no whitespace before it, which RFC 2047 5 does not
+        // allow and no conformant reader will decode.
+        //
+        // And two adjacent words that both need encoding go into *one* word,
+        // gap included, because 6.2 removes whitespace between two encoded
+        // words -- so emitting them separately would send "Jose Nunez" and
+        // deliver "JoseNunez".
+        if(held.empty()) out += gap;
+        else             held += gap;
+
+        held += word;
+    }
+
+    flush();
+
+    return out;
+}
+}
+}
+}

--- a/jlib/util/encoded_word.hh
+++ b/jlib/util/encoded_word.hh
@@ -1,0 +1,92 @@
+/* -*- mode: C++ c-basic-offset: 4 -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef JLIB_UTIL_ENCODED_WORD_HH
+#define JLIB_UTIL_ENCODED_WORD_HH
+
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace jlib {
+namespace util {
+
+/**
+ * RFC 2047 encoded words: reading and writing a header that is not ASCII.
+ *
+ *     rfc2047::decode("=?utf-8?B?U2Now7ZuZW4gVGFn?=")   ->  "Sch\xc3\xb6nen Tag"
+ *     rfc2047::encode("Sch\xc3\xb6nen Tag", "utf-8")    ->  "=?utf-8?B?U2Now7ZuZW4=?= Tag"
+ *
+ * The grammar is in jlib/util/rfc2047.hh.  What is not in the grammar, and is
+ * most of the work, is *where* a word may appear: section 5 requires that one
+ * be delimited by whitespace or by the punctuation of the construct it sits
+ * in, and section 6.2 says whitespace between two adjacent encoded words is
+ * not part of the text and disappears when they are decoded.  Both are
+ * checked here.
+ *
+ * ## Charsets are named, not converted
+ *
+ * decode() returns the octets the sender encoded, in whatever charset they
+ * named.  Nothing here transcodes, so a header mixing two charsets decodes to
+ * a string that no single charset describes -- which is a property of RFC 2047
+ * and not of this implementation.  The two-argument form hands back every
+ * charset seen, in order, so a caller that does transcode has what it needs
+ * and a caller that does not can at least notice.
+ *
+ * ## What is not decoded
+ *
+ * A word that does not parse, is not delimited, or names an encoding other
+ * than B or Q is left exactly as it was written.  Showing a user
+ * "=?x-unknown?Z?...?=" is worse than showing them the text, but it is much
+ * better than showing them a guess.
+ */
+namespace rfc2047 {
+
+/** Decode every encoded word in a header field value. */
+std::string decode(std::string_view s);
+
+/**
+ * As decode(), and collects the charset each word named, in order.
+ *
+ * Empty if the value held no encoded words.  A repeated charset appears once
+ * per word, not once per distinct name, so its size is the number of words
+ * that were decoded.
+ */
+std::string decode(std::string_view s, std::vector<std::string>& charsets);
+
+/**
+ * Encode the words of s that need it, and leave the rest alone.
+ *
+ * Splits on whitespace and encodes a *whole* word if any part of it is not
+ * ASCII, because section 5 requires an encoded word to be delimited -- the
+ * previous implementation here started the encoded word at the first byte
+ * over 0x7F, so "Jose Nunez" with a tilde in it produced
+ * "Jose N=?utf-8?B?...?=", which no conformant reader will decode.
+ *
+ * Long runs are split across several words so that none exceeds the 75
+ * characters section 2 allows.
+ */
+std::string encode(std::string_view s, const std::string& charset);
+
+}
+
+}
+}
+
+#endif // JLIB_UTIL_ENCODED_WORD_HH

--- a/jlib/util/rfc2045.hh
+++ b/jlib/util/rfc2045.hh
@@ -18,22 +18,22 @@
  *
  */
 
-#ifndef JLIB_NET_RFC2045_HH
-#define JLIB_NET_RFC2045_HH
+#ifndef JLIB_UTIL_RFC2045_HH
+#define JLIB_UTIL_RFC2045_HH
 
 namespace jlib {
-namespace net {
+namespace util {
 
 /**
  * MIME's Content-Type and Content-Disposition, as ABNF.
  *
- * Appended to jlib::net::rfc5322::LEXICAL, because RFC 2045 5.1 is explicit
+ * Appended to jlib::util::rfc5322::LEXICAL, because RFC 2045 5.1 is explicit
  * that it is not defining its own lexical layer: "comments are allowed in
  * accordance with RFC 822", and quoted-string is that document's.  So the
  * quoted-string a boundary parameter is written in is literally the same
  * production as the one a display name is written in, and it is written once.
  *
- * See jlib/net/content_type.hh for what reads it.
+ * See jlib/util/content_type.hh for what reads it.
  *
  * ## Where this departs from the published text
  *
@@ -117,4 +117,4 @@ tchar           =  %x21 / %x23-27 / %x2A-2B / %x2D-2E / %x30-39 /
 }
 }
 
-#endif // JLIB_NET_RFC2045_HH
+#endif // JLIB_UTIL_RFC2045_HH

--- a/jlib/util/rfc2047.hh
+++ b/jlib/util/rfc2047.hh
@@ -1,0 +1,91 @@
+/* -*- mode: C++ c-basic-offset: 4 -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef JLIB_UTIL_RFC2047_HH
+#define JLIB_UTIL_RFC2047_HH
+
+namespace jlib {
+namespace util {
+
+/**
+ * RFC 2047 encoded words, as ABNF.
+ *
+ * How a Subject or a display name carries a character that a header field may
+ * not: the text is encoded to ASCII and wrapped in a marker naming the charset
+ * it came from.
+ *
+ *     Subject: =?utf-8?B?U2Now7ZuZW4gVGFn?=
+ *
+ * Read by jlib::util::abnf::compile(); see jlib/util/encoded_word.hh for what
+ * uses it.  Self-contained -- unlike rfc2045.hh it does not append to
+ * rfc5322::LEXICAL, because an encoded word may not contain whitespace or a
+ * comment and so has no use for CFWS.
+ *
+ * ## Where this departs from the published text
+ *
+ * Marked with "; jlib:" comments, as the other grammars here are.  RFC 2047
+ * writes its productions in the RFC 822 style with prose exclusions, so
+ * etchar and etext are those exclusions worked out as ranges -- the same
+ * situation as tchar in rfc2045.hh, and the test spells out every excluded
+ * character for the same reason.
+ *
+ * ## What the grammar does not decide
+ *
+ * Where an encoded word is *allowed* to appear.  RFC 2047 section 5 gives
+ * three contexts -- as a token in unstructured text, inside a comment, and as
+ * a word in a phrase -- and in each of them the word must be delimited by
+ * whitespace or by the enclosing punctuation.  A grammar for the word itself
+ * cannot say that; encoded_word.cc checks the delimiters around each match,
+ * which is what stops "=?" in the middle of an ordinary token from being read
+ * as the start of one.
+ *
+ * Nor the 75-character limit in section 2.  It is stated as a MUST and real
+ * senders exceed it constantly, so it is accepted on the way in and obeyed on
+ * the way out.
+ */
+namespace rfc2047 {
+
+inline const char* const ENCODED_WORD = R"ABNF(
+; RFC 2047 2
+encoded-word    =  "=?" charset ["*" language] "?" encoding "?" encoded-text "?="
+charset         =  etoken
+language        =  etoken
+encoding        =  etoken
+
+; "any printable ASCII character other than '?' or SPACE"
+; jlib: as ranges.  0x3F is "?" and 0x20 is the space.
+encoded-text    =  1*etext
+etext           =  %x21-3E / %x40-7E
+
+; RFC 2047 2: "any CHAR except SPACE, CTLs, and especials", where
+;     especials = "(" / ")" / "<" / ">" / "@" / "," / ";" / ":" / <"> /
+;                 "/" / "[" / "]" / "?" / "." / "="
+; jlib: as ranges.  Note especials is not RFC 2045's tspecials -- it adds "."
+; and it does not exclude "\", so this is not rfc2045.hh's token and cannot
+; borrow it.
+etoken          =  1*etchar
+etchar          =  %x21 / %x23-27 / %x2A-2B / %x2D / %x30-39 / %x41-5A /
+                   %x5C / %x5E-7E
+)ABNF";
+
+}
+}
+}
+
+#endif // JLIB_UTIL_RFC2047_HH

--- a/jlib/util/rfc5322.hh
+++ b/jlib/util/rfc5322.hh
@@ -1,0 +1,88 @@
+/* -*- mode: C++ c-basic-offset: 4 -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef JLIB_UTIL_RFC5322_HH
+#define JLIB_UTIL_RFC5322_HH
+
+namespace jlib {
+namespace util {
+
+/**
+ * RFC 5322 section 3.2, the lexical tokens the mail RFCs share.
+ *
+ * Here rather than in jlib/net because three grammars need them and only one
+ * of the three is about addresses.  RFC 2045 5.1 says its Content-Type
+ * parameters use "the parameter syntax of RFC 822", RFC 2047 2 builds an
+ * encoded word out of the same tokens, and RFC 5322 3.4 uses them for
+ * addresses -- so the quoted-string a boundary is written in, the one an
+ * encoded word's charset may be written in, and the one a display name is
+ * written in are one production, written once.
+ *
+ * Appended to by:
+ *
+ *     jlib/util/rfc2045.hh    Content-Type and Content-Disposition
+ *     jlib/util/rfc2047.hh    encoded words
+ *     jlib/net/rfc5322.hh     addresses
+ *
+ * See jlib/util/abnf.hh for what reads it, and jlib/net/rfc5322.hh for the
+ * house rules on marking a departure from a published grammar.
+ */
+namespace rfc5322 {
+
+inline const char* const LEXICAL = R"ABNF(
+; 3.2.1 quoted characters
+quoted-pair     =  "\" (VCHAR / WSP)
+
+; 3.2.2 folding white space and comments
+FWS             =  [*WSP CRLF] 1*WSP
+ctext           =  %d33-39 / %d42-91 / %d93-126
+ccontent        =  ctext / quoted-pair / comment
+comment         =  "(" *([FWS] ccontent) [FWS] ")"
+CFWS            =  (1*([FWS] comment) [FWS]) / FWS
+
+; 3.2.3 atom
+atext           =  ALPHA / DIGIT / "!" / "#" / "$" / "%" / "&" / "'" /
+                   "*" / "+" / "-" / "/" / "=" / "?" / "^" / "_" / "`" /
+                   "{" / "|" / "}" / "~"
+atom            =  [CFWS] atom-text [CFWS]
+atom-text       =  1*atext                    ; jlib: names the value inside
+                                              ; the CFWS, which the span
+                                              ; otherwise includes
+dot-atom        =  [CFWS] dot-atom-text [CFWS]
+dot-atom-text   =  atom-text *("." atom-text) ; jlib: 1*atext respelled, so one
+                                              ; extractor serves both policies
+
+; 3.2.4 quoted strings
+qtext           =  %d33 / %d35-91 / %d93-126
+qcontent        =  qtext / quoted-pair
+quoted-string   =  [CFWS] DQUOTE qs-body DQUOTE [CFWS]
+qs-body         =  *([FWS] qcontent) [FWS]    ; jlib: names what is between the
+                                              ; quotes, which 3.2.4 says is the
+                                              ; whole of the value -- so the
+                                              ; trailing FWS is inside it, or a
+                                              ; parameter written as "a long "
+                                              ; loses its last space
+
+)ABNF";
+
+}
+}
+}
+
+#endif // JLIB_UTIL_RFC5322_HH

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -61,6 +61,7 @@ TESTS = \
  \
 	util_test \
 	util_codec_test \
+	util_rfc2047_test \
 	util_headers_test \
 	util_headers_manual_test \
 	util_headers_fold_test \
@@ -147,6 +148,9 @@ sys_sync_test_LDADD   = $(JSYS_LA)
 
 util_test_SOURCES = util_test.cc
 util_test_LDADD   = $(JUTIL_LA)
+util_rfc2047_test_SOURCES       = util_rfc2047_test.cc
+util_rfc2047_test_LDADD         = $(JUTIL_LA)
+
 util_codec_test_SOURCES         = util_codec_test.cc
 util_codec_test_LDADD           = $(JUTIL_LA)
 

--- a/tests/net_address_test.cc
+++ b/tests/net_address_test.cc
@@ -287,7 +287,7 @@ static void extending_the_grammar() {
     // RFC 6532 is written as one incremental alternative, and so is this.
     using namespace jlib::util::abnf;
 
-    grammar g = compile(std::string(jlib::net::rfc5322::LEXICAL) +
+    grammar g = compile(std::string(jlib::util::rfc5322::LEXICAL) +
                         jlib::net::rfc5322::CORE +
                         jlib::net::rfc5322::OBSOLETE + R"ABNF(
 atext           =/ UTF8-non-ascii
@@ -361,7 +361,7 @@ static void the_grammar_itself() {
         std::string why;
 
         try {
-            grammar g = compile(std::string(jlib::net::rfc5322::LEXICAL) +
+            grammar g = compile(std::string(jlib::util::rfc5322::LEXICAL) +
                                 jlib::net::rfc5322::CORE + d);
             g.check();
             built = true;

--- a/tests/net_mime_test.cc
+++ b/tests/net_mime_test.cc
@@ -25,8 +25,8 @@
 // parse error a caller can see -- the message simply does not come apart into
 // its pieces, and an attachment goes missing.
 
-#include <jlib/net/content_type.hh>
-#include <jlib/net/rfc2045.hh>
+#include <jlib/util/content_type.hh>
+#include <jlib/util/rfc2045.hh>
 #include <jlib/net/rfc5322.hh>
 #include <jlib/net/Email.hh>
 
@@ -35,8 +35,8 @@
 #include <iostream>
 #include <string>
 
-using jlib::net::content_type;
-using jlib::net::split_multipart;
+using jlib::util::content_type;
+using jlib::util::split_multipart;
 
 static int failures = 0;
 
@@ -418,8 +418,8 @@ static void the_grammar_itself() {
     std::string why;
 
     try {
-        grammar g = compile(std::string(jlib::net::rfc5322::LEXICAL) +
-                            jlib::net::rfc2045::CONTENT);
+        grammar g = compile(std::string(jlib::util::rfc5322::LEXICAL) +
+                            jlib::util::rfc2045::CONTENT);
         g.check();
         built = true;
     }

--- a/tests/util_rfc2047_test.cc
+++ b/tests/util_rfc2047_test.cc
@@ -1,0 +1,336 @@
+/* -*- mode: C++ c-basic-offset: 4 -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// RFC 2047 encoded words: how a Subject or a display name carries a character
+// that a header field may not.
+//
+// The address and MIME tests both disclaimed this and said it was Headers'
+// job.  This is that job, and the interesting half of it is not the grammar --
+// it is section 5, which says where an encoded word may appear, and section
+// 6.2, which says what happens to the whitespace between two of them.
+
+#include <jlib/util/encoded_word.hh>
+#include <jlib/util/rfc2047.hh>
+#include <jlib/util/Headers.hh>
+
+#include <jlib/util/abnf.hh>
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+using jlib::util::Headers;
+namespace rfc2047 = jlib::util::rfc2047;
+
+static int failures = 0;
+
+static void ok(const std::string& what, bool good, const std::string& detail = "") {
+    if(!good) ++failures;
+    std::cout << (good ? "  ok   " : "  FAIL ") << what;
+    if(!detail.empty()) std::cout << ": " << detail;
+    std::cout << "\n";
+}
+
+// Written out as escapes so the file stays ASCII and the bytes are unambiguous.
+static const char* const SCHOENEN = "Sch\xc3\xb6nen Tag";        // Schönen Tag
+static const char* const JOSE     = "Jos\xc3\xa9 N\xc3\xba\xc3\xb1" "ez";
+
+static void the_two_encodings() {
+    std::cout << "decoding:\n";
+
+    ok("B, which is base64",
+       rfc2047::decode("=?utf-8?B?U2Now7ZuZW4gVGFn?=") == SCHOENEN,
+       rfc2047::decode("=?utf-8?B?U2Now7ZuZW4gVGFn?="));
+
+    // RFC 2047 4.2: like quoted-printable, except "_" is a space -- because a
+    // real space would end the word and "=20" everywhere is unreadable.
+    ok("Q, which is quoted-printable with a twist",
+       rfc2047::decode("=?utf-8?Q?Sch=C3=B6nen_Tag?=") == SCHOENEN,
+       rfc2047::decode("=?utf-8?Q?Sch=C3=B6nen_Tag?="));
+
+    ok("lowercase b and q too",
+       rfc2047::decode("=?utf-8?b?U2No?=") == "Sch" &&
+       rfc2047::decode("=?utf-8?q?S=63h?=") == "Sch");
+
+    ok("a word among ordinary text",
+       rfc2047::decode("Re: =?utf-8?B?U2Now7ZuZW4=?= Tag") == "Re: " + std::string(SCHOENEN),
+       rfc2047::decode("Re: =?utf-8?B?U2Now7ZuZW4=?= Tag"));
+
+    ok("and text with no words in it is untouched",
+       rfc2047::decode("no encoded words here") == "no encoded words here");
+
+    // RFC 2231 5's language tag, which is legal and rare.
+    ok("a language tag is accepted and discarded",
+       rfc2047::decode("=?utf-8*de?B?U2No?=") == "Sch",
+       rfc2047::decode("=?utf-8*de?B?U2No?="));
+}
+
+static void the_charsets_come_back() {
+    std::cout << "\nwhich charset:\n";
+
+    std::vector<std::string> cs;
+
+    rfc2047::decode("=?iso-8859-1?Q?a?= =?utf-8?B?Yg==?=", cs);
+
+    ok("one per word, in order",
+       cs.size() == 2 && cs[0] == "iso-8859-1" && cs[1] == "utf-8",
+       cs.empty() ? "none" : cs[0] + " " + (cs.size() > 1 ? cs[1] : ""));
+
+    // A single out-parameter cannot describe that string, which is a property
+    // of RFC 2047 rather than of this code: the two halves are in different
+    // encodings and nothing here transcodes.
+    std::string one;
+    Headers::decode("=?iso-8859-1?Q?a?= =?utf-8?B?Yg==?=", one);
+
+    ok("and Headers::decode reports the first", one == "iso-8859-1", one);
+
+    rfc2047::decode("nothing encoded", cs);
+    ok("none when there were no words", cs.empty());
+
+    ok("names fold to lower case",
+       (rfc2047::decode("=?UTF-8?B?U2No?=", cs), cs.size() == 1 && cs[0] == "utf-8"),
+       cs.empty() ? "" : cs[0]);
+}
+
+static void where_a_word_may_appear() {
+    std::cout << "\nsection 5, which the grammar cannot say:\n";
+
+    // An encoded word has to be delimited.  Without this rule, a "=?" in the
+    // middle of an ordinary token starts a decode -- and a URL with a query
+    // string in it is the case that turns up.
+    ok("not decoded in the middle of a token",
+       rfc2047::decode("x=?utf-8?B?U2No?=") == "x=?utf-8?B?U2No?=");
+
+    ok("nor is a stray one in a URL",
+       rfc2047::decode("http://x/?a==?b") == "http://x/?a==?b");
+
+    ok("but it is at the start of the field",
+       rfc2047::decode("=?utf-8?B?U2No?= x") == "Sch x");
+
+    ok("and inside a comment",
+       rfc2047::decode("(=?utf-8?B?U2No?=)") == "(Sch)",
+       rfc2047::decode("(=?utf-8?B?U2No?=)"));
+
+    // Left alone rather than guessed at.
+    ok("an unterminated word",
+       rfc2047::decode("=?utf-8?B?U2No") == "=?utf-8?B?U2No");
+    ok("an encoding that is neither B nor Q",
+       rfc2047::decode("=?utf-8?Z?U2No?=") == "=?utf-8?Z?U2No?=");
+    ok("a word with a piece missing",
+       rfc2047::decode("=?utf-8?B?=") == "=?utf-8?B?=");
+    ok("and an empty charset",
+       rfc2047::decode("=??B?U2No?=") == "=??B?U2No?=");
+}
+
+static void the_whitespace_rule() {
+    std::cout << "\nsection 6.2, the whitespace between two words:\n";
+
+    // "the 'linear-white-space' between adjacent 'encoded-word's is ignored"
+    // -- because a long name gets folded across two of them and must come back
+    // as one word.
+    ok("goes away between two adjacent words",
+       rfc2047::decode("=?utf-8?B?U2No?= =?utf-8?B?w7ZuZW4=?=") == "Sch\xc3\xb6nen",
+       rfc2047::decode("=?utf-8?B?U2No?= =?utf-8?B?w7ZuZW4=?="));
+
+    ok("including a fold",
+       rfc2047::decode("=?utf-8?B?U2No?=\r\n =?utf-8?B?w7ZuZW4=?=") == "Sch\xc3\xb6nen");
+
+    // But only between two of them.
+    ok("and stays where a word is not on both sides",
+       rfc2047::decode("=?utf-8?B?U2No?=  plain  =?utf-8?B?w7ZuZW4=?=")
+           == "Sch  plain  \xc3\xb6nen",
+       rfc2047::decode("=?utf-8?B?U2No?=  plain  =?utf-8?B?w7ZuZW4=?="));
+
+    ok("including before the first",
+       rfc2047::decode("  =?utf-8?B?U2No?=") == "  Sch");
+    ok("and after the last",
+       rfc2047::decode("=?utf-8?B?U2No?=  ") == "Sch  ");
+}
+
+static void encoding() {
+    std::cout << "\nencoding:\n";
+
+    ok("ASCII is left exactly alone",
+       rfc2047::encode("plain ascii", "utf-8") == "plain ascii");
+
+    // The old encoder started the encoded word at the first byte over 0x7F, so
+    // a word with an accent in the middle of it produced
+    // "Jose N=?utf-8?B?...?=" -- an encoded word with no whitespace before it,
+    // which section 5 does not allow and no conformant reader will decode.
+    const std::string one = rfc2047::encode(SCHOENEN, "utf-8");
+
+    ok("a whole word is encoded, not the tail of one",
+       one == "=?utf-8?B?U2Now7ZuZW4=?= Tag", one);
+
+    ok("and the ASCII word beside it is not", one.find(" Tag") != std::string::npos);
+
+    // Two adjacent words that both need encoding go into one word, because
+    // 6.2 would eat the space between two.  This is the assertion that caught
+    // it: the first version emitted two and delivered "JoseNunez".
+    const std::string two = rfc2047::encode(JOSE, "utf-8");
+
+    ok("two adjacent words become one, gap included",
+       two == "=?utf-8?B?Sm9zw6kgTsO6w7Fleg==?=", two);
+
+    for(const char* s : { "plain ascii", SCHOENEN, JOSE, "", " ", "a  b",
+                          "\xc3\xa9", "  leading", "trailing  ",
+                          "mixed \xc3\xa9 and ascii \xc3\xa9 again" }) {
+        ok(std::string("round trips: \"") + s + "\"",
+           rfc2047::decode(rfc2047::encode(s, "utf-8")) == s,
+           rfc2047::decode(rfc2047::encode(s, "utf-8")));
+    }
+}
+
+static void the_length_limit() {
+    std::cout << "\nsection 2, seventy-five characters:\n";
+
+    std::string long_word = "a ";
+
+    for(int i = 0; i < 40; i++) long_word += "\xc3\xa9";
+
+    long_word += " b";
+
+    const std::string out = rfc2047::encode(long_word, "utf-8");
+
+    bool fits = true;
+    std::size_t words = 0;
+
+    for(std::string::size_type i = 0; (i = out.find("=?", i)) != out.npos; ) {
+        const std::string::size_type j = out.find("?=", i + 2);
+
+        if(j == out.npos) break;
+
+        words++;
+        if(j + 2 - i > 75) fits = false;
+        i = j + 2;
+    }
+
+    ok("a long run is split across several words", words > 1,
+       std::to_string(words));
+    ok("and none of them exceeds 75 characters", fits);
+    ok("and it still round trips",
+       rfc2047::decode(out) == long_word, rfc2047::decode(out));
+
+    // A charset name long enough to leave no room is still handled rather
+    // than producing an encoded word with no text in it.
+    const std::string wide =
+        rfc2047::encode("\xc3\xa9\xc3\xa9", std::string(80, 'x'));
+
+    ok("an absurd charset name does not produce an empty word",
+       wide.find("?B??=") == std::string::npos, wide.substr(0, 40));
+}
+
+static void through_headers() {
+    std::cout << "\nthrough Headers:\n";
+
+    Headers h("Subject: =?utf-8?B?U2Now7ZuZW4=?= Tag\r\n"
+              "From: =?utf-8?Q?Jos=C3=A9?= <jose@x.com>\r\n"
+              "\r\n");
+
+    ok("a Subject is decoded",
+       h.get("SUBJECT") == SCHOENEN, h.get("SUBJECT"));
+    ok("and a display name",
+       h.get("FROM") == "Jos\xc3\xa9 <jose@x.com>", h.get("FROM"));
+
+    std::string charset;
+    h.get("SUBJECT", charset);
+
+    ok("with the charset it named", charset == "utf-8", charset);
+
+    // A header folded across two encoded words, which is what a long name
+    // arrives as and what 6.2 exists for.
+    Headers folded("Subject: =?utf-8?B?U2No?=\r\n =?utf-8?B?w7ZuZW4=?=\r\n\r\n");
+
+    ok("a folded pair of words rejoins with no gap",
+       folded.get("SUBJECT") == "Sch\xc3\xb6nen", folded.get("SUBJECT"));
+
+    ok("and encode is the inverse",
+       Headers::decode(Headers::encode(SCHOENEN, "utf-8"), charset) == SCHOENEN);
+}
+
+static void the_grammar_itself() {
+    std::cout << "\nthe grammar:\n";
+
+    using namespace jlib::util::abnf;
+
+    bool built = false;
+    std::string why;
+
+    try {
+        grammar g = compile(jlib::util::rfc2047::ENCODED_WORD);
+        g.check();
+        built = true;
+    }
+    catch(exception& e) { why = e.what(); }
+
+    ok("it compiles and checks", built, why);
+
+    // etchar is the one place the RFC states an exclusion in prose and the
+    // grammar states ranges, so a reader cannot check it by comparing.  Every
+    // character of especials, plus the space, spelled out.  Note it is not
+    // RFC 2045's tspecials: especials adds "." and does not exclude "\".
+    for(char c : std::string(" ()<>@,;:\"/[]?.=")) {
+        const std::string s = std::string("=?ut") + c + "f8?B?U2No?=";
+
+        ok(std::string("etchar excludes '") + c + "'",
+           rfc2047::decode(s) == s, rfc2047::decode(s));
+    }
+
+    ok("but not a backslash, which especials does not list",
+       rfc2047::decode("=?ut\\f8?B?U2No?=") == "Sch",
+       rfc2047::decode("=?ut\\f8?B?U2No?="));
+}
+
+int main() {
+    std::cout << std::unitbuf;
+
+    the_two_encodings();
+    the_charsets_come_back();
+    where_a_word_may_appear();
+    the_whitespace_rule();
+    encoding();
+    the_length_limit();
+    through_headers();
+    the_grammar_itself();
+
+    // What a green run does NOT establish.
+    //
+    // Not that the decoded bytes are readable.  decode() returns the octets
+    // the sender encoded, in whatever charset they named; nothing here
+    // transcodes, so a header mixing two charsets comes back as a string that
+    // no single charset describes.  That is RFC 2047's shape, not this
+    // implementation's, and the two-argument form exists so a caller can at
+    // least see it happen.
+    //
+    // Not the full placement rules of section 5.  It gives three contexts --
+    // unstructured text, a comment, and a word in a phrase -- with slightly
+    // different rules in each, and what is implemented is the one thing common
+    // to all three: an encoded word must be delimited.  In particular nothing
+    // here refuses an encoded word inside a quoted string, which section 5
+    // forbids.
+    //
+    // Not the 75-character limit on the way in.  It is a MUST that real
+    // senders break constantly, so a longer word is accepted; encode() obeys
+    // it going out, which is the direction jlib controls.
+    //
+    // Not Q on the way out.  encode() always writes B, which is correct but
+    // wasteful for a string that is mostly ASCII -- "=?utf-8?Q?Sch=C3=B6nen?="
+    // is shorter and readable, and a real mail client would choose.
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
Closes #90 and closes #91.  The address test and the MIME test both disclaimed RFC
2047 and said it was Headers' job; this is that job, and the move had to come
first because Headers is in util and the grammars were in net.

    macOS  41 tests, 41 pass, 0 skip
    Linux  42 tests, 41 pass, 1 skip

    jlib/net/{content_type,rfc2045} ->  jlib/util/
    jlib/util/rfc5322.hh                new -- section 3.2, split out
    jlib/util/rfc2047.hh                new -- the grammar
    jlib/util/encoded_word.{hh,cc}      new -- the codec
    tests/util_rfc2047_test.cc          new
    jlib/util/Headers.cc                -110 net

the move, and why it was blocking

    Headers::parse ended with the fourth hand-rolled copy of MIME parameter
    parsing in the tree:

        std::vector<std::string> ctypev = tokenize(ctype, ";");
        if(x->find("charset=") != std::string::npos)
            m_charset = trim(x->substr(...));

    Every bug the other three had.  tokenize on ";" splits inside a quoted
    value, so boundary="a;b" was cut in half; find() anywhere rather than a
    whole-name comparison, so a boundary containing those letters won; and the
    value kept its quotes, so m_charset came back as "utf-8" with the
    quotation marks still on it and never matched a charset name anywhere.

    content_type could not be used from there.  It was in jlib/net and the
    dependency direction is sys <- util <- crypt <- net.  That was the wrong
    place for it: it parses a MIME header, Headers parses MIME headers, and
    nothing about it is specific to a mail client.

    So content_type and rfc2045.hh are in util, and rfc5322.hh's LEXICAL --
    section 3.2's quoted-string, comment, CFWS, atom -- is its own header in
    util, because three grammars need it and only one of the three is about
    addresses.  jlib/net/rfc5322.hh keeps the address productions and appends
    to it.  Headers::parse is one line now and the fourth copy is gone.

what the old RFC 2047 decoder did

    Forty lines of find() and substr(), with the two bug classes this
    repository has spent the year on.

        m = val.find("?", z);
        if(val[m+2] == '?') {
            charset = val.substr(z, m-z);

    `m` was never checked against npos.  With no second "?", m+2 wraps to 1 --
    so it read val[1], and substr(z, npos-z) took the whole rest of the string
    as the charset.  That is the same npos truncation already fixed in
    extract_address, MFolder, Imap4 and util::excise.

    And after `val.replace(i, k + END.length() - i, dec)` it resumed from `k`,
    an index into the string as it had been *before* the replacement -- which
    is shorter now.  A header with two encoded words could lose the second.
    The same shape as the util::recode loop.

    Neither showed up in a test because a header with one well-formed encoded
    word in it works fine either way.

the interesting half is not the grammar

    rfc2047.hh is nine productions.  What it cannot say is section 5 -- where
    an encoded word is *allowed* to appear -- and section 6.2, and those are
    where the behaviour lives.

    Section 5: a word must be delimited by whitespace or by the punctuation of
    the construct around it.  Without that rule a "=?" in the middle of an
    ordinary token starts a decode, and the case that turns up is a URL with a
    query string in it.  So "http://x/?a==?b" is left alone.

    Section 6.2: whitespace between two *adjacent* encoded words is not part
    of the text and disappears.  It exists because a long name gets folded
    across two words and has to come back as one.  Held-back whitespace, not
    emitted until something decides whether it survives.

    That rule also caught a bug in the encoder I had just written.  Encoding
    "Jose Nunez" with accents produced two encoded words with a space between
    them -- and 6.2 ate the space, so it decoded to "JoseNunez".  Two adjacent
    words that both need encoding go into one word now, gap included.

encoding was producing headers no reader will decode

    The old encoder started the encoded word at the first byte over 0x7F:

        Jose N=?utf-8?B?w7rDsWV6?=

    An encoded word with no whitespace before it, which section 5 does not
    allow -- so a conformant reader displays it verbatim and the user sees the
    markup.  Any name with an accent anywhere but the first letter of the
    first word.  A whole word at a time now, and a long run split across
    several words so none exceeds the 75 characters section 2 allows.

what a green run does not establish

    Written down in the test.  Not that the decoded bytes are readable -- the
    octets come back in whatever charset the sender named and nothing here
    transcodes, so a header mixing two charsets decodes to a string no single
    charset describes.  That is RFC 2047's shape, not this implementation's,
    and the two-argument form exists so a caller can see it happen.

    Not the full placement rules of section 5.  It gives three contexts with
    slightly different rules; what is implemented is the one thing common to
    all three.  Nothing here refuses an encoded word inside a quoted string,
    which section 5 forbids.

    Not the 75-character limit on the way in -- a MUST that real senders break
    constantly, so it is accepted and only obeyed going out.

    Not Q on the way out.  encode() always writes B, which is correct but
    wasteful for a mostly-ASCII string: "=?utf-8?Q?Sch=C3=B6nen?=" is shorter
    and readable, and a real client would choose between them.
