### PR TITLE
Read Date: headers against RFC 5322 section 3.3

### DIFF
--- a/jlib/net/Email.cc
+++ b/jlib/net/Email.cc
@@ -186,10 +186,18 @@ namespace jlib {
             std::string s2 = j2[j2.m_sort];
             
             if(j1.m_sort == "DATE" && j2.m_sort == "DATE") {
-                jlib::util::Date d1; d1.set(s1);
-                jlib::util::Date d2; d2.set(s2);
-                //cout << d1.time() << " -- " << d2.time() << endl;
-                return d1.time() < d2.time();
+                // A message with no Date header, or one nothing can read, is
+                // as old as possible and sorts first.  Not an exception:
+                // Date::set throws now where it used to guess, and a
+                // comparator that throws part way through std::sort leaves the
+                // range in an unspecified state -- which is a worse answer
+                // than putting one message in the wrong place.
+                const auto when = [](const std::string& s) -> time_t {
+                    try { return jlib::util::Date::parse_rfc5322(s); }
+                    catch(jlib::util::Date::exception&) { return 0; }
+                };
+
+                return when(s1) < when(s2);
             }
             else if(j1.m_sort == "SIZE" && j2.m_sort == "SIZE") {
                 return (j1.get_data_size() < j2.get_data_size());

--- a/jlib/util/Date.cc
+++ b/jlib/util/Date.cc
@@ -19,6 +19,10 @@
  */
 
 #include <jlib/util/Date.hh>
+#include <jlib/util/rfc5322.hh>
+
+#include <jlib/util/abnf.hh>
+#include <jlib/util/util.hh>
 
 #include <sstream>
 #include <iostream>
@@ -310,9 +314,19 @@ namespace jlib {
             std::string sfmt;
             sfmt.append(fmt[i],1);
             switch(fmt[i]) {
-            case 'O':
-                auto_parse(is);
+            case 'O': {
+                // "%O" is an RFC 5322 date-time, and set() intercepts it
+                // before build_date is ever called with one.  Reaching here
+                // means the directive is embedded in a longer format string,
+                // which it cannot be: a date-time is the whole of the value.
+                std::string rest;
+
+                std::getline(is, rest);
+
+                set(rest, "%O");
+
                 return;
+            }
             case 'H':
             case 'k':
                 is >> ibuf;
@@ -419,119 +433,164 @@ namespace jlib {
             
         }
         
-        void Date::auto_parse(std::istream& is) {
-            std::vector<std::string> elems;
-            std::string buf, s;
-            std::string fmt;
-            while(!is.eof()) {
-                is >> buf;
-                elems.push_back(buf);
-            }
-            for(std::vector<std::string>::size_type i=0;i<elems.size();i++) {
-                //std::cout << "i = "<<i<<", elems[i] = "<<elems[i]<<std::endl;
-                elems[i] = sanitize(elems[i]);
-                if(is_alpha(elems[i])) {
-                    elems[i] = first_upper(elems[i]);
-                    try {
-                        find_month(elems[i], SHORT);
-                        fmt += "%b ";
-                    }
-                    catch(exception& e) {
-                        try {
-                            find_month(elems[i], LONG);
-                            fmt += "%B ";
-                        }
-                        catch(exception& e) {
-                            try {
-                                find_weekday(elems[i], SHORT);
-                                fmt += "%a ";
-                            }
-                            catch(exception& e) {
-                                try {
-                                    find_weekday(elems[i], LONG);
-                                    fmt += "%A ";
-                                }
-                                catch(exception& e) {
-                                    if(is_timezone(elems[i])) {
-                                        fmt += "%Z ";
-                                    }
-                                    else {
-                                        throw exception("couldn't parse "+elems[i]+" into a valid date field");
-                                    }
-                                }
-                            }
-                            
-                        }
-                    }
-                }
-                else if(is_digit(elems[i])) {
-                    if(elems[i].length() == 4) {
-                        fmt += "%Y ";
-                    }
-                    else if(elems[i].length() == 2 || elems[i].length() == 1) {
-                        int k;
-                        std::istringstream isk(elems[i]);
-                        isk >> k;
-                        if(k > 31 || k == 0) {
-                            fmt += "%y ";
-                        }
-                        else {
-                            fmt += "%d ";
-                        }
-                    }
-                }
-                else {
-                    if(is_time(elems[i])) {
-                        //std::cout << elems[i] << " is_time"<<std::endl;
-                        //std::cout << "i = "<<i<<std::endl;
-                        if((i+1 < elems.size()) && (elems[i+1] == "AM" || elems[i+1] == "PM")) {
-                            //std::cout << "elems[i+1] = " << elems[i+1] <<std::endl;
-                            //std::cout << elems[i] << " is 12"<<std::endl;
-                            fmt += "%r ";
-                            i++;
-                        }
-                        else {
-                            //std::cout << elems[i] << " is 24"<<std::endl;
-                            fmt += "%T ";
-                        }
-                        //std::cout << "i = "<<i<<std::endl;
-                    }
-                    else if(is_timezone(elems[i])) {
-                        fmt += "%Z ";
-                    }
-                    else{
-                        throw exception("couldn't parse "+elems[i]+" into a valid date field");
-                    }
-                }
-                
-            }
-            
-            while(fmt[fmt.length()-1] == ' ')
-                fmt.erase(fmt.length()-1);
-            
-            /* 
-             * now that we have the format std::string built, rebuild our std::istream
-             * and call build_date normally
-             */
-            
-            for(std::vector<std::string>::size_type i=0;i<elems.size();i++)
-                s += (elems[i]+" ");
-            while(s[s.length()-1] == ' ')
-                s.erase(s.length()-1);
-            
-            std::istringstream is2(s);
-            //std::cout << "s = "<<s<<"; fmt = "<<fmt<<std::endl;
-            build_date(is2,fmt);
-        }
-        
         std::string Date::get(const std::string& fmt) const {
             return build_date(fmt);
         }
         
+        namespace {
+
+            /** Built on first use, for the reason at crypt/curve.hh:42. */
+            const abnf::grammar& dates() {
+                static abnf::grammar g = [] {
+                    abnf::grammar g = abnf::compile(std::string(rfc5322::LEXICAL) +
+                                                    rfc5322::DATE_TIME);
+                    g.check();
+
+                    return g;
+                }();
+
+                return g;
+            }
+
+            abnf::options parse_options() {
+                abnf::options o;
+
+                o.captures = abnf::options::capture_policy::listed;
+                o.capture_only = { "day-digits", "month", "year-digits",
+                                   "hour-digits", "minute-digits",
+                                   "second-digits",
+                                   "zone-sign", "zone-offset", "obs-zone" };
+
+                return o;
+            }
+
+            int month_of(std::string_view name) {
+                static const char* const MONTHS[] = {
+                    "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+                    "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
+                };
+
+                for(int i = 0; i < 12; i++) {
+                    if(name == MONTHS[i]) return i;
+                }
+
+                return 0;
+            }
+
+            /**
+             * RFC 5322 4.3, the zones that are names.
+             *
+             * The single military letters are deliberately absent: 4.3 says
+             * they "were defined incorrectly" in RFC 822 and that a parser
+             * SHOULD treat them as -0000, which is what falling through to
+             * zero does.  Reading "A" as +0100 would be following the older
+             * document's mistake.
+             */
+            int offset_of(const std::string& name) {
+                static const std::map<std::string, int> ZONES = {
+                    { "UTC",   0 }, { "UT",    0 }, { "GMT",   0 },
+                    { "EST", -300 }, { "EDT", -240 },
+                    { "CST", -360 }, { "CDT", -300 },
+                    { "MST", -420 }, { "MDT", -360 },
+                    { "PST", -480 }, { "PDT", -420 },
+                };
+
+                const std::map<std::string, int>::const_iterator i =
+                    ZONES.find(upper(name));
+
+                return i == ZONES.end() ? 0 : i->second;
+            }
+
+            /**
+             * Days from 1970-01-01 to a civil date, Howard Hinnant's algorithm.
+             *
+             * Rather than timegm(), which is not in any C or C++ standard, or
+             * mktime(), which would apply the local zone to a time that
+             * already carries its own.
+             */
+            long long days_from_civil(long long y, unsigned m, unsigned d) {
+                y -= m <= 2;
+
+                const long long era = (y >= 0 ? y : y - 399) / 400;
+                const unsigned yoe = static_cast<unsigned>(y - era * 400);
+                const unsigned doy = (153 * (m + (m > 2 ? -3 : 9)) + 2) / 5 + d - 1;
+                const unsigned doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+
+                return era * 146097 + static_cast<long long>(doe) - 719468;
+            }
+
+        }
+
+        time_t Date::parse_rfc5322(const std::string& s) {
+            abnf::match m;
+
+            try {
+                m = dates().at("date-time").parse(trim(s), parse_options());
+            }
+            catch(abnf::budget_exceeded& e) {
+                throw exception(std::string("jlib::util::Date: gave up reading \"")
+                                + s + "\": " + e.what());
+            }
+            catch(abnf::error& e) {
+                throw exception("jlib::util::Date: \"" + s + "\" is not an RFC 5322 "
+                                "date-time, at column " + std::to_string(e.column()));
+            }
+
+            const int day = int_value(m["day-digits"].str());
+            const int mon = month_of(m["month"].text());
+
+            int year = int_value(m["year-digits"].str());
+            const std::size_t digits = m["year-digits"].str().size();
+
+            // RFC 5322 4.3: a two-digit year 00-49 is 20xx and 50-99 is 19xx;
+            // three digits are the year minus 1900.  This is the rule the
+            // obsolete syntax needs and the old code had no notion of -- it
+            // decided between %y and %Y by whether the token was four
+            // characters long and left the rest to strptime.
+            if(digits == 2)      year += (year < 50 ? 2000 : 1900);
+            else if(digits == 3) year += 1900;
+
+            const int hour = int_value(m["hour-digits"].str());
+            const int min = int_value(m["minute-digits"].str());
+            const int sec = m["second-digits"] ? int_value(m["second-digits"].str()) : 0;
+
+            int offset = 0;
+
+            if(m["zone-offset"]) {
+                const std::string o = m["zone-offset"].str();
+
+                offset = int_value(o.substr(0, 2)) * 60 + int_value(o.substr(2, 2));
+
+                if(m["zone-sign"].text() == "-") offset = -offset;
+            }
+            else if(m["obs-zone"]) {
+                offset = offset_of(m["obs-zone"].str());
+            }
+
+            const long long days = days_from_civil(year, static_cast<unsigned>(mon + 1),
+                                                   static_cast<unsigned>(day));
+
+            return static_cast<time_t>(days * 86400 + hour * 3600 + min * 60 + sec
+                                       - offset * 60);
+        }
+
+        bool Date::valid(const std::string& s) {
+            abnf::options o;
+
+            o.captures = abnf::options::capture_policy::none;
+
+            return static_cast<bool>(dates().at("date-time").try_parse(trim(s), o));
+        }
+
         void Date::set(const std::string& s, const std::string& fmt) {
-            //std::cout << "setting "<<s<<" to format "<<fmt<<std::endl;
             std::memset(&m_time, 0, sizeof(struct tm));
             m_current_tz = "";
+
+            if(fmt == "%O") {
+                set(parse_rfc5322(s));
+                return;
+            }
+
             std::istringstream is(s);
             build_date(is,fmt);
             reinit();
@@ -553,31 +612,8 @@ namespace jlib {
             }
         }
         
-        std::string Date::sanitize(const std::string& s) const {
-            std::string ret = s;
-            std::string bad = "();,\"\'[]";
-            std::string::size_type i;
-            while((i=ret.find_first_of(bad)) != s.npos) {
-                ret.erase(i,1);
-            }
-            return ret;
-        }
         
-        bool Date::is_alpha(const std::string& s) const {
-            for(std::string::size_type i=0; i<s.length(); i++) {
-                if(!isalpha(s[i]))
-                    return false;
-            }
-            return true;
-        }
         
-        bool Date::is_digit(const std::string& s) const {
-            for(std::string::size_type i=0; i<s.length(); i++) {
-                if(!isdigit(s[i]))
-                    return false;
-            }
-            return true;
-        }
         
         std::string Date::first_upper(const std::string& s) const {
             std::string ret = s;
@@ -590,47 +626,10 @@ namespace jlib {
             return ret;
         }
         
-        bool Date::is_time(const std::string& s) const {
-            return (
-                    s.length() == 8 &&
-                    isdigit(s[0]) &&
-                    isdigit(s[1]) &&
-                    s[2] == ':' &&
-                    isdigit(s[3]) &&
-                    isdigit(s[4]) &&
-                    s[5] == ':' &&
-                    isdigit(s[6]) &&
-                    isdigit(s[7])
-                    );
-        }
-        
-        bool Date::is_timezone(const std::string& s) const {
-            /*
-              bool nzone = ( (s.length() == 5) && (s[0] == '-' || s[0] == '+') && (is_digit(s.substr(1,4))) );
-              
-              bool szone = (
-              s.length() == 3 || 
-              s.length() == 5 || 
-              (s == "/etc/localtime") 
-              );
-              
-              std::string::size_type i = s.find("/");
-              bool lszone = (i != s.npos && is_alpha(s.substr(0,i)) && is_alpha(s.substr(i+1)));
-              return (nzone || szone || lszone);
-            */
-            // i used to actually give a damn about this field, for now
-            // i'm just going to call anything I don't recognize a timezone
-            return true;
-        }
         
         
-        bool Date::is_date(const std::string& s) const {
-            return true;
-        }
         
-        std::string Date::which_date(const std::string& s) const {
-            return s;
-        }
+        
         
         void Date::debug_print() const {
             std::cout << "m_time.tm_sec = " << m_time.tm_sec << std::endl;

--- a/jlib/util/Date.hh
+++ b/jlib/util/Date.hh
@@ -163,7 +163,37 @@ namespace jlib {
             virtual void set(struct tm* t);
             
             virtual std::string get(const std::string& fmt="%a, %d %b %Y %H:%M:%S %z") const;
+
+            /**
+             * Read a date.
+             *
+             * The default format "%O" means an RFC 5322 date-time -- the thing
+             * in a Date: header -- read against section 3.3's grammar, in
+             * jlib/util/rfc5322.hh.  Section 4.3's obsolete forms are accepted,
+             * because a Date: header is written by whoever sent the message
+             * and refusing one means refusing to sort a mailbox.
+             *
+             * Any other format string is a strftime-style one and is read by
+             * build_date() as before.
+             *
+             * Throws Date::exception on a date it cannot read.  It used to
+             * guess: is_timezone() returned true for every input, so the two
+             * "couldn't parse" throws below it were unreachable and any
+             * garbage became a format string that strptime then half-applied.
+             */
             virtual void set(const std::string& s, const std::string& fmt="%O");
+
+            /** Would it parse as an RFC 5322 date-time? */
+            static bool valid(const std::string& s);
+
+            /**
+             * An RFC 5322 date-time as seconds since the epoch.
+             *
+             * The zone in the header is applied, so this is an absolute
+             * instant and does not depend on where the machine reading it is.
+             * Throws Date::exception.
+             */
+            static time_t parse_rfc5322(const std::string& s);
             
             /**
              * return the current date as a time_t
@@ -201,47 +231,15 @@ namespace jlib {
              */
             void build_date(std::istream& is, const std::string& fmt);
             
-            /**
-             * automagically parse the date string, building a best
-             * guess as to the format
-             *
-             */
-            void auto_parse(std::istream& is);
-            
+
             /**
              * reinitialize m_time by calling mktime() and localtime(), 
              * successively
              */
             void reinit();
             
-            /**
-             * get rid of punctuation 
-             *
-             */
-            std::string sanitize(const std::string& s) const;
-            
-            /**
-             * is the entire std::string alpha
-             *
-             */
-            bool is_alpha(const std::string& s) const;
-            
-            /**
-             * is the entire std::string digit
-             *
-             */
-            bool is_digit(const std::string& s) const;
-            
-            bool is_time(const std::string& s) const;
-            bool is_timezone(const std::string& s) const;
-            bool is_date(const std::string& s) const;
-            
-            /**
-             * return the format std::string for the passed date
-             *
-             */
-            std::string which_date(const std::string& s) const;
-            
+
+
             /**
              * convert the std::string to first letter uppercase, ow lower
              *

--- a/jlib/util/rfc5322.hh
+++ b/jlib/util/rfc5322.hh
@@ -24,7 +24,10 @@ namespace jlib {
 namespace util {
 
 /**
- * RFC 5322 section 3.2, the lexical tokens the mail RFCs share.
+ * The parts of RFC 5322 that are not about addresses.
+ *
+ * Section 3.2's lexical tokens, which the mail RFCs share, and section 3.3's
+ * date-time, which is read by jlib::util::Date.
  *
  * Here rather than in jlib/net because three grammars need them and only one
  * of the three is about addresses.  RFC 2045 5.1 says its Content-Type
@@ -79,6 +82,75 @@ qs-body         =  *([FWS] qcontent) [FWS]    ; jlib: names what is between the
                                               ; parameter written as "a long "
                                               ; loses its last space
 
+)ABNF";
+
+/**
+ * Section 3.3, the Date: header.  Appended to LEXICAL.
+ *
+ * Section 4.3's obsolete forms are all here and all *first*, because every one
+ * of them subsumes the modern form it sits beside -- obs-day is
+ * "[CFWS] 1*2DIGIT [CFWS]" where day requires a trailing FWS, obs-year takes
+ * two digits where year takes four -- so under ordered choice the modern form
+ * would match a prefix, commit, and strand the rest.  The same reordering, for
+ * the same reason, as jlib/net/rfc5322.hh's OBSOLETE block.
+ *
+ * There is no policy switch here.  A Date: header is not something a client
+ * gets to be strict about: it is written by whatever sent the message, it is
+ * frequently obsolete syntax, and refusing to read one means refusing to sort
+ * a mailbox.
+ */
+inline const char* const DATE_TIME = R"ABNF(
+; 3.3
+date-time       =  [ day-of-week "," ] date time [CFWS]
+
+day-of-week     =  obs-day-of-week / ([FWS] day-name)
+day-name        =  "Mon" / "Tue" / "Wed" / "Thu" / "Fri" / "Sat" / "Sun"
+
+date            =  day month year
+day             =  obs-day / ([FWS] day-digits FWS)
+month           =  "Jan" / "Feb" / "Mar" / "Apr" / "May" / "Jun" /
+                   "Jul" / "Aug" / "Sep" / "Oct" / "Nov" / "Dec"
+year            =  obs-year / (FWS year-digits FWS)
+
+time            =  time-of-day zone
+time-of-day     =  hour ":" minute [ ":" second ]
+hour            =  obs-hour / hour-digits
+minute          =  obs-minute / minute-digits
+second          =  obs-second / second-digits
+
+; jlib: names for the digits, which the RFC writes inline.  The obsolete
+; forms wrap each field in [CFWS], so the span of "day" can be " 1 (the 2nd) "
+; -- and a comment is allowed to contain digits.  Scraping them out of the
+; span would read that comment as part of the date.
+day-digits      =  1*2DIGIT
+year-digits     =  2*DIGIT
+hour-digits     =  2DIGIT
+minute-digits   =  2DIGIT
+second-digits   =  2DIGIT
+
+; jlib: [CFWS] before the numeric form, which the RFC writes as FWS.  A
+; Date: header that folds before its zone, or carries a comment there, is
+; common and means what it says.
+zone            =  ([CFWS] zone-sign zone-offset) / ([CFWS] obs-zone)
+zone-sign       =  "+" / "-"
+zone-offset     =  4DIGIT
+
+; 4.3
+obs-day-of-week =  [CFWS] day-name [CFWS]
+obs-day         =  [CFWS] day-digits [CFWS]
+obs-year        =  [CFWS] year-digits [CFWS]
+obs-hour        =  [CFWS] hour-digits [CFWS]
+obs-minute      =  [CFWS] minute-digits [CFWS]
+obs-second      =  [CFWS] second-digits [CFWS]
+
+; jlib: "UTC" added, and first, because it is not RFC 5322 and it is
+; everywhere -- without it "UT" matches and strands the "C".  The single
+; letters come last for the same reason: "G" would take the first character
+; of "GMT".
+obs-zone        =  "UTC" / "UT" / "GMT" /
+                   "EST" / "EDT" / "CST" / "CDT" /
+                   "MST" / "MDT" / "PST" / "PDT" /
+                   %d65-73 / %d75-90 / %d97-105 / %d107-122
 )ABNF";
 
 }

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -63,6 +63,7 @@ TESTS = \
 	util_test \
 	util_codec_test \
 	util_url_test \
+	util_date_test \
 	util_rfc2047_test \
 	util_headers_test \
 	util_headers_manual_test \
@@ -155,6 +156,9 @@ util_test_SOURCES = util_test.cc
 util_test_LDADD   = $(JUTIL_LA)
 util_rfc2047_test_SOURCES       = util_rfc2047_test.cc
 util_rfc2047_test_LDADD         = $(JUTIL_LA)
+
+util_date_test_SOURCES          = util_date_test.cc
+util_date_test_LDADD            = $(JUTIL_LA)
 
 util_url_test_SOURCES           = util_url_test.cc
 util_url_test_LDADD             = $(JUTIL_LA)

--- a/tests/util_date_test.cc
+++ b/tests/util_date_test.cc
@@ -1,0 +1,302 @@
+/* -*- mode: C++ c-basic-offset: 4 -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// The Date: header, read against RFC 5322 section 3.3.
+//
+// Live: Email::operator< parses both sides every time a mailbox is sorted by
+// date.  What was there guessed a strftime format token by token, and could
+// not fail -- is_timezone() returned true for every possible input, so the two
+// "couldn't parse" throws below it were unreachable and any string at all
+// produced a format that strptime then half-applied.
+
+#include <jlib/util/Date.hh>
+#include <jlib/util/rfc5322.hh>
+
+#include <jlib/util/abnf.hh>
+
+#include <iostream>
+#include <string>
+
+using jlib::util::Date;
+
+static int failures = 0;
+
+static void ok(const std::string& what, bool good, const std::string& detail = "") {
+    if(!good) ++failures;
+    std::cout << (good ? "  ok   " : "  FAIL ") << what;
+    if(!detail.empty()) std::cout << ": " << detail;
+    std::cout << "\n";
+}
+
+static time_t when(const char* s) {
+    try { return Date::parse_rfc5322(s); }
+    catch(Date::exception&) { return -1; }
+}
+
+static void the_canonical_example() {
+    std::cout << "RFC 5322 appendix A.1.1:\n";
+
+    // The date on the RFC's own example message.
+    ok("Fri, 21 Nov 1997 09:55:06 -0600",
+       when("Fri, 21 Nov 1997 09:55:06 -0600") == 880127706,
+       std::to_string(when("Fri, 21 Nov 1997 09:55:06 -0600")));
+
+    // The instant is absolute: the zone in the header is applied, so this does
+    // not depend on where the machine reading it is.  The old code reached for
+    // strptime's %Z, which cannot set an offset at all.
+    ok("the same instant, written five ways",
+       when("Fri, 21 Nov 1997 15:55:06 +0000") == 880127706 &&
+       when("Fri, 21 Nov 1997 15:55:06 GMT")   == 880127706 &&
+       when("Fri, 21 Nov 1997 15:55:06 UT")    == 880127706 &&
+       when("Fri, 21 Nov 1997 10:55:06 EST")   == 880127706 &&
+       when("Fri, 21 Nov 1997 07:55:06 PST")   == 880127706);
+
+    // The day-name is not consulted.  RFC 5322 3.3 says it may disagree with
+    // the date, and the date wins.
+    ok("a wrong day-name does not change the answer",
+       when("Sun, 21 Nov 1997 09:55:06 -0600") == 880127706);
+}
+
+static void real_headers() {
+    std::cout << "\nwhat arrives in the post:\n";
+
+    // Every one of these is the same instant written differently.
+    struct { const char* what; const char* s; } same[] = {
+        { "no day-name",          "21 Nov 1997 09:55:06 -0600" },
+        { "no space after comma", "Fri,21 Nov 1997 09:55:06 -0600" },
+        { "a trailing comment",   "Fri, 21 Nov 1997 09:55:06 -0600 (CST)" },
+        { "a comment mid-date",   "Fri, 21 (the 21st) Nov 1997 09:55:06 -0600" },
+        { "folded before the zone",
+          "Fri, 21 Nov 1997 09:55:06\r\n  -0600" },
+        { "leading and trailing space",
+          "  Fri, 21 Nov 1997 09:55:06 -0600  " },
+    };
+
+    for(const auto& g : same) {
+        ok(g.what, when(g.s) == 880127706, std::to_string(when(g.s)));
+    }
+
+    // These are different instants, so they get their own assertions -- the
+    // first draft of this test put them in the list above and expected them to
+    // come out the same, which they very much should not.
+    ok("no seconds means zero seconds",
+       when("Fri, 21 Nov 1997 09:55 -0600") == 880127706 - 6,
+       std::to_string(when("Fri, 21 Nov 1997 09:55 -0600")));
+
+    ok("a one-digit day is that day",
+       when("Sat, 1 Nov 1997 09:55:06 -0600") ==
+       when("Sat, 01 Nov 1997 09:55:06 -0600"),
+       std::to_string(when("Sat, 1 Nov 1997 09:55:06 -0600")));
+
+    ok("and it is twenty days before the twenty-first",
+       880127706 - when("Sat, 1 Nov 1997 09:55:06 -0600") == 20 * 86400);
+}
+
+static void obsolete_syntax() {
+    std::cout << "\nsection 4.3, which real mail is full of:\n";
+
+    // 4.3: two digits, 00-49 is 20xx and 50-99 is 19xx; three digits are the
+    // year minus 1900.  The old code decided between %y and %Y by whether the
+    // token was four characters long and left the rest to strptime.
+    ok("a two-digit year in the nineties",
+       when("Fri, 21 Nov 97 09:55:06 -0600") == 880127706,
+       std::to_string(when("Fri, 21 Nov 97 09:55:06 -0600")));
+
+    ok("and one in the twenty-first century",
+       when("Sat, 01 Jan 05 00:00:00 +0000") == when("Sat, 01 Jan 2005 00:00:00 +0000"));
+
+    ok("00 is 2000, not 1900",
+       when("Sat, 01 Jan 00 00:00:00 +0000") == when("Sat, 01 Jan 2000 00:00:00 +0000"));
+    ok("50 is 1950",
+       when("Sun, 01 Jan 50 00:00:00 +0000") == when("Sun, 01 Jan 1950 00:00:00 +0000"));
+    ok("and three digits are 1900 plus",
+       when("Thu, 01 Jan 104 00:00:00 +0000") == when("Thu, 01 Jan 2004 00:00:00 +0000"));
+
+    // Comments anywhere a field may carry CFWS.  This is the reason the digits
+    // have rules of their own: obs-day's span can be " 21 (the 21st) " and a
+    // comment is allowed to contain digits, so scraping the span would read
+    // the comment as part of the date.
+    ok("a comment with a number in it is not the number",
+       when("Fri, 21 (the 2nd) Nov 1997 09:55:06 -0600") == 880127706,
+       std::to_string(when("Fri, 21 (the 2nd) Nov 1997 09:55:06 -0600")));
+}
+
+static void zones() {
+    std::cout << "\nzones:\n";
+
+    const time_t noon = when("Thu, 01 Jan 1970 12:00:00 +0000");
+
+    ok("+0000 is the epoch's noon", noon == 43200, std::to_string(noon));
+    ok("a positive offset is subtracted",
+       when("Thu, 01 Jan 1970 12:00:00 +0100") == noon - 3600);
+    ok("and a negative one added",
+       when("Thu, 01 Jan 1970 12:00:00 -0100") == noon + 3600);
+    ok("minutes count too",
+       when("Thu, 01 Jan 1970 12:00:00 +0530") == noon - (5 * 3600 + 30 * 60));
+
+    ok("the named North American zones",
+       when("Thu, 01 Jan 1970 12:00:00 EST") == noon + 5 * 3600 &&
+       when("Thu, 01 Jan 1970 12:00:00 EDT") == noon + 4 * 3600 &&
+       when("Thu, 01 Jan 1970 12:00:00 PST") == noon + 8 * 3600);
+
+    // Not RFC 5322, and everywhere.  Without it "UT" matches and strands the
+    // "C", so the whole header fails.
+    ok("UTC, which the RFC does not list", when("Thu, 01 Jan 1970 12:00:00 UTC") == noon);
+
+    // RFC 5322 4.3: the single military letters "were defined incorrectly" in
+    // RFC 822, and a parser SHOULD treat them as -0000.  Reading "A" as +0100
+    // would be repeating the older document's mistake.
+    ok("a military letter parses and means unknown",
+       when("Thu, 01 Jan 1970 12:00:00 A") == noon &&
+       when("Thu, 01 Jan 1970 12:00:00 Z") == noon);
+
+    // -0000 means "the zone is not known", which is not the same as UTC, but
+    // there is nowhere in a time_t to put the difference.
+    ok("-0000 reads as zero", when("Thu, 01 Jan 1970 12:00:00 -0000") == noon);
+}
+
+static void it_can_fail_now() {
+    std::cout << "\nwhat it refuses:\n";
+
+    // The whole of #93.  is_timezone() was:
+    //
+    //     // i used to actually give a damn about this field, for now
+    //     // i'm just going to call anything I don't recognize a timezone
+    //     return true;
+    //
+    // and it was the last test in both branches of the classifier, so nothing
+    // ever reached a throw and every one of these produced a format string.
+    for(const char* s : { "garbage", "", "   ", "not a date at all",
+                          "Mon, 25 Aug 2026",            // no time
+                          "25 Aug 2026 14:30:00",        // no zone
+                          "Mon, 32 Foo 2026 25:99 -0700",// no such month
+                          "Mon, 25 Aug 2026 14:30:00 -07", // short zone
+                          "Mon, 25 Aug 2026 1:2:3 -0700" }) {
+        ok(std::string("\"") + s + "\"", !Date::valid(s));
+    }
+
+    // And it says where.
+    std::string msg;
+
+    try { Date::parse_rfc5322("Mon, 32 Foo 2026 25:99 -0700"); }
+    catch(Date::exception& e) { msg = e.what(); }
+
+    ok("with a column", msg.find("column") != std::string::npos, msg);
+
+    // set() throws too, which is the entry point Email uses.
+    bool threw = false;
+
+    try { Date d; d.set("garbage"); }
+    catch(Date::exception&) { threw = true; }
+
+    ok("and set() does not silently produce a wrong time", threw);
+}
+
+static void the_grammar_itself() {
+    std::cout << "\nthe grammar:\n";
+
+    using namespace jlib::util::abnf;
+
+    bool built = false;
+    std::string why;
+
+    try {
+        grammar g = compile(std::string(jlib::util::rfc5322::LEXICAL) +
+                            jlib::util::rfc5322::DATE_TIME);
+        g.check();
+        built = true;
+    }
+    catch(exception& e) { why = e.what(); }
+
+    ok("it compiles and checks", built, why);
+
+    // Every month name, since a wrong table here is a silent twelve-month
+    // error rather than a parse failure.
+    static const char* const MONTHS[] = {
+        "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+        "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
+    };
+
+    time_t previous = 0;
+    bool ordered = true;
+
+    for(int i = 0; i < 12; i++) {
+        const std::string s = std::string("01 ") + MONTHS[i] + " 2001 00:00:00 +0000";
+        const time_t t = when(s.c_str());
+
+        if(t <= previous) ordered = false;
+
+        previous = t;
+    }
+
+    ok("the twelve months are in order and a month apart", ordered);
+
+    ok("January the first, 2001, is where it should be",
+       when("Mon, 01 Jan 2001 00:00:00 +0000") == 978307200,
+       std::to_string(when("Mon, 01 Jan 2001 00:00:00 +0000")));
+
+    // A leap day, which the civil-days arithmetic has to get right: 2000 was
+    // a leap year, 1900 was not, and the rule that decides is the one people
+    // implement wrong.
+    ok("29 February 2000 is where it should be",
+       when("Tue, 29 Feb 2000 00:00:00 +0000") == 951782400,
+       std::to_string(when("Tue, 29 Feb 2000 00:00:00 +0000")));
+
+    ok("and 1 March 1900 is one day after 28 February 1900",
+       when("Thu, 01 Mar 1900 00:00:00 +0000") -
+       when("Wed, 28 Feb 1900 00:00:00 +0000") == 86400);
+
+    // Shape, not sense.  "30 Feb" parses and rolls over, which is what the
+    // disclaimer at the bottom is about.
+    ok("30 February parses, because the grammar checks shape",
+       Date::valid("Wed, 30 Feb 2000 00:00:00 +0000"));
+}
+
+int main() {
+    std::cout << std::unitbuf;
+
+    the_canonical_example();
+    real_headers();
+    obsolete_syntax();
+    zones();
+    it_can_fail_now();
+    the_grammar_itself();
+
+    // What a green run does NOT establish.
+    //
+    // Not that the date is real.  The grammar checks shape, not sense:
+    // "31 Feb", "25:99:99" and a day of 99 all parse, and the arithmetic
+    // rolls them over into the following month or day rather than refusing
+    // them.  RFC 5322 does not require a parser to reject them and mail
+    // contains them; a client that dropped a message because its clock was
+    // wrong would be worse than one that filed it a day late.
+    //
+    // Not the local-time accessors.  parse_rfc5322 returns an absolute
+    // instant; Date::set(time_t) then runs it through localtime, so year(),
+    // hour() and the rest depend on TZ.  Nothing here sets TZ, so those are
+    // not asserted -- what is asserted is the time_t, which does not.
+    //
+    // Not -0000.  RFC 5322 3.3 distinguishes it from +0000: it means the zone
+    // is unknown rather than that the sender was at UTC.  There is nowhere in
+    // a time_t to keep that, so both read as zero.
+    //
+    // Not the other direction.  Date::get() still builds its output with the
+    // strftime-style code this branch did not touch.
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
Closes #93.  The last of the seven from the parsing survey.

    macOS  44 tests, 44 pass, 0 skip
    Linux  45 tests, 44 pass, 1 skip

    jlib/util/rfc5322.hh      +DATE_TIME
    jlib/util/Date.{hh,cc}    -230 net; the guesser and its six helpers
    jlib/net/Email.cc         the comparator that would now throw
    tests/util_date_test.cc   new

it could not fail

    Date::auto_parse worked out a strftime format by classifying each
    whitespace-separated token, and the last classifier in both branches was:

        bool Date::is_timezone(const std::string& s) const {
            /* ... commented-out implementation ... */
            // i used to actually give a damn about this field, for now
            // i'm just going to call anything I don't recognize a timezone
            return true;
        }

    It returns true for every input, so the two `throw exception("couldn't
    parse ...")` lines below it were unreachable.  Any string at all -- an
    empty one, a Subject line, a base64 blob -- produced a format string, which
    strptime then half-applied to whatever was left in the struct tm.  Nothing
    ever reported a failure, so nothing was ever noticed.

    Three more, all in the same function.  `while(!is.eof()) { is >> buf; ... }`
    pushed a phantom empty token, which is_alpha("") accepted vacuously
    because the loop body never ran.  `fmt[fmt.length()-1]` underflows on
    empty input.  And is_alpha/is_digit passed a plain char to isalpha and
    isdigit, which is undefined for a negative value -- the same bug that went
    out with Email::is_valid, reachable here through any Date: header with an
    RFC 2047 encoded word in it.

    This is live.  Email::operator< parses both sides every time a mailbox is
    sorted by date.

what it is now

    RFC 5322 section 3.3, in jlib/util/rfc5322.hh beside section 3.2's
    lexical tokens, which it needs for CFWS.  Section 4.3's obsolete forms are
    all there and all first, because every one of them subsumes the modern
    form beside it -- obs-day is "[CFWS] 1*2DIGIT [CFWS]" where day requires a
    trailing FWS, obs-year takes two digits where year takes four.  The same
    reordering, for the same reason, as the address grammar's.

    There is no strict policy.  A Date: header is written by whoever sent the
    message and refusing one means refusing to sort a mailbox.

    Two marked deviations.  "UTC" is added and comes first, because it is not
    in RFC 5322, it is everywhere, and without it "UT" matches and strands the
    "C".  And zone takes [CFWS] where the RFC writes FWS, so a header that
    folds before its zone reads.

    The single military letters parse and mean zero.  RFC 5322 4.3 says they
    "were defined incorrectly" in RFC 822 and SHOULD be treated as -0000;
    reading "A" as +0100 would be repeating the older document's mistake.

    The two-digit year rule from 4.3 is implemented: 00-49 is 20xx, 50-99 is
    19xx, three digits are plus 1900.  The old code decided between %y and %Y
    by whether the token happened to be four characters long.

the digits have rules of their own

        day-digits   =  1*2DIGIT
        year-digits  =  2*DIGIT

    because obs-day wraps the field in [CFWS] on both sides and a comment may
    contain digits.  The span of "day" in

        Fri, 21 (the 2nd) Nov 1997 09:55:06 -0600

    is " 21 (the 2nd) ", and scraping digits out of it reads the comment as
    part of the date.  The test asserts that one directly.

the arithmetic

    Howard Hinnant's days_from_civil, rather than timegm() -- which is in no C
    or C++ standard -- or mktime(), which would apply the local zone to a time
    that already carries its own.  The zone in the header is applied, so what
    comes back is an absolute instant that does not depend on where the machine
    reading it is.  strptime's %Z, which the old code reached for, cannot set
    an offset at all.

a comparator that throws is worse than a wrong answer

    Date::set throws now where it used to guess, and Email::operator< called
    it on both sides.  A comparator that throws part way through std::sort
    leaves the range in an unspecified state, so an unreadable Date: header is
    caught there and treated as the epoch: that message sorts first, and the
    other forty-nine in the folder stay where they belong.

what a green run does not establish

    Not that the date is real.  The grammar checks shape: "31 Feb",
    "25:99:99" and a day of 99 all parse, and the arithmetic rolls them over.
    RFC 5322 does not require a parser to reject them, mail contains them, and
    a client that dropped a message because the sender's clock was wrong would
    be worse than one that filed it a day late.

    Not -0000.  Section 3.3 distinguishes it from +0000 -- it means the zone is
    unknown rather than that the sender was at UTC -- and there is nowhere in a
    time_t to keep the difference.

    Not the local-time accessors.  parse_rfc5322 returns an instant; set()
    runs it through localtime, so year() and hour() depend on TZ.  What the
    test asserts is the time_t, which does not.

    Not Date::get().  The other direction still builds its output with the
    strftime-style code this branch did not touch.
