### PR TITLE
Read IMAP responses against RFC 3501's grammar, and prove it against a server

### DIFF
--- a/DOCKER
+++ b/DOCKER
@@ -27,5 +27,17 @@ autogen/configure/make steps.  A .dockerignore keeps the host's build trees
 and generated autotools output out of the image so the container always
 bootstraps for its own platform.
 
+The image also installs dovecot-imapd, for tests/net_imap_live_test.  That
+test starts a Dovecot on a high port with a Maildir it seeds, drives
+jlib::net::Imap4 against it, and stops it again -- it is the only thing in the
+suite that talks to a server rather than to a std::istringstream, and the only
+way to exercise a literal, because only a server decides when to send one.
+
+Outside the container there is usually no dovecot, and the test reports SKIP
+(exit 77) rather than failing.  It needs to run as root: Dovecot refuses to
+start imap-login as root, so the config leaves that process on the package's
+own unprivileged user, and the seeded Maildir has to be chowned to an ordinary
+uid because Dovecot also refuses a mail uid of 0.
+
 Note: the crypt_groth_test allocates heavily.  If it is killed with exit 137
 the container hit its memory ceiling -- raise the Docker VM's RAM allocation.

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,12 @@
 # virtualization layer, which makes C++ compilation dramatically slower.
 # Dependencies are installed in their own layer so edits to the source do not
 # re-run apt.
+#
+# dovecot-imapd is here for tests/net_imap_live_test, which starts a real IMAP
+# server on a high port with a seeded Maildir and drives jlib::net::Imap4
+# against it.  It is the only way to exercise the literal handling end to end:
+# a std::istringstream can be made to produce any response, but only a server
+# decides when to send a literal.
 
 FROM ubuntu:24.04
 
@@ -39,6 +45,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libgl-dev \
         libglu1-mesa-dev \
         freeglut3-dev \
+        dovecot-imapd \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /src/jlib

