### PR TITLE
Give jlib an accepting end, a resolver that knows IPv6, and sockets that can time out

### DIFF
--- a/jlib/net/net.hh
+++ b/jlib/net/net.hh
@@ -162,36 +162,21 @@ namespace jlib {
         }
 
         namespace http {
-            typedef enum { v10, v11 } version;
-            
-            class Request {
-            public:
-                typedef enum { get, head, post, put, connect } method;
-
-                Request(method m, util::URL u);
-                
-                version m_version;
-                method m_method;
-                util::URL m_url;
-                util::Headers m_headers;
-                std::string m_data;
-            };
-
-            class Response {
-            public:
-                std::string get_text() const;
-                static std::string get_text(int status);
-
-                int m_status;
-                version m_version;
-                util::Headers m_headers;
-                std::string m_data;
-            };
-
+            // Request, Response and request() were declared here and defined
+            // nowhere -- no constructor, no get_text(), no request(), in any
+            // file in the tree.  Twenty-odd years of a header promising an HTTP
+            // client that did not exist; the only thing here that ever ran is
+            // get(), below.  They are gone rather than kept as a sketch,
+            // because the sketch had already started to constrain the real
+            // thing: Request held a util::Headers, which is an RFC 5322 header
+            // set that decodes encoded-words, and HTTP fields are not that.
+            //
+            // get() is HTTP/1.0, plaintext-only, and treats any status but 200
+            // as an error, so it cannot follow a redirect or read the body of a
+            // 400 -- which is precisely what an OAuth2 token endpoint answers
+            // with when it has something to tell you.  Nothing in the tree
+            // calls it.  It goes when there is something to replace it with.
             std::string get(jlib::util::URL url);
-            
-            Response request(const Request& r);
-
         }
 
         namespace html {

--- a/jlib/sys/Makefile.am
+++ b/jlib/sys/Makefile.am
@@ -1,12 +1,13 @@
 AM_CPPFLAGS = -I$(top_srcdir) $(OPENSSL_CFLAGS)
 
 lib_LTLIBRARIES = libjsys.la
-libjsys_la_SOURCES = tfstream.cc sys.cc Directory.cc Servent.cc pipe.cc
+libjsys_la_SOURCES = tfstream.cc sys.cc Directory.cc Servent.cc pipe.cc listener.cc
 libjsys_la_LDFLAGS = -version-info $(LIBJ_SO_VERSION) -release $(JLIB_RELEASE) -no-undefined
 libjsys_la_LIBADD = $(PTHREAD_LIBS)
 
 libjsysincludedir = $(includedir)/jlib-1.2/jlib/sys
 libjsysinclude_HEADERS = tfstream.hh socketstream.hh sslstream.hh proxystream.hh \
+                         listener.hh \
                          sslproxystream.hh serialstream.hh pstream.hh \
                          sys.hh Directory.hh auto.hh sync.hh ringbuffer.hh Servent.hh \
                          ASServent.hh pipe.hh object.hh joystick.hh

--- a/jlib/sys/listener.cc
+++ b/jlib/sys/listener.cc
@@ -1,0 +1,201 @@
+/* -*- mode: C++ c-basic-offset: 4  -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+#include <jlib/sys/listener.hh>
+#include <jlib/sys/sys.hh>
+
+#include <cerrno>
+#include <cstring>
+#include <sstream>
+#include <utility>
+
+#include <fcntl.h>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <poll.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+namespace jlib {
+namespace sys {
+
+namespace {
+
+    unsigned short port_of(const struct sockaddr_storage& ss) {
+        if(ss.ss_family == AF_INET6)
+            return ntohs(reinterpret_cast<const struct sockaddr_in6*>(&ss)->sin6_port);
+
+        return ntohs(reinterpret_cast<const struct sockaddr_in*>(&ss)->sin_port);
+    }
+
+}
+
+listener::listener(unsigned short port, const std::string& host, int backlog) {
+    struct addrinfo hints;
+    std::memset(&hints, 0, sizeof(hints));
+
+    hints.ai_family = AF_UNSPEC;
+    hints.ai_socktype = SOCK_STREAM;
+    hints.ai_flags = AI_PASSIVE;
+
+    std::ostringstream o; o << port;
+    const std::string service = o.str();
+
+    struct addrinfo* res = 0;
+    const int gai = ::getaddrinfo(host.empty() ? 0 : host.c_str(),
+                                  service.c_str(), &hints, &res);
+
+    if(gai != 0 || res == 0)
+        throw exception("error resolving " + (host.empty() ? std::string("*") : host) +
+                        ": " + ::gai_strerror(gai));
+
+    int last = 0;
+
+    for(struct addrinfo* ai = res; ai != 0 && m_sock == -1; ai = ai->ai_next) {
+        const int fd = ::socket(ai->ai_family, ai->ai_socktype, ai->ai_protocol);
+
+        if(fd < 0) {
+            last = errno;
+            continue;
+        }
+
+        // Otherwise the port sits in TIME_WAIT for a couple of minutes after
+        // the process exits, and a test that runs twice in a row fails the
+        // second time for no reason the test can see.
+        int on = 1;
+        ::setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &on, sizeof(on));
+
+        if(::bind(fd, ai->ai_addr, ai->ai_addrlen) < 0 || ::listen(fd, backlog) < 0) {
+            last = errno;
+            ::close(fd);
+            continue;
+        }
+
+        m_sock = fd;
+    }
+
+    ::freeaddrinfo(res);
+
+    if(m_sock == -1)
+        throw exception("error listening on " + host + ":" + service + ": " +
+                        std::strerror(last));
+
+    // Ask the socket what it got, rather than believing what was asked for:
+    // with port 0 the kernel chose, and the caller needs the answer to put in
+    // a redirect URI or to connect a test client to.
+    struct sockaddr_storage ss;
+    socklen_t len = sizeof(ss);
+
+    if(::getsockname(m_sock, reinterpret_cast<struct sockaddr*>(&ss), &len) < 0) {
+        const int e = errno;
+        close();
+        throw exception(std::string("error in getsockname(): ") + std::strerror(e));
+    }
+
+    m_port = port_of(ss);
+
+    ::fcntl(m_sock, F_SETFD, FD_CLOEXEC);
+}
+
+listener::~listener() {
+    close();
+}
+
+listener::listener(listener&& other) noexcept
+    : m_sock(other.m_sock),
+      m_port(other.m_port)
+{
+    other.m_sock = -1;
+    other.m_port = 0;
+}
+
+listener& listener::operator=(listener&& other) noexcept {
+    if(this != &other) {
+        close();
+        m_sock = other.m_sock;
+        m_port = other.m_port;
+        other.m_sock = -1;
+        other.m_port = 0;
+    }
+
+    return *this;
+}
+
+int listener::accept(double timeout) {
+    if(m_sock == -1)
+        throw exception("accept() on a closed listener");
+
+    if(timeout > 0) {
+        struct pollfd p;
+
+        p.fd = m_sock;
+        p.events = POLLIN;
+        p.revents = 0;
+
+        int r;
+
+        // poll(2) coming back EINTR is not the timeout expiring, and treating
+        // it as one would make a stray SIGCHLD look like "nobody connected".
+        while((r = ::poll(&p, 1, static_cast<int>(timeout * 1000))) < 0 && errno == EINTR)
+            ;
+
+        if(r == 0)
+            return -1;
+
+        if(r < 0)
+            throw exception(std::string("error in poll(): ") + std::strerror(errno));
+    }
+
+    int fd;
+
+    while((fd = ::accept(m_sock, 0, 0)) < 0 && errno == EINTR)
+        ;
+
+    if(fd < 0)
+        throw exception(std::string("error in accept(): ") + std::strerror(errno));
+
+    return fd;
+}
+
+std::unique_ptr<socketstream> listener::accept_stream(double timeout) {
+    const int fd = accept(timeout);
+
+    if(fd < 0)
+        return std::unique_ptr<socketstream>();
+
+    try {
+        return std::make_unique<socketstream>(adopt, fd);
+    }
+    catch(...) {
+        ::close(fd);
+        throw;
+    }
+}
+
+void listener::close() {
+    if(m_sock != -1) {
+        ::close(m_sock);
+        m_sock = -1;
+    }
+}
+
+}
+}

--- a/jlib/sys/listener.hh
+++ b/jlib/sys/listener.hh
@@ -1,0 +1,123 @@
+/* -*- mode: C++ c-basic-offset: 4  -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+#ifndef JLIB_SYS_LISTENER_HH
+#define JLIB_SYS_LISTENER_HH
+
+#include <jlib/sys/socketstream.hh>
+
+#include <memory>
+#include <string>
+
+namespace jlib {
+namespace sys {
+
+/**
+ * The accepting end of a socket.
+ *
+ * jlib has been a client for twenty-five years: there was no bind, no listen
+ * and no accept anywhere in it, and basic_socketbuf had exactly one
+ * constructor, which connected.  Two things want the other end.  An OAuth2
+ * authorization-code flow has to receive the redirect the browser makes to
+ * http://127.0.0.1:<port>/, and the tests that need a server currently
+ * hand-roll socket/bind/listen/getsockname inline -- sys_tls_sigpipe_test did,
+ * and it was the model for this.
+ *
+ * Deliberately small.  It binds one address, accepts connections one at a time,
+ * and hands each one back as a stream; it is not a server and does not want to
+ * become one.
+ *
+ * The default address is loopback, not INADDR_ANY.  A receiver for a browser
+ * redirect that binds every interface is reachable from the network, and what
+ * arrives on it is an authorization code.
+ */
+class listener {
+public:
+    class exception : public std::exception {
+    public:
+        exception(const std::string& msg = "") {
+            m_msg = "listener exception: " + msg;
+        }
+        virtual ~exception() {}
+        virtual const char* what() const noexcept { return m_msg.c_str(); }
+    protected:
+        std::string m_msg;
+    };
+
+    /**
+     * Bind and listen.
+     *
+     * @param port     the port, or 0 to let the kernel pick one -- port()
+     *                 then says which, which is what a test and an OAuth
+     *                 redirect URI both need.
+     * @param host     the address to bind; loopback by default.  Resolved
+     *                 with getaddrinfo, so "127.0.0.1", "::1" and "localhost"
+     *                 all work, and "" means every interface -- say it out
+     *                 loud if that is what you want, and expect it not to
+     *                 work: a host with the macOS application firewall set to
+     *                 block incoming connections, or any equivalent, filters
+     *                 exactly that and leaves loopback alone.
+     * @param backlog  listen(2)'s backlog.
+     */
+    explicit listener(unsigned short port = 0,
+                      const std::string& host = "127.0.0.1",
+                      int backlog = 8);
+
+    ~listener();
+
+    listener(const listener&) = delete;
+    listener& operator=(const listener&) = delete;
+
+    listener(listener&& other) noexcept;
+    listener& operator=(listener&& other) noexcept;
+
+    /** The port actually bound, which is the interesting one when 0 was asked for. */
+    unsigned short port() const { return m_port; }
+
+    int get_socket() const { return m_sock; }
+
+    /**
+     * Wait for one connection and return its descriptor.
+     *
+     * @param timeout  seconds to wait; zero waits forever.
+     * @return the descriptor, or -1 if the timeout ran out.  A timeout is not
+     *         an error -- a caller polling for a browser redirect while the
+     *         user is still typing their password expects it -- so it is a
+     *         return value and everything else throws.
+     *
+     * The caller owns the descriptor and must close it, or hand it to
+     * accept_stream()'s buffer instead.
+     */
+    int accept(double timeout = 0);
+
+    /** accept(), wrapped in a stream.  Null if the timeout ran out. */
+    std::unique_ptr<socketstream> accept_stream(double timeout = 0);
+
+    void close();
+
+private:
+    int m_sock = -1;
+    unsigned short m_port = 0;
+};
+
+}
+}
+
+#endif // JLIB_SYS_LISTENER_HH

