### PR TITLE
Run programs without a shell, and stop building command lines from strings

### DIFF
--- a/jlib/apps/jm3u.cc
+++ b/jlib/apps/jm3u.cc
@@ -40,6 +40,8 @@ int main(int argc, char** argv) {
 	    player = ::getenv("JM3U_PLAYER");
 	}
 
+	std::string out, err;
+
 	for(int i = 1; i < argc; i++) {
 	    std::string path = argv[i];
 	    std::ifstream ifs(path.c_str());
@@ -49,11 +51,9 @@ int main(int argc, char** argv) {
 		if(ifs) {
 		    mp3 = util::trim(mp3);
 		    std::cout << "Playing " << mp3 << std::endl;
-		    std::stringstream ss;
-		    ss << player << " \"" << mp3 << "\"";
-		    std::string cmd = ss.str();
-		    std::cout << cmd << std::endl;
-		    sys::shell(cmd);
+		    // Was a command line with the path in quotes, which a
+		    // filename containing a quote, a backtick or a $ escapes.
+		    sys::run({player, mp3}, out, err);
 		}
 	    }
 	}

--- a/jlib/net/MBox.cc
+++ b/jlib/net/MBox.cc
@@ -25,6 +25,8 @@
 #include <jlib/net/MFolder.hh>
 #include <jlib/net/MBox.hh>
 
+#include <filesystem>
+
 #include <jlib/sys/sys.hh>
 #include <jlib/sys/Directory.hh>
 