--- a/jlib/net/Imap4.cc
+++ b/jlib/net/Imap4.cc
@@ -746,59 +746,70 @@ namespace jlib {
         }
         void Imap4::login(sys::socketstream& sock, const std::string& user, const std::string& pass) {
             if(user!="" && pass != "") {
-                handshake(sock,"LOGIN "+user+" "+pass);
+                handshake(sock, "LOGIN " + imap::quote(user) + " " + imap::quote(pass));
             }
             else {
-                handshake(sock,"LOGIN "+m_user+" "+m_pass);            
+                handshake(sock, "LOGIN " + imap::quote(m_user) + " " + imap::quote(m_pass));
             }
             m_state = Authenticated;
         }
 
         std::vector<std::string> Imap4::select(sys::socketstream& sock, const std::string& path) {
-            std::vector<std::string> config = handshake(sock,"SELECT \""+path+"\"");
+            std::vector<std::string> config = handshake(sock, "SELECT " + imap::quote(path));
             parse(config);
             m_state = Selected;
             return config;
         }
         
         std::vector<std::string> Imap4::examine(sys::socketstream& sock, const std::string& path) {
-            std::vector<std::string> ret = handshake(sock,"EXAMINE \""+path+"\"");
+            std::vector<std::string> ret = handshake(sock, "EXAMINE " + imap::quote(path));
             parse(ret);
             m_state = Selected;
             return ret;
         }
 
         void Imap4::create(sys::socketstream& sock, const std::string& path) {
-            handshake(sock,"CREATE \""+path+"\"");
+            handshake(sock, "CREATE " + imap::quote(path));
         }
         void Imap4::remove(sys::socketstream& sock, const std::string& path) {
-            handshake(sock,"DELETE \""+path+"\"");
+            handshake(sock, "DELETE " + imap::quote(path));
         }
         void Imap4::rename(sys::socketstream& sock, const std::string& old_name, const std::string& new_name) {
-            handshake(sock,"RENAME \""+old_name+"\" \""+new_name+"\"");
+            handshake(sock, "RENAME " + imap::quote(old_name) + " " + imap::quote(new_name));
         }
         void Imap4::subscribe(sys::socketstream& sock, const std::string& path) {
-            handshake(sock,"SUBSCRIBE \""+path+"\"");
+            handshake(sock, "SUBSCRIBE " + imap::quote(path));
         }
         void Imap4::unsubscribe(sys::socketstream& sock, const std::string& path) {
-            handshake(sock,"UNSUBSCRIBE \""+path+"\"");
+            handshake(sock, "UNSUBSCRIBE " + imap::quote(path));
         }
 
         std::vector<ListItem> Imap4::list(sys::socketstream& sock, const std::string& ref, const std::string& path) {
             std::vector<ListItem> ret;
-            std::vector<std::string> ls = handshake(sock,"LIST \""+ref+"\" \""+path+"\"");
-            for(unsigned int i=0;i<ls.size()-1;i++) {
+            std::vector<std::string> ls = handshake(sock, "LIST " + imap::quote(ref) + " " + imap::quote(path));
+
+            // i + 1 < size(), not i < size() - 1: the last response is the
+            // tagged completion and is not a list item, and on an empty vector
+            // size() - 1 is SIZE_MAX.
+            for(std::size_t i = 0; i + 1 < ls.size(); i++) {
                 ret.push_back(ListItem(ls[i]));
             }
+
             return ret;
         }
 
         std::vector<ListItem> Imap4::lsub(sys::socketstream& sock, const std::string& ref, const std::string& path) {
             std::vector<ListItem> ret;
-            std::vector<std::string> ls = handshake(sock,"LIST \""+ref+"\" \""+path+"\"");
-            for(unsigned int i=0;i<ls.size()-1;i++) {
+
+            // LSUB, not LIST.  This sent LIST, so asking for the subscribed
+            // mailboxes returned all of them -- which is not a parse error, or
+            // any kind of error, just the wrong answer.
+            std::vector<std::string> ls = handshake(sock, "LSUB " + imap::quote(ref) + " " + imap::quote(path));
+
+            for(std::size_t i = 0; i + 1 < ls.size(); i++) {
                 ret.push_back(ListItem(ls[i]));
             }
+
             return ret;
         }
 
@@ -810,9 +821,11 @@ namespace jlib {
                 (path == "INBOX" ? path : (m_url.get_path_no_slash() + path));
             tag(1);
             if(getenv("JLIB_NET_IMAP4_DEBUG")) {
-                std::cout << tag() << " APPEND \""<<path<<"\" ("<<flag<<") {"<<data.length()<<"}"<<std::endl;
+                std::cout << tag() << " APPEND " << imap::quote(path)
+                          << " (" << flag << ") {" << data.length() << "}" << std::endl;
             }
-            sock << tag() << " APPEND \""<<path<<"\" ("<<flag<<") {"<<data.length()<<"}"<<ENDL << std::flush;
+            sock << tag() << " APPEND " << imap::quote(path)
+                 << " (" << flag << ") {" << data.length() << "}" << ENDL << std::flush;
             sys::getline(sock,buf);
             if(getenv("JLIB_NET_IMAP4_DEBUG")) {
                 std::cout <<buf<<std::endl;
@@ -891,7 +904,7 @@ namespace jlib {
         void Imap4::copy(sys::socketstream& sock, std::pair<unsigned int,unsigned int> set, const std::string& box) {
             std::string path = (box == "INBOX" ? box : (m_url.get_path_no_slash() + box));
             std::ostringstream cmd;
-            cmd << "COPY " << set.first << ":" << set.second << " \"" << path << "\"";
+            cmd << "COPY " << set.first << ":" << set.second << " " << imap::quote(path);
             std::vector<std::string> ret = handshake(sock,cmd.str());
         }
         

--- a/jlib/net/Imap4.cc
+++ b/jlib/net/Imap4.cc
@@ -21,7 +21,7 @@
 #include <jlib/net/net.hh>
 #include <jlib/net/Imap4.hh>
 
-#include <jlib/util/abnf.hh>
+#include <jlib/net/imap_response.hh>
 
 #include <jlib/sys/sys.hh>
 #include <jlib/sys/sslstream.hh>
@@ -146,70 +146,6 @@ namespace jlib {
 
 
 
-        namespace {
-
-            /**
-             * RFC 3501's literal introducer, and RFC 7888's.
-             *
-             * Two productions, so this is a small thing to reach for a grammar
-             * over -- but it is the RFC's own two productions, which is the
-             * point: what is accepted here can be checked by reading 4.3
-             * rather than by reading this.  Built once, on first use, for the
-             * reason in crypt/curve.hh:42.
-             */
-            const util::abnf::grammar& imap_literal() {
-                static util::abnf::grammar g = [] {
-                    util::abnf::grammar g = util::abnf::compile(
-                        "literal-introducer = \"{\" number [\"+\"] \"}\"\r\n"
-                        "number             = 1*DIGIT\r\n");
-                    g.check();
-
-                    return g;
-                }();
-
-                return g;
-            }
-
-        }
-
-        bool Imap4::literal_size(const std::string& line, std::size_t& n) {
-            // The introducer is the last thing on the line, so this is where
-            // it has to start if it is anywhere.
-            const std::string::size_type b = line.rfind('{');
-
-            if(b == line.npos) return false;
-
-            util::abnf::options o;
-            o.captures = util::abnf::options::capture_policy::listed;
-            o.capture_only = { "number" };
-
-            const util::abnf::parse_result r =
-                imap_literal().at("literal-introducer").try_parse(line.substr(b), o);
-
-            // A whole-input match, so "{12} more words" is not a literal and
-            // neither is "{}", "{-1}" or "{12x}".
-            if(!r) return false;
-
-            const std::string digits = r.root()["number"].str();
-
-            // A count from the network decides how many octets to read, so it
-            // is refused rather than clamped when it is absurd.  Two gigabytes
-            // is past anything a mail server will send in one literal and is
-            // also where the long this used to be held in would have gone
-            // negative.
-            try {
-                const unsigned long long v = std::stoull(digits);
-
-                if(v > 0x7FFFFFFFull) return false;
-
-                n = static_cast<std::size_t>(v);
-            }
-            catch(std::exception&) {
-                return false;
-            }
-
-            return true;
-        }
 
         Imap4::Imap4(util::URL url) 
             : m_url(url)
@@ -328,7 +264,7 @@ namespace jlib {
 
             std::size_t literal = 0;
 
-            if(!literal_size(buf, literal)) {
+            if(!imap::literal_size(buf, literal)) {
                 throw exception("expected a literal at the end of: " + buf);
             }
 
@@ -443,7 +379,7 @@ namespace jlib {
 
             std::size_t literal = 0;
 
-            if(!literal_size(buf, literal)) {
+            if(!imap::literal_size(buf, literal)) {
                 throw exception("expected a literal at the end of: " + buf);
             }
 
@@ -496,7 +432,7 @@ namespace jlib {
             std::vector<std::string> bufvec = util::tokenize(buf);
             std::size_t literal = 0;
 
-            if(!literal_size(buf, literal)) {
+            if(!imap::literal_size(buf, literal)) {
                 throw exception("expected a literal at the end of: " + buf);
             }
 
@@ -654,10 +590,25 @@ namespace jlib {
             }
             sock << com << ENDL << std::flush;
 
-            std::string end = (idle ? "+" : tag());
+            const std::string end = (idle ? "+" : tag());
 
+            // One *response* at a time, not one line.  RFC 3501 4.3 lets a
+            // response carry a literal -- "{32}" CRLF and then that many
+            // octets of message content -- and those octets may contain a line
+            // that looks exactly like the tagged completion this loop is
+            // waiting for.  Reading lines therefore stopped in the middle of a
+            // message, and every command after it read the rest of that
+            // message as its own response.
             while(!util::begins(buf, end)) {
-                sys::getline(sock, buf);
+                buf = imap::read(sock);
+
+                // The trailing CRLF comes off, as sys::getline used to take
+                // it, so that what a caller sees is unchanged for every
+                // response that has no literal in it.
+                while(!buf.empty() && (buf.back() == '\n' || buf.back() == '\r')) {
+                    buf.pop_back();
+                }
+
                 if(getenv("JLIB_NET_IMAP4_DEBUG")) std::cout << buf << std::endl;
                 ret.push_back(buf);
             }
@@ -672,7 +623,12 @@ namespace jlib {
                 sock << "DONE" << ENDL << std::flush;
 
                 while(!util::begins(buf, tag())) {
-                    sys::getline(sock, buf);
+                    buf = imap::read(sock);
+
+                    while(!buf.empty() && (buf.back() == '\n' || buf.back() == '\r')) {
+                        buf.pop_back();
+                    }
+
                     if(getenv("JLIB_NET_IMAP4_DEBUG")) std::cout << buf << std::endl;
                     ret.push_back(buf);
                 }

--- a/jlib/net/Imap4.hh
+++ b/jlib/net/Imap4.hh
@@ -348,27 +348,6 @@ namespace jlib {
 
             
             /**
-             * The octet count of the literal a response line ends with.
-             *
-             * RFC 3501 4.3: a literal is "{" number "}" CRLF followed by that
-             * many octets, and RFC 7888 adds the non-synchronising "{n+}".
-             * The count is the only way to know where the literal ends, so
-             * getting it wrong desynchronises the connection for good.
-             *
-             * Returns false when the line does not end in a literal, which is
-             * the case the old code got wrong: it took the last token of the
-             * line and asked util::slice for what was between "{" and "}",
-             * and slice returns its whole input when the delimiters are not
-             * there.  int_value of that is 0, so a response with no literal --
-             * an error, a NIL, a server that answered something else -- read
-             * zero octets and then consumed the message body as though it were
-             * protocol.
-             *
-             * Static and public because it is worth testing without a server.
-             */
-            static bool literal_size(const std::string& line, std::size_t& n);
-
-            /**
              * The FETCH command retrieves data associated with a message in the
              * mailbox.  The data items to be fetched may be either a single atom
              * or a parenthesized list.  The currently defined data items that

--- a/jlib/net/Makefile.am
+++ b/jlib/net/Makefile.am
@@ -4,7 +4,7 @@ lib_LTLIBRARIES = libjnet.la
 libjnet_la_SOURCES = Email.cc MailBox.cc Imap4Box.cc Pop3.cc MBox.cc \
                      Imap4.cc Imap4Fetch.cc net.cc MFolder.cc Imap4Folder.cc \
                      MailFolder.cc ASMailBox.cc ASImapBox.cc ASMBox.cc \
-                     address.cc
+                     address.cc imap_response.cc
 libjnet_la_LDFLAGS = -version-info $(LIBJ_SO_VERSION) -release $(JLIB_RELEASE) -no-undefined
 libjnet_la_LIBADD = $(top_builddir)/jlib/sys/libjsys.la \
                     $(top_builddir)/jlib/util/libjutil.la \
@@ -15,4 +15,5 @@ libjnetincludedir = $(includedir)/jlib-1.2/jlib/net
 libjnetinclude_HEADERS = Imap4Box.hh Pop3.hh MBox.hh Email.hh \
                          Imap4.hh Imap4Fetch.hh net.hh MFolder.hh \
                          Imap4Folder.hh MailBox.hh MailFetch.hh MailFolder.hh \
-                         ASMailBox.hh ASImapBox.hh ASMBox.hh address.hh rfc5322.hh
+                         ASMailBox.hh ASImapBox.hh ASMBox.hh address.hh rfc5322.hh \
+                         imap_response.hh rfc3501.hh

--- a/jlib/net/imap_response.cc
+++ b/jlib/net/imap_response.cc
@@ -1,0 +1,383 @@
+/* -*- mode: C++ c-basic-offset: 4 -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <jlib/net/imap_response.hh>
+#include <jlib/net/rfc3501.hh>
+
+#include <jlib/util/abnf.hh>
+#include <jlib/util/util.hh>
+
+#include <istream>
+
+namespace jlib {
+namespace net {
+namespace imap {
+
+namespace {
+
+using util::abnf::grammar;
+using util::abnf::match;
+using util::abnf::options;
+using util::abnf::rule;
+
+/**
+ * The grammar, with literal supplied in combinators.
+ *
+ * RFC 3501 4.3 writes the length constraint in a comment because ABNF cannot
+ * express it, so rfc3501.hh references `literal` and never defines it and
+ * counted() defines it here.  check() runs after, not before -- an undefined
+ * rule is exactly what it would object to.
+ *
+ * Function-local for the reason at crypt/curve.hh:42.
+ */
+const grammar& responses()
+{
+    static grammar g = [] {
+        grammar g = util::abnf::compile(rfc3501::RESPONSE);
+
+        const rule size = util::abnf::as("literal-size",
+                                         +util::abnf::core::DIGIT());
+
+        g.define("literal",
+                 util::abnf::lit("{") >> size >> util::abnf::lit("}")
+                 >> util::abnf::core::CRLF()
+                 >> util::abnf::as("literal-text", util::abnf::counted(size)));
+
+        g.check();
+
+        return g;
+    }();
+
+    return g;
+}
+
+options parse_options()
+{
+    options o;
+
+    o.captures = options::capture_policy::listed;
+    o.capture_only = {
+        "continue-req", "response-tagged", "response-data",
+        "rtag", "cond-name", "resp-text-code", "text",
+        "mailbox-data", "capability-data", "list-name", "count-name",
+        "mailbox", "delim", "capability", "message-data", "number",
+        "flag-list", "flag",
+        "msg-att", "msg-att-item", "att-name", "att-section", "att-value",
+        "att-group",
+        "nstring", "nil", "quoted-body", "literal-text",
+    };
+
+    return o;
+}
+
+/** The text of an astring or an attribute value, however it was written. */
+std::string text_of(const match& m)
+{
+    // A parenthesised value is handed back as written: jlib does not
+    // interpret an ENVELOPE or a BODYSTRUCTURE, and reaching inside for the
+    // first string it finds -- which is what this did before the test caught
+    // it -- turns "(\"d\" \"s\" NIL NIL)" into "d".
+    if(m["att-group"]) return m.str();
+
+    if(const match q = m["quoted-body"]) {
+        // RFC 3501 4.3: inside a quoted string, only DQUOTE and backslash may
+        // be escaped, and each stands for itself.
+        std::string out;
+        const std::string_view s = q.text();
+
+        for(std::size_t i = 0; i < s.size(); i++) {
+            if(s[i] == '\\' && i + 1 < s.size()) i++;
+
+            out += s[i];
+        }
+
+        return out;
+    }
+
+    if(const match l = m["literal-text"]) return l.str();
+    if(m["nil"])                          return std::string();
+
+    return m.str();
+}
+
+}
+
+// ------------------------------------------------------------------ reading
+
+bool literal_size(const std::string& line, std::size_t& n)
+{
+    // The introducer is the last thing on the line, so this is where it has to
+    // start if it is anywhere.
+    const std::string::size_type b = line.rfind('{');
+
+    if(b == line.npos) return false;
+
+    static const grammar& g = [] () -> const grammar& {
+        static grammar h = [] {
+            grammar h = util::abnf::compile(
+                "literal-introducer = \"{\" number [\"+\"] \"}\"\r\n"
+                "number             = 1*DIGIT\r\n");
+            h.check();
+
+            return h;
+        }();
+
+        return h;
+    }();
+
+    options o;
+    o.captures = options::capture_policy::listed;
+    o.capture_only = { "number" };
+
+    const util::abnf::parse_result r =
+        g.at("literal-introducer").try_parse(line.substr(b), o);
+
+    // A whole-input match, so "{12} more words" is not a literal and neither
+    // is "{}", "{-1}" or "{12x}".
+    if(!r) return false;
+
+    try {
+        const unsigned long long v = std::stoull(r.root()["number"].str());
+
+        // This decides how many octets to read and it comes from the network.
+        if(v > 0x7FFFFFFFull) return false;
+
+        n = static_cast<std::size_t>(v);
+    }
+    catch(std::exception&) {
+        return false;
+    }
+
+    return true;
+}
+
+std::string read(std::istream& is)
+{
+    std::string out;
+
+    for(;;) {
+        std::string line;
+
+        if(!std::getline(is, line)) {
+            throw error("connection ended in the middle of a response");
+        }
+
+        // Exactly one CRLF comes off and goes straight back on.  A literal's
+        // octets are message content and a line of them may genuinely end in
+        // CR; sys::getline erases every trailing one.
+        const bool crlf = !line.empty() && line.back() == '\r';
+
+        if(crlf) line.pop_back();
+
+        out += line;
+        out += crlf ? "\r\n" : "\n";
+
+        std::size_t n = 0;
+
+        if(!literal_size(line, n)) return out;
+
+        // Exactly n octets, whatever they are.
+        std::string body(n, '\0');
+
+        is.read(&body[0], static_cast<std::streamsize>(n));
+
+        if(is.gcount() != static_cast<std::streamsize>(n)) {
+            throw error("connection ended inside a literal");
+        }
+
+        out += body;
+    }
+}
+
+// ------------------------------------------------------------------ parsing
+
+struct reader {
+
+    static void condition_of(response& r, const match& m)
+    {
+        const match c = m["cond-name"];
+
+        if(!c) return;
+
+        const std::string name = util::upper(c.str());
+
+        if(name == "OK")           r.m_condition = response::condition::ok;
+        else if(name == "NO")      r.m_condition = response::condition::no;
+        else if(name == "BAD")     r.m_condition = response::condition::bad;
+        else if(name == "PREAUTH") r.m_condition = response::condition::preauth;
+        else if(name == "BYE")     r.m_condition = response::condition::bye;
+
+        if(const match code = m["resp-text-code"]) r.m_code = code.str();
+        if(const match text = m["text"])           r.m_text = text.str();
+    }
+
+    static void flags_of(response& r, const match& m)
+    {
+        for(const match& f : m.all("flag")) r.m_flags.push_back(f.str());
+    }
+
+    static void data_of(response& r, const match& m)
+    {
+        // capability-data is a sibling of mailbox-data in response-data, not
+        // a part of it -- so looking for "CAPABILITY" inside mailbox-data,
+        // which is what this did, found nothing and silently produced a
+        // response with no name and no capabilities.
+        if(const match c = m["capability-data"]) {
+            r.m_name = "CAPABILITY";
+
+            for(const match& one : c.all("capability")) {
+                r.m_capabilities.push_back(one.str());
+            }
+
+            return;
+        }
+
+        const match d = m["mailbox-data"];
+
+        if(d) {
+            if(const match n = d["list-name"])       r.m_name = util::upper(n.str());
+            else if(const match c = d["count-name"]) r.m_name = util::upper(c.str());
+            else if(util::ibegins(d.str(), "FLAGS")) r.m_name = "FLAGS";
+            else if(util::ibegins(d.str(), "SEARCH")) r.m_name = "SEARCH";
+            else if(util::ibegins(d.str(), "STATUS")) r.m_name = "STATUS";
+
+            flags_of(r, d);
+
+            if(const match mb = d["mailbox"]) r.m_mailbox = text_of(mb);
+
+            if(const match dl = d["delim"]) {
+                // DQUOTE QUOTED-CHAR DQUOTE, so the delimiter is the middle.
+                const std::string s = dl.str();
+
+                r.m_delimiter = s.size() >= 3 ? s.substr(1, s.size() - 2)
+                                              : std::string();
+            }
+
+            for(const match& n : d.all("number")) {
+                if(r.m_name == "SEARCH") r.m_numbers.push_back(std::stoul(n.str()));
+                else                     r.m_number = std::stoul(n.str());
+            }
+
+            return;
+        }
+
+        const match msg = m["message-data"];
+
+        if(!msg) return;
+
+        if(const match n = msg["number"]) r.m_number = std::stoul(n.str());
+
+        r.m_name = msg["msg-att"] ? "FETCH" : "EXPUNGE";
+
+        for(const match& item : msg.all("msg-att-item")) {
+            if(const match fl = item["flag-list"]) {
+                flags_of(r, fl);
+                r.m_attributes["FLAGS"] = fl.str();
+
+                continue;
+            }
+
+            const match name = item["att-name"];
+
+            if(!name) continue;
+
+            std::string key = util::upper(name.str());
+
+            // The section is part of what was asked for: a caller that fetched
+            // BODY[HEADER] looks for BODY[HEADER].
+            if(const match sec = item["att-section"]) key += sec.str();
+
+            const match value = item["att-value"];
+
+            r.m_attributes[key] = value ? text_of(value) : std::string();
+        }
+    }
+
+    static response of(const match& m, std::string_view raw)
+    {
+        response r;
+
+        r.m_raw = std::string(raw);
+
+        if(m["continue-req"]) {
+            r.m_kind = response::kind::continuation;
+
+            if(const match t = m["text"]) r.m_text = t.str();
+            if(const match c = m["resp-text-code"]) r.m_code = c.str();
+
+            return r;
+        }
+
+        if(const match t = m["response-tagged"]) {
+            r.m_kind = response::kind::tagged;
+            r.m_tag = m["rtag"].str();
+
+            condition_of(r, t);
+
+            return r;
+        }
+
+        r.m_kind = response::kind::untagged;
+
+        const match d = m["response-data"];
+
+        condition_of(r, d);
+        data_of(r, d);
+
+        return r;
+    }
+};
+
+response response::parse(std::string_view s)
+{
+    try {
+        return reader::of(responses().at("response").parse(s, parse_options()), s);
+    }
+    catch(util::abnf::budget_exceeded& e) {
+        throw error(std::string("gave up reading a response: ") + e.what());
+    }
+    catch(util::abnf::error& e) {
+        // Not e.what(): the expected set for this grammar is most of ASCII.
+        throw error("not an IMAP response at column " + std::to_string(e.column())
+                    + ": " + e.context_line());
+    }
+}
+
+response response::read(std::istream& is)
+{
+    return parse(imap::read(is));
+}
+
+bool response::valid(std::string_view s)
+{
+    options o;
+
+    o.captures = options::capture_policy::none;
+
+    return static_cast<bool>(responses().at("response").try_parse(s, o));
+}
+
+bool response::ok() const
+{
+    return m_condition == condition::ok || m_condition == condition::preauth;
+}
+
+}
+}
+}

--- a/jlib/net/imap_response.cc
+++ b/jlib/net/imap_response.cc
@@ -118,6 +118,44 @@ std::string text_of(const match& m)
 
 }
 
+// ------------------------------------------------------------------ writing
+
+std::string quote(std::string_view s)
+{
+    // ASTRING-CHAR, as rfc3501.hh works it out: the run that needs no quoting
+    // at all.  The empty string is not one of them -- "" is how an empty
+    // astring is written.
+    const auto bare = [](unsigned char c) {
+        return c == 0x21 || (c >= 0x23 && c <= 0x24) || (c >= 0x26 && c <= 0x27) ||
+               (c >= 0x2B && c <= 0x5B) || (c >= 0x5D && c <= 0x7A) ||
+               (c >= 0x7C && c <= 0x7E);
+    };
+
+    bool plain = !s.empty();
+
+    for(unsigned char c : s) {
+        if(c == '\r' || c == '\n' || c == '\0') {
+            throw error("a CR, LF or NUL cannot go in an IMAP command argument");
+        }
+
+        if(!bare(c)) plain = false;
+    }
+
+    if(plain) return std::string(s);
+
+    std::string out = "\"";
+
+    for(char c : s) {
+        // RFC 3501 4.3: inside a quoted string these two, and only these two,
+        // are escaped.
+        if(c == '"' || c == '\\') out += '\\';
+
+        out += c;
+    }
+
+    return out + "\"";
+}
+
 // ------------------------------------------------------------------ reading
 
 bool literal_size(const std::string& line, std::size_t& n)

--- a/jlib/net/imap_response.hh
+++ b/jlib/net/imap_response.hh
@@ -1,0 +1,198 @@
+/* -*- mode: C++ c-basic-offset: 4 -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef JLIB_NET_IMAP_RESPONSE_HH
+#define JLIB_NET_IMAP_RESPONSE_HH
+
+#include <cstddef>
+#include <iosfwd>
+#include <map>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace jlib {
+namespace net {
+
+/**
+ * IMAP4rev1 responses, read against RFC 3501's grammar.
+ *
+ * The grammar is in jlib/net/rfc3501.hh.  What this adds is the part a
+ * grammar cannot do on its own: getting a whole response off the wire in the
+ * first place.
+ *
+ * ## A response is not a line
+ *
+ *     * 12 FETCH (BODY[HEADER] {13}
+ *     From: a@b.c
+ *     )
+ *
+ * That is one response over three lines, and the thirteen octets after the
+ * "{13}" are message content that may contain anything at all -- including a
+ * line that looks exactly like the tagged completion the client is waiting
+ * for.  Reading until a line starts with the tag, which is what Imap4 did for
+ * twenty-five years, therefore stops in the wrong place and every command
+ * after it reads part of somebody's email as its response.
+ *
+ * read() follows the literals.  Nothing else can.
+ */
+namespace imap {
+
+/**
+ * The octet count of the literal a response line ends with.
+ *
+ * RFC 3501 4.3: "{" number "}" CRLF, then that many octets.  Returns false
+ * when the line does not end in one -- which is the case that used to give
+ * zero and read no octets at all, because it went through util::slice, and
+ * slice returns its whole input when the delimiters are not there.
+ *
+ * A count over 2^31-1 is refused rather than clamped: it decides how many
+ * octets to read and it comes from the network.
+ */
+bool literal_size(const std::string& line, std::size_t& n);
+
+/**
+ * Read one complete response, following any literals in it.
+ *
+ * Everything up to and including the CRLF that ends the response, with each
+ * literal's octets in place.  Throws imap::error if the stream ends first --
+ * a truncated response is not a short one.
+ */
+std::string read(std::istream& is);
+
+/** A response that could not be read. */
+class error : public std::runtime_error {
+public:
+    explicit error(const std::string& msg)
+        : std::runtime_error("jlib::net::imap::error: " + msg) {}
+};
+
+/**
+ * One parsed response.
+ *
+ * Every accessor is empty or zero for a response of a kind that does not
+ * carry that piece; nothing throws for asking.
+ */
+class response {
+public:
+    /** RFC 3501 7: which of the three shapes this is. */
+    enum class kind { tagged, untagged, continuation };
+
+    /** The condition of an OK/NO/BAD/PREAUTH/BYE, or none. */
+    enum class condition { none, ok, no, bad, preauth, bye };
+
+    response() = default;
+
+    /** Parse one complete response.  Throws imap::error. */
+    static response parse(std::string_view s);
+
+    /** read() then parse(). */
+    static response read(std::istream& is);
+
+    static bool valid(std::string_view s);
+
+    kind type() const { return m_kind; }
+
+    /** The tag of a tagged response, or "" for the other two. */
+    const std::string& tag() const { return m_tag; }
+
+    condition status() const { return m_condition; }
+
+    /** OK or PREAUTH.  False for a response that carries no condition. */
+    bool ok() const;
+
+    /** The "[UIDVALIDITY 3857529045]" of a resp-text, without its brackets. */
+    const std::string& code() const { return m_code; }
+
+    /** The human-readable remainder.  Not for a program to act on. */
+    const std::string& text() const { return m_text; }
+
+    /**
+     * What kind of data an untagged response carries.
+     *
+     * "FLAGS", "LIST", "LSUB", "SEARCH", "STATUS", "EXISTS", "RECENT",
+     * "EXPUNGE", "FETCH", "CAPABILITY", or "" when it carries a condition
+     * instead.
+     */
+    const std::string& name() const { return m_name; }
+
+    /** The number in "* 12 EXISTS" or "* 12 FETCH (...)".  0 when there is none. */
+    unsigned long number() const { return m_number; }
+
+    /** The message numbers of a SEARCH. */
+    const std::vector<unsigned long>& numbers() const { return m_numbers; }
+
+    /** The flags of a FLAGS, a LIST, or a FETCH's FLAGS attribute. */
+    const std::vector<std::string>& flags() const { return m_flags; }
+
+    /** A LIST or LSUB line's hierarchy delimiter, or "" for NIL. */
+    const std::string& delimiter() const { return m_delimiter; }
+
+    /** A LIST, LSUB or STATUS line's mailbox name. */
+    const std::string& mailbox() const { return m_mailbox; }
+
+    const std::vector<std::string>& capabilities() const { return m_capabilities; }
+
+    /**
+     * A FETCH's attributes, by the name they were asked for.
+     *
+     * The key is the attribute with its section: "RFC822.SIZE", "UID",
+     * "BODY[HEADER]".  A string value has its quotes removed and its literal
+     * resolved; anything parenthesised -- an ENVELOPE, a BODYSTRUCTURE, an
+     * extension nobody here has heard of -- comes back as it was written,
+     * because jlib does not interpret those and inventing a representation
+     * for them would be worse than handing them over.
+     *
+     * NIL and the empty string are both "".  RFC 3501 distinguishes them and
+     * a std::string cannot; nothing in jlib has needed the difference.
+     */
+    const std::map<std::string,std::string>& attributes() const { return m_attributes; }
+
+    /** What the server actually sent, literals and all. */
+    const std::string& str() const { return m_raw; }
+
+protected:
+    kind m_kind = kind::untagged;
+    condition m_condition = condition::none;
+
+    std::string m_raw;
+    std::string m_tag;
+    std::string m_code;
+    std::string m_text;
+    std::string m_name;
+    std::string m_delimiter;
+    std::string m_mailbox;
+
+    unsigned long m_number = 0;
+
+    std::vector<unsigned long> m_numbers;
+    std::vector<std::string> m_flags;
+    std::vector<std::string> m_capabilities;
+    std::map<std::string,std::string> m_attributes;
+
+    friend struct reader;
+};
+
+}
+
+}
+}
+
+#endif // JLIB_NET_IMAP_RESPONSE_HH

--- a/jlib/net/imap_response.hh
+++ b/jlib/net/imap_response.hh
@@ -56,6 +56,35 @@ namespace net {
 namespace imap {
 
 /**
+ * A string as an IMAP command may carry it: bare, or quoted and escaped.
+ *
+ * The inverse of RFC 3501 4.3's `quoted` production, which the response
+ * parser here reads -- a quoted string is the same thing in both directions,
+ * which is why this lives beside the reader.
+ *
+ * Every command in Imap4 used to build its arguments by hand:
+ *
+ *     handshake(sock, "LOGIN " + user + " " + pass);
+ *     handshake(sock, "SELECT \"" + path + "\"");
+ *
+ * A password or a mailbox name containing a space produced a malformed
+ * command; one containing a quote or a backslash produced a differently
+ * malformed one.  And one containing "{5}" produced a *literal introducer* --
+ * the server answers "+" and then reads the next five octets as data, which
+ * desynchronises the connection for good.
+ *
+ * Throws imap::error on a value containing CR, LF or NUL.  None of the three
+ * can appear in a quoted string at all, and a CR is how a command becomes two
+ * commands.
+ *
+ * Not modified UTF-7.  RFC 3501 5.1.3 says a mailbox name with a non-ASCII
+ * character in it is encoded that way, and jlib does not do it -- the octets
+ * go out as they came in, which is what most servers accept in practice and
+ * is a gap rather than a decision.
+ */
+std::string quote(std::string_view s);
+
+/**
  * The octet count of the literal a response line ends with.
  *
  * RFC 3501 4.3: "{" number "}" CRLF, then that many octets.  Returns false

--- a/jlib/net/rfc3501.hh
+++ b/jlib/net/rfc3501.hh
@@ -1,0 +1,186 @@
+/* -*- mode: C++ c-basic-offset: 4 -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef JLIB_NET_RFC3501_HH
+#define JLIB_NET_RFC3501_HH
+
+namespace jlib {
+namespace net {
+
+/**
+ * IMAP4rev1 responses, from RFC 3501 section 9, as ABNF.
+ *
+ * The half of section 9 a client reads.  Commands are what jlib writes and it
+ * knows what it wrote; responses are what a server sends and they have to be
+ * taken as they come.
+ *
+ * Read by jlib::util::abnf::compile(); see jlib/net/imap_response.hh for what
+ * uses it.  Self-contained -- IMAP is not RFC 822 and borrows none of its
+ * lexical layer.
+ *
+ * ## literal is deliberately not defined here
+ *
+ * RFC 3501 4.3 writes it
+ *
+ *     literal = "{" number "}" CRLF *CHAR8
+ *             ; Number represents the number of CHAR8s
+ *
+ * with the actual constraint in a *comment*, because ABNF cannot say "this
+ * many of them".  This grammar therefore references `literal` and never
+ * defines it; imap_response.cc supplies it in combinators with abnf's
+ * counted(), and only then calls check().
+ *
+ * That seam is the reason jlib::util::abnf has two public layers rather than
+ * one.  It was argued for in the plan on the strength of this exact
+ * production, three branches before anything could use it.
+ *
+ * ## Where this departs from the published text
+ *
+ * Marked with "; jlib:", as the other grammars here are.
+ *
+ * **An attribute value is matched by shape, not by production.**  RFC 3501
+ * gives ENVELOPE and BODYSTRUCTURE full grammars -- roughly sixty productions
+ * between them -- and jlib does not interpret either.  Transcribing sixty
+ * productions in order to ignore what they match would be worse than saying
+ * so: att-value accepts a balanced parenthesised group, a string, or a number.
+ * The attributes jlib *does* read -- FLAGS, UID, RFC822.SIZE, RFC822 and its
+ * variants, BODY[...] -- come back with their values parsed.
+ *
+ * This also means an attribute nobody here has heard of does not fail the
+ * response.  MODSEQ, X-GM-MSGID and every other extension a server volunteers
+ * parse as a name and a value, which is what a client should do with them.
+ *
+ * **Reordered alternatives**, as everywhere: mailbox is astring rather than
+ * "INBOX" / astring, because astring subsumes it and ordered choice would
+ * otherwise take the "INBOX" of "INBOXES" and strand the rest.  INBOX being
+ * case-insensitive is a rule about what a mailbox name *means*, not about how
+ * it is written, and belongs in the code that compares them.
+ *
+ * **TEXT-CHAR runs to %xFF.**  RFC 3501 defines CHAR as %x01-7F, so a server
+ * that puts UTF-8 in a human-readable error message is out of spec -- and
+ * they do it, and refusing to read the response is a worse answer than
+ * reading a message jlib will not interpret anyway.
+ *
+ * ## What is not here
+ *
+ * Commands, which jlib writes.  ENVELOPE, BODYSTRUCTURE and the STATUS
+ * attributes as productions, per the note above.  Anything from an extension:
+ * this is RFC 3501, not 4466, 4551, 6154 or 9051.
+ */
+namespace rfc3501 {
+
+inline const char* const RESPONSE = R"ABNF(
+; 9.  One response: a continuation, an untagged data line, or the tagged
+; completion of a command.
+response        =  continue-req / response-data / response-tagged
+
+continue-req    =  "+" [ SP resp-text ] CRLF
+response-tagged =  rtag SP resp-cond-state CRLF
+response-data   =  "*" SP ( resp-cond-state / mailbox-data / message-data /
+                            capability-data ) CRLF
+
+; jlib: named rtag.  "tag" is what abnf calls the thing a capture is named
+; with, and having a rule of that name in a grammar it reads is asking for a
+; misreading by whoever comes next.
+rtag            =  1*ASTRING-CHAR
+
+; jlib: one rule for what the RFC splits across resp-cond-state,
+; resp-cond-auth and resp-cond-bye -- they differ only in which of the five
+; names they allow, and which are legal where is a rule about the state the
+; connection is in rather than about the text.
+resp-cond-state =  cond-name SP resp-text
+cond-name       =  "OK" / "NO" / "BAD" / "PREAUTH" / "BYE"
+
+resp-text       =  [ "[" resp-text-code "]" SP ] text
+resp-text-code  =  1*( %x01-5C / %x5E-FF )   ; jlib: "any TEXT-CHAR except ]"
+text            =  *TEXT-CHAR
+
+; 7.2
+mailbox-data    =  ( "FLAGS" SP flag-list )
+                /  ( list-name SP mailbox-list )
+                /  ( "SEARCH" *( SP number ) )
+                /  ( "STATUS" SP mailbox SP att-group )
+                /  ( number SP count-name )
+list-name       =  "LIST" / "LSUB"
+count-name      =  "EXISTS" / "RECENT"
+
+mailbox-list    =  flag-list SP ( delim / nil ) SP mailbox
+delim           =  DQUOTE QUOTED-CHAR DQUOTE
+mailbox         =  astring        ; jlib: "INBOX" / astring, reordered away
+
+capability-data =  "CAPABILITY" *( SP capability )
+capability      =  1*ATOM-CHAR
+
+; 7.4
+message-data    =  number SP ( "EXPUNGE" / ( "FETCH" SP msg-att ) )
+msg-att         =  "(" [ msg-att-item *( SP msg-att-item ) ] ")"
+
+; jlib: FLAGS first and by name, because it is one of the five jlib reads and
+; its value has a shape worth keeping.  Everything else is a name and a value.
+msg-att-item    =  ( "FLAGS" SP flag-list )
+                /  ( att-name [ att-section ] SP att-value )
+; jlib: "-" and "_" added.  Every attribute RFC 3501 itself defines is
+; [A-Z0-9.], but an extension's is not -- X-GM-MSGID is the one everybody
+; meets -- and an unknown attribute should parse as a name and a value rather
+; than fail the whole response.
+att-name        =  1*( ALPHA / DIGIT / "." / "-" / "_" )
+; jlib: [ "." number ] added.  A response carries the origin octet alone --
+; "BODY[]<0>" -- and the "<origin.length>" form belongs to the command; a
+; server that echoes the command's form back would otherwise desynchronise the
+; connection rather than merely say something odd.
+att-section     =  "[" *( %x01-5C / %x5E-FF ) "]" [ "<" number [ "." number ] ">" ]
+att-value       =  att-group / nstring / number
+att-group       =  "(" *( att-group / nstring / number / att-atom / SP ) ")"
+att-atom        =  1*ATOM-CHAR
+
+; 9, flags
+flag-list       =  "(" [ flag *( SP flag ) ] ")"
+flag            =  ( "\" ( "*" / atom ) ) / atom
+atom            =  1*ATOM-CHAR
+
+; 4.3, strings.  literal is referenced and never defined: see the header note.
+astring         =  string / 1*ASTRING-CHAR
+string          =  quoted / literal
+quoted          =  DQUOTE quoted-body DQUOTE
+quoted-body     =  *QUOTED-CHAR       ; jlib: names what is between the quotes
+nstring         =  string / nil
+nil             =  "NIL"
+number          =  1*DIGIT
+
+; 9, character classes.  The RFC states these as exclusions in prose; these
+; are those exclusions worked out as ranges, and the test spells out every
+; excluded character.
+;
+;   atom-specials   = "(" / ")" / "{" / SP / CTL / list-wildcards /
+;                     quoted-specials / resp-specials
+;   list-wildcards  = "%" / "*"
+;   quoted-specials = DQUOTE / "\"
+;   resp-specials   = "]"
+ATOM-CHAR       =  %x21 / %x23-24 / %x26-27 / %x2B-5B / %x5E-7A / %x7C-7E
+ASTRING-CHAR    =  ATOM-CHAR / "]"
+TEXT-CHAR       =  %x01-09 / %x0B-0C / %x0E-FF   ; jlib: past %x7F, see above
+QUOTED-CHAR     =  %x01-09 / %x0B-0C / %x0E-21 / %x23-5B / %x5D-FF
+                /  ( "\" ( DQUOTE / "\" ) )
+)ABNF";
+
+}
+}
+}
+
+#endif // JLIB_NET_RFC3501_HH

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -55,6 +55,7 @@ TESTS = \
 	net_mbox_crlf_test \
 	net_protocol_test \
 	net_imap_test \
+	net_imap_live_test \
 	net_mime_test \
 	net_same_address_test \
  \
@@ -134,6 +135,9 @@ net_email_received_test_SOURCES = net_email_received_test.cc
 net_email_received_test_LDADD   = $(JNET_LA)
 net_mime_test_SOURCES           = net_mime_test.cc
 net_mime_test_LDADD             = $(JNET_LA) $(JUTIL_LA)
+
+net_imap_live_test_SOURCES      = net_imap_live_test.cc
+net_imap_live_test_LDADD        = $(JNET_LA) $(JUTIL_LA) $(JSYS_LA)
 
 net_imap_test_SOURCES           = net_imap_test.cc
 net_imap_test_LDADD             = $(JNET_LA) $(JUTIL_LA)

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -54,6 +54,7 @@ TESTS = \
 	net_email_multipart_test \
 	net_mbox_crlf_test \
 	net_protocol_test \
+	net_imap_test \
 	net_mime_test \
 	net_same_address_test \
  \
@@ -133,6 +134,9 @@ net_email_received_test_SOURCES = net_email_received_test.cc
 net_email_received_test_LDADD   = $(JNET_LA)
 net_mime_test_SOURCES           = net_mime_test.cc
 net_mime_test_LDADD             = $(JNET_LA) $(JUTIL_LA)
+
+net_imap_test_SOURCES           = net_imap_test.cc
+net_imap_test_LDADD             = $(JNET_LA) $(JUTIL_LA)
 
 net_protocol_test_SOURCES       = net_protocol_test.cc
 net_protocol_test_LDADD         = $(JNET_LA) $(JUTIL_LA)

--- a/tests/net_imap_live_test.cc
+++ b/tests/net_imap_live_test.cc
@@ -1,0 +1,413 @@
+/* -*- mode: C++ c-basic-offset: 4 -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// jlib::net::Imap4 against a real IMAP server.
+//
+// Everything else in the suite feeds a std::istringstream, which can be made
+// to produce any response at all -- but only a server decides *when* to send
+// a literal, and the literal is what the line-based reader could not do.  So
+// this one starts a Dovecot on a high port with a Maildir it seeds, and talks
+// to it.
+//
+// Exit 77 (SKIP) when there is no dovecot to start, which is every machine
+// that is not the build container.
+
+#include <jlib/net/Imap4.hh>
+#include <jlib/net/imap_response.hh>
+
+#include <jlib/sys/socketstream.hh>
+#include <jlib/sys/sys.hh>
+
+#include <jlib/util/URL.hh>
+#include <jlib/util/util.hh>
+
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <unistd.h>
+
+namespace fs = std::filesystem;
+
+static int failures = 0;
+
+static void ok(const std::string& what, bool good, const std::string& detail = "") {
+    if(!good) ++failures;
+    std::cout << (good ? "  ok   " : "  FAIL ") << what;
+    if(!detail.empty()) std::cout << ": " << detail;
+    std::cout << "\n";
+}
+
+static std::string show(const std::string& s) {
+    std::string out;
+
+    for(char c : s) {
+        if(c == '\r')      out += "\\r";
+        else if(c == '\n') out += "\\n";
+        else               out += c;
+    }
+
+    return out;
+}
+
+// A password that is exactly what the old code could not send.  A space ends
+// an argument, a quote ends a quoted one, and a backslash escapes whatever
+// follows -- so "LOGIN " + user + " " + pass produced a malformed command and
+// the server said BAD.
+static const char* const PASSWORD = "pa ss \"quoted\" back\\slash";
+
+/**
+ * A message body that impersonates every tag jlib is going to use.
+ *
+ * Imap4::tag() counts up from A00001, so a body containing all twenty of the
+ * first tags followed by "OK FETCH completed" looks, line by line, exactly
+ * like the completion the client is waiting for.  Reading lines stops at the
+ * first of them; reading responses does not.
+ */
+static std::string impersonating_body()
+{
+    std::string s = "From: b@c.d\r\nSubject: two\r\n\r\n";
+
+    for(int i = 1; i <= 20; i++) {
+        char tag[16];
+
+        std::snprintf(tag, sizeof tag, "A%05d", i);
+
+        s += std::string(tag) + " OK FETCH completed\r\n";
+    }
+
+    return s;
+}
+
+namespace {
+
+struct server {
+    fs::path dir;
+    unsigned int port = 0;
+    bool running = false;
+
+    ~server() { stop(); }
+
+    bool start()
+    {
+        // A port derived from the pid, so two builds on one machine do not
+        // collide.
+        port = 14000 + static_cast<unsigned int>(::getpid() % 900);
+
+        dir = fs::temp_directory_path() / ("jlib-imap-" + std::to_string(::getpid()));
+
+        fs::remove_all(dir);
+        fs::create_directories(dir / "run");
+        fs::create_directories(dir / "mail" / "Maildir" / "cur");
+        fs::create_directories(dir / "mail" / "Maildir" / "new");
+        fs::create_directories(dir / "mail" / "Maildir" / "tmp");
+
+        // Dovecot refuses a mail uid of 0, and refuses to run imap-login as
+        // root at all, so the Maildir belongs to an ordinary uid and the login
+        // process keeps the package's own unprivileged user.
+        const unsigned int uid = 1000;
+
+        {
+            std::ofstream f(dir / "users");
+
+            f << "joe:{PLAIN}" << PASSWORD << ":" << uid << ":" << uid
+              << "::" << (dir / "mail").string() << "\n";
+        }
+
+        {
+            std::ofstream f(dir / "conf");
+
+            f << "protocols = imap\n"
+              << "listen = 127.0.0.1\n"
+              << "base_dir = " << (dir / "run").string() << "\n"
+              << "log_path = " << (dir / "log").string() << "\n"
+              << "ssl = no\n"
+              << "disable_plaintext_auth = no\n"
+              << "mail_location = maildir:" << (dir / "mail" / "Maildir").string() << "\n"
+              << "service imap-login {\n"
+              << "  inet_listener imap {\n    port = " << port << "\n  }\n"
+              << "  chroot =\n"
+              << "}\n"
+              << "passdb {\n  driver = passwd-file\n  args = "
+              << (dir / "users").string() << "\n}\n"
+              << "userdb {\n  driver = passwd-file\n  args = "
+              << (dir / "users").string() << "\n}\n";
+        }
+
+        {
+            std::ofstream f(dir / "mail" / "Maildir" / "new" / "1", std::ios::binary);
+            f << "From: a@b.c\r\nSubject: one\r\n\r\nhello\r\n";
+        }
+
+        {
+            std::ofstream f(dir / "mail" / "Maildir" / "new" / "2", std::ios::binary);
+            f << impersonating_body();
+        }
+
+        std::string out, err;
+
+        jlib::sys::run({ "chown", "-R", std::to_string(uid) + ":" + std::to_string(uid),
+                         (dir / "mail").string() }, out, err);
+
+        // dovecot daemonizes, so this returns once it has forked.
+        if(jlib::sys::run({ "dovecot", "-c", (dir / "conf").string() }, out, err) != 0) {
+            std::cerr << "dovecot would not start: " << err << out << "\n";
+
+            return false;
+        }
+
+        running = true;
+
+        // Wait for the listener rather than sleeping a guessed interval.
+        for(int i = 0; i < 100; i++) {
+            try {
+                jlib::sys::socketstream probe("127.0.0.1", port);
+
+                return true;
+            }
+            catch(std::exception&) {
+                ::usleep(50000);
+            }
+        }
+
+        std::cerr << "dovecot never listened on " << port << "\n";
+
+        return false;
+    }
+
+    void stop()
+    {
+        if(running) {
+            std::string out, err;
+
+            jlib::sys::run({ "dovecot", "-c", (dir / "conf").string(), "stop" }, out, err);
+            running = false;
+        }
+
+        std::error_code ec;
+
+        fs::remove_all(dir, ec);
+    }
+
+    std::string log() const
+    {
+        std::ifstream f(dir / "log");
+
+        return std::string(std::istreambuf_iterator<char>(f), {});
+    }
+};
+
+}
+
+int main() {
+    std::cout << std::unitbuf;
+
+    {
+        std::string out, err;
+
+        try {
+            if(jlib::sys::run({ "dovecot", "--version" }, out, err) != 0) {
+                std::cerr << "dovecot does not run here; skipping\n";
+                return 77;
+            }
+        }
+        catch(std::exception& e) {
+            std::cerr << "no dovecot: " << e.what() << "; skipping\n";
+            return 77;
+        }
+    }
+
+    server s;
+
+    if(!s.start()) {
+        std::cerr << s.log();
+        std::cerr << "could not start a server; skipping\n";
+
+        return 77;
+    }
+
+    std::cout << "dovecot on 127.0.0.1:" << s.port << "\n";
+
+    jlib::util::URL url("imap://joe@127.0.0.1:" + std::to_string(s.port) + "/INBOX");
+
+    url.set_pass(PASSWORD);
+
+    jlib::net::Imap4 imap(url);
+
+    try {
+        std::unique_ptr<jlib::sys::socketstream> sock(imap.connect());
+
+        ok("the greeting reads", true);
+
+        // The whole of (b): every command used to build its arguments by
+        // concatenation, so this password produced "LOGIN joe pa ss "quoted"
+        // back\slash" and the server answered BAD.
+        imap.login(*sock, "", "");
+
+        ok("LOGIN with a space, a quote and a backslash in the password", true);
+
+        std::vector<jlib::net::ListItem> ls = imap.list(*sock, "", "*");
+
+        bool inbox = false;
+
+        for(jlib::net::ListItem& i : ls) {
+            if(jlib::util::upper(i.get_name()) == "INBOX") inbox = true;
+        }
+
+        ok("LIST finds INBOX", inbox, std::to_string(ls.size()) + " mailboxes");
+
+        // A mailbox whose name needs quoting, which is the same fix seen from
+        // the other end.
+        imap.create(*sock, "My Mail");
+        imap.subscribe(*sock, "My Mail");
+
+        bool spaced = false;
+
+        for(jlib::net::ListItem& i : imap.list(*sock, "", "*")) {
+            if(i.get_name().find("My Mail") != std::string::npos) spaced = true;
+        }
+
+        ok("a mailbox with a space in its name can be created and listed", spaced);
+
+        // LSUB sent LIST, so it answered with every mailbox rather than the
+        // subscribed ones.  INBOX is not subscribed here and "My Mail" is.
+        std::vector<jlib::net::ListItem> subs = imap.lsub(*sock, "", "*");
+
+        bool only_subscribed = !subs.empty();
+
+        for(jlib::net::ListItem& i : subs) {
+            if(jlib::util::upper(i.get_name()) == "INBOX") only_subscribed = false;
+        }
+
+        ok("LSUB answers with the subscribed mailboxes, not all of them",
+           only_subscribed, std::to_string(subs.size()) + " subscribed");
+
+        imap.select(*sock, "INBOX");
+
+        ok("SELECT", true);
+
+        // The reason this test exists.  One of these two messages is a body
+        // that says "A00001 OK FETCH completed" and nineteen variations, which
+        // is what the client is waiting for -- and it has to come back whole.
+        std::string one, two;
+
+        for(int i = 0; i < 2; i++) {
+            const std::string raw = imap.get(*sock, i, false).raw();
+
+            if(raw.find("Subject: one") != std::string::npos)      one = raw;
+            else if(raw.find("Subject: two") != std::string::npos) two = raw;
+        }
+
+        ok("a plain message comes back", one == "From: a@b.c\r\nSubject: one\r\n\r\nhello\r\n",
+           show(one));
+
+        ok("and one whose body impersonates every tag jlib uses",
+           two == impersonating_body(),
+           two == impersonating_body()
+               ? std::string()
+               : "got " + std::to_string(two.size()) + " of "
+                 + std::to_string(impersonating_body().size()) + " octets");
+
+        imap.logout(*sock);
+
+        ok("LOGOUT", true);
+
+        // The control.  Everything above says the new reader works; this says
+        // the old one would not have, against this same server, rather than
+        // asking anyone to take it on trust.
+        //
+        // A second connection, driven by hand, reading *lines* until one
+        // begins with the tag -- which is exactly what Imap4::handshake did.
+        {
+            jlib::sys::socketstream raw("127.0.0.1", s.port);
+
+            std::string line;
+
+            jlib::sys::getline(raw, line);                       // greeting
+
+            raw << "B1 LOGIN joe " << jlib::net::imap::quote(PASSWORD)
+                << "\r\n" << std::flush;
+
+            while(line.rfind("B1 ", 0) != 0) jlib::sys::getline(raw, line);
+
+            raw << "B2 SELECT INBOX\r\n" << std::flush;
+
+            while(line.rfind("B2 ", 0) != 0) jlib::sys::getline(raw, line);
+
+            // Ask for the message whose body impersonates the tag, using that
+            // very tag.
+            raw << "A00001 FETCH 2 (RFC822)\r\n" << std::flush;
+
+            std::string collected;
+            int lines = 0;
+
+            while(lines++ < 200) {
+                jlib::sys::getline(raw, line);
+                collected += line + "\r\n";
+
+                if(line.rfind("A00001 ", 0) == 0) break;
+            }
+
+            ok("reading lines stops inside the message, as it always did",
+               collected.find("A00020 OK FETCH completed") == std::string::npos,
+               "stopped after " + std::to_string(lines) + " lines");
+
+            // And the same fetch, read as responses, does not.
+            jlib::sys::socketstream good("127.0.0.1", s.port);
+
+            jlib::net::imap::read(good);
+
+            good << "C1 LOGIN joe " << jlib::net::imap::quote(PASSWORD)
+                 << "\r\n" << std::flush;
+
+            while(jlib::net::imap::read(good).rfind("C1 ", 0) != 0) ;
+
+            good << "C2 SELECT INBOX\r\n" << std::flush;
+
+            while(jlib::net::imap::read(good).rfind("C2 ", 0) != 0) ;
+
+            good << "A00001 FETCH 2 (RFC822)\r\n" << std::flush;
+
+            const std::string whole = jlib::net::imap::read(good);
+
+            ok("reading responses does not",
+               whole.find("A00020 OK FETCH completed") != std::string::npos);
+        }
+    }
+    catch(std::exception& e) {
+        ok("the session ran without throwing", false, e.what());
+        std::cerr << s.log();
+    }
+
+    // What a green run does NOT establish.
+    //
+    // Not interoperability.  One server, one version, one configuration, with
+    // TLS off and plaintext authentication on -- which is exactly what no real
+    // account allows.  What it establishes is that jlib's reader survives a
+    // response a real server chose to send as a literal.
+    //
+    // Not the commands #85 is about.  SEARCH, UID and a ranged FETCH are still
+    // unimplemented; this exercises what was already there.
+    //
+    // Not TLS.  imaps:// goes through sys::sslstream, which no test here
+    // reaches -- setting up a certificate Dovecot and OpenSSL both accept is a
+    // branch of its own.
+    return failures ? 1 : 0;
+}

--- a/tests/net_imap_test.cc
+++ b/tests/net_imap_test.cc
@@ -1,0 +1,416 @@
+/* -*- mode: C++ c-basic-offset: 4 -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// IMAP4rev1 responses, read against RFC 3501 section 9.
+//
+// The section worth reading is "a response is not a line".  Everything else
+// here is a grammar doing what a grammar does; that one is the bug this was
+// written for, and it is the reason jlib::util::abnf has two public layers.
+
+#include <jlib/net/imap_response.hh>
+#include <jlib/net/rfc3501.hh>
+
+#include <jlib/util/abnf.hh>
+
+#include <iostream>
+#include <sstream>
+#include <string>
+
+namespace imap = jlib::net::imap;
+
+using imap::response;
+
+static int failures = 0;
+
+static void ok(const std::string& what, bool good, const std::string& detail = "") {
+    if(!good) ++failures;
+    std::cout << (good ? "  ok   " : "  FAIL ") << what;
+    if(!detail.empty()) std::cout << ": " << detail;
+    std::cout << "\n";
+}
+
+static std::string show(const std::string& s) {
+    std::string out;
+
+    for(char c : s) {
+        if(c == '\r')      out += "\\r";
+        else if(c == '\n') out += "\\n";
+        else               out += c;
+    }
+
+    return out;
+}
+
+static void a_response_is_not_a_line() {
+    std::cout << "a response is not a line:\n";
+
+    // RFC 3501 4.3: a literal is "{" number "}" CRLF and then exactly that
+    // many octets.  They are message content, so they may contain anything --
+    // including a line that looks exactly like the tagged completion the
+    // client is waiting for.
+    //
+    // Imap4::handshake read lines until one began with the tag.  Given this
+    // stream it stopped inside the message, and every command after it read
+    // the rest of that message as its own response.
+    std::istringstream is(
+        "* 12 FETCH (BODY[HEADER] {33}\r\n"
+        "a001 OK this looks like the end\r\n"   // 33 octets of content
+        ")\r\n"
+        "a001 OK FETCH completed\r\n");
+
+    const std::string first = imap::read(is);
+
+    ok("the whole FETCH is one response",
+       first == "* 12 FETCH (BODY[HEADER] {33}\r\n"
+                "a001 OK this looks like the end\r\n)\r\n",
+       show(first));
+
+    const std::string second = imap::read(is);
+
+    ok("and the real completion is the next one",
+       second == "a001 OK FETCH completed\r\n", show(second));
+
+    // The parsed form gets the content back exactly.
+    const response r = response::parse(first);
+
+    ok("the literal's octets come back whole",
+       r.attributes().at("BODY[HEADER]") == "a001 OK this looks like the end\r\n",
+       show(r.attributes().count("BODY[HEADER]")
+            ? r.attributes().at("BODY[HEADER]") : std::string()));
+
+    // Two literals in one response, which LIST does when a mailbox name needs
+    // one and so does a FETCH of more than one part.
+    std::istringstream two(
+        "* 12 FETCH (BODY[1] {5}\r\nhello BODY[2] {5}\r\nworld)\r\n"
+        "a002 OK done\r\n");
+
+    const response t = response::parse(imap::read(two));
+
+    ok("and two of them in one response",
+       t.attributes().count("BODY[1]") && t.attributes().at("BODY[1]") == "hello" &&
+       t.attributes().count("BODY[2]") && t.attributes().at("BODY[2]") == "world");
+
+    // A truncated stream is not a short response.
+    std::istringstream cut("* 12 FETCH (BODY[] {100}\r\nnot a hundred octets\r\n");
+
+    bool threw = false;
+
+    try { imap::read(cut); }
+    catch(imap::error&) { threw = true; }
+
+    ok("a connection that drops inside a literal throws", threw);
+}
+
+static void the_literal_introducer() {
+    std::cout << "\nwhere a literal starts:\n";
+
+    struct { const char* line; bool found; std::size_t n; } cases[] = {
+        { "* 12 FETCH (RFC822 {1234}",   true, 1234 },
+        { "* 12 FETCH (RFC822 {0}",      true, 0 },
+        { "* 12 FETCH (RFC822 {1234+}",  true, 1234 },   // RFC 7888
+        { "* 12 FETCH (FLAGS (\\Seen))", false, 0 },
+        { "a001 OK FETCH completed",     false, 0 },
+        { "",                            false, 0 },
+        { "* 12 FETCH {}",               false, 0 },
+        { "* 12 FETCH {abc}",            false, 0 },
+        { "* 12 FETCH {12} and more",    false, 0 },
+        { "* 12 FETCH {2147483648}",     false, 0 },
+        { "* 12 FETCH {2147483647}",     true, 2147483647u },
+    };
+
+    for(const auto& c : cases) {
+        std::size_t n = 12345;
+
+        ok(std::string("\"") + c.line + "\"",
+           imap::literal_size(c.line, n) == c.found && (!c.found || n == c.n));
+    }
+}
+
+static void the_three_shapes() {
+    std::cout << "\nRFC 3501 7, the three shapes:\n";
+
+    const response t = response::parse("a001 OK LOGIN completed\r\n");
+
+    ok("a tagged completion",
+       t.type() == response::kind::tagged && t.tag() == "a001" && t.ok(),
+       t.tag());
+    ok("with its text", t.text() == "LOGIN completed", t.text());
+
+    const response n = response::parse("a002 NO [ALERT] mailbox is full\r\n");
+
+    ok("a failure is not ok()", !n.ok() &&
+       n.status() == response::condition::no);
+    ok("and its response-text-code comes out of its brackets",
+       n.code() == "ALERT" && n.text() == "mailbox is full", n.code());
+
+    const response u = response::parse("* OK [UIDVALIDITY 3857529045] UIDs valid\r\n");
+
+    ok("an untagged condition",
+       u.type() == response::kind::untagged && u.ok() &&
+       u.code() == "UIDVALIDITY 3857529045", u.code());
+
+    const response c = response::parse("+ Ready for additional command text\r\n");
+
+    ok("a continuation", c.type() == response::kind::continuation &&
+       c.text() == "Ready for additional command text", c.text());
+
+    ok("and an empty one, which AUTHENTICATE gets",
+       response::valid("+ \r\n") && response::valid("+\r\n"));
+
+    // PREAUTH and BYE are conditions the RFC keeps in separate productions
+    // because of where they may appear; they read the same way.
+    ok("PREAUTH is ok()",
+       response::parse("* PREAUTH IMAP4rev1 ready\r\n").ok());
+    ok("BYE is not",
+       !response::parse("* BYE Autologout\r\n").ok() &&
+       response::parse("* BYE Autologout\r\n").status() == response::condition::bye);
+}
+
+static void the_data_responses() {
+    std::cout << "\nwhat an untagged response carries:\n";
+
+    {
+        const response r = response::parse("* CAPABILITY IMAP4rev1 STARTTLS AUTH=GSSAPI\r\n");
+
+        ok("CAPABILITY", r.name() == "CAPABILITY" && r.capabilities().size() == 3 &&
+           r.capabilities()[2] == "AUTH=GSSAPI",
+           r.capabilities().empty() ? "none" : r.capabilities()[2]);
+    }
+
+    {
+        const response r = response::parse("* FLAGS (\\Answered \\Seen $Label1)\r\n");
+
+        ok("FLAGS, including one that is not a system flag",
+           r.name() == "FLAGS" && r.flags().size() == 3 && r.flags()[2] == "$Label1",
+           r.flags().empty() ? "none" : r.flags()[2]);
+    }
+
+    {
+        const response r =
+            response::parse("* LIST (\\Noselect \\HasChildren) \"/\" \"My Mail\"\r\n");
+
+        ok("LIST", r.name() == "LIST" && r.mailbox() == "My Mail" &&
+           r.delimiter() == "/" && r.flags().size() == 2, r.mailbox());
+    }
+
+    {
+        // A NIL delimiter means the mailbox has no hierarchy.
+        const response r = response::parse("* LSUB () NIL INBOX\r\n");
+
+        ok("LSUB with a NIL delimiter",
+           r.name() == "LSUB" && r.mailbox() == "INBOX" &&
+           r.delimiter().empty() && r.flags().empty(), r.mailbox());
+    }
+
+    {
+        // A mailbox name that needs a literal, which is what the line-based
+        // reader could not do at all.
+        const response r = response::parse("* LIST () \"/\" {8}\r\nMy Mail!\r\n");
+
+        ok("a mailbox name in a literal", r.mailbox() == "My Mail!", r.mailbox());
+    }
+
+    ok("EXISTS",  response::parse("* 172 EXISTS\r\n").number() == 172);
+    ok("RECENT",  response::parse("* 1 RECENT\r\n").number() == 1);
+    ok("EXPUNGE", response::parse("* 44 EXPUNGE\r\n").name() == "EXPUNGE" &&
+                  response::parse("* 44 EXPUNGE\r\n").number() == 44);
+
+    {
+        const response r = response::parse("* SEARCH 2 84 882\r\n");
+
+        ok("SEARCH", r.name() == "SEARCH" && r.numbers().size() == 3 &&
+           r.numbers()[1] == 84);
+    }
+
+    ok("and a SEARCH that found nothing",
+       response::parse("* SEARCH\r\n").numbers().empty());
+}
+
+static void fetch_attributes() {
+    std::cout << "\nFETCH:\n";
+
+    const response r = response::parse(
+        "* 12 FETCH (FLAGS (\\Seen) RFC822.SIZE 44827 UID 4827313)\r\n");
+
+    ok("the message number", r.name() == "FETCH" && r.number() == 12);
+    ok("the flags",          r.flags().size() == 1 && r.flags()[0] == "\\Seen");
+    ok("a numeric attribute", r.attributes().at("RFC822.SIZE") == "44827");
+    ok("and the uid",         r.attributes().at("UID") == "4827313");
+
+    // The section is part of the key, because it is part of what was asked
+    // for: a caller that fetched BODY[HEADER] looks for BODY[HEADER].
+    const response b = response::parse(
+        "* 12 FETCH (BODY[HEADER.FIELDS (FROM TO)] {13}\r\nFrom: a@b.c\r\n)\r\n");
+
+    ok("a section is part of the name",
+       b.attributes().count("BODY[HEADER.FIELDS (FROM TO)]") == 1,
+       b.attributes().empty() ? "none" : b.attributes().begin()->first);
+
+    // A quoted string, with the escaping RFC 3501 4.3 allows: only DQUOTE and
+    // backslash, and each stands for itself.
+    const response q = response::parse(
+        "* 1 FETCH (RFC822.TEXT \"say \\\" hi\\\\\")\r\n");
+
+    ok("a quoted value is unquoted and unescaped",
+       q.attributes().at("RFC822.TEXT") == "say \" hi\\",
+       q.attributes().at("RFC822.TEXT"));
+
+    ok("NIL is empty", response::parse("* 1 FETCH (RFC822.TEXT NIL)\r\n")
+                           .attributes().at("RFC822.TEXT").empty());
+
+    // ENVELOPE and BODYSTRUCTURE are sixty productions jlib does not
+    // interpret, so they come back as written rather than half-understood.
+    // An early version of the reader reached inside for the first string it
+    // found and turned this into "d".
+    const response e = response::parse(
+        "* 12 FETCH (ENVELOPE (\"d\" \"s\" NIL NIL))\r\n");
+
+    ok("a parenthesised value is handed over whole",
+       e.attributes().at("ENVELOPE") == "(\"d\" \"s\" NIL NIL)",
+       e.attributes().at("ENVELOPE"));
+
+    // An attribute nobody here has heard of does not fail the response.  This
+    // matters: servers volunteer MODSEQ, X-GM-MSGID and others unasked.
+    const response x = response::parse(
+        "* 12 FETCH (MODSEQ (12345) X-GM-MSGID 1278455344230334865 UID 9)\r\n");
+
+    ok("an unknown attribute parses rather than failing",
+       x.attributes().at("MODSEQ") == "(12345)" &&
+       x.attributes().at("X-GM-MSGID") == "1278455344230334865" &&
+       x.attributes().at("UID") == "9");
+
+    ok("and a partial fetch's origin octet",
+       response::parse("* 1 FETCH (BODY[]<0> \"x\")\r\n")
+           .attributes().count("BODY[]<0>") == 1);
+}
+
+static void what_it_refuses() {
+    std::cout << "\nnot a response:\n";
+
+    for(const char* s : { "garbage\r\n", "\r\n", "",
+                          "* 12 FETCH (FLAGS (\\Seen)\r\n",     // unbalanced
+                          "* 12 FETCH\r\n",                     // no attributes
+                          "a001 MAYBE something\r\n",           // no such condition
+                          "* LIST (\\Noselect) \"/\"\r\n",      // no mailbox
+                          "a001 OK no newline" }) {
+        ok(std::string("\"") + show(s) + "\"", !response::valid(s));
+    }
+
+    std::string msg;
+
+    try { response::parse("garbage\r\n"); }
+    catch(imap::error& e) { msg = e.what(); }
+
+    ok("and the message says where", msg.find("column") != std::string::npos, msg);
+}
+
+static void the_grammar_itself() {
+    std::cout << "\nthe grammar:\n";
+
+    using namespace jlib::util::abnf;
+
+    // It does not compile on its own: literal is referenced and never
+    // defined, because RFC 3501 4.3 puts the length constraint in a comment.
+    grammar g = compile(jlib::net::rfc3501::RESPONSE);
+
+    bool undefined = false;
+
+    try { g.check(); }
+    catch(grammar_error&) { undefined = true; }
+
+    ok("literal is left for the combinators to define", undefined);
+
+    // And this is what imap_response.cc does, which is the whole argument for
+    // both layers of abnf being public.
+    const rule size = as("literal-size", +core::DIGIT());
+
+    g.define("literal", lit("{") >> size >> lit("}") >> core::CRLF()
+                       >> as("literal-text", counted(size)));
+
+    bool built = false;
+    std::string why;
+
+    try { g.check(); built = true; }
+    catch(exception& e) { why = e.what(); }
+
+    ok("and then it checks", built, why);
+
+    // ATOM-CHAR is stated in the RFC as an exclusion in prose, so a reader
+    // cannot check it by comparing.  Every excluded printable character.
+    // Tested in an unquoted mailbox name -- which is an astring, so the run
+    // stops at the first character it may not contain and the CRLF that has
+    // to follow is not there.
+    //
+    // Not in a flag list, which is where this was first written: a space
+    // there is the separator between two flags, so "(a b)" is two flags and
+    // proves nothing at all.
+    for(char c : std::string(" (){%*\"\\")) {
+        const std::string s = std::string("* LSUB () NIL a") + c + "b\r\n";
+
+        ok(std::string("ATOM-CHAR excludes '") + c + "'", !response::valid(s));
+    }
+
+    ok("a space in a flag list is a separator, not a flag character",
+       response::valid("* FLAGS (a b)\r\n") &&
+       response::parse("* FLAGS (a b)\r\n").flags().size() == 2);
+
+    // "]" is resp-specials: not an ATOM-CHAR, but an ASTRING-CHAR.
+    ok("and \"]\", which an astring may still contain",
+       !response::valid("* FLAGS (a]b)\r\n") &&
+       response::valid("* LSUB () NIL a]b\r\n"));
+}
+
+int main() {
+    std::cout << std::unitbuf;
+
+    a_response_is_not_a_line();
+    the_literal_introducer();
+    the_three_shapes();
+    the_data_responses();
+    fetch_attributes();
+    what_it_refuses();
+    the_grammar_itself();
+
+    // What a green run does NOT establish.
+    //
+    // Not that jlib speaks IMAP.  No server was involved: these are strings
+    // and a std::istringstream.  What is established is that a response with a
+    // literal in it is read whole, which is the thing the line-based reader
+    // could not do.
+    //
+    // Not RFC 3501 conformance.  The commands are not here -- jlib writes
+    // those and knows what it wrote -- and ENVELOPE, BODYSTRUCTURE and the
+    // STATUS attributes are matched by shape rather than by their sixty-odd
+    // productions, because jlib does not interpret them.  rfc3501.hh says
+    // exactly which departures there are.
+    //
+    // Not extensions.  This is RFC 3501, not 4466, 4551, 6154 or 9051.  An
+    // extension's attribute parses as a name and a value, which is the most a
+    // client that has not implemented it should do.
+    //
+    // Not NIL.  RFC 3501 distinguishes NIL from the empty string and a
+    // std::string cannot; both come back as "".
+    //
+    // Not the rest of Imap4.  handshake() reads responses now rather than
+    // lines, so every command benefits -- but its callers still take the
+    // response apart with util::tokenize and a linear scan.  Putting them on
+    // response's accessors, and implementing SEARCH, UID and a ranged FETCH
+    // against it, is the other half of #85.
+    return failures ? 1 : 0;
+}

--- a/tests/net_protocol_test.cc
+++ b/tests/net_protocol_test.cc
@@ -28,7 +28,7 @@
 
 #include <jlib/net/net.hh>
 #include <jlib/net/Pop3.hh>
-#include <jlib/net/Imap4.hh>
+#include <jlib/net/imap_response.hh>
 
 #include <iostream>
 #include <sstream>
@@ -37,7 +37,7 @@
 using jlib::net::dot_stuff;
 using jlib::net::dot_unstuff;
 using jlib::net::Pop3;
-using jlib::net::Imap4;
+namespace imap = jlib::net::imap;
 
 static int failures = 0;
 
@@ -211,7 +211,7 @@ static void imap_literals() {
 
     for(const auto& c : cases) {
         std::size_t n = 12345;
-        const bool got = Imap4::literal_size(c.line, n);
+        const bool got = imap::literal_size(c.line, n);
 
         ok(std::string("\"") + c.line + "\"",
            got == c.found && (!c.found || n == c.n),


### PR DESCRIPTION
The first half of #85.  The issue asked for three commands and said doing them
without a grammar and a response type first would put three more hand-scanned
responses in a file that already has too many.  This is the grammar, the
response type, the command-side quoting that turned out to be broken as well,
and an end-to-end test against a real IMAP server.

    macOS  46 tests, 45 pass, 1 skip   (no dovecot, so the live test skips)
    Linux  47 tests, 46 pass, 1 skip   (x_window_test, headless)

    jlib/net/rfc3501.hh             new -- section 9's response half
    jlib/net/imap_response.{hh,cc}  new -- read(), quote(), response
    jlib/net/Imap4.cc               handshake reads responses; every command
                                    quotes its arguments
    tests/net_imap_test.cc          new
    tests/net_imap_live_test.cc     new -- against dovecot
    Dockerfile, DOCKER              dovecot-imapd

a response is not a line

        * 12 FETCH (BODY[HEADER] {33}
        a001 OK this looks like the end
        )

    RFC 3501 4.3: a literal is "{" number "}" CRLF and then exactly that many
    octets, and those octets are message content -- so they may contain a line
    that looks exactly like the tagged completion the client is waiting for.

    Imap4::handshake read lines until one began with the tag.  Given that
    stream it stopped in the middle of the message, and every command after it
    read the rest of the message as its own response.  imap::read() follows the
    literals; handshake() calls it, so every command benefits, not only the
    three #85 is about.

    The live test does not ask anyone to take that on trust.  It seeds a
    Maildir with a message whose body is twenty lines of

        A00001 OK FETCH completed
        A00002 OK FETCH completed
        ...

    -- Imap4::tag() counts up from A00001, so that body impersonates every tag
    jlib is going to use -- then fetches it two ways over two connections and
    asserts both halves:

        ok   reading lines stops inside the message, as it always did:
             stopped after 5 lines
        ok   reading responses does not

this is what abnf has two public layers for

    RFC 3501 4.3 writes the production as

        literal = "{" number "}" CRLF *CHAR8
                ; Number represents the number of CHAR8s

    with the constraint in a *comment*, because ABNF cannot say "this many".
    rfc3501.hh references `literal` and never defines it; imap_response.cc
    supplies it with counted() and only then calls check().

        const rule size = as("literal-size", +core::DIGIT());

        g.define("literal", lit("{") >> size >> lit("}") >> core::CRLF()
                            >> as("literal-text", counted(size)));
        g.check();

    counted() was built in the first branch of this arc, argued for on the
    strength of this exact production, and has been waiting for a use since.

the commands were as bad as the responses

    Every one of them built its arguments by concatenation:

        handshake(sock, "LOGIN " + user + " " + pass);
        handshake(sock, "SELECT \"" + path + "\"");

    A password or mailbox name with a space in it produced a malformed
    command; one with a quote or a backslash produced a differently malformed
    one.  And one containing "{5}" produced a *literal introducer* -- the
    server answers "+" and reads the next five octets as data, and the
    connection is gone.

    imap::quote() is the inverse of the `quoted` production the reader already
    had, which is why it lives beside it.  Fourteen call sites.  It throws on a
    CR, an LF or a NUL, none of which can go in a quoted string and the first
    of which is how one command becomes two.

    The live test logs in with the password

        pa ss "quoted" back\slash

    which is exactly what the old code could not send.

three more bugs found on the way

    Imap4::lsub sent LIST.  Not a parse error or any kind of error -- asking
    for the subscribed mailboxes simply returned all of them.  The live test
    subscribes to one mailbox and asserts LSUB does not report the other.

    Two loops read `for(i = 0; i < ls.size() - 1; i++)` over a vector that is
    empty in the one case nobody had hit.

    And in the reader itself, caught by its own test while being written:
    text_of() reached into a parenthesised value for the first string it found,
    so ENVELOPE ("d" "s" NIL NIL) came back as "d"; and capability-data is a
    *sibling* of mailbox-data inside response-data, not a part of it, so
    CAPABILITY silently produced a response with no name and no capabilities.

    One of my own assertions was wrong too: ATOM-CHAR's exclusions were being
    tested inside a flag list, where a space is the separator between two flags
    -- "(a b)" is two flags and proves nothing.  They are tested in an unquoted
    mailbox name now, and the separator gets an assertion of its own.

what is not transcribed, and why

    ENVELOPE and BODYSTRUCTURE are roughly sixty productions between them and
    jlib interprets neither, so an attribute value is matched by shape.  That
    also means an attribute nobody here has heard of does not fail the
    response, which matters because servers volunteer MODSEQ and X-GM-MSGID
    unasked.  Commands are absent: jlib writes those and knows what it wrote.

what a green run does not establish

    Not interoperability.  The live test is one server, one version, one
    configuration, with TLS off and plaintext authentication on -- which is
    exactly what no real account allows.  What it establishes is that jlib's
    reader survives a response a real server chose to send as a literal.

    Not TLS.  imaps:// goes through sys::sslstream and nothing here reaches it;
    a certificate Dovecot and OpenSSL both accept is a branch of its own.

    Not RFC 3501 conformance, for the reasons above.  Not extensions.  Not NIL,
    which the RFC distinguishes from the empty string and a std::string cannot.

    And not the rest of Imap4.  handshake reads responses correctly now, but
    its callers still take them apart with util::tokenize and a linear scan.
    Putting them on response's accessors, and implementing SEARCH, UID and a
    ranged FETCH against it, is the other half of #85.
