### PR TITLE
Read URLs against RFC 3986's grammar

### DIFF
--- a/jlib/util/Makefile.am
+++ b/jlib/util/Makefile.am
@@ -11,4 +11,4 @@ libjutilincludedir = $(includedir)/jlib-1.2/jlib/util
 libjutilinclude_HEADERS = abnf.hh Regex.hh MimeType.hh util.hh Date.hh xml.hh \
                           URL.hh Headers.hh Timer.hh json.hh \
                           content_type.hh rfc2045.hh rfc5322.hh \
-                          encoded_word.hh rfc2047.hh
+                          encoded_word.hh rfc2047.hh rfc3986.hh

--- a/jlib/util/URL.cc
+++ b/jlib/util/URL.cc
@@ -21,20 +21,42 @@
 
 #include <jlib/util/util.hh>
 #include <jlib/util/URL.hh>
-#include <jlib/util/Regex.hh>
+#include <jlib/util/rfc3986.hh>
+
+#include <jlib/util/abnf.hh>
 
 #include <cstdlib>
 
-const std::string FULL_URL       = "^([[:alnum:]]+)://([[:graph:]]+):([[:print:]]+)@([[:graph:]]+):([[:digit:]]+)(\\/.*)\\?(.*)$";
-const std::string BASIC_URL      = "^([[:alnum:]]+)://([[:graph:]]+)$";
-const std::string HOST_WITH_PATH = "^([^/ ]*)(\\/.*)$";
-const std::string HOST_WITH_USER = "^([[:graph:]]+)@([[:graph:]]+)$";
-const std::string HOST_WITH_PORT = "^([[:graph:]]+):([[:digit:]]+)$";
-const std::string USER_WITH_PASS = "^([[:graph:]]+):([[:graph:]]+)$";
-const std::string PATH_WITH_QS   = "^(\\/.+)\\?(.*)$";
-
 namespace jlib {
     namespace util {
+
+        namespace {
+
+            /** Built on first use, for the reason at crypt/curve.hh:42. */
+            const abnf::grammar& uri_grammar() {
+                static abnf::grammar g = [] {
+                    abnf::grammar g = abnf::compile(rfc3986::URI_GRAMMAR);
+                    g.check();
+
+                    return g;
+                }();
+
+                return g;
+            }
+
+            abnf::options parse_options() {
+                abnf::options o;
+
+                o.captures = abnf::options::capture_policy::listed;
+                o.capture_only = { "scheme", "authority", "userinfo", "host", "port",
+                                   "path-abempty", "path-absolute",
+                                   "path-rootless", "query", "fragment",
+                                   "IP-literal" };
+
+                return o;
+            }
+
+        }
 
         URL::URL() {
             
@@ -64,91 +86,116 @@ namespace jlib {
         void URL::parse(const std::string& url) {
             if(std::getenv("JLIB_UTIL_URL_DEBUG"))
                 std::cerr << "jlib::util::URL::parse(\""<<url<<"\")"<<std::endl;
-            
-            // On a local: this overwrote its own parameter.
+
+            // The trim used to be computed into a local and then never read --
+            // every one of the five regexes below it matched against the
+            // untrimmed string, and all five were anchored, so a leading space
+            // or a trailing newline made a URL unparseable.
             const std::string text = jlib::util::trim(url);
-            jlib::util::Regex full_url(FULL_URL);
-            
-            if(full_url(url)) {
-                set_protocol(full_url[1]);
-                set_user(full_url[2]);
-                set_pass(full_url[3]);
-                set_host(full_url[4]);
-                set_port(full_url[5]);
-                set_path(full_url[6]);
-                set_qs(full_url[7]);
+
+            abnf::match m;
+
+            try {
+                m = uri_grammar().at("URI").parse(text, parse_options());
             }
-            else {
-                jlib::util::Regex basic_url(BASIC_URL);                
+            catch(abnf::budget_exceeded& e) {
+                throw exception(std::string("gave up reading a URL: ") + e.what());
+            }
+            catch(abnf::error& e) {
+                throw exception("not a URL at column " + std::to_string(e.column())
+                                + "\n  " + e.context_line() + "\n  "
+                                + std::string(e.column() - 1, ' ') + "^");
+            }
 
-                if(basic_url(url)) {
-                    set_protocol(basic_url[1]);
+            // RFC 3986 6.2.2.1: the scheme and the host are case insensitive,
+            // and lower case is the canonical form.  Every caller in jlib was
+            // doing this for itself, with util::lower, at every comparison.
+            m_protocol = lower(m["scheme"].str());
 
-                    std::string host = basic_url[2];
+            m_authority = static_cast<bool>(m["authority"]);
 
-                    jlib::util::Regex host_with_path(HOST_WITH_PATH);
+            const abnf::match user = m["userinfo"];
 
-                    if(host_with_path(host)) {
-                        host = host_with_path[1];
-                        std::string path = host_with_path[2];
+            m_user.clear();
+            m_pass.clear();
 
-                        jlib::util::Regex path_with_qs(PATH_WITH_QS);
+            if(user) {
+                // The RFC treats userinfo as opaque and deprecates putting a
+                // password in it at all (3.2.1), but that is how a mail
+                // account is written, and the first colon is where every
+                // client splits it.
+                const std::string text = user.str();
+                const std::string::size_type colon = text.find(':');
 
-                        if(path_with_qs(path)) {
-                            path = path_with_qs[1];
-                            std::string qs = path_with_qs[2];
-                            set_qs(qs);
-                        }
-
-                        set_path(path);
-                    }
-
-                    jlib::util::Regex host_with_user(HOST_WITH_USER);
-                    
-                    if(host_with_user(host)) {
-                        std::string user = host_with_user[1];
-                        host = host_with_user[2];
-                        
-                        jlib::util::Regex user_with_pass(USER_WITH_PASS);
-
-                        if(user_with_pass(user)) {
-                            user = user_with_pass[1];
-                            std::string pass = user_with_pass[2];
-                            set_pass(pass);
-                        }
-                        
-                        set_user(user);
-                    }
-
-                    jlib::util::Regex host_with_port(HOST_WITH_PORT);
-
-                    if(host_with_port(host)) {
-                        host = host_with_port[1];
-                        std::string port = host_with_port[2];
-                        set_port(port);
-                    }
-
-                    set_host(host);
-                    
+                if(colon == text.npos) {
+                    m_user = uri::decode(text);
                 }
                 else {
-                    throw exception("failed to match basic URL syntax: "+
-                                    BASIC_URL+" at jlib::util::URL::parse, passed string \""+url+"\"");
+                    m_user = uri::decode(text.substr(0, colon));
+                    m_pass = uri::decode(text.substr(colon + 1));
                 }
-                
-                
             }
-            
+
+            const abnf::match host = m["host"];
+
+            m_host_literal = static_cast<bool>(m["IP-literal"]);
+
+            if(m_host_literal) {
+                // Without the brackets: they delimit the literal, they are not
+                // part of the address, and getaddrinfo does not want them.
+                const std::string text = host.str();
+
+                m_host = text.substr(1, text.size() - 2);
+            }
+            else {
+                m_host = lower(uri::decode(host.str()));
+            }
+
+            m_port = m["port"] ? m["port"].str() : std::string();
+
+            // hier-part names the path differently depending on which shape it
+            // took, and exactly one of the three can be present.
+            m_path.clear();
+
+            for(const char* n : { "path-abempty", "path-absolute", "path-rootless" }) {
+                if(const abnf::match p = m[n]) {
+                    m_path = p.str();
+                    break;
+                }
+            }
+
+            m_fragment = m["fragment"] ? uri::decode(m["fragment"].str()) : std::string();
+
+            set_qs(m["query"] ? m["query"].str() : std::string());
+        }
+
+        bool URL::valid(const std::string& url) {
+            try {
+                URL u(url);
+                return true;
+            }
+            catch(exception&) {
+                return false;
+            }
         }
 
         std::map<std::string,std::string> URL::parse_qs(const std::string& qs) {
             std::map<std::string,std::string> ret;
 
+            // Percent-decoded, which it never was: a value written "%20" came
+            // back as the three characters.  Split at the *first* "=", because
+            // a value may contain one and a name may not.
             std::vector<std::string> tokens = tokenize(qs,"&");
             for(std::vector<std::string>::size_type i=0;i<tokens.size();i++) {
                 std::string::size_type j;
                 if( (j=tokens[i].find("=")) != std::string::npos ) {
-                    ret[tokens[i].substr(0,j)] = tokens[i].substr(j+1);
+                    ret[uri::decode(tokens[i].substr(0,j))] =
+                        uri::decode(tokens[i].substr(j+1));
+                }
+                else if(!tokens[i].empty()) {
+                    // "?flag" with no "=" is a name with an empty value, not
+                    // something to drop on the floor.
+                    ret[uri::decode(tokens[i])] = std::string();
                 }
             }
 
@@ -165,7 +212,7 @@ namespace jlib {
                     ret += "&";
                 }
                 first = false;
-                ret += i->first+"="+i->second;
+                ret += uri::encode(i->first)+"="+uri::encode(i->second);
             }
 
             return ret;
@@ -205,6 +252,10 @@ namespace jlib {
                 return m_path.substr(n);
             else 
                 return "";
+        }
+
+        std::string URL::get_fragment() const {
+            return m_fragment;
         }
 
         std::string URL::get_qs() const {
@@ -247,6 +298,10 @@ namespace jlib {
             m_delim = std::move(delim);
         }
 
+        void URL::set_fragment(const std::string& fragment) {
+            m_fragment = std::move(fragment);
+        }
+
         void URL::set_qs(const std::string& qs) {
             m_qs = qs;
             m_qs_hash = parse_qs(qs);
@@ -280,16 +335,32 @@ namespace jlib {
         }
 
         std::string URL::coagulate() const {
-            std::string ret = m_protocol + "://";
+            std::string ret = m_protocol + ":";
+
+            if(!m_authority) {
+                // "mailto:joe@example.com" -- no "//", and no room for a user,
+                // a host or a port either.  RFC 3986 3: the authority is
+                // present exactly when the "//" is.
+                return ret + m_path + (m_qs.empty() ? "" : "?" + m_qs)
+                           + (m_fragment.empty() ? "" : "#" + uri::encode(m_fragment));
+            }
+
+            ret += "//";
+
+            // Back the way they came: what parse() decoded, and the brackets
+            // it took off a literal.  Without the re-encoding a password
+            // containing an "@" would produce a URL that reads back with a
+            // different host.
+            const std::string host = m_host_literal ? "[" + m_host + "]" : m_host;
 
             if(m_user != "" && m_pass != "") {
-                ret += (m_user+":"+m_pass+"@"+m_host);
+                ret += (uri::encode(m_user)+":"+uri::encode(m_pass)+"@"+host);
             }
             else if(m_user != "") {
-                ret += (m_user+"@"+m_host);
+                ret += (uri::encode(m_user)+"@"+host);
             }
             else {
-                ret += m_host;
+                ret += host;
             }
 
             if(m_port != "") {
@@ -300,6 +371,10 @@ namespace jlib {
 
             if(m_qs != "") {
                 ret += ("?"+m_qs);
+            }
+
+            if(m_fragment != "") {
+                ret += ("#"+uri::encode(m_fragment));
             }
 
             return ret;

--- a/jlib/util/URL.hh
+++ b/jlib/util/URL.hh
@@ -69,7 +69,35 @@ namespace jlib {
              * doing a copy; measured, moving a 2M Email copied 4M.
              */
 
+            /**
+             * Read a URI, against RFC 3986's own grammar.
+             *
+             * Throws URL::exception, with a column, on anything that is not
+             * one.  A scheme is required: "example.com/x" is a relative
+             * reference and jlib has no base to resolve it against.
+             *
+             * The scheme and the host are lowercased, which RFC 3986 6.2.2.1
+             * says is the canonical form and which every caller here was
+             * doing for itself.  The userinfo is percent-decoded, so
+             * "joe%40example.com" comes back as "joe@example.com"; the path
+             * and the query are not, because "%2F" in a path is a character
+             * and "/" is a separator and decoding loses the difference.
+             */
             void parse(const std::string& url);
+
+            /** Would it parse?  The way to ask without catching. */
+            static bool valid(const std::string& url);
+
+            /**
+             * Split a query string into its pairs, percent-decoding both
+             * sides.
+             *
+             * "+" is not a space here.  That convention belongs to HTML's
+             * application/x-www-form-urlencoded, not to RFC 3986, where "+"
+             * is a sub-delim that stands for itself -- and a URL class that
+             * silently turned it into a space would corrupt every base64
+             * value anyone put in a query.
+             */
             static std::map<std::string,std::string> parse_qs(const std::string& qs);
             static std::string parse_qs(std::map<std::string,std::string> qs);
 
@@ -82,6 +110,9 @@ namespace jlib {
             std::string get_path_no_slash() const;
 
             std::string get_delim() const;
+
+            /** The "#fragment", without its "#", or "" when there was none. */
+            std::string get_fragment() const;
 
             std::string get_qs() const;
             std::map<std::string,std::string> get_qs_hash() const;
@@ -100,6 +131,7 @@ namespace jlib {
             void set_port(const std::string& port);
             void set_path(const std::string& path);
             void set_delim(const std::string& delim);
+            void set_fragment(const std::string& fragment);
             void set_qs(const std::string& qs);
             void set_qs(std::map<std::string,std::string> qs);
            
@@ -125,6 +157,28 @@ namespace jlib {
             std::string m_port;
             std::string m_path;
             std::string m_qs;
+            std::string m_fragment;
+
+            /**
+             * Whether the URI had an authority -- a "//" after the scheme.
+             *
+             * Not the same as having a host: "mbox:///home/joe/Mail" has an
+             * authority and it is empty, while "mailto:joe@example.com" has
+             * none at all, and coagulate() has to put back what was there.
+             * True by default so that a URL built through a constructor,
+             * which takes a host, still writes one.
+             */
+            bool m_authority = true;
+
+            /**
+             * Whether the host was written as "[...]".
+             *
+             * Kept so that get_host() can hand back the bare address -- which
+             * is what getaddrinfo wants -- and coagulate() can put the
+             * brackets back.
+             */
+            bool m_host_literal = false;
+
             std::string m_delim;
             std::map<std::string,std::string> m_qs_hash;
         };

--- a/jlib/util/rfc3986.hh
+++ b/jlib/util/rfc3986.hh
@@ -1,0 +1,170 @@
+/* -*- mode: C++ c-basic-offset: 4 -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef JLIB_UTIL_RFC3986_HH
+#define JLIB_UTIL_RFC3986_HH
+
+namespace jlib {
+namespace util {
+
+/**
+ * RFC 3986 Appendix A, the URI grammar, as ABNF.
+ *
+ * Pasted from the RFC, which prints it as ABNF already -- so unlike RFC 2045
+ * and RFC 2047 there was nothing to translate out of prose, and a reader can
+ * check this against Appendix A line by line.
+ *
+ * Read by jlib::util::abnf::compile(); see jlib/util/URL.hh for what uses it.
+ * Self-contained: a URI has no comments and no folding, so nothing here
+ * borrows rfc5322::LEXICAL.
+ *
+ * ## Where this departs from the published text
+ *
+ * Three places, each marked "; jlib:".
+ *
+ * **dec-octet is reversed.**  As published it reads
+ *
+ *     dec-octet = DIGIT / %x31-39 DIGIT / "1" 2DIGIT
+ *               / "2" %x30-34 DIGIT / "25" %x30-35
+ *
+ * and under ordered choice the bare DIGIT matches the "2" of "255" and wins,
+ * leaving "55" for a "." that is not there.  Longest first.
+ *
+ * **host drops IPv4address.**  The RFC writes
+ *
+ *     host = IP-literal / IPv4address / reg-name
+ *
+ * but reg-name is *( unreserved / pct-encoded / sub-delims ) and unreserved
+ * includes DIGIT and ".", so reg-name already matches every IPv4address and
+ * a great deal more.  Leaving IPv4address in the middle makes "1.2.3.4.5" --
+ * a perfectly good reg-name -- fail, because IPv4address matches "1.2.3.4",
+ * commits, and strands ".5".  The rule is still here, unreferenced, so that a
+ * caller holding a host can ask whether it is a dotted quad.
+ *
+ * **IPv6address is restructured**, and this is the one place a reader cannot
+ * check the grammar against Appendix A line by line.  The RFC writes nine
+ * alternatives, each counting how many h16 groups sit either side of the "::":
+ *
+ *     / [ *5( h16 ":" ) h16 ] "::" h16
+ *
+ * Under possessive repetition that cannot work.  Given "2001:db8::1", the
+ * "*5( h16 ":" )" matches "2001:" and then "db8:" -- taking the first colon of
+ * the "::" -- and then h16 must match ":" and fails.  The repetition does not
+ * give the colon back, so the alternative fails, and so does every other one.
+ * ABNF has no way to write "not followed by another colon", so there is no
+ * faithful transcription that works.
+ *
+ * What is here instead is "an optional run of groups, then '::', then an
+ * optional run" -- the same shape, without the counting.  It accepts
+ * everything RFC 3986 does and some things it does not: more than eight
+ * groups, an IPv4address somewhere other than the end, and more than one of
+ * them.  That is the right trade for a URI parser, whose job is to find where
+ * the host ends; whether the characters between the brackets are an address
+ * is getaddrinfo's decision and it has to make it again regardless.
+ *
+ * **A rule per path shape is what hier-part already had.**  No change; noted
+ * because a reader will look for one name and find four.
+ *
+ * ## What the grammar does not decide
+ *
+ * Not whether the URI means anything.  "imap://-b.example/" parses and no
+ * server will answer; scheme-specific rules -- which schemes have an
+ * authority, what a default port is, whether userinfo is allowed -- are the
+ * scheme's business and RFC 3986 says so.
+ *
+ * Not normalisation.  RFC 3986 section 6 has a whole algorithm for deciding
+ * whether two URIs are equivalent: case folding the scheme and host,
+ * normalising percent-encoding, removing dot segments.  None of that is here.
+ *
+ * Not IDN.  A host is octets; RFC 3987's internationalised form and its
+ * punycode encoding are not implemented.
+ */
+namespace rfc3986 {
+
+inline const char* const URI_GRAMMAR = R"ABNF(
+URI             =  scheme ":" hier-part [ "?" query ] [ "#" fragment ]
+
+hier-part       =  ( "//" authority path-abempty )
+                /  path-absolute
+                /  path-rootless
+                /  path-empty
+
+scheme          =  ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )
+
+authority       =  [ userinfo "@" ] host [ ":" port ]
+userinfo        =  *( unreserved / pct-encoded / sub-delims / ":" )
+host            =  IP-literal / reg-name   ; jlib: IPv4address removed from
+                                           ; the middle -- reg-name already
+                                           ; matches every dotted quad, and
+                                           ; keeping it here made a name like
+                                           ; 1.2.3.4.5 fail
+port            =  *DIGIT
+
+IP-literal      =  "[" ( IPv6address / IPvFuture ) "]"
+IPvFuture       =  "v" 1*HEXDIG "." 1*( unreserved / sub-delims / ":" )
+
+; jlib: restructured.  See the note in the header -- the RFC's nine counted
+; alternatives cannot work under possessive repetition, because "*5( h16 ":" )"
+; eats the first colon of the "::" it is supposed to stop in front of and ABNF
+; has no way to say "not followed by".
+IPv6address     =  ( [ ipv6-head ] "::" [ ipv6-tail ] ) / ipv6-tail
+ipv6-head       =  h16 *( ":" h16 )
+ipv6-tail       =  ipv6-part *( ":" ipv6-part )
+ipv6-part       =  IPv4address / h16   ; IPv4address first: it is only ever
+                                       ; the last part, and h16 would take
+                                       ; the "1" of "1.2.3.4" and stop
+
+h16             =  1*4HEXDIG
+
+IPv4address     =  dec-octet "." dec-octet "." dec-octet "." dec-octet
+
+; jlib: reversed.  As published the bare DIGIT is first and matches the "2"
+; of "255", which then commits and strands the rest.
+dec-octet       =  "25" %x30-35         ; 250-255
+                /  "2" %x30-34 DIGIT    ; 200-249
+                /  "1" 2DIGIT           ; 100-199
+                /  %x31-39 DIGIT        ; 10-99
+                /  DIGIT                ; 0-9
+
+reg-name        =  *( unreserved / pct-encoded / sub-delims )
+
+path-abempty    =  *( "/" segment )
+path-absolute   =  "/" [ segment-nz *( "/" segment ) ]
+path-rootless   =  segment-nz *( "/" segment )
+path-empty      =  ""                   ; jlib: the RFC writes 0<pchar>, which
+                                        ; is its notation for "nothing"
+
+segment         =  *pchar
+segment-nz      =  1*pchar
+pchar           =  unreserved / pct-encoded / sub-delims / ":" / "@"
+
+query           =  *( pchar / "/" / "?" )
+fragment        =  *( pchar / "/" / "?" )
+
+pct-encoded     =  "%" HEXDIG HEXDIG
+unreserved      =  ALPHA / DIGIT / "-" / "." / "_" / "~"
+sub-delims      =  "!" / "$" / "&" / "'" / "(" / ")"
+                /  "*" / "+" / "," / ";" / "="
+)ABNF";
+
+}
+}
+}
+
+#endif // JLIB_UTIL_RFC3986_HH

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -62,6 +62,7 @@ TESTS = \
  \
 	util_test \
 	util_codec_test \
+	util_url_test \
 	util_rfc2047_test \
 	util_headers_test \
 	util_headers_manual_test \
@@ -154,6 +155,9 @@ util_test_SOURCES = util_test.cc
 util_test_LDADD   = $(JUTIL_LA)
 util_rfc2047_test_SOURCES       = util_rfc2047_test.cc
 util_rfc2047_test_LDADD         = $(JUTIL_LA)
+
+util_url_test_SOURCES           = util_url_test.cc
+util_url_test_LDADD             = $(JUTIL_LA)
 
 util_codec_test_SOURCES         = util_codec_test.cc
 util_codec_test_LDADD           = $(JUTIL_LA)

--- a/tests/util_url_test.cc
+++ b/tests/util_url_test.cc
@@ -1,0 +1,339 @@
+/* -*- mode: C++ c-basic-offset: 4 -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// URLs, read against RFC 3986's own grammar.
+//
+// This is where every mail account in gtkmail comes from -- "imaps://user:pass
+// @mail.example.com/INBOX" in a config file -- so getting the pieces wrong
+// means connecting to the wrong host, or with the wrong password, or not at
+// all.  It used to be five POSIX regexes applied to each other's output.
+
+#include <jlib/util/URL.hh>
+#include <jlib/util/rfc3986.hh>
+
+#include <jlib/util/abnf.hh>
+
+#include <iostream>
+#include <string>
+
+using jlib::util::URL;
+
+static int failures = 0;
+
+static void ok(const std::string& what, bool good, const std::string& detail = "") {
+    if(!good) ++failures;
+    std::cout << (good ? "  ok   " : "  FAIL ") << what;
+    if(!detail.empty()) std::cout << ": " << detail;
+    std::cout << "\n";
+}
+
+static void a_mail_account() {
+    std::cout << "what a mail account looks like:\n";
+
+    const URL u("imaps://joe:secret@mail.example.com:993/INBOX");
+
+    ok("scheme", u.get_protocol() == "imaps", u.get_protocol());
+    ok("user",   u.get_user() == "joe", u.get_user());
+    ok("pass",   u.get_pass() == "secret", u.get_pass());
+    ok("host",   u.get_host() == "mail.example.com", u.get_host());
+    ok("port",   u.get_port() == "993" && u.get_port_val() == 993, u.get_port());
+    ok("path",   u.get_path() == "/INBOX", u.get_path());
+
+    const URL bare("imap://mail.example.com/INBOX");
+
+    ok("and without credentials",
+       bare.get_user().empty() && bare.get_pass().empty() &&
+       bare.get_host() == "mail.example.com" && bare.get_port().empty());
+
+    // A local mbox: a scheme, an empty authority, and an absolute path.
+    const URL local("mbox:///home/joe/Mail/inbox");
+
+    ok("a local mailbox has no host and a path",
+       local.get_host().empty() && local.get_path() == "/home/joe/Mail/inbox",
+       local.get_path());
+}
+
+static void the_trim_that_was_dead() {
+    std::cout << "\nthe trim:\n";
+
+    // parse() computed `const std::string text = trim(url)` and then matched
+    // every one of its five anchored regexes against `url`, untrimmed.  So a
+    // config file line with a trailing newline on it did not parse.
+    const URL u("  imaps://mail.example.com/INBOX\n");
+
+    ok("leading and trailing whitespace is ignored",
+       u.get_protocol() == "imaps" && u.get_path() == "/INBOX",
+       u.coagulate());
+}
+
+static void the_cascade_split_in_the_wrong_places() {
+    std::cout << "\nwhere the old regexes went wrong:\n";
+
+    // FULL_URL required user AND pass AND port AND path AND query all present,
+    // so it never matched an ordinary URL and everything fell through to a
+    // cascade of [[:graph:]] patterns applied in a fixed order.
+
+    // HOST_WITH_USER was ^([[:graph:]]+)@([[:graph:]]+)$, and "@" is a graph
+    // character, so leftmost-longest took "a@b" as the user.  There is no
+    // reading under which that is a URL: neither userinfo nor host may
+    // contain an unescaped "@".
+    ok("two at-signs is not a URL", !URL::valid("http://a@b@c/"));
+
+    // HOST_WITH_PATH ran first, so a password containing "/" was cut into the
+    // path and the rest of the authority went with it.  "/" is not allowed in
+    // userinfo, so this is not a URL either -- and saying so beats silently
+    // connecting somewhere else.
+    ok("a slash in the userinfo is not a URL",
+       !URL::valid("imap://user:pa/ss@host/INBOX"));
+
+    // Percent-encode it and it is fine, which is the answer the RFC gives.
+    const URL u("imap://user:pa%2Fss@host/INBOX");
+
+    ok("percent-encoded, it parses and decodes",
+       u.get_pass() == "pa/ss" && u.get_host() == "host", u.get_pass());
+
+    // An email address as a username is how several providers do it.
+    const URL at("imap://joe%40example.com:pw@mail.example.com/INBOX");
+
+    ok("an at-sign in a username, encoded",
+       at.get_user() == "joe@example.com" && at.get_host() == "mail.example.com",
+       at.get_user() + " / " + at.get_host());
+
+    // USER_WITH_PASS split on ":" with the same greedy pattern.  RFC 3986
+    // allows a colon in the userinfo and everyone splits at the first.
+    const URL colon("imap://user:a:b@host/");
+
+    ok("a colon in the password splits at the first one",
+       colon.get_user() == "user" && colon.get_pass() == "a:b",
+       colon.get_user() + " / " + colon.get_pass());
+}
+
+static void case_folding() {
+    std::cout << "\nRFC 3986 6.2.2.1:\n";
+
+    const URL u("IMAPS://Mail.Example.COM/INBOX");
+
+    // Every caller in jlib was doing lower(get_protocol()) at the point of
+    // comparison; doing it once, here, is where it belongs.
+    ok("the scheme folds", u.get_protocol() == "imaps", u.get_protocol());
+    ok("and the host",     u.get_host() == "mail.example.com", u.get_host());
+
+    // The path does not.  RFC 3986 is explicit that only the scheme and the
+    // host are case insensitive, and an IMAP mailbox name is case sensitive.
+    ok("the path does not", u.get_path() == "/INBOX", u.get_path());
+}
+
+static void ip_literals() {
+    std::cout << "\nIPv6 literals:\n";
+
+    const URL u("http://[::1]:8080/x");
+
+    // Without the brackets: they delimit the literal and getaddrinfo does not
+    // want them.
+    ok("come back without their brackets", u.get_host() == "::1", u.get_host());
+    ok("with the port beside them",        u.get_port() == "8080");
+    ok("and go back in with them",
+       u.coagulate() == "http://[::1]:8080/x", u.coagulate());
+
+    for(const char* s : { "http://[2001:db8::1]/", "http://[::ffff:1.2.3.4]/",
+                          "http://[2001:0db8:0000:0000:0000:ff00:0042:8329]/" }) {
+        ok(s, URL::valid(s));
+    }
+
+    // The "::" is what defeats a faithful transcription of RFC 3986's
+    // IPv6address: "*5( h16 \":\" )" eats the first of the two colons and
+    // possessive repetition does not give it back.  See rfc3986.hh.
+    ok("an address with :: in the middle parses",
+       URL("http://[2001:db8::1]/").get_host() == "2001:db8::1");
+
+    ok("and empty brackets do not", !URL::valid("http://[]/"));
+    ok("nor brackets full of text", !URL::valid("http://[not an addr]/"));
+
+    // A dotted quad is a perfectly good registered name as far as the grammar
+    // is concerned, which is why IPv4address is not in the host rule.
+    ok("a dotted quad parses",     URL("http://1.2.3.4/").get_host() == "1.2.3.4");
+    ok("and so does one with five parts",
+       URL("http://1.2.3.4.5/").get_host() == "1.2.3.4.5",
+       URL("http://1.2.3.4.5/").get_host());
+}
+
+static void query_strings() {
+    std::cout << "\nquery strings:\n";
+
+    const URL u("http://host/p?x=1&y=hello%20world&flag&z=a%3Db");
+
+    ok("the raw query is kept as written",
+       u.get_qs() == "x=1&y=hello%20world&flag&z=a%3Db", u.get_qs());
+
+    // parse_qs never decoded, so a value written "%20" came back as three
+    // characters.
+    ok("and the pairs are decoded",
+       u["x"] == "1" && u["y"] == "hello world", u["y"]);
+
+    ok("a name with no value is a name, not a dropped token",
+       u.get_qs_hash().count("flag") == 1 && u["flag"].empty());
+
+    ok("and an encoded equals stays in the value",
+       u["z"] == "a=b", u["z"]);
+
+    // Round trip through the map form, which now encodes.
+    std::map<std::string,std::string> m;
+
+    m["a b"] = "c&d";
+
+    URL v("http://host/");
+    v.set_qs(m);
+
+    ok("building a query escapes what has to be escaped",
+       v.get_qs() == "a%20b=c%26d", v.get_qs());
+    ok("and reading it back gives the same pairs",
+       URL(v.coagulate())["a b"] == "c&d", URL(v.coagulate())["a b"]);
+
+    ok("a fragment is not part of the query",
+       URL("http://host/p?a=1#top").get_fragment() == "top" &&
+       URL("http://host/p?a=1#top").get_qs() == "a=1");
+}
+
+static void round_trip() {
+    std::cout << "\nround trip:\n";
+
+    for(const char* s : {
+        "imaps://joe:secret@mail.example.com:993/INBOX",
+        "imap://mail.example.com/INBOX",
+        "mbox:///home/joe/Mail/inbox",
+        "http://[::1]:8080/x",
+        "http://host/a/b?x=1&y=2",
+        "http://host/",
+        "mailto:joe@example.com",
+    }) {
+        ok(s, URL(s).coagulate() == s, URL(s).coagulate());
+    }
+
+    // What parse() decoded, coagulate() re-encodes -- otherwise a password
+    // with an "@" in it produces a URL that reads back with a different host,
+    // which is a wrong connection rather than an error.
+    const URL u("imap://joe%40example.com:p%40ss@host/INBOX");
+
+    ok("credentials are re-encoded on the way out",
+       u.coagulate() == "imap://joe%40example.com:p%40ss@host/INBOX",
+       u.coagulate());
+    ok("and survive a second parse",
+       URL(u.coagulate()).get_pass() == "p@ss");
+}
+
+static void what_it_refuses() {
+    std::cout << "\nnot a URL:\n";
+
+    for(const char* s : { "no-scheme", "", "://x", "1http://x/",
+                          "http://user:pa ss@host/", "http://host/\tx" }) {
+        ok(std::string("\"") + s + "\"", !URL::valid(s));
+    }
+
+    // "http:/" *is* a URI -- a scheme and an absolute path with nothing in it.
+    // It was on the list above until the test was run: RFC 3986 does not
+    // require an authority, and refusing this would be inventing a rule.
+    ok("\"http:/\" is a URL, with no authority", URL::valid("http:/"));
+
+    // A relative reference is a URI-reference and not a URI.  jlib has no base
+    // to resolve one against, so refusing it beats guessing a scheme.
+    ok("\"example.com/x\" is a relative reference",
+       !URL::valid("example.com/x"));
+
+    // And the error says where.
+    std::string msg;
+
+    try { URL u("http://a@b@c/"); }
+    catch(URL::exception& e) { msg = e.what(); }
+
+    ok("the message carries a column", msg.find("column") != std::string::npos,
+       msg.substr(0, 40));
+}
+
+static void the_grammar_itself() {
+    std::cout << "\nthe grammar:\n";
+
+    using namespace jlib::util::abnf;
+
+    bool built = false;
+    std::string why;
+
+    try {
+        grammar g = compile(jlib::util::rfc3986::URI_GRAMMAR);
+        g.check();
+        built = true;
+    }
+    catch(exception& e) { why = e.what(); }
+
+    ok("it compiles and checks", built, why);
+
+    // dec-octet is the other production reordered for ordered choice: as the
+    // RFC writes it, the bare DIGIT is first and takes the "2" of "255".
+    grammar g = compile(jlib::util::rfc3986::URI_GRAMMAR);
+    options o;
+    o.captures = options::capture_policy::none;
+
+    for(const char* s : { "0", "9", "10", "99", "100", "199", "249", "250", "255" }) {
+        ok(std::string("dec-octet accepts ") + s,
+           static_cast<bool>(g.at("dec-octet").try_parse(s, o)));
+    }
+
+    for(const char* s : { "256", "300", "1000", "01" }) {
+        ok(std::string("and refuses ") + s,
+           !g.at("dec-octet").try_parse(s, o));
+    }
+}
+
+int main() {
+    std::cout << std::unitbuf;
+
+    a_mail_account();
+    the_trim_that_was_dead();
+    the_cascade_split_in_the_wrong_places();
+    case_folding();
+    ip_literals();
+    query_strings();
+    round_trip();
+    what_it_refuses();
+    the_grammar_itself();
+
+    // What a green run does NOT establish.
+    //
+    // Not RFC 3986 conformance.  IPv6address is restructured rather than
+    // transcribed -- the RFC's nine counted alternatives cannot work under
+    // possessive repetition -- and the version here accepts things the RFC
+    // does not: more than eight groups, an IPv4address somewhere other than
+    // the end.  rfc3986.hh says exactly what and why.  Everything else is
+    // Appendix A verbatim but for dec-octet's order.
+    //
+    // Not normalisation.  RFC 3986 section 6 has an algorithm for deciding
+    // whether two URIs are equivalent -- removing dot segments, normalising
+    // percent-encoding, adding a default port.  None of it is here, so
+    // "http://x/a/../b" and "http://x/b" are different URLs to this class.
+    //
+    // Not scheme-specific rules.  Whether a scheme has an authority, what its
+    // default port is, whether userinfo means anything: RFC 3986 leaves all of
+    // that to the scheme and so does this.  "imap://-b.example/" parses.
+    //
+    // Not IDN.  A host is octets.  RFC 3987 and punycode are not implemented,
+    // so an internationalised hostname has to arrive already encoded.
+    //
+    // Not the zone identifier.  "fe80::1%25eth0" is RFC 6874, which RFC 3986
+    // predates, and it does not parse.
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
Closes #92.  Every mail account in gtkmail is a URL in a config file, so this
is where a wrong answer means connecting to the wrong host, or with the wrong
password, or not at all.

    macOS  43 tests, 43 pass, 0 skip
    Linux  44 tests, 43 pass, 1 skip

    jlib/util/rfc3986.hh     new -- Appendix A, pasted
    jlib/util/URL.cc         five regexes and a cascade -> one parse
    tests/util_url_test.cc   new

the trim was dead

        // On a local: this overwrote its own parameter.
        const std::string text = jlib::util::trim(url);
        jlib::util::Regex full_url(FULL_URL);

        if(full_url(url)) {

    `text` was computed and never read.  All five patterns are anchored with ^
    and $ and all five matched against `url`, so a config line with a trailing
    newline on it did not parse.  Fixing the earlier "overwrote its own
    parameter" bug left the trim behind with no caller -- the same shape as the
    dead `body` in MimeType, from the same pass.

FULL_URL could not match an ordinary URL

        ^([[:alnum:]]+)://([[:graph:]]+):([[:print:]]+)@([[:graph:]]+):([[:digit:]]+)(\/.*)\?(.*)$

    Every group mandatory: a username *and* a password *and* an explicit port
    *and* a path *and* a query string.  Nothing anyone types matches it, so
    everything fell through to a cascade of [[:graph:]] patterns applied in a
    fixed order -- path, then user, then port -- and [[:graph:]] contains ":",
    "@" and "/".  POSIX matching is leftmost-longest, so:

        imap://user:pa/ss@host/INBOX    path became "/ss@host/INBOX"
        http://a@b@c/                   user became "a@b"
        imap://user:a:b@host/           password split at the last colon

    Two of those three are not URLs at all -- "/" is not allowed in userinfo
    and neither is an unescaped "@" -- and the parser now says so instead of
    connecting somewhere else.  Percent-encode them and they parse:

        imap://joe%40example.com:pa%2Fss@host/INBOX
        user -> joe@example.com   pass -> pa/ss

    which is the answer RFC 3986 gives, and the form an email-address username
    has to be written in anyway.

nothing was percent-decoded

    Not the userinfo, not the query.  parse_qs split on "&" and "=" and stored
    the halves raw, so a value written "hello%20world" came back as three
    tokens' worth of characters.  Both are decoded now, and coagulate()
    re-encodes -- without that a password containing an "@" produces a URL that
    reads back with a different host, which is a wrong connection rather than
    an error.

    "+" is deliberately not a space.  That convention is HTML's
    application/x-www-form-urlencoded, not RFC 3986, where "+" is a sub-delim
    that stands for itself -- and a URL class that silently turned it into a
    space would corrupt every base64 value anyone put in a query.

what else changed

    The scheme and the host are lowercased, which RFC 3986 6.2.2.1 calls the
    canonical form and which every caller in jlib was doing for itself at the
    point of comparison.  The path is not: an IMAP mailbox name is case
    sensitive.

    An IPv6 literal works, and comes back without its brackets -- they delimit
    the literal and getaddrinfo does not want them -- and goes back in with
    them.  There was no code for this at all before.

    A fragment is parsed rather than swept into the query or the path.

    "mailto:joe@example.com" round trips, which needed knowing whether the URI
    had an authority at all.  That is not the same as having a host:
    "mbox:///home/joe/Mail" has an authority and it is empty.

the one place a reader cannot check the grammar against the RFC

    IPv6address.  The RFC writes nine alternatives that count h16 groups
    either side of the "::":

        / [ *5( h16 ":" ) h16 ] "::" h16

    Under possessive repetition that cannot work.  Given "2001:db8::1" the
    "*5( h16 ":" )" matches "2001:" and then "db8:" -- taking the first colon
    of the "::" -- and then h16 must match ":" and fails.  The repetition does
    not give the colon back, so that alternative fails and so does every other
    one.  ABNF has no way to write "not followed by another colon", so there is
    no faithful transcription that works here.

    What is there instead is the same shape without the counting: an optional
    run of groups, "::", an optional run.  It accepts everything RFC 3986 does
    and some things it does not -- more than eight groups, an IPv4address
    somewhere other than the end.  For a URI parser, whose job is to find where
    the host ends, that is the right trade: whether the characters between the
    brackets are an address is getaddrinfo's decision and it has to make it
    again regardless.  rfc3986.hh says all of this at the point of use.

    dec-octet is reordered for the usual reason -- as published the bare DIGIT
    is first and takes the "2" of "255".  Everything else is Appendix A
    verbatim.

what a green run does not establish

    One assertion in the test was wrong when it was written and the test
    caught it: "http:/" was on the list of things that are not URLs, and it is
    one -- a scheme and an absolute path with nothing in it.  RFC 3986 does not
    require an authority, and refusing it would have been inventing a rule.
    The corrected line says so.

    Not RFC 3986 conformance, for the IPv6 reason above.  Not normalisation --
    section 6's equivalence algorithm is not here, so "http://x/a/../b" and
    "http://x/b" are different URLs.  Not scheme-specific rules: whether a
    scheme has an authority or a default port is the scheme's business and
    "imap://-b.example/" parses.  Not IDN.  Not RFC 6874's zone identifier.

    Noted in passing: util::Regex is down to one live caller,
    Email::parse_received, which pulls a dotted quad out of a Received header
    with "[[:digit:]]{1,3}" four times -- so it accepts 999.999.999.999.
    rfc3986::IPv4address is now sitting right there and is correct.
