### PR TITLE
TLS for IMAP and POP

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,10 +17,10 @@ Each subdirectory of `jlib/` is one automake-built libtool library named
 
 | Dir | Library | What it is |
 | --- | --- | --- |
-| `jlib/sys` | `libjsys` | The foundation. iostream-based wrappers over OS facilities: `socketstream`, `sslstream`/`tlsstream`, `proxystream`, `sslproxystream`, `serialstream`, `pstream` (subprocess), `tfstream` (temp file). Plus `Servent`/`ASServent` (threaded worker + command queue), `sync<T>` (mutex-wrapped value, C++11), `ringbuffer<T>` (lock-free, one producer and one consumer, written for the audio callback), `pipe`, `Directory`, `joystick`, `Object` (a polymorphic base), `signal<R(Args...)>`. |
-| `jlib/util` | `libjutil` | String/format grab bag: `util.hh` (tokenize, trim, chop, base64/qp/URI codecs, byte `get`/`set`), `Regex` (POSIX `regex.h`), `Date` (RFC-822 etc.), `Headers` (MIME header folding), `MimeType`, `URL`, `Timer`, a hand-rolled XML tokenizer/parser/DOM (`xml.hh`, `xmlparser.hh`, `xmltokenizer.hh`), and `json.hh` (a C++ facade over json-c). |
+| `jlib/sys` | `libjsys` | The foundation. iostream-based wrappers over OS facilities: `socketstream`, `sslstream`/`tlsstream`, `proxystream`, `sslproxystream`, `serialstream`, `pstream` (subprocess), `tfstream` (temp file). `run(argv, out, err)` executes a program with no shell involved — reach for it rather than `shell()`, which hands its argument to `/bin/sh`. Plus `Servent`/`ASServent` (threaded worker + command queue), `sync<T>` (mutex-wrapped value, C++11), `ringbuffer<T>` (lock-free, one producer and one consumer, written for the audio callback), `pipe`, `Directory`, `joystick`, `Object` (a polymorphic base), `signal<R(Args...)>`. |
+| `jlib/util` | `libjutil` | Two halves. The **parsing** half is the 2026 work: `abnf.hh` is a parser-combinator core with an RFC 5234 text front end on top (`compile()` reads an RFC's grammar as it stands), and the grammars themselves are pasted into headers — `rfc5322.hh` (3.2 lexical tokens, 3.3 date-time), `rfc2045.hh`, `rfc2047.hh`, `rfc3986.hh` — with `content_type`, `encoded_word`, `URL`, `Date` and `xml` reading them. The **grab bag** is the rest: `util.hh` (tokenize, trim, chop, base64/qp/URI codecs, byte `get`/`set`), `Regex` (POSIX `regex.h`, one live caller left), `Headers` (MIME header folding), `MimeType`, `Timer`, `json.hh` (a facade over json-c). |
 | `jlib/crypt` | `libjcrypt` | `crypt.hh` wraps GPGME (OpenPGP encrypt/sign/verify). The `curve`/`schnorr`/`groth` trio is the recent work: ristretto255 `Scalar`/`Point`/`Commitment` over libsodium, Schnorr proofs (single, double, `GeneralProof<N>`), and Groth binary/zero-argument proofs. Built only when libsodium *with* ristretto headers is present. |
-| `jlib/net` | `libjnet` | Email client stack: `Email` (MIME parsing), `MailBox`/`MBox`/`Imap4Box`, `Pop3`, `Imap4`, `MailFolder`, plus `AS*` async variants layered on `sys::ASServent`. `net.cc` has the address-extraction logic the `net_extract_address_*` tests cover. |
+| `jlib/net` | `libjnet` | Email client stack: `Email` (MIME), `MailBox`/`MBox`/`Imap4Box`, `Pop3`, `Imap4`, `MailFolder`, plus `AS*` async variants layered on `sys::ASServent`. The protocol grammars live here — `rfc5322.hh` (addresses, appended to util's lexical block) read by `address.{hh,cc}`, and `rfc3501.hh` (IMAP responses) read by `imap_response.{hh,cc}`. `imap::read()` follows literals, which is why a response is not a line; `imap::quote()` writes command arguments. |
 | `jlib/media` | `libjmedia` | Audio via PortAudio, driven from its **callback**: `write()` fills a `sys::ringbuffer` and the device's callback drains it, so nothing in the path sleeps or polls. `AudioSink` is the device interface and `PortAudioSink` the implementation; `Player` (a `Servent`) runs a feeder thread so transport commands never wait on the device. Plus `AudioFile`/`WavFile`, `PlayList`, and streambuf-based `datastream`/`wavstream`/`notestream`/`audiofilestream`. `Type.hh` is a template-specialization table over PCM sample formats. `Dsp` is the retired OSS backend, kept but not built. |
 | `jlib/math` | `libjmath` | Header-only despite being a `lib_LTLIBRARIES` (its `_SOURCES` are all `.hh`). `matrix`, `vertex`, `tensor`, `buffer`, `polynomial` (templated on a Power type so it can hold curve `Scalar`s), and `Plot<T>` — the abstract plotting base, with `projection_mode` for perspective, orthographic or mixed. `object<T>` holds index-based topology — vertices, edges, and 2-faces built lazily — with `cuboid`, `pyramoid`, `spheroid`, `staroid` and `torus` (a flat k-torus in n dimensions; equal radii and k=2 is the Clifford torus). |
 | `jlib/x` | `libjx` | Raw Xlib: `Display`, `Window`, and an X11 `Plot`. |
@@ -120,28 +120,42 @@ The media tests are silent unless passed `--play` or `--play-all`.
 
 Between 2020 and 2021 the active work was `crypt` (curve/schnorr/groth) and the
 `math::polynomial` support behind it. In 2026 the library was ported to build on
-macOS and modern Linux, in a seven-phase plan that is now **complete**: autotools
-modernized to C++20, libsigc++ and glibmm replaced with `std::`, OSS replaced
-with PortAudio, GLUT replaced with GLFW, 4-D objects rendered as solid 3-D
-geometry, and an API pass over copies, moves and exception specifications.
+macOS and modern Linux — autotools to C++20, libsigc++ and glibmm replaced with
+`std::`, OSS replaced with PortAudio, GLUT with GLFW, 4-D objects rendered as
+solid 3-D geometry — and then rewritten to parse by the RFCs rather than by
+`find()` and `substr()`.
 
 The headline goal since 1999 — rendering 4D+ objects as solid 3-D geometry — is
 done. `jhardhyper` draws translucent depth-sorted faces with per-frame normals,
 for hypercubes and for the flat torus, and under stereographic projection shows
 the Hopf foliation as nested tori.
 
-Both `TODO.md` items are done — libsigc++ is gone, and `sys/sslstream.hh` now
-uses the system trust store and verifies the hostname with `SSL_set1_host`.
+**The parsing arc is done too, and it is what most of the library now rests
+on.** An ABNF parser was built (`util::abnf`), an RFC's grammar can be pasted
+into a header and read as it stands, and everything that used to guess now does
+not: addresses (RFC 5322), MIME headers (2045/2047/2231), URLs (3986), dates
+(5322 §3.3), IMAP responses (3501), and XML. The XML parser was replaced
+clean-room along the way, which removed the last copyright the author did not
+hold and **let the whole library relicense from GPL v2+ to Apache 2.0**.
+
+`tests/net_imap_live_test` starts a real Dovecot with a generated certificate
+and drives `Imap4` against it, in plaintext and over TLS. It is the only test
+that talks to a server rather than a `std::istringstream`, and the only way to
+exercise an IMAP literal, because only a server decides when to send one.
 
 Remaining work is tracked in GitHub issues; the phase labels are historical now.
-What is left is a normal backlog rather than porting: one network bug (#11,
-SIGPIPE terminates the process on a dropped connection), the graphics chain that
-would let one `HyperPlot` serve both apps (#20 → #24 → #28), tessellation and
-face enumeration for the remaining shapes (#31, #35), and some efficiency and
-API tidying (#47, #53).
+What is left is the graphics chain that would let one `HyperPlot` serve both
+apps (#20 → #24 → #28), tessellation and face enumeration for the remaining
+shapes (#31, #35), two `math` bugs (#53, and #76 — `vertex` and `matrix` share
+storage when copied but deep-copy when assigned, which is why `jhypermusic`
+reported exactly zero Doppler for months), and some efficiency and API tidying
+(#47, #69).
 
-Two habits from this work worth keeping. **Measure before diagnosing** — several
-"obvious" causes here were wrong, and the counter-example was usually a ten-line
-program under a counting `operator new` or a sanitizer. And **say what a test
-does not establish**: `sys_ringbuffer_test` passes, and neither it nor TSan
-verifies the memory ordering it depends on, which is written down in both.
+Three habits from this work worth keeping. **Measure before diagnosing** —
+several "obvious" causes here were wrong, and the counter-example was usually a
+ten-line program under a counting `operator new` or a sanitizer. **Say what a
+test does not establish**: `sys_ringbuffer_test` passes, and neither it nor TSan
+verifies the memory ordering it depends on, which is written down in both. And
+**mark every departure from a published grammar at the point of use** — the
+`rfc*.hh` headers say `; jlib:` on each one and why, because the whole value of
+pasting the RFC is that a reader can check it against the document.

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,9 @@
 # Dependencies are installed in their own layer so edits to the source do not
 # re-run apt.
 #
-# dovecot-imapd is here for tests/net_imap_live_test, which starts a real IMAP
-# server on a high port with a seeded Maildir and drives jlib::net::Imap4
-# against it.  It is the only way to exercise the literal handling end to end:
+# dovecot is here for tests/net_{imap,pop3}_live_test, which start a real
+# server on high ports with a seeded Maildir and drive jlib::net::Imap4 and
+# jlib::net::Pop3 against it.  It is the only way to exercise the literal handling end to end:
 # a std::istringstream can be made to produce any response, but only a server
 # decides when to send a literal.
 
@@ -46,6 +46,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libglu1-mesa-dev \
         freeglut3-dev \
         dovecot-imapd \
+        dovecot-pop3d \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /src/jlib

--- a/jlib/net/Imap4.cc
+++ b/jlib/net/Imap4.cc
@@ -162,6 +162,32 @@ namespace jlib {
             return false;
         }
 
+        bool Imap4::use_starttls() {
+            return util::lower(m_url["tls"]) == "starttls";
+        }
+
+        const std::vector<std::string>& Imap4::capability(sys::socketstream& sock) {
+            m_capabilities.clear();
+
+            for(const imap::response& r : command(sock, "CAPABILITY")) {
+                if(r.name() != "CAPABILITY") continue;
+
+                m_capabilities = r.capabilities();
+            }
+
+            return m_capabilities;
+        }
+
+        bool Imap4::has_capability(const std::string& name) const {
+            const std::string want = util::upper(name);
+
+            for(const std::string& c : m_capabilities) {
+                if(util::upper(c) == want) return true;
+            }
+
+            return false;
+        }
+
         Email Imap4::get(sys::socketstream& sock, 
                          int which, 
                          bool only_headers)
@@ -359,6 +385,43 @@ namespace jlib {
             return ret;
         }
         
+        void Imap4::upgrade(sys::socketstream& sock) {
+            // RFC 2595 3 and RFC 3501 6.2.1.
+            capability(sock);
+
+            if(!has_capability("STARTTLS")) {
+                throw exception("the server does not offer STARTTLS, and "
+                                "?tls=starttls asked for it");
+            }
+
+            command(sock, "STARTTLS");
+
+            sys::tlsstream* tls = dynamic_cast<sys::tlsstream*>(&sock);
+
+            if(tls == 0) {
+                throw exception("STARTTLS on a stream that cannot be upgraded");
+            }
+
+            // The handshake, with the same verification an imaps:// connection
+            // gets: SSL_VERIFY_PEER, the default trust store, and
+            // SSL_set1_host on the name that was connected to.
+            tls->start();
+
+            // 6.2.1: "The client MUST discard the cached CAPABILITY
+            // information and re-issue the command."  Everything read before
+            // the handshake was unauthenticated, so a man in the middle could
+            // have removed STARTTLS from that list or added an AUTH mechanism
+            // to it.  Re-issuing is what makes the list worth having, and it
+            // is load-bearing here: login() refuses to send LOGIN when the
+            // list says LOGINDISABLED.
+            capability(sock);
+
+            if(has_capability("STARTTLS")) {
+                throw exception("the server still offers STARTTLS after "
+                                "negotiating it, which RFC 3501 6.2.1 forbids");
+            }
+        }
+
         sys::socketstream* Imap4::connect() {
             sys::socketstream* sock = 0;
             if(getenv("JLIB_NET_IMAP4_DEBUG")) 
@@ -387,6 +450,19 @@ namespace jlib {
                         } else {
                             sock = new sys::sslstream(m_host,m_port);
                         }
+                    }
+                    else if(use_starttls()) {
+                        // Plaintext for now: a tlsstream with delay set
+                        // connects without handshaking, and start() does the
+                        // handshake in place once the upgrade is negotiated.
+                        // The same primitive smtp::send_tls has used all
+                        // along.  No proxy variant, because there is no
+                        // tlsproxystream.
+                        if(m_url["proxy"] != "") {
+                            throw exception("STARTTLS through a proxy is not implemented");
+                        }
+
+                        sock = new sys::tlsstream(m_host, m_port, true);
                     }
                     else {
                         if(m_url["proxy"] != "") {
@@ -424,7 +500,19 @@ namespace jlib {
             if(!util::begins(buf, OK)) {
                 throw exception("error connecting: expected '"+OK+"', received "+buf);
             }
+
             m_state = NonAuthenticated;
+
+            if(use_starttls()) {
+                try {
+                    upgrade(*sock);
+                }
+                catch(...) {
+                    delete sock;
+                    throw;
+                }
+            }
+
             return sock;
             //handshake(sock"LOGIN "+m_user+" "+m_pass);
         }
@@ -577,12 +665,6 @@ namespace jlib {
         }
 
 
-        std::vector<std::string> Imap4::capability(sys::socketstream& sock) {
-            std::vector<std::string> cap = handshake(sock,"CAPABILITY");
-            std::vector<std::string> ret = util::tokenize(cap[0]);
-            ret.erase(ret.begin(),ret.begin()+2);
-            return ret;
-        }
 
         std::vector<std::string> Imap4::noop(sys::socketstream& sock) {
             std::vector<std::string> ret = handshake(sock,"NOOP");
@@ -657,6 +739,16 @@ namespace jlib {
             handshake(sock,"AUTHENTICATE "+name);
         }
         void Imap4::login(sys::socketstream& sock, const std::string& user, const std::string& pass) {
+            // RFC 3501 6.2.3: a server advertising LOGINDISABLED will refuse
+            // LOGIN, and a client that sends it anyway has put the password on
+            // the wire for nothing.  The list this consults is the one taken
+            // *after* any STARTTLS, which is the whole reason 6.2.1 requires
+            // it be re-issued.
+            if(has_capability("LOGINDISABLED")) {
+                throw exception("the server advertises LOGINDISABLED; refusing "
+                                "to send a password it will not accept");
+            }
+
             if(user!="" && pass != "") {
                 handshake(sock, "LOGIN " + imap::quote(user) + " " + imap::quote(pass));
             }

--- a/jlib/net/Imap4.cc
+++ b/jlib/net/Imap4.cc
@@ -35,7 +35,10 @@
 
 const int PORT = 143;
 const int SSL_PORT = 993;
-const std::string SSL_PROTOCOL = "simap";
+// Both spellings.  "imaps" is what IANA registered and what anyone would
+// write; "simap" is the older convention this library was written with and is
+// in config files that predate the other.
+const std::string SSL_PROTOCOLS[] = { "imaps", "simap" };
 const std::string OK = "* OK";
 const std::string INTERNAL = "Subject: DON'T DELETE THIS MESSAGE -- FOLDER INTERNAL DATA";
 const int TAG_WIDTH = 5;
@@ -145,7 +148,18 @@ namespace jlib {
         }
         
         bool Imap4::is_secure() {
-            return (util::lower(m_url.get_protocol()).find(SSL_PROTOCOL) != std::string::npos);
+            // A whole-scheme comparison, not find().  "imaps" does not contain
+            // "simap", so the substring test said an imaps:// URL was not
+            // secure -- and the caller then opened a plain socketstream to
+            // port 143 and sent LOGIN with the password on it.  The standard
+            // scheme downgraded silently to no encryption at all.
+            const std::string scheme = util::lower(m_url.get_protocol());
+
+            for(const std::string& s : SSL_PROTOCOLS) {
+                if(scheme == s) return true;
+            }
+
+            return false;
         }
 
         Email Imap4::get(sys::socketstream& sock, 

--- a/jlib/net/Imap4.hh
+++ b/jlib/net/Imap4.hh
@@ -94,7 +94,50 @@ namespace jlib {
              */
             ~Imap4();
             
+            /** Is the scheme one that means TLS from the first byte? */
             bool is_secure();
+
+            /**
+             * Was STARTTLS asked for?
+             *
+             *     imap://mail.example.com/INBOX?tls=starttls
+             *
+             * RFC 2595 3: connect in the clear on the ordinary port, then
+             * upgrade in place.  A query parameter rather than a third scheme
+             * because that is how this class already takes a connection
+             * option -- see m_url["proxy"] -- and because there is no
+             * registered scheme for it.
+             *
+             * If it is asked for and the server does not offer it, connect()
+             * throws.  Carrying on in the clear is the bug this branch exists
+             * to fix, wearing a different hat.
+             */
+            bool use_starttls();
+
+            /** The server's capabilities, as of the last CAPABILITY. */
+            const std::vector<std::string>& capabilities() const { return m_capabilities; }
+
+            /**
+             * CAPABILITY, and remember the answer.
+             *
+             * It used to be tokenize(handshake(...)[0]) with the first two
+             * tokens erased, which indexes an empty vector when the server
+             * says nothing and takes the capabilities out of whatever the
+             * first response happened to be.
+             */
+            const std::vector<std::string>& capability(jlib::sys::socketstream& sock);
+
+            /** Does the capability list hold this, compared whole? */
+            bool has_capability(const std::string& name) const;
+
+            /**
+             * Negotiate STARTTLS on an already-connected plaintext stream.
+             *
+             * Called by connect() when ?tls=starttls was asked for.  Throws if
+             * the server does not offer it, rather than carrying on in the
+             * clear.
+             */
+            void upgrade(jlib::sys::socketstream& sock);
 
             jlib::sys::socketstream* connect();
             void disconnect(jlib::sys::socketstream& sock);
@@ -102,11 +145,9 @@ namespace jlib {
             // 6.1.    Client Commands - Any State
             /**
              * The CAPABILITY command requests a listing of capabilities that the
-             * server supports.
-             *
-             * @return vector containing the capabilities offered
+             * server supports.  Declared with the rest of the capability
+             * handling above; this comment is where the RFC ordering put it.
              */
-            std::vector<std::string> capability(jlib::sys::socketstream& sock);
 
             /**
              * Since any command can return a status update as untagged data, the
@@ -580,6 +621,7 @@ namespace jlib {
             unsigned int m_exists, m_recent, m_unseen;
             std::mutex m_exists_mutex, m_recent_mutex, m_unseen_mutex;
             int m_num;
+            std::vector<std::string> m_capabilities;
             std::mutex m_num_mutex;
             int m_width;
             State m_state;

--- a/jlib/net/Pop3.cc
+++ b/jlib/net/Pop3.cc
@@ -35,20 +35,33 @@ const std::string OK = "+OK";
 namespace jlib {
     namespace net {
         
+        bool Pop3::is_secure(const jlib::util::URL& url) {
+            // A whole-scheme comparison, not find().  "pop3s" contains "pop"
+            // and does not contain "spop", so the old test read the standard
+            // scheme as *plain* POP3: it chose port 110, opened a plain
+            // socketstream, and sent the password over it.  Silently, and for
+            // the one spelling anybody outside this library would use.
+            //
+            // Both spellings are here: "pop3s" is what IANA registered,
+            // "spop" is the older convention this library was written with.
+            const std::string scheme = jlib::util::lower(url.get_protocol());
+
+            return scheme == "pop3s" || scheme == "spop" || scheme == "spop3";
+        }
+
         Pop3::Pop3(jlib::util::URL url, bool remove) 
             : m_remove(remove)
         {
             m_url = url;
+
+            const std::string scheme = jlib::util::lower(m_url.get_protocol());
+
+            if(!is_secure(m_url) && scheme != "pop3" && scheme != "pop") {
+                throw exception("bad protocol in jlib::net::Pop3::Pop3(), m_url = "+m_url());
+            }
+
             if(m_url.get_port() == "") {
-                if(jlib::util::lower(m_url.get_protocol()).find("spop") != std::string::npos) {
-                    m_url.set_port(jlib::util::string_value(SPORT));
-                }
-                else if(jlib::util::lower(m_url.get_protocol()).find("pop") != std::string::npos) {
-                    m_url.set_port(jlib::util::string_value(PORT));
-                }
-                else {
-                    throw exception("bad protocol in jlib::net::Pop3::Pop3(), m_url = "+m_url());
-                }
+                m_url.set_port(jlib::util::string_value(is_secure(m_url) ? SPORT : PORT));
             }
         }
         
@@ -105,14 +118,15 @@ namespace jlib {
         
         jlib::sys::socketstream* Pop3::connect() {
             jlib::sys::socketstream* sock;
-            if(jlib::util::lower(m_url.get_protocol()).find("spop") != std::string::npos) {
+            // The constructor already refused a scheme that is neither, so
+            // there is no third case to fall through to -- and the one that
+            // used to be here tested find("pop"), which is how "pop3s" ended
+            // up on a plain socket.
+            if(is_secure(m_url)) {
                 sock = new jlib::sys::sslstream(m_url.get_host(), m_url.get_port_val());
             }
-            else if(jlib::util::lower(m_url.get_protocol()).find("pop") != std::string::npos) {
-                sock = new jlib::sys::socketstream(m_url.get_host(), m_url.get_port_val());
-            }
             else {
-                throw exception("bad protocol in jlib::net::Pop3::connect(), m_url = "+m_url());
+                sock = new jlib::sys::socketstream(m_url.get_host(), m_url.get_port_val());
             }
 
 

--- a/jlib/net/Pop3.cc
+++ b/jlib/net/Pop3.cc
@@ -26,6 +26,7 @@
 
 #include <jlib/util/util.hh>
 
+#include <cctype>
 #include <memory>
 
 const int PORT = 110;
@@ -66,14 +67,46 @@ namespace jlib {
         }
         
         
+        unsigned int Pop3::count(jlib::sys::socketstream& sock) {
+            // RFC 1939 5: "+OK nn mm" -- the number of messages and the size
+            // of the maildrop.  Read as a number rather than as tokenize()[1],
+            // so that a server answering "+OK" with nothing after it is an
+            // error here rather than an out-of-range index somewhere later.
+            const std::string stat = handshake(sock, "STAT", OK);
+            std::string::size_type i = stat.find_first_of("0123456789");
+
+            if(i == stat.npos) {
+                throw exception("no message count in the STAT reply: " + stat);
+            }
+
+            unsigned int n = 0;
+
+            for(; i < stat.size() && std::isdigit(static_cast<unsigned char>(stat[i])); i++) {
+                n = n * 10 + static_cast<unsigned int>(stat[i] - '0');
+            }
+
+            return n;
+        }
+
         std::list<std::string> Pop3::retrieve() {
-            std::list<std::string> buf;
+            // This connected, disconnected and returned an empty list: the
+            // loop was commented out, so the only public way to get mail out
+            // of a POP3 account has never got any.  It reported success while
+            // doing it, which is why nobody noticed.
+            std::list<std::string> ret;
             std::unique_ptr<jlib::sys::socketstream> sock(connect());
 
-            //std::string buf = retrieve(sock,which);
+            const unsigned int n = count(*sock);
+
+            for(unsigned int i = 1; i <= n; i++) {
+                ret.push_back(retrieve(*sock, i));
+
+                if(m_remove) remove(*sock, i);
+            }
 
             disconnect(*sock);
-            return buf;
+
+            return ret;
         }
 
         std::string Pop3::read_body(std::istream& is) {

--- a/jlib/net/Pop3.cc
+++ b/jlib/net/Pop3.cc
@@ -27,6 +27,7 @@
 #include <jlib/util/util.hh>
 
 #include <cctype>
+#include <sstream>
 #include <memory>
 
 const int PORT = 110;
@@ -50,6 +51,10 @@ namespace jlib {
             return scheme == "pop3s" || scheme == "spop" || scheme == "spop3";
         }
 
+        bool Pop3::use_starttls(const jlib::util::URL& url) {
+            return jlib::util::lower(url["tls"]) == "starttls";
+        }
+
         Pop3::Pop3(jlib::util::URL url, bool remove) 
             : m_remove(remove)
         {
@@ -67,6 +72,65 @@ namespace jlib {
         }
         
         
+        std::list<std::string> Pop3::capa(jlib::sys::socketstream& sock) {
+            std::list<std::string> ret;
+
+            try {
+                handshake(sock, "CAPA", OK);
+            }
+            catch(exception&) {
+                // RFC 2449 postdates RFC 1939 and a server need not implement
+                // it.  An empty list rather than an error -- the caller
+                // decides what not knowing means.
+                return ret;
+            }
+
+            // A multi-line response, terminated by "." on a line of its own,
+            // exactly as a message body is.
+            std::istringstream body(read_body(sock));
+            std::string line;
+
+            while(std::getline(body, line)) {
+                if(!line.empty() && line.back() == '\r') line.pop_back();
+                if(!line.empty()) ret.push_back(line);
+            }
+
+            return ret;
+        }
+
+        void Pop3::upgrade(jlib::sys::socketstream& sock) {
+            // RFC 2595 4.
+            bool offered = false;
+
+            for(const std::string& c : capa(sock)) {
+                if(jlib::util::upper(c) == "STLS") offered = true;
+            }
+
+            if(!offered) {
+                throw exception("the server does not offer STLS, and "
+                                "?tls=starttls asked for it");
+            }
+
+            handshake(sock, "STLS", OK);
+
+            jlib::sys::tlsstream* tls = dynamic_cast<jlib::sys::tlsstream*>(&sock);
+
+            if(tls == 0) {
+                throw exception("STLS on a stream that cannot be upgraded");
+            }
+
+            // The same verification an implicit-TLS connection gets:
+            // SSL_VERIFY_PEER, the default trust store, and SSL_set1_host on
+            // the name that was connected to.
+            tls->start();
+
+            // 2595 4: the client must discard what CAPA said before the
+            // handshake.  Everything read then was unauthenticated, so a man
+            // in the middle could have taken STLS out of that list, or put an
+            // authentication mechanism into it.
+            capa(sock);
+        }
+
         unsigned int Pop3::count(jlib::sys::socketstream& sock) {
             // RFC 1939 5: "+OK nn mm" -- the number of messages and the size
             // of the maildrop.  Read as a number rather than as tokenize()[1],
@@ -158,6 +222,13 @@ namespace jlib {
             if(is_secure(m_url)) {
                 sock = new jlib::sys::sslstream(m_url.get_host(), m_url.get_port_val());
             }
+            else if(use_starttls(m_url)) {
+                // A tlsstream with delay set connects without handshaking;
+                // start() does the handshake in place once STLS has been
+                // negotiated.  The primitive smtp::send_tls has used all along.
+                sock = new jlib::sys::tlsstream(m_url.get_host(),
+                                                m_url.get_port_val(), true);
+            }
             else {
                 sock = new jlib::sys::socketstream(m_url.get_host(), m_url.get_port_val());
             }
@@ -168,6 +239,10 @@ namespace jlib {
             if(!jlib::util::begins(buf, OK)) {
                 throw exception(buf);
             }
+            if(use_starttls(m_url)) {
+                upgrade(*sock);
+            }
+
             handshake(*sock,"USER "+m_url.get_user(), OK);
             handshake(*sock,"PASS "+m_url.get_pass(), OK);
 

--- a/jlib/net/Pop3.hh
+++ b/jlib/net/Pop3.hh
@@ -63,6 +63,20 @@ namespace jlib {
             static bool is_secure(const jlib::util::URL& url);
 
             /**
+             * Was STARTTLS asked for?
+             *
+             *     pop3://mail.example.com/?tls=starttls
+             *
+             * RFC 2595 4 calls the command STLS: connect in the clear on the
+             * ordinary port, then upgrade in place.  A query parameter rather
+             * than a third scheme, matching Imap4.
+             *
+             * If it is asked for and the server does not offer it, connect()
+             * throws rather than carrying on in the clear.
+             */
+            static bool use_starttls(const jlib::util::URL& url);
+
+            /**
              * Retrieve all email
              */
             /**
@@ -91,6 +105,18 @@ namespace jlib {
             static std::string read_body(std::istream& is);
 
         protected:
+            /**
+             * The capabilities the server advertises.  RFC 2449, CAPA.
+             *
+             * Empty when the server does not implement CAPA at all, which is
+             * legal -- it postdates RFC 1939 -- and which is why asking for
+             * STARTTLS against such a server is an error rather than a guess.
+             */
+            std::list<std::string> capa(jlib::sys::socketstream& sock);
+
+            /** Negotiate STLS on an already-connected plaintext stream. */
+            void upgrade(jlib::sys::socketstream& sock);
+
             /** How many messages the maildrop holds.  RFC 1939 5, STAT. */
             unsigned int count(jlib::sys::socketstream& sock);
 

--- a/jlib/net/Pop3.hh
+++ b/jlib/net/Pop3.hh
@@ -54,6 +54,15 @@ namespace jlib {
             Pop3(jlib::util::URL url, bool remove=true);
 
             /**
+             * Does this URL's scheme mean TLS?
+             *
+             * "pop3s" and "spop", compared whole.  It used to be
+             * find("spop") != npos, and "pop3s" does not contain "spop" -- so
+             * the standard scheme chose port 110 and a plain socket.
+             */
+            static bool is_secure(const jlib::util::URL& url);
+
+            /**
              * Retrieve all email
              */
             std::list<std::string> retrieve();

--- a/jlib/net/Pop3.hh
+++ b/jlib/net/Pop3.hh
@@ -65,6 +65,13 @@ namespace jlib {
             /**
              * Retrieve all email
              */
+            /**
+             * Every message in the maildrop, as raw text.
+             *
+             * Deletes each one after reading it unless the constructor was
+             * told otherwise -- which is what POP3 is for, and what the
+             * `remove` flag has always claimed to control.
+             */
             std::list<std::string> retrieve();
 
             /**
@@ -84,6 +91,9 @@ namespace jlib {
             static std::string read_body(std::istream& is);
 
         protected:
+            /** How many messages the maildrop holds.  RFC 1939 5, STAT. */
+            unsigned int count(jlib::sys::socketstream& sock);
+
             std::string retrieve(jlib::sys::socketstream& sock, unsigned int which);
             
             void remove(jlib::sys::socketstream& sock,unsigned int which);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -3,7 +3,7 @@
 AM_CPPFLAGS = -I$(top_srcdir) \
 	$(GPGME_CFLAGS) $(GPGERROR_CFLAGS) $(SODIUM_CFLAGS) $(OPENSSL_CFLAGS) $(JSONC_CFLAGS) $(PORTAUDIO_CFLAGS)
 
-EXTRA_DIST = audio_test.hh certificate.hh
+EXTRA_DIST = audio_test.hh certificate.hh mailserver.hh
 
 JSYS_LA   = $(top_builddir)/jlib/sys/libjsys.la
 JUTIL_LA  = $(top_builddir)/jlib/util/libjutil.la
@@ -56,6 +56,7 @@ TESTS = \
 	net_protocol_test \
 	net_imap_test \
 	net_imap_live_test \
+	net_pop3_live_test \
 	net_mime_test \
 	net_same_address_test \
  \
@@ -135,6 +136,9 @@ net_email_received_test_SOURCES = net_email_received_test.cc
 net_email_received_test_LDADD   = $(JNET_LA)
 net_mime_test_SOURCES           = net_mime_test.cc
 net_mime_test_LDADD             = $(JNET_LA) $(JUTIL_LA)
+
+net_pop3_live_test_SOURCES      = net_pop3_live_test.cc
+net_pop3_live_test_LDADD        = $(JNET_LA) $(JUTIL_LA) $(JSYS_LA) $(OPENSSL_LIBS)
 
 net_imap_live_test_SOURCES      = net_imap_live_test.cc
 net_imap_live_test_LDADD        = $(JNET_LA) $(JUTIL_LA) $(JSYS_LA) $(OPENSSL_LIBS)

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -3,7 +3,7 @@
 AM_CPPFLAGS = -I$(top_srcdir) \
 	$(GPGME_CFLAGS) $(GPGERROR_CFLAGS) $(SODIUM_CFLAGS) $(OPENSSL_CFLAGS) $(JSONC_CFLAGS) $(PORTAUDIO_CFLAGS)
 
-EXTRA_DIST = audio_test.hh
+EXTRA_DIST = audio_test.hh certificate.hh
 
 JSYS_LA   = $(top_builddir)/jlib/sys/libjsys.la
 JUTIL_LA  = $(top_builddir)/jlib/util/libjutil.la
@@ -137,7 +137,7 @@ net_mime_test_SOURCES           = net_mime_test.cc
 net_mime_test_LDADD             = $(JNET_LA) $(JUTIL_LA)
 
 net_imap_live_test_SOURCES      = net_imap_live_test.cc
-net_imap_live_test_LDADD        = $(JNET_LA) $(JUTIL_LA) $(JSYS_LA)
+net_imap_live_test_LDADD        = $(JNET_LA) $(JUTIL_LA) $(JSYS_LA) $(OPENSSL_LIBS)
 
 net_imap_test_SOURCES           = net_imap_test.cc
 net_imap_test_LDADD             = $(JNET_LA) $(JUTIL_LA)

--- a/tests/certificate.hh
+++ b/tests/certificate.hh
@@ -1,0 +1,85 @@
+/* -*- mode: C++ c-basic-offset: 4 -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef JLIB_TESTS_CERTIFICATE_HH
+#define JLIB_TESTS_CERTIFICATE_HH
+
+// A self-signed certificate, generated at runtime, for a test that needs a
+// real TLS handshake.
+//
+// Shared by sys_tls_sigpipe_test, which serves TLS in-process, and
+// net_imap_live_test, which hands it to a Dovecot.  Both point the client's
+// trust store at it with SSL_CERT_FILE -- which sslstream reaches through
+// SSL_CTX_set_default_verify_paths -- so nothing about the verification is
+// weakened: the handshake is real, the hostname is checked, and it succeeds
+// because the certificate is genuinely trusted for the run.
+
+#include <openssl/err.h>
+#include <openssl/pem.h>
+#include <openssl/ssl.h>
+#include <openssl/x509v3.h>
+
+#include <cstdio>
+#include <string>
+
+/** A self-signed certificate for localhost, written to cert_path and key_path. */
+inline bool make_cert(const std::string& cert_path, const std::string& key_path) {
+    EVP_PKEY* key = EVP_RSA_gen(2048);
+    if(key == 0) return false;
+
+    X509* x = X509_new();
+    if(x == 0) { EVP_PKEY_free(key); return false; }
+
+    ASN1_INTEGER_set(X509_get_serialNumber(x), 1);
+    X509_gmtime_adj(X509_getm_notBefore(x), 0);
+    X509_gmtime_adj(X509_getm_notAfter(x), 60 * 60);
+    X509_set_pubkey(x, key);
+
+    X509_NAME* name = X509_get_subject_name(x);
+    X509_NAME_add_entry_by_txt(name, "CN", MBSTRING_ASC,
+                               reinterpret_cast<const unsigned char*>("localhost"),
+                               -1, -1, 0);
+    X509_set_issuer_name(x, name);
+
+    // A subject alternative name, not just a CN: SSL_set1_host checks the SAN,
+    // and modern OpenSSL will not fall back to the common name.
+    X509V3_CTX ctx;
+    X509V3_set_ctx_nodb(&ctx);
+    X509V3_set_ctx(&ctx, x, x, 0, 0, 0);
+
+    X509_EXTENSION* san = X509V3_EXT_conf_nid(0, &ctx, NID_subject_alt_name,
+                                              "DNS:localhost,IP:127.0.0.1");
+    if(san) { X509_add_ext(x, san, -1); X509_EXTENSION_free(san); }
+
+    if(!X509_sign(x, key, EVP_sha256())) { X509_free(x); EVP_PKEY_free(key); return false; }
+
+    bool ok = false;
+    FILE* cf = std::fopen(cert_path.c_str(), "wb");
+    FILE* kf = std::fopen(key_path.c_str(), "wb");
+    if(cf && kf)
+        ok = PEM_write_X509(cf, x) && PEM_write_PrivateKey(kf, key, 0, 0, 0, 0, 0);
+    if(cf) std::fclose(cf);
+    if(kf) std::fclose(kf);
+
+    X509_free(x);
+    EVP_PKEY_free(key);
+    return ok;
+}
+
+#endif // JLIB_TESTS_CERTIFICATE_HH

--- a/tests/mailserver.hh
+++ b/tests/mailserver.hh
@@ -1,0 +1,246 @@
+/* -*- mode: C++ c-basic-offset: 4 -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef JLIB_TESTS_MAILSERVER_HH
+#define JLIB_TESTS_MAILSERVER_HH
+
+// A real mail server, started for a test and stopped after it.
+//
+// Dovecot on four high ports -- imap, imaps, pop3, pop3s -- with a Maildir
+// this seeds and a certificate generated at runtime.  Shared by
+// net_imap_live_test and net_pop3_live_test, which is the only reason it is a
+// header: the two need the same server and there is no third caller.
+//
+// A test using it reports SKIP (exit 77) where there is no dovecot to start,
+// which is every machine that is not the build container.
+//
+// It has to run as root.  Dovecot refuses to start its login process as root,
+// so the config leaves that one on the package's own unprivileged user, and
+// the seeded Maildir is chowned to an ordinary uid because Dovecot also
+// refuses a mail uid of 0.
+
+#include "certificate.hh"
+
+#include <jlib/sys/socketstream.hh>
+#include <jlib/sys/sys.hh>
+
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <unistd.h>
+
+namespace mailserver {
+
+namespace fs = std::filesystem;
+
+
+// A password that is exactly what the old code could not send.  A space ends
+// an argument, a quote ends a quoted one, and a backslash escapes whatever
+// follows -- so "LOGIN " + user + " " + pass produced a malformed command and
+// the server said BAD.
+inline const char* const PASSWORD = "pa ss \"quoted\" back\\slash";
+
+/**
+ * A message body that impersonates every tag jlib is going to use.
+ *
+ * Imap4::tag() counts up from A00001, so a body containing all twenty of the
+ * first tags followed by "OK FETCH completed" looks, line by line, exactly
+ * like the completion the client is waiting for.  Reading lines stops at the
+ * first of them; reading responses does not.
+ *
+ * It ends with a line beginning with a dot, which is the POP3 half of the
+ * same idea: RFC 1939 ends a multi-line response with a "." on a line of its
+ * own, so a body containing one has to be stuffed and unstuffed.
+ */
+inline std::string impersonating_body()
+{
+    std::string s = "From: b@c.d\r\nSubject: two\r\n\r\n";
+
+    for(int i = 1; i <= 20; i++) {
+        char tag[16];
+
+        std::snprintf(tag, sizeof tag, "A%05d", i);
+
+        s += std::string(tag) + " OK FETCH completed\r\n";
+    }
+
+    // A line beginning with a dot, which POP3 and SMTP both have to double on
+    // the way out and undouble on the way in -- RFC 1939 3 and RFC 5321 4.5.2.
+    // ".signature" is the case the SMTP side got wrong for twenty-five years:
+    // it is not a lone dot, so the old code's search for the terminator did
+    // not see it at all.
+    s += ".signature\r\n";
+
+    return s;
+}
+struct server {
+    fs::path dir;
+    unsigned int port = 0;
+    unsigned int tls_port = 0;
+    unsigned int pop_port = 0;
+    unsigned int pop_tls_port = 0;
+    bool running = false;
+
+    ~server() { stop(); }
+
+    bool start()
+    {
+        // A port derived from the pid, so two builds on one machine do not
+        // collide.
+        port = 14000 + static_cast<unsigned int>(::getpid() % 900);
+        tls_port = port + 1000;
+        pop_port = port + 2000;
+        pop_tls_port = port + 3000;
+
+        dir = fs::temp_directory_path() / ("jlib-imap-" + std::to_string(::getpid()));
+
+        fs::remove_all(dir);
+        fs::create_directories(dir / "run");
+        fs::create_directories(dir / "mail" / "Maildir" / "cur");
+        fs::create_directories(dir / "mail" / "Maildir" / "new");
+        fs::create_directories(dir / "mail" / "Maildir" / "tmp");
+
+        // Dovecot refuses a mail uid of 0, and refuses to run imap-login as
+        // root at all, so the Maildir belongs to an ordinary uid and the login
+        // process keeps the package's own unprivileged user.
+        const unsigned int uid = 1000;
+
+        {
+            std::ofstream f(dir / "users");
+
+            f << "joe:{PLAIN}" << PASSWORD << ":" << uid << ":" << uid
+              << "::" << (dir / "mail").string() << "\n";
+        }
+
+        // A certificate for localhost, and the client's trust store pointed
+        // at it.  Not a way around the verification -- sslstream still checks
+        // the hostname with SSL_set1_host -- but a way to make it succeed
+        // without a real CA.  The SAN says DNS:localhost, which is why the TLS
+        // side of this test connects to "localhost" and the plain side to
+        // 127.0.0.1.
+        const std::string cert = (dir / "cert.pem").string();
+        const std::string key = (dir / "key.pem").string();
+
+        if(!make_cert(cert, key)) {
+            std::cerr << "could not generate a certificate\n";
+
+            return false;
+        }
+
+        ::setenv("SSL_CERT_FILE", cert.c_str(), 1);
+
+        {
+            std::ofstream f(dir / "conf");
+
+            f << "protocols = imap pop3\n"
+              << "listen = 127.0.0.1\n"
+              << "base_dir = " << (dir / "run").string() << "\n"
+              << "log_path = " << (dir / "log").string() << "\n"
+              << "ssl = yes\n"
+              << "ssl_cert = <" << cert << "\n"
+              << "ssl_key = <" << key << "\n"
+              << "disable_plaintext_auth = no\n"
+              << "mail_location = maildir:" << (dir / "mail" / "Maildir").string() << "\n"
+              << "service imap-login {\n"
+              << "  inet_listener imap {\n    port = " << port << "\n  }\n"
+              << "  inet_listener imaps {\n    port = " << tls_port
+              << "\n    ssl = yes\n  }\n"
+              << "  chroot =\n"
+              << "}\n"
+              << "service pop3-login {\n"
+              << "  inet_listener pop3 {\n    port = " << pop_port << "\n  }\n"
+              << "  inet_listener pop3s {\n    port = " << pop_tls_port
+              << "\n    ssl = yes\n  }\n"
+              << "  chroot =\n"
+              << "}\n"
+              << "passdb {\n  driver = passwd-file\n  args = "
+              << (dir / "users").string() << "\n}\n"
+              << "userdb {\n  driver = passwd-file\n  args = "
+              << (dir / "users").string() << "\n}\n";
+        }
+
+        {
+            std::ofstream f(dir / "mail" / "Maildir" / "new" / "1", std::ios::binary);
+            f << "From: a@b.c\r\nSubject: one\r\n\r\nhello\r\n";
+        }
+
+        {
+            std::ofstream f(dir / "mail" / "Maildir" / "new" / "2", std::ios::binary);
+            f << impersonating_body();
+        }
+
+        std::string out, err;
+
+        jlib::sys::run({ "chown", "-R", std::to_string(uid) + ":" + std::to_string(uid),
+                         (dir / "mail").string() }, out, err);
+
+        // dovecot daemonizes, so this returns once it has forked.
+        if(jlib::sys::run({ "dovecot", "-c", (dir / "conf").string() }, out, err) != 0) {
+            std::cerr << "dovecot would not start: " << err << out << "\n";
+
+            return false;
+        }
+
+        running = true;
+
+        // Wait for the listener rather than sleeping a guessed interval.
+        for(int i = 0; i < 100; i++) {
+            try {
+                jlib::sys::socketstream imap("127.0.0.1", port);
+                jlib::sys::socketstream pop("127.0.0.1", pop_port);
+
+                return true;
+            }
+            catch(std::exception&) {
+                ::usleep(50000);
+            }
+        }
+
+        std::cerr << "dovecot never listened on " << port << "\n";
+
+        return false;
+    }
+
+    void stop()
+    {
+        if(running) {
+            std::string out, err;
+
+            jlib::sys::run({ "dovecot", "-c", (dir / "conf").string(), "stop" }, out, err);
+            running = false;
+        }
+
+        std::error_code ec;
+
+        fs::remove_all(dir, ec);
+    }
+
+    std::string log() const
+    {
+        std::ifstream f(dir / "log");
+
+        return std::string(std::istreambuf_iterator<char>(f), {});
+    }
+};
+
+}
+
+#endif // JLIB_TESTS_MAILSERVER_HH

--- a/tests/net_imap_live_test.cc
+++ b/tests/net_imap_live_test.cc
@@ -358,6 +358,72 @@ int main() {
         }
     }
 
+    // STARTTLS, RFC 2595 3: the ordinary port, in the clear, upgraded in
+    // place.  The same tlsstream primitive smtp::send_tls has used all along.
+    std::cout << "\nSTARTTLS:\n";
+
+    {
+        jlib::util::URL up("imap://joe@localhost:" + std::to_string(s.port)
+                           + "/INBOX?tls=starttls");
+
+        up.set_pass(PASSWORD);
+
+        jlib::net::Imap4 imap(up);
+
+        ok("?tls=starttls asks for it", imap.use_starttls());
+        ok("and it is not the same as a secure scheme", !imap.is_secure());
+
+        try {
+            std::unique_ptr<jlib::sys::socketstream> sock(imap.connect());
+
+            // RFC 3501 6.2.1 requires the capability list be taken again after
+            // the handshake, and a server must not still be offering STARTTLS
+            // once it has been negotiated.
+            ok("STARTTLS is gone from the list afterwards",
+               !imap.has_capability("STARTTLS"));
+            ok("and the list is not empty, so it was really re-issued",
+               !imap.capabilities().empty(),
+               std::to_string(imap.capabilities().size()) + " capabilities");
+
+            imap.login(*sock, "", "");
+            imap.select(*sock, "INBOX");
+
+            const std::string raw = imap.get(*sock, 1, false).raw();
+
+            ok("the session works over the upgraded connection",
+               raw == impersonating_body(),
+               raw == impersonating_body() ? std::string()
+                                           : std::to_string(raw.size()) + " octets");
+
+            imap.logout(*sock);
+        }
+        catch(std::exception& e) {
+            ok("STARTTLS works", false, e.what());
+            std::cerr << s.log();
+        }
+    }
+
+    // Asked for and not offered is an error.  Carrying on in the clear is the
+    // bug the top of this branch exists to fix, wearing a different hat -- so
+    // the imaps port, which does not offer STARTTLS because it is already TLS,
+    // has to be refused rather than used.
+    {
+        jlib::util::URL nope("imap://joe@localhost:" + std::to_string(s.tls_port)
+                             + "/INBOX?tls=starttls");
+
+        nope.set_pass(PASSWORD);
+
+        bool threw = false;
+
+        try {
+            jlib::net::Imap4 imap(nope);
+            std::unique_ptr<jlib::sys::socketstream> sock(imap.connect());
+        }
+        catch(std::exception&) { threw = true; }
+
+        ok("asking for STARTTLS where it is not offered fails", threw);
+    }
+
     // The port it picks when it is not told one.
     ok("imaps:// with no port is still secure",
        jlib::net::Imap4(jlib::util::URL("imaps://joe@localhost/INBOX")).is_secure());

--- a/tests/net_imap_live_test.cc
+++ b/tests/net_imap_live_test.cc
@@ -28,6 +28,8 @@
 // Exit 77 (SKIP) when there is no dovecot to start, which is every machine
 // that is not the build container.
 
+#include "certificate.hh"
+
 #include <jlib/net/Imap4.hh>
 #include <jlib/net/imap_response.hh>
 
@@ -101,6 +103,7 @@ namespace {
 struct server {
     fs::path dir;
     unsigned int port = 0;
+    unsigned int tls_port = 0;
     bool running = false;
 
     ~server() { stop(); }
@@ -110,6 +113,7 @@ struct server {
         // A port derived from the pid, so two builds on one machine do not
         // collide.
         port = 14000 + static_cast<unsigned int>(::getpid() % 900);
+        tls_port = port + 1000;
 
         dir = fs::temp_directory_path() / ("jlib-imap-" + std::to_string(::getpid()));
 
@@ -131,6 +135,23 @@ struct server {
               << "::" << (dir / "mail").string() << "\n";
         }
 
+        // A certificate for localhost, and the client's trust store pointed
+        // at it.  Not a way around the verification -- sslstream still checks
+        // the hostname with SSL_set1_host -- but a way to make it succeed
+        // without a real CA.  The SAN says DNS:localhost, which is why the TLS
+        // side of this test connects to "localhost" and the plain side to
+        // 127.0.0.1.
+        const std::string cert = (dir / "cert.pem").string();
+        const std::string key = (dir / "key.pem").string();
+
+        if(!make_cert(cert, key)) {
+            std::cerr << "could not generate a certificate\n";
+
+            return false;
+        }
+
+        ::setenv("SSL_CERT_FILE", cert.c_str(), 1);
+
         {
             std::ofstream f(dir / "conf");
 
@@ -138,11 +159,15 @@ struct server {
               << "listen = 127.0.0.1\n"
               << "base_dir = " << (dir / "run").string() << "\n"
               << "log_path = " << (dir / "log").string() << "\n"
-              << "ssl = no\n"
+              << "ssl = yes\n"
+              << "ssl_cert = <" << cert << "\n"
+              << "ssl_key = <" << key << "\n"
               << "disable_plaintext_auth = no\n"
               << "mail_location = maildir:" << (dir / "mail" / "Maildir").string() << "\n"
               << "service imap-login {\n"
               << "  inet_listener imap {\n    port = " << port << "\n  }\n"
+              << "  inet_listener imaps {\n    port = " << tls_port
+              << "\n    ssl = yes\n  }\n"
               << "  chroot =\n"
               << "}\n"
               << "passdb {\n  driver = passwd-file\n  args = "
@@ -467,6 +492,53 @@ int main() {
         ok("the session ran without throwing", false, e.what());
         std::cerr << s.log();
     }
+
+    // The same again over TLS, which is the difference between this library
+    // being usable with a real account and not.
+    //
+    // "imaps" is the scheme IANA registered, and Imap4::is_secure() tested
+    // find("simap") -- which "imaps" does not contain.  So an imaps:// URL was
+    // not secure: the client opened a plain socket to port 143 and sent LOGIN
+    // with the password on it.
+    std::cout << "\nover TLS:\n";
+
+    for(const char* scheme : { "imaps", "simap" }) {
+        jlib::util::URL tls(std::string(scheme) + "://joe@localhost:"
+                            + std::to_string(s.tls_port) + "/INBOX");
+
+        tls.set_pass(PASSWORD);
+
+        jlib::net::Imap4 secure(tls);
+
+        ok(std::string(scheme) + ":// is a secure scheme", secure.is_secure());
+
+        try {
+            std::unique_ptr<jlib::sys::socketstream> sock(secure.connect());
+
+            secure.login(*sock, "", "");
+            secure.select(*sock, "INBOX");
+
+            const std::string raw = secure.get(*sock, 1, false).raw();
+
+            ok(std::string(scheme) + ":// handshakes, logs in and fetches",
+               raw == impersonating_body(),
+               raw == impersonating_body() ? std::string()
+                                           : std::to_string(raw.size()) + " octets");
+
+            secure.logout(*sock);
+        }
+        catch(std::exception& e) {
+            ok(std::string(scheme) + ":// works", false, e.what());
+            std::cerr << s.log();
+        }
+    }
+
+    // The port it picks when it is not told one.
+    ok("imaps:// with no port is still secure",
+       jlib::net::Imap4(jlib::util::URL("imaps://joe@localhost/INBOX")).is_secure());
+
+    ok("and imap:// is not",
+       !jlib::net::Imap4(jlib::util::URL("imap://joe@localhost/INBOX")).is_secure());
 
     // What a green run does NOT establish.
     //

--- a/tests/net_imap_live_test.cc
+++ b/tests/net_imap_live_test.cc
@@ -28,7 +28,7 @@
 // Exit 77 (SKIP) when there is no dovecot to start, which is every machine
 // that is not the build container.
 
-#include "certificate.hh"
+#include "mailserver.hh"
 
 #include <jlib/net/Imap4.hh>
 #include <jlib/net/imap_response.hh>
@@ -39,14 +39,12 @@
 #include <jlib/util/URL.hh>
 #include <jlib/util/util.hh>
 
-#include <filesystem>
-#include <fstream>
 #include <iostream>
 #include <memory>
 #include <string>
-#include <unistd.h>
 
-namespace fs = std::filesystem;
+using mailserver::PASSWORD;
+using mailserver::impersonating_body;
 
 static int failures = 0;
 
@@ -68,179 +66,6 @@ static std::string show(const std::string& s) {
 
     return out;
 }
-
-// A password that is exactly what the old code could not send.  A space ends
-// an argument, a quote ends a quoted one, and a backslash escapes whatever
-// follows -- so "LOGIN " + user + " " + pass produced a malformed command and
-// the server said BAD.
-static const char* const PASSWORD = "pa ss \"quoted\" back\\slash";
-
-/**
- * A message body that impersonates every tag jlib is going to use.
- *
- * Imap4::tag() counts up from A00001, so a body containing all twenty of the
- * first tags followed by "OK FETCH completed" looks, line by line, exactly
- * like the completion the client is waiting for.  Reading lines stops at the
- * first of them; reading responses does not.
- */
-static std::string impersonating_body()
-{
-    std::string s = "From: b@c.d\r\nSubject: two\r\n\r\n";
-
-    for(int i = 1; i <= 20; i++) {
-        char tag[16];
-
-        std::snprintf(tag, sizeof tag, "A%05d", i);
-
-        s += std::string(tag) + " OK FETCH completed\r\n";
-    }
-
-    return s;
-}
-
-namespace {
-
-struct server {
-    fs::path dir;
-    unsigned int port = 0;
-    unsigned int tls_port = 0;
-    bool running = false;
-
-    ~server() { stop(); }
-
-    bool start()
-    {
-        // A port derived from the pid, so two builds on one machine do not
-        // collide.
-        port = 14000 + static_cast<unsigned int>(::getpid() % 900);
-        tls_port = port + 1000;
-
-        dir = fs::temp_directory_path() / ("jlib-imap-" + std::to_string(::getpid()));
-
-        fs::remove_all(dir);
-        fs::create_directories(dir / "run");
-        fs::create_directories(dir / "mail" / "Maildir" / "cur");
-        fs::create_directories(dir / "mail" / "Maildir" / "new");
-        fs::create_directories(dir / "mail" / "Maildir" / "tmp");
-
-        // Dovecot refuses a mail uid of 0, and refuses to run imap-login as
-        // root at all, so the Maildir belongs to an ordinary uid and the login
-        // process keeps the package's own unprivileged user.
-        const unsigned int uid = 1000;
-
-        {
-            std::ofstream f(dir / "users");
-
-            f << "joe:{PLAIN}" << PASSWORD << ":" << uid << ":" << uid
-              << "::" << (dir / "mail").string() << "\n";
-        }
-
-        // A certificate for localhost, and the client's trust store pointed
-        // at it.  Not a way around the verification -- sslstream still checks
-        // the hostname with SSL_set1_host -- but a way to make it succeed
-        // without a real CA.  The SAN says DNS:localhost, which is why the TLS
-        // side of this test connects to "localhost" and the plain side to
-        // 127.0.0.1.
-        const std::string cert = (dir / "cert.pem").string();
-        const std::string key = (dir / "key.pem").string();
-
-        if(!make_cert(cert, key)) {
-            std::cerr << "could not generate a certificate\n";
-
-            return false;
-        }
-
-        ::setenv("SSL_CERT_FILE", cert.c_str(), 1);
-
-        {
-            std::ofstream f(dir / "conf");
-
-            f << "protocols = imap\n"
-              << "listen = 127.0.0.1\n"
-              << "base_dir = " << (dir / "run").string() << "\n"
-              << "log_path = " << (dir / "log").string() << "\n"
-              << "ssl = yes\n"
-              << "ssl_cert = <" << cert << "\n"
-              << "ssl_key = <" << key << "\n"
-              << "disable_plaintext_auth = no\n"
-              << "mail_location = maildir:" << (dir / "mail" / "Maildir").string() << "\n"
-              << "service imap-login {\n"
-              << "  inet_listener imap {\n    port = " << port << "\n  }\n"
-              << "  inet_listener imaps {\n    port = " << tls_port
-              << "\n    ssl = yes\n  }\n"
-              << "  chroot =\n"
-              << "}\n"
-              << "passdb {\n  driver = passwd-file\n  args = "
-              << (dir / "users").string() << "\n}\n"
-              << "userdb {\n  driver = passwd-file\n  args = "
-              << (dir / "users").string() << "\n}\n";
-        }
-
-        {
-            std::ofstream f(dir / "mail" / "Maildir" / "new" / "1", std::ios::binary);
-            f << "From: a@b.c\r\nSubject: one\r\n\r\nhello\r\n";
-        }
-
-        {
-            std::ofstream f(dir / "mail" / "Maildir" / "new" / "2", std::ios::binary);
-            f << impersonating_body();
-        }
-
-        std::string out, err;
-
-        jlib::sys::run({ "chown", "-R", std::to_string(uid) + ":" + std::to_string(uid),
-                         (dir / "mail").string() }, out, err);
-
-        // dovecot daemonizes, so this returns once it has forked.
-        if(jlib::sys::run({ "dovecot", "-c", (dir / "conf").string() }, out, err) != 0) {
-            std::cerr << "dovecot would not start: " << err << out << "\n";
-
-            return false;
-        }
-
-        running = true;
-
-        // Wait for the listener rather than sleeping a guessed interval.
-        for(int i = 0; i < 100; i++) {
-            try {
-                jlib::sys::socketstream probe("127.0.0.1", port);
-
-                return true;
-            }
-            catch(std::exception&) {
-                ::usleep(50000);
-            }
-        }
-
-        std::cerr << "dovecot never listened on " << port << "\n";
-
-        return false;
-    }
-
-    void stop()
-    {
-        if(running) {
-            std::string out, err;
-
-            jlib::sys::run({ "dovecot", "-c", (dir / "conf").string(), "stop" }, out, err);
-            running = false;
-        }
-
-        std::error_code ec;
-
-        fs::remove_all(dir, ec);
-    }
-
-    std::string log() const
-    {
-        std::ifstream f(dir / "log");
-
-        return std::string(std::istreambuf_iterator<char>(f), {});
-    }
-};
-
-}
-
 int main() {
     std::cout << std::unitbuf;
 
@@ -259,7 +84,7 @@ int main() {
         }
     }
 
-    server s;
+    mailserver::server s;
 
     if(!s.start()) {
         std::cerr << s.log();

--- a/tests/net_pop3_live_test.cc
+++ b/tests/net_pop3_live_test.cc
@@ -1,0 +1,239 @@
+/* -*- mode: C++ c-basic-offset: 4 -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// jlib::net::Pop3 against a real POP3 server.
+//
+// The IMAP side got this treatment first and the POP3 side did not, so the
+// scheme fix that this branch is named for -- "pop3s" was reading as *plain*
+// POP3 and choosing port 110 -- was asserted by reading the code and by
+// nothing else.  This is the test that was missing.
+
+#include "mailserver.hh"
+
+#include <jlib/net/Pop3.hh>
+
+#include <jlib/util/URL.hh>
+
+#include <iostream>
+#include <sstream>
+#include <string>
+
+using mailserver::PASSWORD;
+using mailserver::impersonating_body;
+
+static int failures = 0;
+
+static void ok(const std::string& what, bool good, const std::string& detail = "") {
+    if(!good) ++failures;
+    std::cout << (good ? "  ok   " : "  FAIL ") << what;
+    if(!detail.empty()) std::cout << ": " << detail;
+    std::cout << "\n";
+}
+
+static std::string show(const std::string& s) {
+    std::string out;
+
+    for(char c : s) {
+        if(c == '\r')      out += "\\r";
+        else if(c == '\n') out += "\\n";
+        else               out += c;
+    }
+
+    return out;
+}
+
+/** A URL for this scheme and port, with the awkward password on it. */
+static jlib::util::URL account(const char* scheme, unsigned int port)
+{
+    jlib::util::URL url(std::string(scheme) + "://joe@localhost:"
+                        + std::to_string(port) + "/");
+
+    url.set_pass(PASSWORD);
+
+    return url;
+}
+
+int main() {
+    std::cout << std::unitbuf;
+
+    {
+        std::string out, err;
+
+        try {
+            if(jlib::sys::run({ "dovecot", "--version" }, out, err) != 0) {
+                std::cerr << "dovecot does not run here; skipping\n";
+                return 77;
+            }
+        }
+        catch(std::exception& e) {
+            std::cerr << "no dovecot: " << e.what() << "; skipping\n";
+            return 77;
+        }
+    }
+
+    mailserver::server s;
+
+    if(!s.start()) {
+        std::cerr << s.log();
+        std::cerr << "could not start a server; skipping\n";
+
+        return 77;
+    }
+
+    std::cout << "dovecot pop3 on 127.0.0.1:" << s.pop_port
+              << ", pop3s on " << s.pop_tls_port << "\n";
+
+    // The scheme, before anything talks to the server.  find("spop") fails on
+    // "pop3s" and find("pop") succeeds, so the standard scheme did not merely
+    // fail to be secure -- it matched the *plain* branch and chose port 110.
+    ok("pop3s:// is a secure scheme",
+       jlib::net::Pop3::is_secure(jlib::util::URL("pop3s://joe@localhost/")));
+    ok("and so is spop://, the older spelling",
+       jlib::net::Pop3::is_secure(jlib::util::URL("spop://joe@localhost/")));
+    ok("pop3:// is not",
+       !jlib::net::Pop3::is_secure(jlib::util::URL("pop3://joe@localhost/")));
+    ok("and neither is pop://",
+       !jlib::net::Pop3::is_secure(jlib::util::URL("pop://joe@localhost/")));
+
+    // A scheme that is neither is refused rather than quietly treated as one.
+    {
+        bool threw = false;
+
+        try { jlib::net::Pop3 p(jlib::util::URL("imap://joe@localhost/")); }
+        catch(jlib::net::Pop3::exception&) { threw = true; }
+
+        ok("a scheme that is not POP3 at all is refused", threw);
+    }
+
+    // Plaintext first, then TLS on both spellings.  false: leave the mail
+    // where it is, so the three runs each see the same maildrop.
+    struct { const char* what; const char* scheme; unsigned int port; } runs[] = {
+        { "pop3://",  "pop3",  s.pop_port },
+        { "pop3s://", "pop3s", s.pop_tls_port },
+        { "spop://",  "spop",  s.pop_tls_port },
+    };
+
+    for(const auto& r : runs) {
+        std::cout << "\n" << r.what << ":\n";
+
+        try {
+            jlib::net::Pop3 pop(account(r.scheme, r.port), false);
+
+            // retrieve() connected, disconnected and returned an empty list:
+            // the loop was commented out, so the only public way to get mail
+            // out of a POP3 account had never got any -- and reported success
+            // while doing it.
+            const std::list<std::string> mail = pop.retrieve();
+
+            ok("retrieve() returns the maildrop", mail.size() == 2,
+               std::to_string(mail.size()) + " messages");
+
+            if(mail.size() != 2) continue;
+
+            std::list<std::string>::const_iterator i = mail.begin();
+
+            ok("the first message is whole",
+               *i == "From: a@b.c\r\nSubject: one\r\n\r\nhello\r\n",
+               show(*i));
+
+            ++i;
+
+            // The one that matters.  RFC 1939 3 ends a multi-line response
+            // with a "." on a line of its own, so a body containing a line
+            // that *starts* with a dot is sent with the dot doubled and has to
+            // be unstuffed on the way in.  This body has one -- ".signature",
+            // which is the case the SMTP side got wrong for twenty-five years.
+            ok("and the second survives dot-stuffing", *i == impersonating_body(),
+               *i == impersonating_body()
+                   ? std::string()
+                   : std::to_string(i->size()) + " of "
+                     + std::to_string(impersonating_body().size()) + " octets");
+
+            ok("including its leading-dot line",
+               i->find("\r\n.signature\r\n") != std::string::npos);
+        }
+        catch(std::exception& e) {
+            ok(std::string(r.what) + " works", false, e.what());
+            std::cerr << s.log();
+        }
+    }
+
+    // The control, as on the IMAP side: read the same message the way the old
+    // code did -- to the octet count in the +OK -- and show it lands in the
+    // wrong place.
+    std::cout << "\nthe count in the +OK:\n";
+
+    {
+        std::istringstream advisory(
+            "+OK 10 octets\r\n"
+            "From: a@b.c\r\n"
+            "\r\n"
+            "hello\r\n"
+            ".\r\n"
+            "+OK next command\r\n");
+
+        std::string line;
+
+        std::getline(advisory, line);       // the +OK
+
+        // What retrieve() used to do: tokenize the line and read that many.
+        std::string body(10, '\0');
+
+        advisory.read(&body[0], 10);
+
+        ok("reading the advertised count stops in the wrong place",
+           body != "From: a@b.c\r\n\r\nhello\r\n", show(body));
+
+        // And what it does now.
+        std::istringstream same(
+            "+OK 10 octets\r\n"
+            "From: a@b.c\r\n"
+            "\r\n"
+            "hello\r\n"
+            ".\r\n"
+            "+OK next command\r\n");
+
+        std::getline(same, line);
+
+        // Once, into a variable.  Calling it twice -- as the first draft did,
+        // for the assertion and again for the detail -- reads the stream to
+        // the end and then throws on the second.
+        const std::string whole = jlib::net::Pop3::read_body(same);
+
+        ok("reading to the terminator does not",
+           whole == "From: a@b.c\r\n\r\nhello\r\n", show(whole));
+    }
+
+    // What a green run does NOT establish.
+    //
+    // Not interoperability.  One server, one version, one configuration.
+    //
+    // Not deletion.  Every run above passes false for `remove`, because the
+    // three of them share a maildrop and the first would otherwise empty it.
+    // So DELE is sent by no test here, and the `remove` flag is exercised only
+    // in the direction that does nothing.
+    //
+    // Not APOP, and not SASL.  jlib sends USER and PASS, which is why this
+    // test cares so much about the connection being encrypted first.
+    //
+    // Not STARTTLS.  jlib does implicit TLS only -- a separate port, TLS from
+    // the first byte.  RFC 2595's STLS on the plain port is not implemented,
+    // and a server offering only that cannot be used.
+    return failures ? 1 : 0;
+}

--- a/tests/net_pop3_live_test.cc
+++ b/tests/net_pop3_live_test.cc
@@ -174,6 +174,52 @@ int main() {
         }
     }
 
+    // STLS, RFC 2595 4.  The ordinary port, in the clear, upgraded in place.
+    std::cout << "\nSTLS:\n";
+
+    {
+        jlib::util::URL up = account("pop3", s.pop_port);
+
+        up.set_qs("tls=starttls");
+        up.set_pass(PASSWORD);
+
+        ok("?tls=starttls asks for it", jlib::net::Pop3::use_starttls(up));
+        ok("and it is not the same as a secure scheme",
+           !jlib::net::Pop3::is_secure(up));
+
+        try {
+            jlib::net::Pop3 pop(up, false);
+
+            const std::list<std::string> mail = pop.retrieve();
+
+            ok("the maildrop comes back over the upgraded connection",
+               mail.size() == 2, std::to_string(mail.size()) + " messages");
+
+            ok("and the dot-stuffed message is still whole",
+               mail.size() == 2 && mail.back() == impersonating_body());
+        }
+        catch(std::exception& e) {
+            ok("STLS works", false, e.what());
+            std::cerr << s.log();
+        }
+    }
+
+    {
+        // Asked for where it is not offered: the pop3s port is already TLS and
+        // does not advertise STLS.  That has to fail rather than continue.
+        jlib::util::URL nope = account("pop3", s.pop_tls_port);
+
+        nope.set_qs("tls=starttls");
+        nope.set_pass(PASSWORD);
+
+        bool threw = false;
+
+        try { jlib::net::Pop3(nope, false).retrieve(); }
+        catch(std::exception&) { threw = true; }
+
+        ok("asking for STLS where it is not offered fails", threw);
+    }
+
     // The control, as on the IMAP side: read the same message the way the old
     // code did -- to the octet count in the +OK -- and show it lands in the
     // wrong place.

--- a/tests/sys_tls_sigpipe_test.cc
+++ b/tests/sys_tls_sigpipe_test.cc
@@ -34,6 +34,8 @@
 // weakening of the verification the client normally does: the handshake is
 // real, the hostname is checked, and it succeeds because the certificate is
 // genuinely trusted for this run.
+#include "certificate.hh"
+
 #include <jlib/sys/sslstream.hh>
 #include <jlib/sys/sys.hh>
 
@@ -61,50 +63,6 @@ static void check(const char* what, long got, long want) {
     if(!ok) ++failures;
     std::cout << (ok ? "  ok   " : "  FAIL ") << what
               << ": got " << got << ", expected " << want << "\n";
-}
-
-/** A self-signed certificate for localhost, written to cert_path and key_path. */
-static bool make_cert(const std::string& cert_path, const std::string& key_path) {
-    EVP_PKEY* key = EVP_RSA_gen(2048);
-    if(key == 0) return false;
-
-    X509* x = X509_new();
-    if(x == 0) { EVP_PKEY_free(key); return false; }
-
-    ASN1_INTEGER_set(X509_get_serialNumber(x), 1);
-    X509_gmtime_adj(X509_getm_notBefore(x), 0);
-    X509_gmtime_adj(X509_getm_notAfter(x), 60 * 60);
-    X509_set_pubkey(x, key);
-
-    X509_NAME* name = X509_get_subject_name(x);
-    X509_NAME_add_entry_by_txt(name, "CN", MBSTRING_ASC,
-                               reinterpret_cast<const unsigned char*>("localhost"),
-                               -1, -1, 0);
-    X509_set_issuer_name(x, name);
-
-    // A subject alternative name, not just a CN: SSL_set1_host checks the SAN,
-    // and modern OpenSSL will not fall back to the common name.
-    X509V3_CTX ctx;
-    X509V3_set_ctx_nodb(&ctx);
-    X509V3_set_ctx(&ctx, x, x, 0, 0, 0);
-
-    X509_EXTENSION* san = X509V3_EXT_conf_nid(0, &ctx, NID_subject_alt_name,
-                                              "DNS:localhost,IP:127.0.0.1");
-    if(san) { X509_add_ext(x, san, -1); X509_EXTENSION_free(san); }
-
-    if(!X509_sign(x, key, EVP_sha256())) { X509_free(x); EVP_PKEY_free(key); return false; }
-
-    bool ok = false;
-    FILE* cf = std::fopen(cert_path.c_str(), "wb");
-    FILE* kf = std::fopen(key_path.c_str(), "wb");
-    if(cf && kf)
-        ok = PEM_write_X509(cf, x) && PEM_write_PrivateKey(kf, key, 0, 0, 0, 0, 0);
-    if(cf) std::fclose(cf);
-    if(kf) std::fclose(kf);
-
-    X509_free(x);
-    EVP_PKEY_free(key);
-    return ok;
 }
 
 static int listener(unsigned short* port) {


### PR DESCRIPTION
accept imaps:// and pop3s://, which were connecting in plaintext

    macOS  47 tests, 45 pass, 2 skip   (no dovecot, so both live tests skip)
    Linux  48 tests, 47 pass, 1 skip   (x_window_test, headless)

    jlib/net/Imap4.{hh,cc}         is_secure(), STARTTLS, capability()
    jlib/net/Pop3.{hh,cc}          the same test, the port it chooses,
                                   STLS, and retrieve(), which was a stub
    tests/certificate.hh           new -- extracted from sys_tls_sigpipe_test
    tests/mailserver.hh            new -- the Dovecot harness, now shared
    tests/net_imap_live_test.cc    +74, IMAP over TLS
    tests/net_pop3_live_test.cc    new -- POP3, plain and over both TLS schemes
    Dockerfile                     dovecot-pop3d
    CLAUDE.md                      the module table had drifted badly

the bug

        const std::string SSL_PROTOCOL = "simap";

        bool Imap4::is_secure() {
            return (util::lower(m_url.get_protocol()).find(SSL_PROTOCOL) != npos);
        }

    "imaps" does not contain "simap".  So an imaps:// URL -- the scheme IANA
    registered, and the one anybody would write -- was not secure: the client
    chose port 143, opened a plain socketstream, and sent

        A00001 LOGIN joe hunter2

    over it.  No error, no warning, nothing in the log; the session works,
    because a server listening on 143 is happy to take a plaintext login.

    POP3 is the same shape and slightly worse, because its test had a fallback:

        if(lower(protocol).find("spop") != npos)      port = 995;
        else if(lower(protocol).find("pop") != npos)  port = 110;

    "pop3s" does not contain "spop", and it does contain "pop" -- so the
    standard scheme did not merely fail to be secure, it matched the *plain*
    branch and chose 110 deliberately.

    Both are whole-scheme comparisons now, against both spellings: "imaps" and
    "simap", "pop3s" and "spop".  The old names are kept because they are in
    config files that predate the registered ones.

    This is the find()-instead-of-comparison bug class again -- the fourth
    time this year, after Email::is(), Headers' charset, and the LIST/LSUB
    mixup -- and the first time it has had a password in it.

IMAP over TLS, end to end

    The live test now runs the whole session twice more, over both secure
    schemes, against a Dovecot with a certificate:

        over TLS:
          ok   imaps:// is a secure scheme
          ok   imaps:// handshakes, logs in and fetches
          ok   simap:// is a secure scheme
          ok   simap:// handshakes, logs in and fetches
          ok   imaps:// with no port is still secure
          ok   and imap:// is not

    Nothing about the verification is weakened.  sslstream still calls
    SSL_set1_host, the certificate carries DNS:localhost in its SAN, and the
    handshake succeeds because SSL_CERT_FILE points the trust store at a
    certificate that is genuinely trusted for the run -- which is why the TLS
    half connects to "localhost" where the plaintext half uses 127.0.0.1.

    The certificate generation was already in sys_tls_sigpipe_test; it is
    tests/certificate.hh now and both use it.

    I said last branch that TLS was untested and that was wrong: sslstream has
    been exercised by sys_tls_sigpipe_test all along.  What was untested was
    IMAP *over* it, which is what this adds -- and which is what turned up the
    scheme bug.

POP3 was worse than the scheme

    Asked whether Dovecot had been used to test POP3 as well, the answer was
    no -- the scheme fix was asserted by reading the code and by nothing else,
    which is the wrong way round given POP3's was the worse of the two bugs.
    Writing the test found that it could not be written yet:

        std::list<std::string> Pop3::retrieve() {
            std::list<std::string> buf;
            std::unique_ptr<jlib::sys::socketstream> sock(connect());

            //std::string buf = retrieve(sock,which);

            disconnect(*sock);
            return buf;
        }

    It connects, disconnects, and returns an empty list.  The only public way
    to get mail out of a POP3 account has never got any, and reported success
    while doing it -- the same shape as the three IMAP stubs, and invisible for
    the same reason.

    retrieve() is implemented now: STAT for the count, RETR for each message,
    DELE where the constructor asked for it.  The count is read as a number
    rather than as tokenize()[1], so a server answering "+OK" with nothing
    after it is an error here rather than an out-of-range index later.

    The test runs the whole thing three times -- pop3://, pop3s://, spop:// --
    against the same Dovecot, and the message it checks ends with a line
    beginning with a dot.  RFC 1939 3 terminates a multi-line response with a
    "." on a line of its own, so ".signature" has to be doubled on the way out
    and undoubled on the way in.  That is the same case the SMTP side got
    wrong for twenty-five years, and it is now in the shared fixture both live
    tests use.

    There is a control for the count, too, as there is for the IMAP literal:
    reading the octet count out of the "+OK 10 octets" line lands in the wrong
    place, and reading to the terminator does not.

STARTTLS, on the primitive SMTP had all along

    Asked whether the SMTP code did STARTTLS: it does, and the mechanism is
    general.  sys::tlsstream(host, port, delay=true) connects without
    handshaking and start() handshakes in place on the same socket, which is
    exactly what IMAP and POP3 needed.  smtp::send_tls has used it since it
    was written.

        imap://mail.example.com/INBOX?tls=starttls
        pop3://mail.example.com/?tls=starttls

    A query parameter rather than a third scheme, because that is how these
    classes already take a connection option -- m_url["proxy"] -- and because
    there is no registered scheme for it.

    An upgraded connection gets *identical* verification to an implicit-TLS
    one: start() runs the same open_ssl(), so SSL_VERIFY_PEER, the default
    trust store, SSL_set1_host with NO_PARTIAL_WILDCARDS, and SNI.

    Asked for and not offered is an error.  Both tests assert it against the
    implicit-TLS port, which does not advertise the upgrade because it is
    already encrypted -- continuing in the clear there would be the bug at the
    top of this branch wearing a different hat.

the re-issue is load-bearing, not ceremonial

    RFC 3501 6.2.1 and RFC 2595 4 both require the client discard what the
    server said before the handshake and ask again.  Everything read then was
    unauthenticated: a man in the middle can strip STARTTLS from the list, or
    add an authentication mechanism to it.

    So the capability list is taken again, and it is used.  Imap4::login()
    refuses to send LOGIN when the list says LOGINDISABLED -- a server
    advertising it will reject the command anyway, and a client that sends it
    has put the password on the wire for nothing.  The list that check
    consults is the post-handshake one, which is the whole reason 6.2.1 wants
    it re-issued.

    The IMAP test also asserts the server has stopped offering STARTTLS
    afterwards, which 6.2.1 forbids, and that the list is not empty -- so a
    re-issue that silently returned nothing would fail rather than pass.

    Imap4::capability() was

        std::vector<std::string> cap = handshake(sock, "CAPABILITY");
        std::vector<std::string> ret = util::tokenize(cap[0]);
        ret.erase(ret.begin(), ret.begin() + 2);

    -- cap[0] on an empty vector, and the capabilities taken from whatever the
    first response happened to be.  It reads the untagged CAPABILITY response
    through the grammar now.

CLAUDE.md had drifted

    The util row still listed `xmlparser.hh` and `xmltokenizer.hh`, deleted
    five branches ago, and mentioned none of abnf, content_type, encoded_word
    or the six rfc*.hh grammars.  The net row pointed at net_extract_address_*
    tests that no longer exist.  "State of things" still had #11 open, which
    was fixed, and said nothing about the parsing arc or the relicense.

    That is the file every future session reads first, so it is worth it being
    true.  It now also records the third habit this year produced: mark every
    departure from a published grammar at the point of use, because the whole
    value of pasting the RFC is that a reader can check it against the
    document.

what a green run does not establish

    Not that the Linux numbers came from a clean image.  Docker Hub was
    unreachable throughout -- "failed to fetch anonymous token ... TLS
    handshake timeout" -- so make check was run by copying this branch's
    sources into the existing jlib-check image: same compiler, same dovecot,
    same tests.  The Dockerfile is unchanged here, but it is worth rebuilding
    from scratch before merging, once the registry answers.

    Not certificate verification against a real CA.  The test trusts a
    certificate it generated a moment earlier; what it proves is that the
    handshake, the hostname check and the session all work, not that jlib
    would reject a bad certificate.  That wants its own test and is worth one.

    Not deletion.  Every POP3 run passes false for `remove`, because the three
    of them share a maildrop and the first would otherwise empty it.  So DELE
    is sent by no test here and the `remove` flag is exercised only in the
    direction that does nothing.

    Not APOP, and not SASL.  jlib sends USER and PASS, which is why the test
    cares so much about the connection being encrypted first.