@@ -149,15 +151,34 @@ namespace jlib {
         }
 
         void MBoxBuf::delete_folder(std::list<std::string> path) {
-            if(!is_inbox(path)) {
-                jlib::sys::shell("rm "+m_maildir+MailNode::pathstr(path));
+            if(is_inbox(path)) return;
+
+            // This was sys::shell("rm "+m_maildir+pathstr(path)).  The folder
+            // name comes from the filesystem or, for an IMAP account being
+            // mirrored, from the server -- so it was a command line built out
+            // of a string jlib did not choose, handed to /bin/sh, running rm.
+            // A folder named "x; rm -rf $HOME" did that.  A folder named
+            // "My Mail" merely failed, because rm saw two arguments.
+            std::error_code ec;
+
+            std::filesystem::remove_all(m_maildir + MailNode::pathstr(path), ec);
+
+            if(ec) {
+                throw exception("could not delete folder: " + ec.message());
             }
         }
 
         void MBoxBuf::rename_folder(std::list<std::string> path, std::list<std::string> npath) {
-            if(!is_inbox(path)) {
-                jlib::sys::shell("mv "+m_maildir+MailNode::pathstr(path)+" "+
-                                 m_maildir+MailNode::pathstr(npath));
+            if(is_inbox(path)) return;
+
+            // Was sys::shell("mv "+...+" "+...), with the same hazard twice.
+            std::error_code ec;
+
+            std::filesystem::rename(m_maildir + MailNode::pathstr(path),
+                                    m_maildir + MailNode::pathstr(npath), ec);
+
+            if(ec) {
+                throw exception("could not rename folder: " + ec.message());
             }
         }
 

--- a/jlib/net/net.cc
+++ b/jlib/net/net.cc
@@ -855,13 +855,17 @@ namespace jlib {
         namespace html {
             std::string render(const std::string& s) {
                 sys::tfstream buf;
-                std::string cmd,out,err;
+                std::string out, err;
 
                 buf << s;
                 buf.close();
-                cmd = "lynx -dump -force_html "+buf.get_path();
-                sys::shell(cmd,out,err);
-                    
+
+                // The path is jlib's own temporary name, so this was not
+                // exploitable -- but it was the same shape as the four that
+                // were, and there is no reason for a shell to be here.
+                sys::run({ "lynx", "-dump", "-force_html", buf.get_path() },
+                         out, err);
+
                 return out;
             }
         }

--- a/jlib/sys/sys.cc
+++ b/jlib/sys/sys.cc
@@ -31,6 +31,13 @@
 #include <cstdlib>
 #include <cstring>
 
+#include <fcntl.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <fstream>
+#include <vector>
+
 
 const int SZ = 1024;
 
@@ -249,6 +256,80 @@ namespace jlib {
                 return false;
             }
             return true;
+        }
+
+        int run(const std::vector<std::string>& argv, std::string& out, std::string& err) {
+            if(argv.empty()) {
+                throw sys_exception("jlib::sys::run() with no program to run");
+            }
+
+            // Output goes to temp files rather than pipes, which is what
+            // shell() does and avoids the deadlock a pair of pipes needs a
+            // poll loop to escape: a child that fills the stderr pipe while
+            // the parent is still reading stdout blocks forever.
+            tfstream outf, errf;
+            const std::string outp = outf.get_path(), errp = errf.get_path();
+
+            outf.close();
+            errf.close();
+
+            std::vector<char*> args;
+
+            for(const std::string& a : argv) {
+                args.push_back(const_cast<char*>(a.c_str()));
+            }
+
+            args.push_back(nullptr);
+
+            const pid_t pid = fork();
+
+            if(pid < 0) {
+                throw sys_exception("fork() in jlib::sys::run(): " +
+                                    std::string(std::strerror(errno)));
+            }
+
+            if(pid == 0) {
+                // The child.  Nothing here may throw or allocate in a way that
+                // matters -- between fork and exec, only async-signal-safe
+                // calls are defined in a process that might have threads.
+                const int o = ::open(outp.c_str(), O_WRONLY | O_TRUNC);
+                const int e = ::open(errp.c_str(), O_WRONLY | O_TRUNC);
+
+                if(o >= 0) { ::dup2(o, STDOUT_FILENO); ::close(o); }
+                if(e >= 0) { ::dup2(e, STDERR_FILENO); ::close(e); }
+
+                ::execvp(args[0], args.data());
+
+                // Only reached if exec failed.  _exit, not exit: the child
+                // shares the parent's stdio buffers and must not flush them.
+                ::_exit(127);
+            }
+
+            int status = 0;
+
+            while(::waitpid(pid, &status, 0) < 0) {
+                if(errno != EINTR) {
+                    throw sys_exception("waitpid() in jlib::sys::run(): " +
+                                        std::string(std::strerror(errno)));
+                }
+            }
+
+            std::ifstream ofs(outp.c_str()), efs(errp.c_str());
+
+            getstring(ofs, out);
+            getstring(efs, err);
+
+            if(WIFSIGNALED(status)) {
+                return 128 + WTERMSIG(status);
+            }
+
+            const int code = WIFEXITED(status) ? WEXITSTATUS(status) : -1;
+
+            if(code == 127 && out.empty() && err.empty()) {
+                throw sys_exception("could not run \"" + argv[0] + "\"");
+            }
+
+            return code;
         }
 
         void shell(const std::string& cmd) {

--- a/jlib/sys/sys.hh
+++ b/jlib/sys/sys.hh
@@ -26,6 +26,7 @@
 #include <string>
 
 #include <functional>
+#include <vector>
 
 #include <signal.h>
 #include <sys/socket.h>
@@ -141,9 +142,34 @@ namespace jlib {
         bool locked(const std::string& s);
 
         /**
+         * Run a program.  No shell is involved.
+         *
+         * argv[0] is the program, looked up on PATH, and the rest are its
+         * arguments exactly as written -- a space, a quote, a semicolon or a
+         * backtick in one of them is a character in an argument and nothing
+         * else.  Its standard output and standard error come back in out and
+         * err, and the return value is the exit status.
+         *
+         *     sys::run({ "file", "--mime-type", "-b", path }, out, err);
+         *
+         * This is what to reach for.  shell() below builds a command line and
+         * hands it to /bin/sh, so every caller of it that interpolates a
+         * string it did not choose is an injection: jlib had five, and two of
+         * them were "rm" and "mv" on a folder name that came from a mail
+         * server.
+         *
+         * Throws sys::exception if the program could not be started.  A
+         * program that ran and failed is not an exception -- that is what the
+         * status is for.
+         */
+        int run(const std::vector<std::string>& argv, std::string& out, std::string& err);
+
+        /**
          * run the std::string as a shell command, and throw an exception
          * if the command fails
-         * 
+         *
+         * The string is parsed by /bin/sh, so anything interpolated into it
+         * is code.  Use run() unless a shell is what is actually wanted.
          */
         void shell(const std::string& cmd);
 

--- a/jlib/util/MimeType.cc
+++ b/jlib/util/MimeType.cc
@@ -23,6 +23,7 @@
 
 #include <jlib/util/util.hh>
 #include <jlib/util/MimeType.hh>
+#include <jlib/util/content_type.hh>
 
 //#include <gnome-1.0/gnome.h>
 
@@ -30,80 +31,55 @@ namespace jlib {
     namespace util {
         
         
-        std::string MimeType::get_type_from_file(const std::string& path) {
-            //return gnome_mime_type_of_file(path.c_str());
-            std::string out, err;
-            sys::shell("file "+path, out, err);
+        namespace {
 
-            return parse_file_output(out);
+            /**
+             * file(1), asked for the answer rather than for a sentence.
+             *
+             * --mime-type -b prints "image/jpeg" and nothing else, so there is
+             * no output to parse.  What was here instead ran icontains() over
+             * file's English prose looking for the words "image" and "JPEG" --
+             * and over the *whole* of its output, which begins with the
+             * filename, so a file called JPEG-notes.txt was an image/jpeg.
+             * The variable that was supposed to cut the name off was computed
+             * and never read.
+             */
+            std::string sniff(const std::string& path) {
+                std::string out, err;
+
+                // sys::run, not sys::shell: the path is a filename, and
+                // "file "+path handed it to /bin/sh.  A file named
+                // "x; rm -rf ~" ran as a command.
+                if(sys::run({ "file", "--mime-type", "-b", path }, out, err) != 0) {
+                    return "application/octet-stream";
+                }
+
+                const std::string type = util::trim(out);
+
+                // A type is "type/subtype" and nothing else.  file prints
+                // "cannot open ..." on stdout for a file it cannot read, and
+                // that is not a media type.
+                if(!content_type::valid(type)) {
+                    return "application/octet-stream";
+                }
+
+                return type;
+            }
+
+        }
+
+        std::string MimeType::get_type_from_file(const std::string& path) {
+            return sniff(path);
         }
 
         std::string MimeType::get_type_from_data(const std::string& data) {
-            std::string ret;
-            std::string out, err;
             jlib::sys::tfstream in;
+
             in << data;
             in.close();
 
-            sys::shell("file "+in.get_path(), out, err);
-            return parse_file_output(out);
+            return sniff(in.get_path());
         }
 
-        std::string MimeType::parse_file_output(const std::string& data) {
-            // On a local: this overwrote its own parameter.
-            const std::string body = (data.find(":") != std::string::npos)
-                ? data.substr(data.find(":"))
-                : data;
-            std::string ret;
-
-            if(icontains(data, "image")) {
-                ret = "image/";
-                if(icontains(data, "JPEG")) {
-                    ret += "jpeg";
-                }
-                else if(icontains(data, "GIF")) {
-                    ret += "gif";
-                }
-                else if(icontains(data, "PNG")) {
-                    ret += "png";
-                }
-                else 
-                    ret = "application/octet-stream";
-            }
-            else if(icontains(data, "audio")) {
-                ret = "audio/";
-                if(icontains(data, "wav")) {
-                    ret += "x-wav";
-                }
-                else
-                    ret = "application/octet-stream";
-            }
-            
-
-            else if(icontains(data, "document")) {
-                if(icontains(data, "postscript"))
-                    ret = "application/postscript";
-                else if(icontains(data, "pdf"))
-                    ret = "application/x-pdf";
-                else
-                    ret = "application/octet-stream";
-            }
-
-            else if(icontains(data, "text")) {
-                ret += "text/";
-                if(icontains(data, "HTML")) {
-                    ret += "html";
-                }
-                else {
-                    ret += "plain";
-                }
-            }
-            else {
-                ret = "application/octet-stream";
-            }
-            
-            return ret;
-        }
-        
     }
 }

--- a/jlib/util/MimeType.hh
+++ b/jlib/util/MimeType.hh
@@ -47,27 +47,21 @@ namespace jlib {
             };
 
             /**
-             * Get the Mime-Type from the given filename
+             * The media type of the file at path.
              *
-             * @param path path to file
+             * Asks file(1) with --mime-type, which prints the answer rather
+             * than a sentence about it, so nothing has to be parsed out.
+             * "application/octet-stream" when file cannot say -- an
+             * unidentifiable attachment should still be sendable.
              *
-             * @return std::string description of data's MIME type
+             * The path is passed as an argument and never through a shell.
+             * It used to be interpolated into "file "+path and handed to
+             * /bin/sh, so a file named "x; rm -rf ~" ran as a command.
              */
             static std::string get_type_from_file(const std::string& path);
 
-            /**
-             * Get the Mime-Type from the given filename
-             *
-             * @param path path to file
-             *
-             * @return std::string description of data's MIME type
-             */
+            /** The media type of a blob, via a temporary file. */
             static std::string get_type_from_data(const std::string& data);
-          
-            /**
-             * parse the text output of the UNIX file command into a mime-type
-             */
-            static std::string parse_file_output(const std::string& data);
         };
         
     }

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -58,6 +58,7 @@ TESTS = \
 	net_same_address_test \
  \
 	sys_sync_test \
+	sys_run_test \
  \
 	util_test \
 	util_codec_test \
@@ -142,6 +143,9 @@ net_same_address_test_LDADD     = $(JNET_LA)
 
 net_email_multipart_test_SOURCES = net_email_multipart_test.cc
 net_email_multipart_test_LDADD   = $(JNET_LA)
+
+sys_run_test_SOURCES            = sys_run_test.cc
+sys_run_test_LDADD              = $(JSYS_LA) $(JUTIL_LA)
 
 sys_sync_test_SOURCES = sys_sync_test.cc
 sys_sync_test_LDADD   = $(JSYS_LA)

--- a/tests/sys_run_test.cc
+++ b/tests/sys_run_test.cc
@@ -1,0 +1,253 @@
+/* -*- mode: C++ c-basic-offset: 4 -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Running a program without a shell, and identifying a file without asking a
+// shell to do it.
+//
+// jlib had five places that built a command line by concatenating a string it
+// did not choose, and handed the result to /bin/sh.  Two of them ran "rm" and
+// "mv" on a mail folder's name.
+
+#include <jlib/sys/sys.hh>
+#include <jlib/util/MimeType.hh>
+#include <jlib/util/content_type.hh>
+
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+
+namespace fs = std::filesystem;
+
+static int failures = 0;
+
+static void ok(const std::string& what, bool good, const std::string& detail = "") {
+    if(!good) ++failures;
+    std::cout << (good ? "  ok   " : "  FAIL ") << what;
+    if(!detail.empty()) std::cout << ": " << detail;
+    std::cout << "\n";
+}
+
+static std::string trimmed(const std::string& s) {
+    const std::size_t a = s.find_first_not_of(" \t\r\n");
+
+    if(a == s.npos) return std::string();
+
+    return s.substr(a, s.find_last_not_of(" \t\r\n") - a + 1);
+}
+
+static void arguments_are_arguments() {
+    std::cout << "sys::run:\n";
+
+    std::string out, err;
+
+    ok("it runs a program", jlib::sys::run({ "echo", "hello" }, out, err) == 0 &&
+       trimmed(out) == "hello", trimmed(out));
+
+    // Every one of these is punctuation to a shell and a character to
+    // everything else.  If any of them were interpreted, the output would
+    // differ from the input.
+    const std::vector<std::string> nasty = {
+        "echo", "a b", "c;d", "$HOME", "`id`", "$(id)", "x&&y", "*", "'q'", "\"r\"",
+    };
+
+    jlib::sys::run(nasty, out, err);
+
+    std::string want;
+
+    for(std::size_t i = 1; i < nasty.size(); i++) {
+        if(i > 1) want += " ";
+        want += nasty[i];
+    }
+
+    ok("and passes its arguments through untouched", trimmed(out) == want,
+       trimmed(out));
+
+    ok("the exit status comes back",
+       jlib::sys::run({ "false" }, out, err) != 0 &&
+       jlib::sys::run({ "true" }, out, err) == 0);
+
+    // A program that ran and failed is a status, not an exception.  One that
+    // could not be started at all is an exception, because there is no status
+    // to report and returning 127 would be indistinguishable from a program
+    // that exited 127 on purpose.
+    bool threw = false;
+
+    try { jlib::sys::run({ "jlib-no-such-program-xyzzy" }, out, err); }
+    catch(std::exception&) { threw = true; }
+
+    ok("a program that is not there throws", threw);
+
+    threw = false;
+    try { jlib::sys::run({}, out, err); }
+    catch(std::exception&) { threw = true; }
+
+    ok("and so does nothing to run", threw);
+
+    ok("stderr comes back separately",
+       jlib::sys::run({ "sh", "-c", "echo o; echo e >&2" }, out, err) == 0 &&
+       trimmed(out) == "o" && trimmed(err) == "e",
+       trimmed(out) + " / " + trimmed(err));
+
+    // Bigger than a pipe buffer, which is what the temp files are for: a
+    // child filling stderr while the parent reads stdout deadlocks a naive
+    // two-pipe implementation.
+    jlib::sys::run({ "sh", "-c",
+                     "i=0; while [ $i -lt 4000 ]; do echo aaaaaaaaaaaaaaaaaaaa;"
+                     " echo bbbbbbbbbbbbbbbbbbbb >&2; i=$((i+1)); done" },
+                   out, err);
+
+    ok("and neither side deadlocks on a lot of output",
+       out.size() > 80000 && err.size() > 80000,
+       std::to_string(out.size()) + " / " + std::to_string(err.size()));
+}
+
+static void a_filename_that_is_a_command() {
+    std::cout << "\na filename chosen by somebody else:\n";
+
+    const fs::path dir = fs::temp_directory_path() / "jlib-run-test";
+
+    fs::remove_all(dir);
+    fs::create_directories(dir);
+
+    // The marker goes in the working directory, because that is where a
+    // shell invoked by system() would create it -- and so the name itself can
+    // stay free of slashes and be a filename rather than a path.
+    const std::string tag = "jlib-run-test-pwned";
+    const fs::path marker = fs::current_path() / tag;
+
+    fs::remove(marker);
+
+    // A name that is a shell command.  Legal on every filesystem jlib builds
+    // for, and exactly what "file "+path handed to /bin/sh would have run.
+    const fs::path nasty = dir / ("hello.txt; touch " + tag);
+
+    {
+        std::ofstream f(nasty);
+        f << "just some text\n";
+    }
+
+    ok("the file exists", fs::exists(nasty));
+
+    const std::string type = jlib::util::MimeType::get_type_from_file(nasty.string());
+
+    ok("the marker was not created", !fs::exists(marker), type);
+
+    fs::remove(marker);
+    ok("and a type came back",
+       jlib::util::content_type::valid(type), type);
+
+    fs::remove_all(dir);
+}
+
+static void identifying_a_file() {
+    std::cout << "\nMimeType:\n";
+
+    const fs::path dir = fs::temp_directory_path() / "jlib-mime-test";
+
+    fs::remove_all(dir);
+    fs::create_directories(dir);
+
+    // The name used to decide the type: every icontains() ran over the whole
+    // of file(1)'s output, and that output begins with the filename.
+    const fs::path misleading = dir / "JPEG-notes.txt";
+
+    {
+        std::ofstream f(misleading);
+        f << "This file talks about JPEG and GIF and PNG images.\n";
+    }
+
+    const std::string type =
+        jlib::util::MimeType::get_type_from_file(misleading.string());
+
+    ok("a text file called JPEG-notes.txt is not an image",
+       type.rfind("image/", 0) != 0, type);
+
+    ok("it is text", type.rfind("text/", 0) == 0, type);
+
+    // A real one, by its content rather than its name.
+    const fs::path png = dir / "not-called-an-image";
+
+    {
+        std::ofstream f(png, std::ios::binary);
+        const unsigned char sig[] = {
+            0x89, 'P', 'N', 'G', 0x0D, 0x0A, 0x1A, 0x0A,
+            0, 0, 0, 13, 'I', 'H', 'D', 'R',
+            0, 0, 0, 1, 0, 0, 0, 1, 8, 6, 0, 0, 0,
+        };
+        f.write(reinterpret_cast<const char*>(sig), sizeof sig);
+    }
+
+    ok("and a PNG is one whatever it is called",
+       jlib::util::MimeType::get_type_from_file(png.string()) == "image/png",
+       jlib::util::MimeType::get_type_from_file(png.string()));
+
+    ok("a file that is not there is octet-stream, not an exception",
+       jlib::util::MimeType::get_type_from_file((dir / "absent").string())
+           == "application/octet-stream");
+
+    ok("and a blob is identified by its content",
+       jlib::util::MimeType::get_type_from_data("%PDF-1.4\n%\xc7\xec\x8f\xa2\n")
+           == "application/pdf",
+       jlib::util::MimeType::get_type_from_data("%PDF-1.4\n%\xc7\xec\x8f\xa2\n"));
+
+    fs::remove_all(dir);
+}
+
+int main() {
+    std::cout << std::unitbuf;
+
+    // file(1) is not guaranteed to be installed, and neither is a shell that
+    // takes -c.  Exit 77 is SKIP, which is how the tests here report a machine
+    // that cannot run them.
+    std::string out, err;
+
+    try {
+        if(jlib::sys::run({ "file", "--version" }, out, err) != 0) {
+            std::cerr << "file(1) does not understand --version; skipping\n";
+            return 77;
+        }
+    }
+    catch(std::exception& e) {
+        std::cerr << "no file(1): " << e.what() << "; skipping\n";
+        return 77;
+    }
+
+    arguments_are_arguments();
+    a_filename_that_is_a_command();
+    identifying_a_file();
+
+    // What a green run does NOT establish.
+    //
+    // Not that jlib no longer runs a shell.  sys::shell() is still there and
+    // still hands its argument to /bin/sh, which is what it is for; what
+    // changed is that nothing in the library calls it any more.  A future
+    // caller that concatenates a string into it is the same bug again, and no
+    // test can see that coming.
+    //
+    // Not that MimeType is right about any particular file.  It asks file(1)
+    // and repeats the answer, so what it says depends on the version of
+    // file(1) installed and on its magic database.  The two assertions above
+    // are about which input decides -- the content, not the name -- and not
+    // about the specific strings.
+    //
+    // Not Windows.  fork() and execvp() are POSIX, and so is everything else
+    // in jlib::sys.
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
Closes #94, and four more sites the issue did not know about.

    macOS  42 tests, 42 pass, 0 skip
    Linux  43 tests, 42 pass, 1 skip

    jlib/sys/sys.{hh,cc}         sys::run(), new
    jlib/util/MimeType.{hh,cc}   -60 net
    jlib/net/MBox.cc             rm and mv -> std::filesystem
    jlib/net/net.cc              html::render
    jlib/apps/jm3u.cc
    tests/sys_run_test.cc        new

the issue was about one site and there were five

    #94 was filed against MimeType, which did

        sys::shell("file "+path, out, err);

    and sys::shell hands its argument to /bin/sh.  Grepping for the other
    callers found four more, and two of them are worse:

        MBox.cc:153   shell("rm "+m_maildir+pathstr(path))
        MBox.cc:159   shell("mv "+...+" "+...)

    The folder name comes from the filesystem, or -- for an IMAP account being
    mirrored locally -- from the server.  A folder named "x; rm -rf $HOME"
    ran that.  A folder named "My Mail" merely failed, because rm saw two
    arguments and neither of them existed.

    net.cc's html::render passed a tfstream path, which is jlib's own name and
    was not exploitable; jm3u quoted the filename with '"', which a filename
    containing a quote, a backtick or a $ escapes.

    Nothing in the library calls sys::shell any more.

the correction #94 needs

    The issue said "jlib/sys/sys.hh already declares secure_shell beside shell
    for this".  That is wrong, and worth writing down rather than quietly
    fixing: secure_shell is not more secure against injection.  It goes
    through system() exactly as shell does; the only difference is that it
    scrubs its temporary files before deleting them.  Reaching for it would
    have felt like a fix and changed nothing.

sys::run

        int run(const std::vector<std::string>& argv,
                std::string& out, std::string& err);

    fork and execvp.  argv[0] is looked up on PATH and the rest are arguments
    exactly as written, so a space, a quote, a semicolon or a backtick in one
    of them is a character and nothing else.  The test asserts that by running
    echo with nine arguments of pure shell punctuation and comparing the output
    to the input.

    Output goes to temporary files rather than pipes.  That is not laziness:
    two pipes read in sequence deadlock as soon as the child fills the one the
    parent is not reading, and the test pushes 84KB to each side, which is
    well past a pipe buffer.

    A program that runs and fails returns its status.  One that could not be
    started throws -- there is no status to report, and returning 127 would be
    indistinguishable from a program that exited 127 on purpose.

MimeType stopped parsing English

    file(1) has had --mime-type since 2003.  It prints "image/jpeg" and
    nothing else, so there is no output to parse and parse_file_output is
    gone -- with it the second half of #94:

        const std::string body = (data.find(":") != ...) ? ... : data;
        if(icontains(data, "image")) {

    body was computed and never read, so every test ran over the whole of
    file's output, which begins with the filename.  A text file called
    JPEG-notes.txt was an image/jpeg.  The test asserts that one directly.

    It also returns better answers than before: the old parser knew eight
    types and collapsed everything else to application/octet-stream, and now
    whatever file(1) knows comes through.  What it cannot identify is still
    octet-stream rather than an exception, because an unidentifiable
    attachment should still be sendable.

    The returned string is checked with content_type::valid() before being
    handed back, because file prints "cannot open ..." on stdout and that is
    not a media type.

MBox does not need a subprocess at all

    delete_folder and rename_folder are std::filesystem::remove_all and
    ::rename now.  No fork, no shell, an error_code instead of a shell exit
    status, and MBoxBuf::exception where there used to be a sys_exception
    about a command line.

what a green run does not establish

    Not that jlib no longer runs a shell.  sys::shell is still there and still
    does what it says; what changed is that nothing in the library calls it.
    A future caller that concatenates into it is this bug again, and no test
    sees that coming.

    Not that MimeType is right about a given file -- it repeats what file(1)
    says, so the answer depends on the installed version and its magic
    database.  The assertions are about which input decides, the content
    rather than the name.

    Not Windows.  fork() and execvp() are POSIX, as is the rest of jlib::sys.
