### PR TITLE
Put Imap4 on the response grammar; add SEARCH, UID and a ranged FETCH

### DIFF
--- a/jlib/net/Imap4.cc
+++ b/jlib/net/Imap4.cc
@@ -48,87 +48,51 @@ namespace jlib {
 
         ListItem::ListItem() {}
         ListItem::ListItem(const std::string& line) {
-            // These were unsigned int, which truncates npos to 0xFFFFFFFF: a
-            // reply with no "(" left i as that, i+1 wrapped to 0, and the
-            // find(")") that followed searched from the start of the line.
-            // line.substr(j+1) then threw, or returned a slice of something
-            // unrelated.  This is the same bug class already fixed and
-            // regression-tested in net::extract_address.
-            std::string::size_type i, j;
+            // Eighty lines of find() and tokenize() used to live here, with a
+            // comment saying that reading LIST properly needed the grammar
+            // rather than more guards.  This is that grammar.
+            //
+            // What it got wrong, when it got anything wrong, was quiet: a
+            // mailbox name in a literal was invisible because the response
+            // never arrived whole; a name containing a quote, a space or a
+            // parenthesis was cut in the wrong place; and a truncated reply
+            // produced a nameless item the caller then skipped.
+            imap::response r;
 
-            i = line.find("(");
-            j = (i == line.npos) ? line.npos : line.find(")", i+1);
+            try {
+                // The reader hands back the response without its CRLF, and
+                // the grammar wants it.
+                r = imap::response::parse(line + "\r\n");
+            }
+            catch(imap::error& e) {
+                if(getenv("JLIB_NET_IMAP4_DEBUG")) {
+                    std::cout << "not a LIST response: " << e.what() << std::endl;
+                }
 
-            if(i == line.npos || j == line.npos) {
                 return;
             }
 
-            std::string ending = line.substr(j+1);
-            std::vector<std::string> etokens = util::tokenize(ending," ",false);
+            if(r.name() != "LIST" && r.name() != "LSUB") return;
 
-            // A truncated reply used to index etokens[0] and etokens[1] with
-            // no size check.  Leaving the item as it is means the caller sees
-            // a nameless non-folder and skips it, which is the same outcome as
-            // a mailbox it cannot select -- rather than a crash from the
-            // network.  Reading LIST properly needs the grammar, not more
-            // guards; that is a later branch.
-            if(etokens.empty() || etokens[0].empty()) {
-                return;
-            }
-            if(getenv("JLIB_NET_IMAP4_DEBUG")) {
-                std::cout << "ending = '"<<ending<<"'"<<std::endl;
-                for(unsigned int i=0;i<etokens.size();i++) {
-                    std::cout << "etokens["<<i<<"] = "<<etokens[i]<<std::endl;
-                }
-            }
-            // 
-            if(etokens[0][0] == '"') {
-                m_delim = util::slice(ending,"\"", "\"");
-                std::string b = ending.substr(ending.find(m_delim)+m_delim.length()+2);
-                etokens = util::tokenize(b," ",false);
-                
-                if(etokens[0][0] == '"') {
-                    m_name = util::slice(b,"\"", "\"");
-                }
-                else {
-                    m_name = etokens[0];
-                }
-            }
-            else {
-                m_delim = etokens[0];
-                if(etokens.size() < 2 || etokens[1].empty()) {
-                    return;
-                }
-                if(etokens[1][0] == '"') {
-                    std::string b = ending;
-                    b = b.substr(b.find(m_delim)+m_delim.length()+1);
-                    m_name = util::slice(b,"\"", "\"");
-                }
-                else {
-                    m_name = etokens[1];
-                }
-            }
+            m_name = r.mailbox();
+            m_delim = r.delimiter();
+            m_attr = r.flags();
 
-            m_attr = util::tokenize(line.substr(i+1,j-i-1));
             m_is_folder = true;
             m_is_parent = true;
-            for(unsigned int i=0;i<m_attr.size();i++) {
-                std::string attr = util::upper(m_attr[i]);
-                if(attr.find("NOSELECT") != std::string::npos) {
-                    m_is_folder = false;
-                }
-                else if(attr.find("NOINFERIORS") != std::string::npos) {
-                    m_is_parent = false;
-                }
+
+            for(const std::string& a : m_attr) {
+                const std::string flag = util::upper(a);
+
+                if(flag == "\\NOSELECT")         m_is_folder = false;
+                else if(flag == "\\NOINFERIORS") m_is_parent = false;
             }
+
             if(getenv("JLIB_NET_IMAP4_DEBUG")) {
                 std::cout << "m_name = <"<<m_name<<">: m_delim = <"<<m_delim<<">: m_attr = ";
-                for(unsigned int i=0;i<m_attr.size();i++)
-                    std::cout << "<"<<m_attr[i]<<">";
+                for(const std::string& a : m_attr) std::cout << "<"<<a<<">";
                 std::cout << "is_folder(): " << is_folder() << "; "
                           << "is_parent(): " << is_parent() << std::endl;
-                    
-                std::cout << std::endl;
             }
         }
         
@@ -188,149 +152,140 @@ namespace jlib {
                          int which, 
                          bool only_headers)
         {
-            Email ret;
-            std::set<Email:: flag_type> flags;
-            std::vector<std::string>::iterator i;
-            std::string buf;
-            std::vector<std::string> info;
-            std::vector<std::string> flagv;
-            std::string s = util::string_value(which+1);
-            std::string flagbuf;
-            int size = 0, header_size = 0;
+            // A hundred and forty lines used to live here.  They tokenized the
+            // response on whitespace, looked for "(FLAGS" and then for
+            // "RFC822.SIZE" -- and, failing that, for "(RFC822.SIZE", because
+            // whether the parenthesis was attached depended on where the
+            // attribute happened to fall.  A FETCH response is not a
+            // whitespace-separated list of tokens, and every one of those
+            // guesses was a way of pretending it is.
+            const std::string s = util::string_value(which + 1);
+            const std::string what = only_headers ? "RFC822.HEADER" : "RFC822";
 
             tag(1);
 
-            std::string req = 
-                tag() + " FETCH " + s + ":" + s + " (FLAGS RFC822.SIZE " + 
-                (only_headers ? "RFC822.HEADER" : "RFC822") + ")";
-            
-            if(getenv("JLIB_NET_IMAP4_DEBUG")) 
-                std::cout << req << std::endl;
+            const std::string req = tag() + " FETCH " + s + ":" + s
+                                  + " (FLAGS RFC822.SIZE " + what + ")";
+
+            if(getenv("JLIB_NET_IMAP4_DEBUG")) std::cout << req << std::endl;
 
             sock << req << ENDL << std::flush;
-            sys::getline(sock, buf);
 
-            if(getenv("JLIB_NET_IMAP4_DEBUG")) 
-                std::cout << buf << std::endl;
+            Email ret;
+            std::set<Email::flag_type> flags;
+            std::vector<std::string> flagv;
+            bool got = false;
 
-            if(buf.find(tag()+" NO") == 0) {
-                throw exception(buf.substr(tag().length()+1));
-            }
-            
-            info = util::tokenize(buf);
-            if(getenv("JLIB_NET_IMAP4_DEBUG")) 
-                std::cout << "Response parsed into " << info.size() << " tokens" << std::endl;
+            for(;;) {
+                const std::string raw = imap::read(sock);
 
-            i = find(info.begin(),info.end(), "(FLAGS");
-            if(i != info.end()) {
-                for(i++; (i != info.end() && *i != "RFC822.SIZE"); i++) {
-                    std::string flag = *i;
-                    
-                    if(getenv("JLIB_NET_IMAP4_DEBUG")) 
-                        std::cout << "Found flag: " << flag << std::endl;
-                    
-                    std::string::size_type x; 
-                    while((x=flag.find("(")) != std::string::npos) {
-                        flag.erase(x,x+1);
+                if(getenv("JLIB_NET_IMAP4_DEBUG")) std::cout << raw;
+
+                const imap::response r = imap::response::parse(raw);
+
+                if(r.type() == imap::response::kind::tagged) {
+                    if(!r.ok()) throw exception(r.text());
+
+                    break;
+                }
+
+                if(r.name() != "FETCH") continue;
+
+                const std::map<std::string,std::string>& att = r.attributes();
+                std::map<std::string,std::string>::const_iterator a;
+
+                if((a = att.find("RFC822.SIZE")) != att.end()) {
+                    ret.set_data_size(util::int_value(a->second));
+                }
+
+                if((a = att.find(what)) != att.end()) {
+                    got = true;
+
+                    // Email::create throws on a message it cannot make sense
+                    // of, and a mailbox with one bad message in it should
+                    // still open.
+                    try {
+                        ret.create(a->second);
                     }
-                    while((x=flag.find(")")) != std::string::npos) {
-                        flag.erase(x,x+1);
+                    catch(std::exception& e) {
+                        if(getenv("JLIB_NET_IMAP4_DEBUG")) {
+                            std::cout << "could not read message " << s << ": "
+                                      << e.what() << std::endl;
+                        }
                     }
-                    
-                    flagv.push_back(flag);
                 }
+
+                flagv = r.flags();
             }
 
-            i = find(info.begin(),info.end(), "RFC822.SIZE");
-            if(i == info.end()) {
-                if(getenv("JLIB_NET_IMAP4_DEBUG")) 
-                    std::cout << "Didn't find token RFC822.SIZE, look for (RFC822.SIZE" << std::endl;
-
-                i = find(info.begin(),info.end(), "(RFC822.SIZE");
+            if(!got) {
+                throw exception("no " + what + " in the response to " + req);
             }
 
-            if(i != info.end() && (++i) != info.end()) {
-                if(getenv("JLIB_NET_IMAP4_DEBUG")) 
-                    std::cout << "Found RFC822.SIZE:" << *i << std::endl;
-
-                size = util::int_value(*i);
-            } else {
-                if(getenv("JLIB_NET_IMAP4_DEBUG")) 
-                    std::cout << "Didn't find tokens RFC822.SIZE or (RFC822.SIZE" << std::endl;
+            for(const std::string& f : flagv) {
+                if(f == "\\Seen")          flags.insert(Email::seen_flag);
+                else if(f == "\\Answered") flags.insert(Email::answered_flag);
+                else if(f == "\\Deleted")  flags.insert(Email::deleted_flag);
             }
 
-            if(getenv("JLIB_NET_IMAP4_DEBUG")) 
-                std::cout << "Parse header size from token" << info.back() << std::endl;
-
-            std::size_t literal = 0;
-
-            if(!imap::literal_size(buf, literal)) {
-                throw exception("expected a literal at the end of: " + buf);
-            }
-
-            header_size = static_cast<long>(literal);
-            if(getenv("JLIB_NET_IMAP4_DEBUG")) 
-                std::cout << "Header size:" << header_size << std::endl;
-            
-            if(getenv("JLIB_NET_IMAP4_DEBUG")) std::cout << "reading " << header_size << "bytes..." << std::flush;
-            sys::getstring(sock, buf, header_size);
-            if(getenv("JLIB_NET_IMAP4_DEBUG")) std::cout << "done" << std::endl;
-
-            if(getenv("JLIB_NET_IMAP4_DEBUG")) {
-                std::cout << buf << std::endl;
-            }
-            
-            if(getenv("JLIB_NET_IMAP4_DEBUG")) std::cout << "creating email from buffer with size " << size << std::endl;
-            try { 
-                ret.create(buf); 
-            } 
-            catch(std::exception& e) {
-                if(getenv("JLIB_NET_IMAP4_DEBUG")) 
-                    std::cout << "caught exception while creating email: " << e.what() << std::endl;
-            }
-            catch(...) {
-                if(getenv("JLIB_NET_IMAP4_DEBUG")) 
-                    std::cout << "caught exception while creating email " << size << std::endl;
-            }
-            ret.set_data_size(size);
-
-            if(getenv("JLIB_NET_IMAP4_DEBUG")) {
-                std::cout << "iterating over flagv: size " << flagv.size() << std::endl;
-            }
-
-            for(i = flagv.begin(); i != flagv.end(); i++) {
-                if(getenv("JLIB_NET_IMAP4_DEBUG")) {
-                    std::cout << "checking flag " << *i << std::endl;
-                }
-                
-                if(*i == "\\Seen") {
-                    flags.insert(flags.begin(), Email::seen_flag);
-                }
-                else if(*i == "\\Answered") {
-                    flags.insert(flags.begin(), Email::answered_flag);
-                }
-                else if(*i == "\\Deleted") {
-                    flags.insert(flags.begin(), Email::deleted_flag);
-                }
-            }
-
-            if(!only_headers) {
-                flags.insert(flags.begin(), Email::seen_flag);
-            }
+            // Fetching the body marks it read, whatever the server said.
+            if(!only_headers) flags.insert(Email::seen_flag);
 
             ret.set_flags(flags);
 
-            while(!util::begins(buf, tag())) {
-                sys::getline(sock, buf);
-                if(getenv("JLIB_NET_IMAP4_DEBUG")) std::cout << buf << std::endl;
-            }
-            
-            if(buf.find(tag()+" NO") == 0 || buf.find(tag()+" BAD") == 0) {
-                throw exception(buf.substr(tag().length()+1));
+            return ret;
+        }
+
+        std::string Imap4::fetch_attribute(sys::socketstream& sock,
+                                           unsigned int which,
+                                           const std::string& items,
+                                           const std::string& want,
+                                           unsigned int& size)
+        {
+            const std::string s = util::string_value(which + 1);
+            const std::string req = tag(1) + " FETCH " + s + ":" + s
+                                  + " (" + items + ")";
+
+            if(getenv("JLIB_NET_IMAP4_DEBUG")) std::cout << req << std::endl;
+
+            sock << req << ENDL << std::flush;
+
+            std::string ret;
+            bool got = false;
+
+            size = 0;
+
+            for(;;) {
+                const std::string raw = imap::read(sock);
+
+                if(getenv("JLIB_NET_IMAP4_DEBUG")) std::cout << raw;
+
+                const imap::response r = imap::response::parse(raw);
+
+                if(r.type() == imap::response::kind::tagged) {
+                    if(!r.ok()) throw exception(r.text());
+
+                    break;
+                }
+
+                if(r.name() != "FETCH") continue;
+
+                const std::map<std::string,std::string>& att = r.attributes();
+                std::map<std::string,std::string>::const_iterator a;
+
+                if((a = att.find("RFC822.SIZE")) != att.end()) {
+                    size = util::int_value(a->second);
+                }
+
+                if((a = att.find(want)) != att.end()) {
+                    ret = a->second;
+                    got = true;
+                }
             }
 
-            return ret;            
-            
+            if(!got) throw exception("no " + want + " in the response to " + req);
+
+            return ret;
         }
 
         std::string Imap4::retrieve_headers(unsigned int which, 
@@ -354,53 +309,8 @@ namespace jlib {
                                        unsigned int which, 
                                        const std::string& mailbox,
                                        unsigned int& size) {
-
-            std::string buf;
-            //std::vector<std::string> info;
-            std::string s = util::valueOf(which+1);
-            //info = handshake(sock"FETCH "+s+":"+s+" (FLAGS RFC822)");
-            tag(1);
-            if(getenv("JLIB_NET_IMAP4_DEBUG")) std::cout << std::string(tag()+" FETCH "+s+":"+s+" (FLAGS RFC822.HEADER)") << std::endl;
-            sock << std::string(tag()+" FETCH "+s+":"+s+" (FLAGS RFC822.SIZE RFC822.HEADER)") << ENDL << std::flush;
-            sys::getline(sock, buf);
-            if(getenv("JLIB_NET_IMAP4_DEBUG")) std::cout << buf << std::endl;
-            if(buf.find(tag()+" NO") == 0) {
-                throw exception(buf.substr(tag().length()+1));
-            }
-            std::vector<std::string> bufvec = util::tokenize(buf);
-
-            std::vector<std::string>::iterator i = find(bufvec.begin(),bufvec.end(), "RFC822.SIZE");
-            if(i != bufvec.end() && (++i) != bufvec.end()) {
-                size = util::int_value(*i);
-            }
-            else {
-                size = 0;
-            }
-
-            std::size_t literal = 0;
-
-            if(!imap::literal_size(buf, literal)) {
-                throw exception("expected a literal at the end of: " + buf);
-            }
-
-            const long n = static_cast<long>(literal);
-            
-            if(getenv("JLIB_NET_IMAP4_DEBUG")) std::cout << "DEBUG: reading " << n << " bytes from server...\n";            
-            std::string ret;
-            sys::getstring(sock, ret, n);
-            if(getenv("JLIB_NET_IMAP4_DEBUG")) std::cout << ret << std::endl;
-            if(getenv("JLIB_NET_IMAP4_DEBUG")) std::cout << "DEBUG: finished reading\n";
-            
-            while(!util::begins(buf, tag())) {
-                sys::getline(sock, buf);
-                if(getenv("JLIB_NET_IMAP4_DEBUG")) std::cout << buf << std::endl;
-            }
-            
-            if(buf.find(tag()+" NO") == 0 || buf.find(tag()+" BAD") == 0) {
-                throw exception(buf.substr(tag().length()+1));
-            }
-
-            return ret;            
+            return fetch_attribute(sock, which, "FLAGS RFC822.SIZE RFC822.HEADER",
+                                   "RFC822.HEADER", size);
         }
 
         std::string Imap4::retrieve(int which, const std::string& mailbox) {
@@ -420,43 +330,18 @@ namespace jlib {
 
         std::string Imap4::retrieve(sys::socketstream& sock, int which, const std::string& mailbox) 
         {
-            std::string buf;
-            //std::vector<std::string> info;
-            std::string s = util::valueOf(which+1);
-            //info = handshake(sock"FETCH "+s+":"+s+" (FLAGS RFC822)");
-            sock << std::string(tag(1)+" FETCH "+s+":"+s+" (FLAGS RFC822)") << ENDL << std::flush;
-            sys::getline(sock, buf);
-            if(buf.find(tag()+" NO") == 0) {
-                throw exception(buf.substr(tag().length()+1));
-            }
-            std::vector<std::string> bufvec = util::tokenize(buf);
-            std::size_t literal = 0;
+            unsigned int size = 0;
+            const std::string ret =
+                fetch_attribute(sock, static_cast<unsigned int>(which),
+                                "FLAGS RFC822", "RFC822", size);
 
-            if(!imap::literal_size(buf, literal)) {
-                throw exception("expected a literal at the end of: " + buf);
-            }
+            // Fetching the body marks it read; say so explicitly rather than
+            // relying on the server having done it.
+            const std::pair<unsigned int, unsigned int> p(which + 1, which + 1);
+            const std::vector<std::string> f { "\\Seen" };
 
-            const long n = static_cast<long>(literal);
-            
-            if(getenv("JLIB_NET_IMAP4_DEBUG")) std::cout << "DEBUG: reading " << n << " bytes from server...\n";            
-            std::string ret;
-            sys::getstring(sock, ret, n);
-            if(getenv("JLIB_NET_IMAP4_DEBUG")) std::cout << ret << std::endl;
-            if(getenv("JLIB_NET_IMAP4_DEBUG")) std::cout << "DEBUG: finished reading\n";
-            
-            while(!util::begins(buf, tag())) {
-                sys::getline(sock, buf);
-                if(getenv("JLIB_NET_IMAP4_DEBUG")) std::cout << buf << std::endl;
-            }
-            
-            if(buf.find(tag()+" NO") == 0 || buf.find(tag()+" BAD") == 0) {
-                throw exception(buf.substr(tag().length()+1));
-            }
+            store(sock, p, "+FLAGS.SILENT", f);
 
-            std::pair<unsigned int, unsigned int> p(which+1,which+1);
-            std::vector<std::string> f; f.push_back("\\Seen");
-            store(sock,p,"+FLAGS.SILENT",f);
-            
             return ret;
         }
         
@@ -648,18 +533,31 @@ namespace jlib {
         }
 
         void Imap4::parse(std::vector<std::string> hand) {
-            for(unsigned int i=0;i<hand.size();i++) {
-                if(util::icontains(hand[i], "exists")) {
-                    std::vector<std::string> tok = util::tokenize(hand[i]);
-                    exists(util::int_value(tok[1]));
+            // icontains(line, "exists") matched any line with those letters
+            // anywhere in it, and then read tok[1] with no size check.  The
+            // UNSEEN branch read tok[2], which on
+            //
+            //     * OK [UNSEEN 1] First unseen.
+            //
+            // is the string "[UNSEEN" -- so int_value gave 0 and the unseen
+            // count has been zero for as long as there has been one.
+            for(const std::string& line : hand) {
+                imap::response r;
+
+                try {
+                    r = imap::response::parse(line + "\r\n");
                 }
-                else if(util::icontains(hand[i], "recent")) {
-                    std::vector<std::string> tok = util::tokenize(hand[i]);
-                    recent(util::int_value(tok[1]));
+                catch(imap::error&) {
+                    continue;
                 }
-                else if(util::icontains(hand[i], "unseen")) {
-                    std::vector<std::string> tok = util::tokenize(hand[i]);
-                    unseen(util::int_value(tok[2]));
+
+                if(r.name() == "EXISTS")      exists(r.number());
+                else if(r.name() == "RECENT") recent(r.number());
+
+                // The unseen count is a response-text-code on an OK, not a
+                // data response: "* OK [UNSEEN 12] Message 12 is first unseen".
+                if(util::ibegins(r.code(), "UNSEEN ")) {
+                    unseen(util::int_value(r.code().substr(7)));
                 }
             }
         }
@@ -872,7 +770,90 @@ namespace jlib {
             handshake(sock,"EXPUNGE");
         }
 
-                std::vector<std::string> Imap4::fetch(sys::socketstream& sock, std::pair<unsigned int,unsigned int> set, std::vector<std::string> n) {
+                std::vector<imap::response> Imap4::command(sys::socketstream& sock,
+                                                   const std::string& data)
+        {
+            const std::string com = tag(1) + " " + data;
+
+            if(getenv("JLIB_NET_IMAP4_DEBUG")) std::cout << com << std::endl;
+
+            sock << com << ENDL << std::flush;
+
+            std::vector<imap::response> ret;
+
+            for(;;) {
+                const std::string raw = imap::read(sock);
+
+                if(getenv("JLIB_NET_IMAP4_DEBUG")) std::cout << raw;
+
+                const imap::response r = imap::response::parse(raw);
+
+                if(r.type() == imap::response::kind::tagged) {
+                    if(!r.ok()) throw exception(r.text());
+
+                    return ret;
+                }
+
+                if(r.type() == imap::response::kind::untagged) ret.push_back(r);
+            }
+        }
+
+        std::vector<unsigned long> Imap4::search(sys::socketstream& sock,
+                                                 const std::string& criteria,
+                                                 const std::string& charset)
+        {
+            std::string cmd = "SEARCH ";
+
+            if(!charset.empty()) cmd += "CHARSET " + imap::quote(charset) + " ";
+
+            std::vector<unsigned long> ret;
+
+            // 6.4.4: the answer comes back as untagged SEARCH responses, and
+            // a server is allowed to split them across more than one.
+            for(const imap::response& r : command(sock, cmd + criteria)) {
+                if(r.name() != "SEARCH") continue;
+
+                ret.insert(ret.end(), r.numbers().begin(), r.numbers().end());
+            }
+
+            return ret;
+        }
+
+        std::vector<imap::response> Imap4::uid(sys::socketstream& sock,
+                                               const std::string& command_name,
+                                               const std::string& args)
+        {
+            return command(sock, "UID " + command_name + " " + args);
+        }
+
+        std::string Imap4::fetch_partial(sys::socketstream& sock,
+                                         unsigned int which,
+                                         const std::string& section,
+                                         std::size_t origin,
+                                         std::size_t length)
+        {
+            std::ostringstream cmd;
+            const std::string s = util::string_value(which + 1);
+
+            cmd << "FETCH " << s << ":" << s << " (BODY.PEEK[" << section << "]<"
+                << origin << "." << length << ">)";
+
+            for(const imap::response& r : command(sock, cmd.str())) {
+                if(r.name() != "FETCH") continue;
+
+                // The response echoes the section and the *origin* but not the
+                // length -- "BODY[]<0>" for a request of "<0.1024>" -- so the
+                // key is not the string that was sent, and it comes back as
+                // BODY rather than BODY.PEEK.
+                for(const auto& a : r.attributes()) {
+                    if(util::ibegins(a.first, "BODY[")) return a.second;
+                }
+            }
+
+            throw exception("no BODY in the response to " + cmd.str());
+        }
+
+        std::vector<std::string> Imap4::fetch(sys::socketstream& sock, std::pair<unsigned int,unsigned int> set, std::vector<std::string> n) {
             std::ostringstream cmd;
             cmd << "FETCH "<<set.first<<":"<<set.second<<" (";
             for(unsigned int i=0;i<n.size();i++) {

--- a/jlib/net/Imap4.hh
+++ b/jlib/net/Imap4.hh
@@ -25,6 +25,7 @@
 
 #include <jlib/util/URL.hh>
 #include <jlib/net/Email.hh>
+#include <jlib/net/imap_response.hh>
 
 #include <cstddef>
 #include <vector>
@@ -421,6 +422,83 @@ namespace jlib {
              */
             std::string retrieve_headers(unsigned int which, const std::string& mailbox,unsigned int& size);
             std::string retrieve_headers(jlib::sys::socketstream& sock, unsigned int which, const std::string& mailbox,unsigned int& size);
+
+            /**
+             * Send a command and return the untagged responses it produced.
+             *
+             * What handshake() would be if it had existed after the grammar:
+             * whole responses, parsed, with the tagged completion checked and
+             * dropped.  Throws Imap4::exception on NO or BAD.
+             */
+            std::vector<imap::response> command(jlib::sys::socketstream& sock,
+                                                const std::string& data);
+
+            /**
+             * SEARCH, RFC 3501 6.4.4.  The message numbers that matched.
+             *
+             * criteria is the search key -- "UNSEEN", "FROM joe", "SINCE
+             * 1-Jan-2026" -- and charset names the encoding its strings are
+             * in, if they are not ASCII.
+             *
+             * This used to send a bare tag with no command at all and return
+             * whatever the server said about that, which is BAD.
+             */
+            std::vector<unsigned long> search(jlib::sys::socketstream& sock,
+                                              const std::string& criteria,
+                                              const std::string& charset = "");
+
+            /**
+             * UID, RFC 3501 6.4.8: the same commands keyed by unique id.
+             *
+             *     uid(sock, "SEARCH", "UNSEEN")
+             *     uid(sock, "FETCH", "4827313 (RFC822.SIZE)")
+             *
+             * The one gtkmail most needs: a sequence number shifts under an
+             * EXPUNGE from another client, so any state a client keeps across
+             * a connection has to be keyed by UID.
+             *
+             * Also a stub before this: a bare tag and no command.
+             */
+            std::vector<imap::response> uid(jlib::sys::socketstream& sock,
+                                            const std::string& command,
+                                            const std::string& args);
+
+            /**
+             * A byte range of one part, RFC 3501 6.4.5.
+             *
+             * The replacement for PARTIAL, which was withdrawn in RFC 3501 in
+             * favour of a FETCH with an origin and a length -- so the method
+             * that used to be called partial() is gone and this is not it.
+             *
+             *     fetch_partial(sock, 0, "", 0, 1024)      the first KB
+             *     fetch_partial(sock, 0, "HEADER", 0, 512)
+             *
+             * A server may return fewer octets than were asked for; it may
+             * not return more.
+             */
+            std::string fetch_partial(jlib::sys::socketstream& sock,
+                                      unsigned int which,
+                                      const std::string& section,
+                                      std::size_t origin,
+                                      std::size_t length);
+
+            /**
+             * FETCH one message and return one of its attributes.
+             *
+             * items is what to ask for -- "FLAGS RFC822.SIZE RFC822.HEADER" --
+             * and want is which of them to return.  RFC822.SIZE, if it was
+             * asked for and the server sent it, goes into size.
+             *
+             * Reads whole responses, so an attribute that arrives as a literal
+             * arrives whole; retrieve() and retrieve_headers() each used to
+             * take the response apart with util::tokenize and a linear search
+             * for the attribute name.
+             */
+            std::string fetch_attribute(jlib::sys::socketstream& sock,
+                                        unsigned int which,
+                                        const std::string& items,
+                                        const std::string& want,
+                                        unsigned int& size);
             
             /**
              * Remove this email from it's server

--- a/tests/net_imap_live_test.cc
+++ b/tests/net_imap_live_test.cc
@@ -303,6 +303,15 @@ int main() {
 
         ok("SELECT", true);
 
+        // parse() read the SELECT responses with icontains() and an index into
+        // a tokenized line.  The UNSEEN branch took tok[2], which on
+        // "* OK [UNSEEN 1] First unseen." is the string "[UNSEEN" -- so the
+        // count was zero for as long as there was one.
+        ok("EXISTS comes back", imap.exists() == 2,
+           std::to_string(imap.exists()));
+        ok("and UNSEEN is not zero", imap.unseen() == 1,
+           std::to_string(imap.unseen()));
+
         // The reason this test exists.  One of these two messages is a body
         // that says "A00001 OK FETCH completed" and nineteen variations, which
         // is what the client is waiting for -- and it has to come back whole.
@@ -324,6 +333,69 @@ int main() {
                ? std::string()
                : "got " + std::to_string(two.size()) + " of "
                  + std::to_string(impersonating_body().size()) + " octets");
+
+        // SEARCH, which was a bare tag and no command.
+        const std::vector<unsigned long> all = imap.search(*sock, "ALL");
+
+        ok("SEARCH ALL finds both messages",
+           all.size() == 2 && all[0] == 1 && all[1] == 2,
+           std::to_string(all.size()) + " found");
+
+        const std::vector<unsigned long> subject =
+            imap.search(*sock, "HEADER SUBJECT \"two\"");
+
+        ok("and a header search finds the one",
+           subject.size() == 1 && subject[0] == 2,
+           std::to_string(subject.size()) + " found");
+
+        ok("a search that matches nothing returns nothing",
+           imap.search(*sock, "HEADER SUBJECT \"nothing here\"").empty());
+
+        // UID, which was also a bare tag.  A sequence number shifts under an
+        // EXPUNGE from another client; a UID does not, which is why gtkmail
+        // needs this one.
+        const std::vector<jlib::net::imap::response> uids =
+            imap.uid(*sock, "SEARCH", "ALL");
+
+        unsigned long first_uid = 0;
+
+        for(const jlib::net::imap::response& r : uids) {
+            if(r.name() == "SEARCH" && !r.numbers().empty()) first_uid = r.numbers()[0];
+        }
+
+        ok("UID SEARCH answers with unique ids", first_uid != 0,
+           std::to_string(first_uid));
+
+        const std::vector<jlib::net::imap::response> byuid =
+            imap.uid(*sock, "FETCH", std::to_string(first_uid) + " (RFC822.SIZE)");
+
+        bool sized = false;
+
+        for(const jlib::net::imap::response& r : byuid) {
+            if(r.name() == "FETCH" && r.attributes().count("RFC822.SIZE")) sized = true;
+        }
+
+        ok("and UID FETCH takes one", sized);
+
+        // A byte range.  PARTIAL was withdrawn in RFC 3501 in favour of this,
+        // which is why the method that used to be called partial() is gone.
+        // Eleven octets, which is "From: a@b.c" -- twelve would take the CR
+        // as well, which is what the first draft of this line asked for and
+        // then did not expect.
+        const std::string head = imap.fetch_partial(*sock, 0, "", 0, 11);
+
+        ok("a partial fetch returns only what was asked for",
+           head == "From: a@b.c", "|" + show(head) + "|");
+
+        const std::string middle = imap.fetch_partial(*sock, 0, "", 6, 5);
+
+        ok("from the offset given", middle == "a@b.c", "|" + show(middle) + "|");
+
+        // A server may return fewer octets than asked for; it may not return
+        // more.
+        ok("and no more than the message holds",
+           imap.fetch_partial(*sock, 0, "", 0, 100000).size() == 36,
+           std::to_string(imap.fetch_partial(*sock, 0, "", 0, 100000).size()));
 
         imap.logout(*sock);
 


### PR DESCRIPTION
Closes #85.  The other half: the grammar landed last branch and handshake()
started reading whole responses, but every caller still took them apart with
util::tokenize and a linear scan.  Now none of them do, and the three commands
the issue is named for exist.

    macOS  46 tests, 45 pass, 1 skip   (no dovecot, so the live test skips)
    Linux  47 tests, 46 pass, 1 skip   (x_window_test, headless)

    jlib/net/Imap4.cc            +256 -275, so 275 lines of guessing removed
    jlib/net/Imap4.hh            +78, the new commands
    tests/net_imap_live_test.cc  +72, all of it against a real server

    On the Linux run: Docker Hub was unreachable while this was written --
    "failed to fetch anonymous token ... TLS handshake timeout" -- so the
    image could not be rebuilt from scratch.  The numbers above come from
    copying this branch's sources into the existing jlib-check image and
    running make check there: same compiler, same dovecot, same test.  The
    Dockerfile is unchanged on this branch, so there was nothing new for a
    from-scratch build to prove, but it is worth saying which was run.

what the guessing looked like

    ListItem, which reads a LIST response, was eighty lines of find() and
    tokenize() carrying a comment from an earlier branch: "Reading LIST
    properly needs the grammar, not more guards; that is a later branch."
    This is that branch.  It is fifteen lines now, and a mailbox name in a
    literal -- which the old reader could not see at all, because the response
    never arrived whole -- comes through.

    Imap4::get was a hundred and forty.  It tokenized on whitespace, looked for
    "(FLAGS", and then for "RFC822.SIZE" -- and, failing that, for
    "(RFC822.SIZE", because whether the parenthesis was attached depended on
    where the attribute happened to fall.  A FETCH response is not a
    whitespace-separated list of tokens and every one of those was a way of
    pretending it is.

    retrieve() and retrieve_headers() each repeated the same scan.  They share
    one helper now, fetch_attribute(), which asks for a list of attributes and
    returns the one wanted.

Imap4::parse read the wrong token

        else if(util::icontains(hand[i], "unseen")) {
            std::vector<std::string> tok = util::tokenize(hand[i]);
            unseen(util::int_value(tok[2]));
        }

    On "* OK [UNSEEN 1] First unseen." the tokens are "*", "OK", "[UNSEEN",
    "1]" -- so tok[2] is the string "[UNSEEN", int_value of it is 0, and the
    unseen count has been zero for as long as there has been one.  UNSEEN is a
    response-text-code on an OK, not a data response, and response::code()
    is where it lives.  The live test asserts it comes back as 1.

    The EXISTS and RECENT branches matched icontains(line, "exists") -- those
    letters anywhere in the line -- and then indexed tok[1] with no size check.

the three commands

        std::vector<unsigned long> search(sock, criteria, charset = "");
        std::vector<imap::response> uid(sock, command, args);
        std::string fetch_partial(sock, which, section, origin, length);

    All three used to be

        std::vector<std::string> ret = handshake(sock, "");
        return ret;

    -- a bare tag with no command, which a server answers BAD, handed back to
    the caller as a plausible-looking vector<string>.

    PARTIAL does not come back under its own name: RFC 3501 withdrew it in
    favour of a FETCH with an origin and a length, so what exists is
    fetch_partial() and it sends BODY.PEEK[section]<origin.length>.  The
    response echoes the section and the origin but not the length, and comes
    back as BODY rather than BODY.PEEK, so the key is not the string that was
    sent -- which the live test would have caught if the code had assumed
    otherwise.

    UID is the one gtkmail needs.  A sequence number shifts under an EXPUNGE
    from another client; a unique id does not, so any state a client keeps
    across a connection has to be keyed by UID.

    command() underneath them is what handshake() would have been if the
    grammar had existed first: send, read whole responses, check the tagged
    completion, hand back the untagged ones parsed.

all of it against a real server

    Nine new assertions in the live test, none of them against a string:

        ok   EXISTS comes back: 2
        ok   and UNSEEN is not zero: 1
        ok   SEARCH ALL finds both messages: 2 found
        ok   and a header search finds the one: 1 found
        ok   a search that matches nothing returns nothing
        ok   UID SEARCH answers with unique ids: 1
        ok   and UID FETCH takes one
        ok   a partial fetch returns only what was asked for: |From: a@b.c|
        ok   from the offset given: |a@b.c|

    That last pair caught my own arithmetic: the first draft asked for twelve
    octets and expected eleven characters, having forgotten the CR.

what a green run does not establish

    Not interoperability.  One server, one version, one configuration, TLS off
    and plaintext authentication on -- which is exactly what no real account
    allows.

    Not TLS.  imaps:// goes through sys::sslstream and nothing here reaches
    it; a certificate Dovecot and OpenSSL both accept is a branch of its own,
    and it is the thing I would do before pointing jlib-mail at a real account.

    Not the whole of RFC 3501.  ENVELOPE and BODYSTRUCTURE are still matched
    by shape rather than transcribed, because jlib interprets neither.  STATUS
    is parsed as a response and has no method.  IDLE still reads its own
    responses in handshake() rather than through command(), because it is the
    one command that does not end with a tagged completion.