--- a/jlib/sys/socketstream.hh
+++ b/jlib/sys/socketstream.hh
@@ -35,13 +35,26 @@
 #include <netinet/in.h>
 #include <sys/types.h>
 #include <sys/socket.h>
+#include <sys/time.h>
 #include <netdb.h>
+#include <poll.h>
 #include <unistd.h>
 #include <fcntl.h>
 #include <errno.h>
 
 namespace jlib {
     namespace sys {
+
+        /**
+         * Tag for the constructor that takes an already-connected descriptor.
+         *
+         * A tag rather than an overload because the fd is an int and so is a
+         * port, and socketbuf(host, 5) meaning two different things depending
+         * on the type of the first argument is the sort of thing that compiles
+         * and then does not work.
+         */
+        struct adopt_t { explicit adopt_t() = default; };
+        inline constexpr adopt_t adopt{};
 
         template< typename charT, typename traitT = std::char_traits<charT> >
         class basic_socketbuf : public std::basic_streambuf<charT,traitT> {
@@ -65,28 +78,65 @@ namespace jlib {
             
             static const unsigned int BUF_SIZE = 1024;
 
-            basic_socketbuf(const std::string& host, unsigned int port) {
-                char_type* tmp;
-                
-                tmp = new char_type[BUF_SIZE];
-                this->setg(tmp,tmp,tmp);
-                
-                tmp = new char_type[BUF_SIZE];
-                this->setp(tmp,tmp+BUF_SIZE);
-                
-                //_M_mode = (std::ios_base::in | std::ios_base::out);
-                
-                m_eintr = false;
-                open_socket(host,port);
+            /**
+             * Connect to host:port.
+             *
+             * @param timeout  seconds to allow the connect; negative takes
+             *                 sys::get_default_connect_timeout(), zero waits
+             *                 forever.
+             */
+            basic_socketbuf(const std::string& host, unsigned int port, double timeout = -1) {
+                init_buffers();
+
+                // A constructor that throws gets no destructor, so the two
+                // buffers just allocated would be lost -- and a failing
+                // connect is the ordinary case for a mail client retrying a
+                // server that is down, so it leaks once a minute rather than
+                // once ever.
+                try {
+                    open_socket(host, port, timeout);
+                }
+                catch(...) {
+                    free_buffers();
+                    throw;
+                }
+            }
+
+            /**
+             * Take over a descriptor that is already connected.
+             *
+             * This is what an accepted connection needs, and until it existed
+             * there was no way to get one into a stream at all: the only
+             * constructor connected, so jlib could be a client and nothing
+             * else.  sys::listener hands its fd in here, and so does the OAuth
+             * redirect receiver.
+             *
+             * The buf owns the descriptor from here and closes it.  host and
+             * port are what to *call* the peer -- they are used for messages,
+             * and by basic_tlsbuf for the name it verifies against -- not for
+             * anything to connect to.
+             */
+            basic_socketbuf(adopt_t, int fd, const std::string& host = "", unsigned int port = 0) {
+                init_buffers();
+                m_host = host;
+                m_port = port;
+                m_sock = fd;
+
+                try {
+                    configure(m_sock);
+                }
+                catch(...) {
+                    close();
+                    free_buffers();
+                    throw;
+                }
             }
 
             virtual ~basic_socketbuf() {
                 if(std::getenv("JLIB_SYS_SOCKET_DEBUG"))
                     std::cerr << "basic_socketbuf::~basic_socketbuf()"<<std::endl;
                 close();
-
-                delete [] this->eback();
-                delete [] this->pbase();
+                free_buffers();
             }
 
             virtual int_type underflow() {
@@ -94,6 +144,7 @@ namespace jlib {
                     std::cerr << "basic_socketbuf::underflow()"<<std::endl;
 
                 m_eintr = false;
+                m_timeout = false;
                 int count = ::read(m_sock, this->eback(), BUF_SIZE);
                 
                 if(count < 0) {
@@ -102,6 +153,13 @@ namespace jlib {
                     //this->setstate(std::ios_base::badbit);
                     if(errno == EINTR) {
                         m_eintr = true;
+                    }
+                    // SO_RCVTIMEO expiring looks exactly like end of stream
+                    // from out here -- eof() is all a streambuf can return --
+                    // so record it, or a caller cannot tell "the server closed"
+                    // from "the server is slow".
+                    if(errno == EAGAIN || errno == EWOULDBLOCK) {
+                        m_timeout = true;
                     }
                     return traits_type::eof();
                     //throw exception("error reading");
@@ -149,6 +207,7 @@ namespace jlib {
                 
                 while( (diff=(total-sofar)) > 0 ) {
                     m_eintr = false;
+                    m_timeout = false;
                     count = write(m_sock, current, diff);
 
                     if(count == -1) {
@@ -156,6 +215,9 @@ namespace jlib {
                             std::cerr <<"exception in jlib::sys::socketstream::sync()"<<std::endl;
                         if(errno == EINTR) {
                             m_eintr = true;
+                        }
+                        if(errno == EAGAIN || errno == EWOULDBLOCK) {
+                            m_timeout = true;
                         }
                         // EPIPE arrives here now instead of as a signal.
                         return traits_type::eof();
@@ -179,67 +241,226 @@ namespace jlib {
 
             bool interrupted() { return m_eintr; }
 
+            /** Whether the last read or write gave up on a timeout. */
+            bool timed_out() const { return m_timeout; }
+
+            /**
+             * How long a read or write may block, in seconds.  Zero is forever.
+             *
+             * Applies from the next call; anything already blocked in read(2)
+             * stays there.  Takes effect through SO_RCVTIMEO and SO_SNDTIMEO,
+             * so a timeout shows up as a short read or an EAGAIN, not as a
+             * signal, and timed_out() says which it was.
+             */
+            void set_timeout(double seconds) {
+                m_io_timeout = seconds < 0 ? 0 : seconds;
+                if(m_sock != -1)
+                    apply_timeout(m_sock, m_io_timeout);
+            }
+
+            double get_timeout() const { return m_io_timeout; }
+
             int get_socket() { return m_sock; }
             
         protected:
-            void open_socket(const std::string& host, unsigned int port) {
+            void init_buffers() {
+                char_type* tmp;
+
+                tmp = new char_type[BUF_SIZE];
+                this->setg(tmp,tmp,tmp);
+
+                tmp = new char_type[BUF_SIZE];
+                this->setp(tmp,tmp+BUF_SIZE);
+
+                //_M_mode = (std::ios_base::in | std::ios_base::out);
+            }
+
+            void free_buffers() {
+                delete [] this->eback();
+                delete [] this->pbase();
+                this->setg(0,0,0);
+                this->setp(0,0);
+            }
+
+            static void apply_timeout(int fd, double seconds) {
+                struct timeval tv;
+
+                tv.tv_sec = static_cast<time_t>(seconds);
+                tv.tv_usec = static_cast<suseconds_t>((seconds - tv.tv_sec) * 1e6);
+
+                // A zero timeval is how the kernel spells "no timeout", so
+                // seconds == 0 turns it off rather than making every call time
+                // out at once.
+                ::setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+                ::setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
+            }
+
+            /** Everything a connected descriptor needs, however it was got. */
+            void configure(int fd) {
+                // Before anything is written: a write to a peer that has gone
+                // away raises SIGPIPE, whose default action is to kill the
+                // process outright, so the error checking elsewhere never runs.
+                nosigpipe(fd);
+
+                if(m_io_timeout < 0)
+                    m_io_timeout = get_default_io_timeout();
+                apply_timeout(fd, m_io_timeout);
+
+                if(fcntl(fd, F_SETFD, FD_CLOEXEC) == -1) {
+                    if(std::getenv("JLIB_SYS_SOCKET_DEBUG"))
+                        std::cerr <<"throwing exception from jlib::sys::socketstream"<<std::endl
+                                  <<"error calling fcntl(sock, F_SETFD, FD_CLOEXEC)"<<std::endl;
+                    throw exception("error calling fcntl(sock, F_SETFD, FD_CLOEXEC)");
+                }
+            }
+
+            /**
+             * connect(2) with a deadline.
+             *
+             * Returns 0 on success and an errno on failure, with ETIMEDOUT for
+             * running out of time.  A blocking connect cannot be given a
+             * deadline at all, so the descriptor goes non-blocking for the
+             * duration and is put back afterwards -- the caller gets an
+             * ordinary blocking socket either way.
+             */
+            int connect_within(int fd, const struct sockaddr* sa, socklen_t len, double seconds) {
+                const int flags = fcntl(fd, F_GETFL, 0);
+
+                if(flags == -1)
+                    return errno;
+
+                if(seconds > 0 && fcntl(fd, F_SETFL, flags | O_NONBLOCK) == -1)
+                    return errno;
+
+                int err = 0;
+
+                if(::connect(fd, sa, len) == 0) {
+                    err = 0;
+                }
+                else if(errno == EINTR) {
+                    m_eintr = true;
+                    err = EINTR;
+                }
+                else if(seconds > 0 && (errno == EINPROGRESS || errno == EWOULDBLOCK)) {
+                    struct pollfd p;
+
+                    p.fd = fd;
+                    p.events = POLLOUT;
+                    p.revents = 0;
+
+                    const int ms = static_cast<int>(seconds * 1000);
+                    const int r = ::poll(&p, 1, ms);
+
+                    if(r == 0) {
+                        err = ETIMEDOUT;
+                    }
+                    else if(r < 0) {
+                        err = errno;
+                        if(err == EINTR)
+                            m_eintr = true;
+                    }
+                    else {
+                        // POLLOUT says the connect finished, not that it
+                        // succeeded -- a refused connection is also writable.
+                        // SO_ERROR is the only thing that says which.
+                        int so = 0;
+                        socklen_t solen = sizeof(so);
+
+                        if(::getsockopt(fd, SOL_SOCKET, SO_ERROR, &so, &solen) < 0)
+                            err = errno;
+                        else
+                            err = so;
+                    }
+                }
+                else {
+                    err = errno;
+                }
+
+                if(seconds > 0)
+                    fcntl(fd, F_SETFL, flags);
+
+                return err;
+            }
+
+            void open_socket(const std::string& host, unsigned int port, double timeout = -1) {
                 m_host = host;
                 m_port = port;
-
-                struct sockaddr_in sa;
-                struct hostent* hp;
-                
-                if( (hp=gethostbyname(host.c_str())) == NULL ) {
-                    m_sock = -1;
-                    if(std::getenv("JLIB_SYS_SOCKET_DEBUG"))
-                        std::cerr <<"throwing exception from jlib::sys::socketstream::open_socket()"<<std::endl
-                                  << "error in gethostbyname("<<host<<")"<<std::endl;
-                    throw exception("error resolving "+host);
-                }
-                
-                std::memset(&sa,0,sizeof(sa));
-                memcpy(reinterpret_cast<char*>(&sa.sin_addr),hp->h_addr,hp->h_length);
-                sa.sin_family = hp->h_addrtype;
-                sa.sin_port = htons((u_short)port);
-                
-                if( (m_sock=socket(hp->h_addrtype,SOCK_STREAM,0)) < 0 ) {
-                    if(std::getenv("JLIB_SYS_SOCKET_DEBUG"))
-                        std::cerr <<"throwing exception from jlib::sys::socketstream::open_socket()"<<std::endl
-                                  << "error in socket()"<<std::endl;
-                    throw exception("error in socket()");
-                }
-                
+                m_sock = -1;
                 m_eintr = false;
-                if(connect(m_sock,reinterpret_cast<struct sockaddr*>(&sa),sizeof(sa)) < 0) {
-                    if(errno == EINTR) {
-                        m_eintr = true;
+
+                const double allow = timeout < 0 ? get_default_connect_timeout() : timeout;
+
+                // getaddrinfo, not gethostbyname.  Two reasons, both of which
+                // had bitten: gethostbyname is IPv4-only, so a name with only
+                // an AAAA record -- which is now an ordinary thing for a mail
+                // or token endpoint to be -- simply did not resolve; and it
+                // returns a pointer to static storage, so two of the threaded
+                // AS* mailboxes resolving at once overwrote each other's answer
+                // and one of them connected somewhere it had never asked for.
+                struct addrinfo hints;
+                std::memset(&hints, 0, sizeof(hints));
+                hints.ai_family = AF_UNSPEC;
+                hints.ai_socktype = SOCK_STREAM;
+
+                std::ostringstream o; o << port;
+                const std::string service = o.str();
+
+                struct addrinfo* res = 0;
+                const int gai = ::getaddrinfo(host.c_str(), service.c_str(), &hints, &res);
+
+                if(gai != 0 || res == 0) {
+                    if(std::getenv("JLIB_SYS_SOCKET_DEBUG"))
+                        std::cerr <<"throwing exception from jlib::sys::socketstream::open_socket()"<<std::endl
+                                  << "error in getaddrinfo("<<host<<")"<<std::endl;
+                    throw exception("error resolving " + host + ": " +
+                                    ::gai_strerror(gai));
+                }
+
+                // Every address the name has, in the order the resolver gave
+                // them, which is the order RFC 6724 wants them tried in.  One
+                // AAAA that happens to be unreachable is no longer the whole
+                // connection.
+                int last = 0;
+
+                for(struct addrinfo* ai = res; ai != 0 && m_sock == -1; ai = ai->ai_next) {
+                    const int fd = ::socket(ai->ai_family, ai->ai_socktype, ai->ai_protocol);
+
+                    if(fd < 0) {
+                        last = errno;
+                        continue;
                     }
-                    ::close(m_sock);
+
+                    last = connect_within(fd, ai->ai_addr, ai->ai_addrlen, allow);
+
+                    if(last == 0)
+                        m_sock = fd;
+                    else
+                        ::close(fd);
+                }
+
+                ::freeaddrinfo(res);
+
+                if(m_sock == -1) {
                     if(std::getenv("JLIB_SYS_SOCKET_DEBUG"))
                         std::cerr <<"throwing exception from jlib::sys::socketstream::open_socket()"<<std::endl
                                   <<"error in connect()"<<std::endl;
-                    std::ostringstream o; o << port;
-                    throw exception("error connecting to " + host + ":" + o.str());
+                    throw exception("error connecting to " + host + ":" + service + ": " +
+                                    std::strerror(last));
                 }
-                
-                // Before anything is written: a write to a peer that has gone
-                // away raises SIGPIPE, whose default action is to kill the
-                // process outright, so the error checking below never runs.
-                nosigpipe(m_sock);
 
-                if(fcntl(m_sock, F_SETFD, 1) == -1) {
-                    if(std::getenv("JLIB_SYS_SOCKET_DEBUG"))
-                        std::cerr <<"throwing exception from jlib::sys::socketstream::open_socket()"<<std::endl
-                                  <<"error calling fcntl(sock, F_SETFD, 1)"<<std::endl;
-                    throw exception("error calling fcntl(sock, F_SETFD, 1)");
-                }
-                //free(hp);
+                configure(m_sock);
             }
 
             std::string m_host;
-            unsigned int m_port;
-            int m_sock;
-            bool m_eintr;
+            unsigned int m_port = 0;
+            int m_sock = -1;
+            bool m_eintr = false;
+            bool m_timeout = false;
+
+            // Negative until configure() resolves it against the library
+            // default, so a set_timeout() before the connect is not overwritten
+            // by one after it.
+            double m_io_timeout = -1;
         };
         
         template<typename charT, typename traitT=std::char_traits<charT> >
@@ -252,12 +473,21 @@ namespace jlib {
                 //exceptions(std::ios_base::badbit);
             }
 
-            basic_socketstream(const std::string& host, unsigned int port)
+            basic_socketstream(const std::string& host, unsigned int port, double timeout = -1)
                 : std::basic_iostream<charT,traitT>(NULL)
             {
                 m_buf = 0;
                 //exceptions(std::ios_base::badbit);
-                m_buf=new basic_socketbuf<charT,traitT>(host,port);
+                m_buf=new basic_socketbuf<charT,traitT>(host,port,timeout);
+                this->init(m_buf);
+            }
+
+            /** Take over an already-connected descriptor; see basic_socketbuf. */
+            basic_socketstream(adopt_t, int fd, const std::string& host = "", unsigned int port = 0)
+                : std::basic_iostream<charT,traitT>(NULL)
+            {
+                m_buf = 0;
+                m_buf=new basic_socketbuf<charT,traitT>(adopt,fd,host,port);
                 this->init(m_buf);
             }
 
@@ -266,10 +496,10 @@ namespace jlib {
                     delete m_buf;
             }
             
-            void open(const std::string& host, unsigned int port) {
+            void open(const std::string& host, unsigned int port, double timeout = -1) {
                 if(m_buf != 0)
                     delete m_buf;
-                m_buf=new basic_socketbuf<charT,traitT>(host,port);
+                m_buf=new basic_socketbuf<charT,traitT>(host,port,timeout);
                 this->init(m_buf);
             }
 
@@ -278,6 +508,14 @@ namespace jlib {
             }
 
             bool interrupted() { return m_buf->interrupted(); }
+
+            /** Whether the last read or write gave up on a timeout. */
+            bool timed_out() const { return m_buf->timed_out(); }
+
+            /** Seconds a read or write may block; zero is forever. */
+            void set_timeout(double seconds) { m_buf->set_timeout(seconds); }
+
+            double get_timeout() const { return m_buf->get_timeout(); }
 
             int get_socket() { return m_buf->get_socket(); }
             

--- a/jlib/sys/sys.cc
+++ b/jlib/sys/sys.cc
@@ -24,6 +24,7 @@
 #include <cerrno>
 #include <jlib/sys/tfstream.hh>
 
+#include <atomic>
 #include <map>
 #include <mutex>
 #include <thread>
@@ -66,6 +67,32 @@ namespace jlib {
                 return i == g_registry.end() ? nullptr : &i->second;
             }
 
+        }
+
+        namespace {
+
+            // Not a mutex-guarded pair: these are set once at startup if they
+            // are set at all, and an atomic read on every connect is cheaper
+            // than a lock.
+            std::atomic<double> g_connect_timeout{30.0};
+            std::atomic<double> g_io_timeout{0.0};
+
+        }
+
+        void set_default_connect_timeout(double seconds) {
+            g_connect_timeout.store(seconds < 0 ? 0 : seconds);
+        }
+
+        double get_default_connect_timeout() {
+            return g_connect_timeout.load();
+        }
+
+        void set_default_io_timeout(double seconds) {
+            g_io_timeout.store(seconds < 0 ? 0 : seconds);
+        }
+
+        double get_default_io_timeout() {
+            return g_io_timeout.load();
         }
 
         void nosigpipe(int fd) {

--- a/jlib/sys/sys.hh
+++ b/jlib/sys/sys.hh
@@ -105,6 +105,38 @@ namespace jlib {
 #endif
         };
 
+        /**
+         * How long a connect() may take before it is given up on, in seconds.
+         *
+         * Until this existed every socket in the library connected with no
+         * timeout at all, so a host that accepted the SYN and then said nothing
+         * -- a firewall configured to drop rather than reject is the ordinary
+         * way to get one -- hung the caller until the kernel's own retry limit
+         * ran out, which is minutes.  A mail client freezing on startup with no
+         * output is exactly that.
+         *
+         * Zero means wait forever, which is the old behaviour.
+         */
+        void set_default_connect_timeout(double seconds);
+        double get_default_connect_timeout();
+
+        /**
+         * How long a read or write on a connected socket may block, in seconds.
+         *
+         * Zero -- the default, and deliberately so -- means forever.  A read
+         * timeout cannot be turned on library-wide without breaking the callers
+         * that are *supposed* to sit on a quiet socket: Imap4::idle() waits on
+         * an IMAP IDLE for as long as the server keeps it open, which is up to
+         * 29 minutes by RFC 2177, and there is no value here that is both long
+         * enough for that and short enough to be useful anywhere else.
+         *
+         * So it is off by default and the caller that knows its own protocol
+         * turns it on, either here or per-socket with
+         * basic_socketbuf::set_timeout().  The HTTP client does.
+         */
+        void set_default_io_timeout(double seconds);
+        double get_default_io_timeout();
+
         void getline(std::istream& is, std::string& s);
 
         /**

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -63,6 +63,7 @@ TESTS = \
  \
 	sys_sync_test \
 	sys_run_test \
+	sys_socket_test \
  \
 	util_test \
 	util_codec_test \
@@ -167,6 +168,9 @@ sys_run_test_LDADD              = $(JSYS_LA) $(JUTIL_LA)
 
 sys_sync_test_SOURCES = sys_sync_test.cc
 sys_sync_test_LDADD   = $(JSYS_LA)
+
+sys_socket_test_SOURCES = sys_socket_test.cc
+sys_socket_test_LDADD   = $(JSYS_LA)
 
 util_test_SOURCES = util_test.cc
 util_test_LDADD   = $(JUTIL_LA)

--- a/tests/sys_socket_test.cc
+++ b/tests/sys_socket_test.cc
@@ -1,0 +1,239 @@
+/* -*- mode: C++ c-basic-offset: 4 -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// The four things basic_socketbuf could not do until now.
+//
+// It could connect, and that was all: no accepting end at all, an IPv4-only
+// resolver, no deadline on connect(), and no way to bound a read.  Each section
+// here is an assertion that could not have been written against the old code,
+// in two cases because the API was missing and in two because the behaviour was
+// "block until something else gives up".
+//
+// Entirely local -- a loopback listener in this same process -- except for the
+// black-hole section, which needs an address that is guaranteed not to answer
+// and takes RFC 5737's TEST-NET-1 for it.
+
+#include <jlib/sys/listener.hh>
+#include <jlib/sys/socketstream.hh>
+#include <jlib/sys/sys.hh>
+
+#include <chrono>
+#include <iostream>
+#include <memory>
+#include <string>
+
+static int failures = 0;
+
+static void ok(const std::string& what, bool good, const std::string& detail = "") {
+    if(!good) ++failures;
+    std::cout << (good ? "  ok   " : "  FAIL ") << what;
+    if(!detail.empty()) std::cout << ": " << detail;
+    std::cout << "\n";
+}
+
+static double seconds_since(std::chrono::steady_clock::time_point t) {
+    return std::chrono::duration<double>(std::chrono::steady_clock::now() - t).count();
+}
+
+// A listener and a client connected to it, both in this process.
+//
+// No thread and no fork, because none is needed: the kernel completes the
+// three-way handshake out of the listen backlog, so the connect returns before
+// anything calls accept().  That is worth saying because it is the reason this
+// test is not the fork-and-hope shape sys_tls_sigpipe_test has to use.
+struct pair {
+    jlib::sys::listener server;
+    jlib::sys::socketstream client;
+    std::unique_ptr<jlib::sys::socketstream> peer;
+
+    pair() : server(), client("127.0.0.1", server.port()) {
+        peer = server.accept_stream(5);
+    }
+};
+
+static void a_listener_accepts_a_connection() {
+    std::cout << "a listener accepts a connection\n";
+
+    try {
+        pair p;
+
+        ok("the kernel picked a port", p.server.port() != 0,
+           std::to_string(p.server.port()));
+
+        if(!p.peer) {
+            ok("accept returned a stream", false, "timed out");
+            return;
+        }
+
+        ok("accept returned a stream", true);
+
+        p.client << "from the client\n" << std::flush;
+
+        std::string line;
+        std::getline(*p.peer, line);
+        ok("what the client wrote arrives at the server", line == "from the client", line);
+
+        *p.peer << "and back again\n" << std::flush;
+
+        std::getline(p.client, line);
+        ok("and the other way", line == "and back again", line);
+    }
+    catch(std::exception& e) {
+        ok("a loopback pair can be set up", false, e.what());
+    }
+}
+
+static void a_connect_that_will_never_answer_gives_up() {
+    std::cout << "a connect that will never answer gives up\n";
+
+    // 192.0.2.0/24 is TEST-NET-1 (RFC 5737): reserved for documentation, so
+    // nothing routes it and nothing answers.  Measured on a machine with no
+    // deadline, a blocking connect(2) here takes 75 seconds to give up, which
+    // is what the old code did on every call.
+    //
+    // The port is deliberately not 80.  A black hole is a property of the
+    // port, not of the address: middleboxes intercept the ports they know --
+    // consumer VPNs and captive portals both do it -- and answer the SYN
+    // themselves for those, wherever they are addressed.  That was found here
+    // on the first run of this test, over a commercial VPN, and measured:
+    //
+    //   80, 443, 8080, 53   connect in 40ms, to any address at all
+    //   8000, 22, 993, 9999 time out, which is the real behaviour
+    //   25                  refused outright (the VPN blocks outbound SMTP)
+    //
+    // Nothing is on the far end of the ones that connect.  Writing to
+    // 192.0.2.1:80 succeeds and is then followed by twelve seconds of silence
+    // and a clean EOF -- the middlebox accepts our handshake at once, goes off
+    // to reach the destination, and closes when it cannot.  Which is a good
+    // demonstration of why a connect deadline is not sufficient on its own and
+    // why the last section here exists: those twelve seconds end in an eof()
+    // that a caller with no timed_out() would read as a complete response.
+    const auto start = std::chrono::steady_clock::now();
+    bool threw = false;
+
+    try {
+        jlib::sys::socketstream sock("192.0.2.1", 9999, 2.0);
+    }
+    catch(std::exception&) {
+        threw = true;
+    }
+
+    const double took = seconds_since(start);
+
+    if(!threw) {
+        // Somebody on the path is answering for an address that has no host,
+        // so there is no black hole to time out against and nothing to assert.
+        std::cout << "  skip  this network answers for TEST-NET-1; no black hole to test\n";
+        return;
+    }
+
+    ok("it fails rather than connecting", threw);
+    ok("and it does so within the timeout, not the kernel's", took < 10.0,
+       std::to_string(took) + "s");
+}
+
+static void an_ipv6_literal_resolves() {
+    std::cout << "an IPv6 literal resolves\n";
+
+    // gethostbyname could not do this at all: it is AF_INET only, so "::1"
+    // came back as an unresolvable name and every v6-only host was simply
+    // unreachable from jlib.  Skipped rather than failed where the machine has
+    // no IPv6, which some container networks do not.
+    std::unique_ptr<jlib::sys::listener> server;
+
+    try {
+        server = std::make_unique<jlib::sys::listener>(0, "::1");
+    }
+    catch(std::exception& e) {
+        std::cout << "  skip  no IPv6 loopback on this host: " << e.what() << "\n";
+        return;
+    }
+
+    try {
+        jlib::sys::socketstream client("::1", server->port());
+        std::unique_ptr<jlib::sys::socketstream> peer = server->accept_stream(5);
+
+        ok("a connection over IPv6 is accepted", peer != nullptr);
+
+        if(peer) {
+            client << "v6\n" << std::flush;
+
+            std::string line;
+            std::getline(*peer, line);
+            ok("and carries data", line == "v6", line);
+        }
+    }
+    catch(std::exception& e) {
+        ok("a connection over IPv6 is accepted", false, e.what());
+    }
+}
+
+static void a_read_can_be_bounded() {
+    std::cout << "a read can be bounded\n";
+
+    try {
+        pair p;
+
+        if(!p.peer) {
+            ok("the pair is up", false, "accept timed out");
+            return;
+        }
+
+        // The peer is connected and says nothing, which is what a hung server
+        // looks like from here.  Without a timeout this getline never returns.
+        p.client.set_timeout(0.5);
+
+        const auto start = std::chrono::steady_clock::now();
+        std::string line;
+        std::getline(p.client, line);
+        const double took = seconds_since(start);
+
+        ok("the read returns", took < 5.0, std::to_string(took) + "s");
+        ok("it took about as long as it was told to", took >= 0.4,
+           std::to_string(took) + "s");
+        ok("and says it timed out rather than that the peer closed",
+           p.client.timed_out());
+
+        // The distinction matters: a streambuf can only answer eof(), so
+        // without timed_out() a caller has no way to tell a slow server from a
+        // finished one, and would treat a stall as a clean end of response.
+        ok("the connection is still open", p.peer->good());
+    }
+    catch(std::exception& e) {
+        ok("a bounded read works", false, e.what());
+    }
+}
+
+int main() {
+    a_listener_accepts_a_connection();
+    a_connect_that_will_never_answer_gives_up();
+    an_ipv6_literal_resolves();
+    a_read_can_be_bounded();
+
+    // What a green run does not establish: that the connect timeout is
+    // enforced by anything but poll(2) on this one host.  A firewall that
+    // DROPs is the case it was written for and TEST-NET-1 is only a stand-in
+    // for one -- on a network that returns ICMP unreachable for it, the
+    // section passes without the deadline ever being reached.  Nor does it say
+    // anything about SO_SNDTIMEO: bounding a write needs a peer that has
+    // stopped reading and a full socket buffer, which is a megabyte of data
+    // and a lot of patience for what it would prove.
+    std::cout << (failures ? "FAILED" : "PASSED") << ": " << failures << " failure(s)\n";
+    return failures ? 1 : 0;
+}

--- a/tests/sys_tls_sigpipe_test.cc
+++ b/tests/sys_tls_sigpipe_test.cc
@@ -36,6 +36,7 @@
 // genuinely trusted for this run.
 #include "certificate.hh"
 
+#include <jlib/sys/listener.hh>
 #include <jlib/sys/sslstream.hh>
 #include <jlib/sys/sys.hh>
 
@@ -54,6 +55,7 @@
 #include <cstdio>
 #include <cstring>
 #include <iostream>
+#include <memory>
 #include <string>
 
 static int failures = 0;
@@ -63,29 +65,6 @@ static void check(const char* what, long got, long want) {
     if(!ok) ++failures;
     std::cout << (ok ? "  ok   " : "  FAIL ") << what
               << ": got " << got << ", expected " << want << "\n";
-}
-
-static int listener(unsigned short* port) {
-    const int fd = ::socket(AF_INET, SOCK_STREAM, 0);
-    if(fd < 0) return -1;
-
-    int on = 1;
-    ::setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &on, sizeof(on));
-
-    struct sockaddr_in a;
-    std::memset(&a, 0, sizeof(a));
-    a.sin_family = AF_INET;
-    a.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
-    a.sin_port = 0;
-
-    if(::bind(fd, reinterpret_cast<struct sockaddr*>(&a), sizeof(a)) < 0) return -1;
-    if(::listen(fd, 1) < 0) return -1;
-
-    socklen_t len = sizeof(a);
-    if(::getsockname(fd, reinterpret_cast<struct sockaddr*>(&a), &len) < 0) return -1;
-
-    *port = ntohs(a.sin_port);
-    return fd;
 }
 
 int main() {
@@ -100,13 +79,22 @@ int main() {
     // What the client will trust, and only for this run.
     ::setenv("SSL_CERT_FILE", cert.c_str(), 1);
 
-    unsigned short port = 0;
-    const int lfd = listener(&port);
-    if(lfd < 0) {
-        std::cerr << "could not set up a loopback socket, skipping" << std::endl;
+    // This used to be twenty lines of socket/bind/listen/getsockname written
+    // out here.  sys::listener is that code, generalised, and this is the
+    // caller it was generalised from.
+    std::unique_ptr<jlib::sys::listener> l;
+
+    try {
+        l = std::make_unique<jlib::sys::listener>();
+    }
+    catch(std::exception& e) {
+        std::cerr << "could not set up a loopback socket, skipping: " << e.what() << std::endl;
         std::remove(cert.c_str()); std::remove(key.c_str());
         return 77;
     }
+
+    const unsigned short port = l->port();
+    const int lfd = l->get_socket();
 
     const pid_t pid = ::fork();
     if(pid < 0) {
@@ -147,7 +135,7 @@ int main() {
         SSL_CTX_use_certificate_file(ctx, cert.c_str(), SSL_FILETYPE_PEM);
         SSL_CTX_use_PrivateKey_file(ctx, key.c_str(), SSL_FILETYPE_PEM);
 
-        const int peer = ::accept(lfd, 0, 0);
+        const int peer = l->accept();
         if(peer >= 0) {
             SSL* ssl = SSL_new(ctx);
             if(ssl) {
@@ -163,7 +151,7 @@ int main() {
         SSL_CTX_free(ctx);
     }
 
-    ::close(lfd);
+    l->close();
 
     int status = 0;
     ::waitpid(pid, &status, 0);


### PR DESCRIPTION
# Foundations for HTTP: an accepting end, getaddrinfo, and deadlines

The first branch of the HTTP/OAuth2 work, and the only one that touches nothing
above `jlib::sys`. Everything here is independently justified -- each item is a
gap that has been in the library since 2000 -- but the reason to do it now is
that an OAuth2 authorization-code flow needs all four.

## What was missing

**There was no accepting end.** No `bind`, no `listen`, no `accept` anywhere in
the tree, and `basic_socketbuf` had exactly one constructor, which connected.
jlib could be a client and nothing else. Two things want the other end: the
OAuth2 redirect that a browser makes to `http://127.0.0.1:<port>/`, and the
tests, which have been hand-rolling `socket`/`bind`/`listen`/`getsockname`
inline -- `sys_tls_sigpipe_test` had twenty lines of it.

**`gethostbyname` was still there** (`socketstream.hh:192`), with both of its
well-known problems live. It is `AF_INET` only, so a name with only an AAAA
record did not resolve at all; and it returns a pointer to static storage, so
two of the threaded `AS*` mailboxes resolving at the same time overwrite each
other's answer and one of them connects somewhere it never asked for.

**Nothing had a deadline.** `connect(2)` was called blocking, so a host that
swallows the SYN -- a firewall configured to DROP rather than REJECT, which is
the ordinary way to get one -- hung the caller until the kernel's own retry
limit ran out. Measured on this branch: 75 seconds. There was no `SO_RCVTIMEO`
either, so a server that accepted the connection and then said nothing hung it
forever.

## What is here

`sys::listener` (`jlib/sys/listener.{hh,cc}`) -- bind, listen, accept, and
`accept_stream()` which hands the connection back as a `socketstream`. It binds
loopback by default, not `INADDR_ANY`, because a receiver for a browser redirect
that is reachable from the network receives authorization codes from the
network. Port 0 asks the kernel to pick, and `port()` says which, which is what
both a test and a redirect URI need. `accept()` takes a timeout and returns -1
when it expires rather than throwing: a caller polling while the user is still
typing their password at the identity provider expects that, and everything else
does throw.

`basic_socketbuf(sys::adopt, fd, ...)` -- the constructor that takes an
already-connected descriptor. A tag rather than an overload, because the fd is
an `int` and so is a port, and `socketbuf(host, 5)` meaning two different things
depending on the type of its first argument is the kind of thing that compiles
and then does not work.

`getaddrinfo` in `open_socket`, trying every address the name has in the order
the resolver gave them -- RFC 6724 order -- so one unreachable AAAA is no longer
the whole connection.

`connect_within()`, which is `connect(2)` with a deadline: non-blocking for the
duration, `poll(POLLOUT)`, then `getsockopt(SO_ERROR)` -- because POLLOUT says
the connect *finished*, not that it succeeded, and a refused connection is also
writable. The descriptor is put back to blocking afterwards, so callers get an
ordinary socket either way. Default 30s, settable with
`sys::set_default_connect_timeout()`.

`set_timeout()` and `timed_out()` on the buf and the stream, over `SO_RCVTIMEO`
and `SO_SNDTIMEO`. `timed_out()` earns its place: a streambuf can only ever
answer `eof()`, so without it a caller cannot tell a slow server from a finished
one and would read a stall as a clean end of response.

**The default I/O timeout is zero -- off -- and that is deliberate.** A read
timeout cannot be turned on library-wide without breaking the callers that are
*supposed* to sit on a quiet socket: `Imap4::idle()` waits on an IMAP IDLE for
as long as the server holds it open, which RFC 2177 puts at up to 29 minutes,
and there is no single value that is both long enough for that and short enough
to be useful anywhere else. So the protocol that knows its own timing turns it
on. The HTTP client will.

Also fixed on the way past: a constructor that threw got no destructor, so the
two 1024-byte buffers it had just allocated were lost. A failing connect is the
ordinary case for a mail client retrying a server that is down, so that leaked
once a minute rather than once ever.

## The dead `http::` stubs are gone

`net.hh` declared `http::Request`, `http::Response` and `http::request()`. None
of the three was defined anywhere in the tree -- no constructor, no
`get_text()`, no `request()`. Twenty-odd years of a header promising an HTTP
client that did not exist, the same shape as the IMAP command stubs and
`Pop3::retrieve()`.

They are deleted rather than kept as a sketch, because the sketch had already
started to constrain the real thing: `Request` held a `util::Headers`, which is
an RFC 5322 header set that RFC 2047-decodes every value it is given, and HTTP
fields are not that. `http::get()` stays for now -- it is the only thing in the
namespace that ever ran -- with a comment saying why it is not usable for this
work: HTTP/1.0, plaintext only, and any status but 200 is an error, so it can
neither follow a redirect nor read the body of a 400, which is exactly what a
token endpoint answers with when it has something to tell you.

## Tests

`tests/sys_socket_test.cc`, four sections, each an assertion that could not have
been written against the old code -- two because the API was missing and two
because the behaviour was "block until something else gives up":

- a loopback listener accepts a connection and data goes both ways. No thread
  and no fork: the kernel completes the handshake out of the listen backlog, so
  the connect returns before anything calls `accept()`;
- a connect to an address that does not answer gives up on *our* deadline
  (2.00s) rather than the kernel's (75s);
- an IPv6 literal resolves, connects and carries data -- which `gethostbyname`
  could not do at all. Skipped where the host has no IPv6;
- a read against a peer that says nothing returns on time and reports
  `timed_out()`, with the connection still open afterwards.

`sys_tls_sigpipe_test` now uses `sys::listener` instead of its own twenty lines.
That is the caller the class was generalised from, so it is also the regression
test for it.

**One thing this branch found, which is worth writing down.** The black-hole
section first used `192.0.2.1:80`, and it connected -- in 40 milliseconds, to an
address in RFC 5737's TEST-NET-1, which by definition has no host.

Run down over a commercial VPN, which is what this machine was on: a black hole
is a property of the *port*, not of the address. Ports 80, 443, 8080 and 53
connect in 40ms to any address at all; 8000, 22, 993 and 9999 time out; 25 is
refused outright, the VPN blocking outbound SMTP. A traceroute confirms the
packets do leave the machine and die past the VPN's exit, so the SYN-ACK is
manufactured somewhere on the tunnel, not by the local stack.

Nothing is behind the ports that answer. Writing to `192.0.2.1:80` succeeds and
is followed by twelve seconds of silence and a clean EOF -- the middlebox
accepts the handshake at once, goes off to reach the destination, and closes
when it cannot. Port 53 does the same with a two-second deadline of its own.

That is worth having as a live example, because it is the case a connect
deadline **cannot** catch: a read stall wearing a successful connect's clothes.
It is what the fourth test section covers and it is the argument for
`timed_out()` existing at all -- without it, those twelve seconds end in an
`eof()` that a caller reads as a complete response.

The test uses port 9999 and says all of this in a comment; it also skips rather
than fails if even that connects, since a network that answers for a nonexistent
host offers nothing to time out against.

**What a green run does not establish.** That the connect deadline is enforced
by anything but `poll(2)` on the two hosts it ran on -- TEST-NET-1 is a stand-in
for a DROPping firewall, not one. And nothing at all about `SO_SNDTIMEO`:
bounding a write needs a peer that has stopped reading and a full socket buffer,
which is a megabyte of data and a lot of patience for what it would prove.

macOS: 46 pass, 3 skip, 0 fail. Linux container: 49 pass, 1 skip, 0 fail.
