### PR TITLE
Drive RFC 3501's AUTHENTICATE exchange, including the cancel that keeps the connection usable

### DIFF
--- a/jlib/net/Imap4.cc
+++ b/jlib/net/Imap4.cc
@@ -569,13 +569,25 @@ namespace jlib {
             bool idle = (data == "IDLE");
 
             if(getenv("JLIB_NET_IMAP4_DEBUG")) {
-                if(util::upper(data.substr(0,5)).find("LOGIN") == 0) {
+                // Two commands carry a credential in an argument, and the
+                // masking here knew about one of them.  AUTHENTICATE's
+                // argument is a base64 SASL message: under PLAIN that is the
+                // password and under XOAUTH2 it is a bearer token, either of
+                // which printed in full to stdout is worse than the password
+                // this was written to hide.  Both are cut to their first
+                // argument -- the username, or the mechanism name.
+                const std::string verb = util::upper(util::tokenize(data).empty()
+                                                     ? std::string()
+                                                     : util::tokenize(data)[0]);
+
+                if(verb == "LOGIN" || verb == "AUTHENTICATE") {
                     std::vector<std::string> tok = util::tokenize(data);
+
                     if(tok.size() >= 2) {
                         std::cout << tag()<<" "<<tok[0] << " " << tok[1] << " ********"<<std::endl;
                     }
                     else {
-                        std::cout << tag() << "LOGIN **** ********"<<std::endl;
+                        std::cout << tag() << " " << verb << " **** ********"<<std::endl;
                     }
                 }
                 else {
@@ -742,8 +754,152 @@ namespace jlib {
             handshake(sock,"LOGOUT");
             m_state = UnConnected;
         }
-        void Imap4::authenticate(sys::socketstream& sock, const std::string& name) {
-            handshake(sock,"AUTHENTICATE "+name);
+        void Imap4::authenticate(sys::socketstream& sock, const std::string& name,
+                                 const sasl_responder& respond)
+        {
+            // Not through handshake() or command(): both loop until a tagged
+            // response and neither can answer a "+", which is the whole of
+            // this exchange.
+            const std::string com = tag(1) + " AUTHENTICATE " + name;
+
+            if(getenv("JLIB_NET_IMAP4_DEBUG")) std::cout << com << std::endl;
+
+            sock << com << ENDL << std::flush;
+
+            // A server that keeps issuing challenges and a responder that
+            // keeps answering the same thing would spin here forever.  No
+            // mechanism jlib speaks needs more than two rounds; the cap is
+            // loose enough not to matter and finite, which is the point.
+            const int MAX_ROUNDS = 8;
+            int rounds = 0;
+
+            std::vector<std::string> capabilities;
+
+            for(;;) {
+                const std::string raw = imap::read(sock);
+
+                if(getenv("JLIB_NET_IMAP4_DEBUG")) std::cout << raw;
+
+                imap::response r;
+
+                try {
+                    r = imap::response::parse(raw);
+                }
+                catch(imap::error& e) {
+                    // Unparseable mid-exchange: the connection is no longer at
+                    // a known boundary, so cancelling would only add to the
+                    // confusion.  Say so and let the caller drop it.
+                    throw exception(std::string("AUTHENTICATE: ") + e.what());
+                }
+
+                if(r.type() == imap::response::kind::continuation) {
+                    std::string answer;
+
+                    if(++rounds > MAX_ROUNDS) {
+                        cancel_authenticate(sock);
+
+                        throw exception("AUTHENTICATE " + name + ": the server is still "
+                                        "challenging after " + util::valueOf(MAX_ROUNDS) +
+                                        " rounds");
+                    }
+
+                    try {
+                        // 6.2.2: the challenge is base64.  Decoded here so a
+                        // responder sees the mechanism's own bytes -- the JSON
+                        // error blob XOAUTH2 sends on failure, for one --
+                        // rather than having to know the encoding.
+                        answer = respond(util::base64::decode(r.text()));
+                    }
+                    catch(...) {
+                        // The responder gave up.  Cancelling is not politeness:
+                        // without it the server is still waiting for a line,
+                        // and the next command sent on this socket is read as
+                        // the answer to this challenge.
+                        cancel_authenticate(sock);
+                        throw;
+                    }
+
+                    sock << util::base64::encode(answer) << ENDL << std::flush;
+
+                    if(getenv("JLIB_NET_IMAP4_DEBUG"))
+                        std::cout << "<" << answer.length() << " octets of "
+                                  << name << " response elided>" << std::endl;
+
+                    continue;
+                }
+
+                if(r.type() == imap::response::kind::untagged) {
+                    if(r.name() == "CAPABILITY") capabilities = r.capabilities();
+
+                    continue;
+                }
+
+                if(!r.ok()) throw exception(r.text());
+
+                // 6.2.2: the capability list changes on authentication, and a
+                // client that goes on using the one it took before is reading
+                // stale advertising -- LOGINDISABLED and the AUTH= mechanisms
+                // are exactly what drops off it.  A server may hand the new
+                // one back in the tagged OK's response code, or as an untagged
+                // response during the exchange; failing both, the cache is
+                // cleared rather than kept, and capability() will fetch it.
+                if(util::ibegins(r.code(), "CAPABILITY ")) {
+                    m_capabilities = util::tokenize(r.code().substr(11));
+                }
+                else {
+                    m_capabilities = capabilities;
+                }
+
+                m_state = Authenticated;
+
+                return;
+            }
+        }
+
+        void Imap4::cancel_authenticate(sys::socketstream& sock) {
+            if(getenv("JLIB_NET_IMAP4_DEBUG")) std::cout << "*" << std::endl;
+
+            sock << "*" << ENDL << std::flush;
+
+            // Read to the tagged completion -- which is a BAD, since the
+            // exchange was cancelled -- so the connection is left at a
+            // response boundary and stays usable.  Anything thrown in here is
+            // swallowed: this runs while another exception is on its way out,
+            // and that one is the interesting one.
+            try {
+                for(;;) {
+                    const imap::response r = imap::response::parse(imap::read(sock));
+
+                    if(r.type() == imap::response::kind::tagged) return;
+
+                    // A second continuation after a cancel would mean the
+                    // server did not take it; there is nothing further to try.
+                    if(r.type() == imap::response::kind::continuation) return;
+                }
+            }
+            catch(...) {
+            }
+        }
+
+        void Imap4::authenticate_plain(sys::socketstream& sock,
+                                       const std::string& user,
+                                       const std::string& pass)
+        {
+            const std::string u = user.empty() && pass.empty() ? m_user : user;
+            const std::string p = user.empty() && pass.empty() ? m_pass : pass;
+
+            // RFC 4616 2: the three fields are separated by NUL, so a NUL in
+            // any of them makes the message mean something else.  The RFC
+            // forbids it outright; refusing beats sending a credential that
+            // has been silently cut in half.
+            if(u.find('\0') != std::string::npos || p.find('\0') != std::string::npos) {
+                throw exception("AUTHENTICATE PLAIN: a NUL in the username or "
+                                "password would change where the fields end");
+            }
+
+            authenticate(sock, "PLAIN", [&u, &p](const std::string&) {
+                return std::string(1, '\0') + u + std::string(1, '\0') + p;
+            });
         }
         void Imap4::login(sys::socketstream& sock, const std::string& user, const std::string& pass) {
             // RFC 3501 6.2.3: a server advertising LOGINDISABLED will refuse

--- a/jlib/net/Imap4.hh
+++ b/jlib/net/Imap4.hh
@@ -28,6 +28,7 @@
 #include <jlib/net/imap_response.hh>
 
 #include <cstddef>
+#include <functional>
 #include <vector>
 #include <mutex>
 #include <map>
@@ -131,6 +132,15 @@ namespace jlib {
             bool has_capability(const std::string& name) const;
 
             /**
+             * Which of RFC 3501 3's four states the connection is in.
+             *
+             * There was no way to ask before -- m_state was written by half
+             * the commands here and read by nobody, which is how
+             * authenticate() came to not set it without anything noticing.
+             */
+            State state() const { return m_state; }
+
+            /**
              * Negotiate STARTTLS on an already-connected plaintext stream.
              *
              * Called by connect() when ?tls=starttls was asked for.  Throws if
@@ -183,13 +193,75 @@ namespace jlib {
 
 
             // 6.2.    Client Commands - Non-Authenticated State
+
+            /**
+             * What answers a SASL challenge.
+             *
+             * Called once per "+" continuation with the server's challenge
+             * already base64-decoded, and returns the client's answer in the
+             * clear -- the driver encodes it.  Returning "" sends an empty
+             * line, which is what a mechanism's final round wants.
+             *
+             * Throwing cancels the exchange: the driver sends the "*" of RFC
+             * 3501 6.2.2, waits for the tagged completion so the connection is
+             * left at a response boundary, and then rethrows.  That is the
+             * point of doing it this way -- a responder that cannot produce an
+             * answer must not just stop talking, because a half-finished
+             * AUTHENTICATE leaves the server waiting for a line and every
+             * later command reads someone else's response.
+             */
+            typedef std::function<std::string(const std::string& challenge)> sasl_responder;
+
             /**
              * The AUTHENTICATE command indicates an authentication mechanism,
              * such as described in [IMAP-AUTH], to the server.
              *
-             * @param name authentication mechanism name
-             */ 
-            void authenticate(jlib::sys::socketstream& sock, const std::string& name);
+             * RFC 3501 6.2.2's exchange, driven to completion: the command
+             * goes out, each "+" continuation is handed to respond(), and the
+             * tagged completion ends it.  A NO or BAD throws, as everywhere
+             * else here.
+             *
+             * What was here before sent the command through handshake(),
+             * which loops until it sees a tagged response -- and a
+             * continuation is not one, so it blocked forever on the first "+"
+             * the server sent.  It never set m_state either.  Nothing called
+             * it, which is the only reason that was not noticed.
+             *
+             * command() cannot be used for this: it treats a continuation as
+             * neither tagged nor untagged and reads straight past it, which
+             * is the same hang one layer down.
+             *
+             * @param name    authentication mechanism name
+             * @param respond what answers each challenge
+             */
+            void authenticate(jlib::sys::socketstream& sock, const std::string& name,
+                              const sasl_responder& respond);
+
+            /**
+             * AUTHENTICATE PLAIN, per RFC 4616.
+             *
+             * The message is authzid NUL authcid NUL password with an empty
+             * authzid.  Worth having over LOGIN even with the same credentials
+             * on the wire: it is the mechanism a server advertises as
+             * AUTH=PLAIN, some servers set LOGINDISABLED and offer only this,
+             * and it is the same driver XOAUTH2 will use.
+             *
+             * Empty arguments take the URL's user and password, as login()
+             * does.
+             */
+            void authenticate_plain(jlib::sys::socketstream& sock,
+                                    const std::string& user = "",
+                                    const std::string& pass = "");
+
+            /**
+             * Cancel an AUTHENTICATE in progress and leave the socket usable.
+             *
+             * RFC 3501 6.2.2's "*", followed by a read to the tagged
+             * completion.  Public because a caller driving authenticate() with
+             * its own responder may want it, but the driver calls it for you
+             * whenever the responder throws.
+             */
+            void cancel_authenticate(jlib::sys::socketstream& sock);
 
             /**
              * The LOGIN command identifies the user to the server and carries

--- a/jlib/net/net.cc
+++ b/jlib/net/net.cc
@@ -672,6 +672,51 @@ namespace jlib {
                 return ret;
             }
 
+            /**
+             * Whether an EHLO reply advertises a SASL mechanism.
+             *
+             * RFC 4954 4: the keyword is AUTH and the mechanisms follow it,
+             * space-separated -- and a server may list them over more than one
+             * line, which is where this went wrong.  What was here walked the
+             * reply, stopped at the *first* line beginning "AUTH", and threw
+             * unless that one line mentioned PLAIN.  So a server answering
+             *
+             *     250-AUTH GSSAPI
+             *     250-AUTH PLAIN LOGIN
+             *
+             * was rejected outright for not supporting an authentication
+             * mechanism it was in the middle of offering.
+             *
+             * It also matched with find(), so "AUTH XPLAINTEXT" counted as
+             * PLAIN.  The comparison is whole tokens now.
+             *
+             * The "AUTH=PLAIN" spelling is here too: it is not in the RFC, it
+             * is what a generation of servers emitted alongside the real line
+             * for a broken client of the day, and refusing to read it costs
+             * nothing.
+             */
+            bool has_auth_mechanism(const std::list<std::string>& lines, const std::string& want) {
+                const std::string upper_want = util::upper(want);
+
+                for(const std::string& line : lines) {
+                    std::vector<std::string> tok = util::tokenize(line);
+
+                    if(tok.empty()) continue;
+
+                    const std::string verb = util::upper(tok[0]);
+
+                    if(verb != "AUTH" && verb.compare(0, 5, "AUTH=") != 0) continue;
+
+                    if(verb.length() > 5 && verb.substr(5) == upper_want) return true;
+
+                    for(std::size_t i = 1; i < tok.size(); i++) {
+                        if(util::upper(tok[i]) == upper_want) return true;
+                    }
+                }
+
+                return false;
+            }
+
             void send_tls(const std::string& mail, const std::string& rcpt, const std::string& data, const std::string& host, unsigned int port) {
                 sys::tlsstream stream(host, port, true);
                 std::list<std::string> r;
@@ -700,20 +745,8 @@ namespace jlib {
                 stream.start();
 
                 r = eshake(stream, "EHLO localhost", "250");
-                bool plain = false;
-                for(std::list<std::string>::iterator i = r.begin(); i != r.end(); i++) {
-                    if(i->find("AUTH") == 0) {
-                        if(i->find("PLAIN") != std::string::npos) {
-                            plain = true;
-                            break;
-                        } else {
-                            throw exception("AUTH option does not include plain: " + (*i));
-                        }
-                    }
-                }
-
-                if(!plain)
-                    throw exception("No AUTH option");
+                if(!has_auth_mechanism(r, "PLAIN"))
+                    throw exception("the server does not offer AUTH PLAIN");
                 
                 std::string token = util::base64::encode(std::string(1, '\0') + user + std::string(1, '\0') + pass);
                 handshake(stream, "AUTH PLAIN " + token, "235");
@@ -726,20 +759,8 @@ namespace jlib {
                 std::list<std::string> r;
 
                 r = eshake(stream, "EHLO localhost", "250");
-                bool plain = false;
-                for(std::list<std::string>::iterator i = r.begin(); i != r.end(); i++) {
-                    if(i->find("AUTH") == 0) {
-                        if(i->find("PLAIN") != std::string::npos) {
-                            plain = true;
-                            break;
-                        } else {
-                            throw exception("AUTH option does not include plain: " + (*i));
-                        }
-                    }
-                }
-
-                if(!plain)
-                    throw exception("No AUTH option");
+                if(!has_auth_mechanism(r, "PLAIN"))
+                    throw exception("the server does not offer AUTH PLAIN");
                 
                 std::string token = util::base64::encode(std::string(1, '\0') + user + std::string(1, '\0') + pass);
                 handshake(stream, "AUTH PLAIN " + token, "235");

--- a/jlib/net/net.hh
+++ b/jlib/net/net.hh
@@ -24,6 +24,7 @@
 #include <string>
 #include <iostream>
 #include <map>
+#include <list>
 #include <vector>
 #include <exception>
 
@@ -159,6 +160,20 @@ namespace jlib {
             void send_tls(const std::string& mail, const std::string& rcpt, const std::string& data, const std::string& host,unsigned int port);
             void send_tls_auth(const std::string& mail, const std::string& rcpt, const std::string& data, const std::string& host,unsigned int port, const std::string& user, const std::string& pass);
             void send_ssl_auth(const std::string& mail, const std::string& rcpt, const std::string& data, const std::string& host,unsigned int port, const std::string& user, const std::string& pass);
+
+            /**
+             * Whether an EHLO reply offers a SASL mechanism.
+             *
+             * @param lines the reply, each line with its "250-" already off,
+             *              as eshake() returns it
+             * @param want  the mechanism, compared case-insensitively and whole
+             *
+             * Exposed because the scan it replaced was wrong in two ways that
+             * only a test can pin down -- it gave up at the first AUTH line,
+             * and it matched substrings -- and neither is reachable from
+             * outside without an SMTP server to answer.
+             */
+            bool has_auth_mechanism(const std::list<std::string>& lines, const std::string& want);
         }
 
         namespace http {

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -55,6 +55,7 @@ TESTS = \
 	net_mbox_crlf_test \
 	net_protocol_test \
 	net_imap_test \
+	net_imap_sasl_test \
 	net_imap_live_test \
 	sys_proxy_live_test \
 	net_pop3_live_test \
@@ -150,6 +151,9 @@ net_imap_live_test_LDADD        = $(JNET_LA) $(JUTIL_LA) $(JSYS_LA) $(OPENSSL_LI
 
 net_imap_test_SOURCES           = net_imap_test.cc
 net_imap_test_LDADD             = $(JNET_LA) $(JUTIL_LA)
+
+net_imap_sasl_test_SOURCES      = net_imap_sasl_test.cc
+net_imap_sasl_test_LDADD        = $(JNET_LA) $(JUTIL_LA) $(JSYS_LA) $(OPENSSL_LIBS)
 
 net_protocol_test_SOURCES       = net_protocol_test.cc
 net_protocol_test_LDADD         = $(JNET_LA) $(JUTIL_LA)

--- a/tests/net_imap_live_test.cc
+++ b/tests/net_imap_live_test.cc
@@ -424,6 +424,84 @@ int main() {
         ok("asking for STARTTLS where it is not offered fails", threw);
     }
 
+    // AUTHENTICATE against a server that decides for itself what it will
+    // accept.  net_imap_sasl_test drives the same code against a scripted
+    // server, which proves the framing; this proves the message.
+    {
+        jlib::util::URL u("imap://joe@127.0.0.1:" + std::to_string(s.port) + "/INBOX");
+
+        u.set_pass(PASSWORD);
+
+        jlib::net::Imap4 imap(u);
+
+        try {
+            std::unique_ptr<jlib::sys::socketstream> sock(imap.connect());
+
+            imap.capability(*sock);
+
+            ok("dovecot offers AUTH=PLAIN", imap.has_capability("AUTH=PLAIN"));
+
+            // The same password as the LOGIN section: a space, a quote and a
+            // backslash.  None of the three means anything inside a SASL
+            // message -- the fields are counted, not delimited -- which is
+            // half the reason to prefer this over LOGIN.
+            imap.authenticate_plain(*sock);
+
+            ok("AUTHENTICATE PLAIN succeeds against a real server",
+               imap.state() == jlib::net::Imap4::Authenticated);
+
+            imap.select(*sock, "INBOX");
+
+            ok("and the session works afterwards", imap.exists() == 2,
+               std::to_string(imap.exists()));
+
+            imap.logout(*sock);
+        }
+        catch(std::exception& e) {
+            ok("AUTHENTICATE PLAIN succeeds against a real server", false, e.what());
+            std::cerr << s.log();
+        }
+    }
+
+    // A mechanism the server has never heard of.  Dovecot answers a tagged NO
+    // without ever sending a continuation, which is the one path the scripted
+    // server cannot claim to have got right by construction.
+    {
+        jlib::util::URL u("imap://joe@127.0.0.1:" + std::to_string(s.port) + "/INBOX");
+
+        u.set_pass(PASSWORD);
+
+        jlib::net::Imap4 imap(u);
+
+        try {
+            std::unique_ptr<jlib::sys::socketstream> sock(imap.connect());
+
+            bool threw = false;
+
+            try {
+                imap.authenticate(*sock, "NOSUCHMECHANISM",
+                                  [](const std::string&) { return std::string(); });
+            }
+            catch(std::exception&) { threw = true; }
+
+            ok("an unknown mechanism is refused", threw);
+
+            // And the connection survives it, which is the assertion that
+            // matters: a client that guesses at mechanisms has to be able to
+            // fall back to the next one on the same socket.
+            imap.authenticate_plain(*sock);
+
+            ok("and the next mechanism works on the same connection",
+               imap.state() == jlib::net::Imap4::Authenticated);
+
+            imap.logout(*sock);
+        }
+        catch(std::exception& e) {
+            ok("and the next mechanism works on the same connection", false, e.what());
+            std::cerr << s.log();
+        }
+    }
+
     // The port it picks when it is not told one.
     ok("imaps:// with no port is still secure",
        jlib::net::Imap4(jlib::util::URL("imaps://joe@localhost/INBOX")).is_secure());
@@ -441,8 +519,9 @@ int main() {
     // Not the commands #85 is about.  SEARCH, UID and a ranged FETCH are still
     // unimplemented; this exercises what was already there.
     //
-    // Not TLS.  imaps:// goes through sys::sslstream, which no test here
-    // reaches -- setting up a certificate Dovecot and OpenSSL both accept is a
-    // branch of its own.
+    // Not the mechanisms that matter for a real account.  AUTH=PLAIN is what
+    // dovecot offers out of the box; XOAUTH2 is what Gmail and Outlook.com
+    // require, and nothing here has ever spoken to either.  The exchange is
+    // the same shape and the credential is not.
     return failures ? 1 : 0;
 }

--- a/tests/net_imap_sasl_test.cc
+++ b/tests/net_imap_sasl_test.cc
@@ -1,0 +1,517 @@
+/* -*- mode: C++ c-basic-offset: 4 -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// RFC 3501 6.2.2's AUTHENTICATE exchange, against a server written here.
+//
+// A scripted server rather than dovecot, for the cases dovecot will not
+// produce on demand: a challenge that arrives in two rounds, a server that
+// challenges forever, a mechanism whose failure is reported as a base64 blob
+// in a continuation rather than as a tagged NO.  Those are the shapes that
+// break a client, and net_imap_live_test covers the ordinary path against a
+// real one.
+//
+// The listener is sys::listener, which did not exist a branch ago; this test
+// is the reason it was worth having.  The server runs on a thread rather than
+// in a fork so it can record what the client actually sent and the assertions
+// can look at it afterwards.
+//
+// What every section here is really testing is the same thing: that after the
+// exchange, however it ended, the connection is still at a response boundary.
+// A client that stops halfway through an AUTHENTICATE leaves the server
+// waiting for a line, and the next command it sends is read as the answer to
+// the challenge -- so every response after that belongs to the command before
+// it.  That is the bug class the literal work fixed, arrived at from the other
+// direction.
+
+#include <jlib/net/Imap4.hh>
+
+#include <jlib/sys/listener.hh>
+#include <jlib/sys/socketstream.hh>
+
+#include <jlib/util/URL.hh>
+#include <jlib/util/util.hh>
+
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace util = jlib::util;
+
+static int failures = 0;
+
+static void ok(const std::string& what, bool good, const std::string& detail = "") {
+    if(!good) ++failures;
+    std::cout << (good ? "  ok   " : "  FAIL ") << what;
+    if(!detail.empty()) std::cout << ": " << detail;
+    std::cout << "\n";
+}
+
+static std::string show(const std::string& s) {
+    std::string out;
+
+    for(char c : s) {
+        if(c == '\r')      out += "\\r";
+        else if(c == '\n') out += "\\n";
+        else if(c == '\0') out += "\\0";
+        else               out += c;
+    }
+
+    return out;
+}
+
+// A server that follows a script.
+//
+// The script is a list of lines to expect and lines to send: each entry sends
+// its reply and then reads one line, which is recorded.  Everything the client
+// sends ends up in sent(), including the "*" of a cancel, which is what most
+// of the assertions here look at.
+class scripted_server {
+public:
+    explicit scripted_server(std::vector<std::string> replies)
+        : m_listener(),
+          m_replies(std::move(replies))
+    {
+        m_thread = std::thread([this] { run(); });
+    }
+
+    ~scripted_server() {
+        m_listener.close();
+
+        if(m_thread.joinable()) m_thread.join();
+    }
+
+    unsigned short port() const { return m_listener.port(); }
+
+    // Safe to call after join(); every section joins by letting the client's
+    // socket close, which ends the server loop.
+    const std::vector<std::string>& sent() {
+        if(m_thread.joinable()) m_thread.join();
+
+        return m_sent;
+    }
+
+private:
+    void run() {
+        try {
+            std::unique_ptr<jlib::sys::socketstream> peer = m_listener.accept_stream(10);
+
+            if(!peer) return;
+
+            *peer << "* OK [CAPABILITY IMAP4rev1 AUTH=PLAIN] ready\r\n" << std::flush;
+
+            for(const std::string& reply : m_replies) {
+                std::string line;
+
+                if(!std::getline(*peer, line)) return;
+
+                while(!line.empty() && line.back() == '\r') line.pop_back();
+
+                m_sent.push_back(line);
+
+                *peer << reply << std::flush;
+            }
+
+            // Anything after the script is still recorded, so a section can
+            // assert that the *next* command got its own response.
+            for(;;) {
+                std::string line;
+
+                if(!std::getline(*peer, line)) return;
+
+                while(!line.empty() && line.back() == '\r') line.pop_back();
+
+                m_sent.push_back(line);
+
+                const std::string tag = util::tokenize(line).empty()
+                                        ? std::string("*") : util::tokenize(line)[0];
+
+                *peer << tag << " OK done\r\n" << std::flush;
+            }
+        }
+        catch(std::exception&) {
+        }
+    }
+
+    jlib::sys::listener m_listener;
+    std::vector<std::string> m_replies;
+    std::vector<std::string> m_sent;
+    std::thread m_thread;
+};
+
+// Every section drives the client through this.
+//
+// The read timeout is the point of it.  A driver that gets the exchange wrong
+// does not fail here, it *deadlocks*: the server is waiting for the line the
+// client owes it and the client is waiting for a response the server will not
+// send until it arrives.  That was confirmed on this branch by taking the "*"
+// out of cancel_authenticate() and running this test, which then hung until it
+// was killed rather than reporting anything.  With the deadline in place the
+// same mutation reports three failures in ten seconds, which is the difference
+// between a test and a hang.
+//
+// A test that hangs on regression is a test that stops make check instead of
+// failing it, so the socket gets a deadline -- sys::socketstream::set_timeout,
+// which is a branch old.  Ten seconds is far longer than a loopback exchange
+// needs and short enough that a broken driver reports rather than waits.
+static std::unique_ptr<jlib::sys::socketstream> connect_to(jlib::net::Imap4& imap) {
+    std::unique_ptr<jlib::sys::socketstream> sock(imap.connect());
+
+    sock->set_timeout(10);
+
+    return sock;
+}
+
+static jlib::util::URL url_for(unsigned short port) {
+    jlib::util::URL u("imap://joe@127.0.0.1:" + std::to_string(port) + "/INBOX");
+
+    u.set_pass("secret");
+
+    return u;
+}
+
+static void plain_is_a_challenge_and_a_response() {
+    std::cout << "\nAUTHENTICATE PLAIN is a challenge and a response:\n";
+
+    // A CAPABILITY first, so the list this asserts about afterwards is one the
+    // client really holds rather than one it never fetched.
+    scripted_server server({ "* CAPABILITY IMAP4rev1 AUTH=PLAIN LOGINDISABLED\r\n"
+                             "A00001 OK capability completed\r\n",
+                             "+ \r\n",
+                             "A00002 OK [CAPABILITY IMAP4rev1] logged in\r\n" });
+
+    jlib::net::Imap4 imap(url_for(server.port()));
+
+    try {
+        std::unique_ptr<jlib::sys::socketstream> sock = connect_to(imap);
+
+        imap.capability(*sock);
+
+        ok("before: the server advertises AUTH=PLAIN and LOGINDISABLED",
+           imap.has_capability("AUTH=PLAIN") && imap.has_capability("LOGINDISABLED"));
+
+        imap.authenticate_plain(*sock, "joe", "secret");
+
+        ok("it completes", true);
+        ok("and leaves the client authenticated",
+           imap.state() == jlib::net::Imap4::Authenticated);
+
+        // 6.2.2: the capability list changes on authentication, which is why
+        // the tagged OK is allowed to carry a new one.  Both of the two that
+        // were there are gone -- and LOGINDISABLED being stale is not
+        // cosmetic, it is login() refusing to send a password the server would
+        // now accept.
+        ok("after: the tagged OK's list replaces it",
+           imap.has_capability("IMAP4rev1") &&
+           !imap.has_capability("AUTH=PLAIN") &&
+           !imap.has_capability("LOGINDISABLED"));
+
+        sock->close();
+    }
+    catch(std::exception& e) {
+        ok("it completes", false, e.what());
+    }
+
+    const std::vector<std::string>& sent = server.sent();
+
+    ok("the command names the mechanism and nothing else",
+       sent.size() >= 2 && sent[1] == "A00002 AUTHENTICATE PLAIN",
+       sent.size() >= 2 ? show(sent[1]) : "");
+
+    if(sent.size() >= 3) {
+        const std::string message = util::base64::decode(sent[2]);
+
+        // RFC 4616 2: authzid NUL authcid NUL passwd, with an empty authzid.
+        ok("the response is the RFC 4616 message, base64",
+           message == std::string("\0joe\0secret", 11), show(message));
+    }
+    else {
+        ok("the response is the RFC 4616 message, base64", false, "nothing was sent");
+    }
+}
+
+static void a_rejected_login_leaves_the_connection_usable() {
+    std::cout << "\na rejected login leaves the connection usable:\n";
+
+    scripted_server server({ "+ \r\n", "A00001 NO [AUTHENTICATIONFAILED] no\r\n" });
+
+    jlib::net::Imap4 imap(url_for(server.port()));
+
+    try {
+        std::unique_ptr<jlib::sys::socketstream> sock = connect_to(imap);
+
+        bool threw = false;
+
+        try {
+            imap.authenticate_plain(*sock, "joe", "wrong");
+        }
+        catch(std::exception&) {
+            threw = true;
+        }
+
+        ok("a tagged NO throws", threw);
+        ok("and the client is not authenticated",
+           imap.state() != jlib::net::Imap4::Authenticated);
+
+        // The point of the section.  If the driver had stopped without
+        // finishing the exchange, this NOOP would be read as the answer to a
+        // challenge and its response would never come.
+        imap.noop(*sock);
+
+        ok("a command afterwards gets its own response", true);
+
+        sock->close();
+    }
+    catch(std::exception& e) {
+        ok("a command afterwards gets its own response", false, e.what());
+    }
+
+    const std::vector<std::string>& sent = server.sent();
+
+    ok("and that command went out under the next tag",
+       sent.size() >= 3 && sent[2] == "A00002 NOOP",
+       sent.size() >= 3 ? show(sent[2]) : "");
+}
+
+static void a_responder_that_gives_up_cancels() {
+    std::cout << "\na responder that gives up cancels the exchange:\n";
+
+    // The mechanism jlib cannot answer -- no credentials, an expired token,
+    // an unparseable challenge.  The client has already sent AUTHENTICATE and
+    // the server is waiting for a line; saying nothing is the one thing it
+    // must not do.
+    scripted_server server({ "+ Zm9v\r\n", "A00001 BAD authentication aborted\r\n" });
+
+    jlib::net::Imap4 imap(url_for(server.port()));
+
+    try {
+        std::unique_ptr<jlib::sys::socketstream> sock = connect_to(imap);
+
+        std::string seen;
+        bool threw = false;
+
+        try {
+            imap.authenticate(*sock, "XOAUTH2",
+                              [&seen](const std::string& challenge) -> std::string {
+                                  seen = challenge;
+
+                                  throw std::runtime_error("no token available");
+                              });
+        }
+        catch(std::exception&) {
+            threw = true;
+        }
+
+        ok("the responder's exception reaches the caller", threw);
+        ok("and it saw the challenge decoded, not as base64", seen == "foo", show(seen));
+
+        imap.noop(*sock);
+
+        ok("a command afterwards gets its own response", true);
+
+        sock->close();
+    }
+    catch(std::exception& e) {
+        ok("a command afterwards gets its own response", false, e.what());
+    }
+
+    const std::vector<std::string>& sent = server.sent();
+
+    ok("the client sent RFC 3501 6.2.2's \"*\"",
+       sent.size() >= 2 && sent[1] == "*", sent.size() >= 2 ? show(sent[1]) : "");
+    ok("and then the next command, under the next tag",
+       sent.size() >= 3 && sent[2] == "A00002 NOOP",
+       sent.size() >= 3 ? show(sent[2]) : "");
+}
+
+static void a_second_challenge_is_answered() {
+    std::cout << "\na second challenge is answered:\n";
+
+    // How XOAUTH2 reports a bad token: not as a tagged NO but as a
+    // continuation carrying a JSON error, and the server will not send the
+    // tagged NO until the client answers it -- with an empty line.  A driver
+    // that handles exactly one round hangs here, holding a socket that looks
+    // alive.
+    const std::string error = "{\"status\":\"401\",\"schemes\":\"Bearer\"}";
+
+    scripted_server server({ "+ \r\n",
+                             "+ " + util::base64::encode(error) + "\r\n",
+                             "A00001 NO invalid credentials\r\n" });
+
+    jlib::net::Imap4 imap(url_for(server.port()));
+
+    try {
+        std::unique_ptr<jlib::sys::socketstream> sock = connect_to(imap);
+
+        std::vector<std::string> challenges;
+        bool threw = false;
+
+        try {
+            imap.authenticate(*sock, "XOAUTH2",
+                              [&challenges](const std::string& challenge) -> std::string {
+                                  challenges.push_back(challenge);
+
+                                  // The first round sends the token; the
+                                  // second acknowledges the error with an
+                                  // empty line, which is what unblocks the
+                                  // tagged NO.
+                                  if(challenges.size() == 1) return "user=joe\001auth=Bearer t\001\001";
+
+                                  return "";
+                              });
+        }
+        catch(std::exception&) {
+            threw = true;
+        }
+
+        ok("two rounds happen", challenges.size() == 2,
+           std::to_string(challenges.size()));
+        ok("the second carries the server's error, decoded",
+           challenges.size() == 2 && challenges[1] == error,
+           challenges.size() == 2 ? challenges[1] : "");
+        ok("and the tagged NO is what throws", threw);
+
+        imap.noop(*sock);
+
+        ok("a command afterwards gets its own response", true);
+
+        sock->close();
+    }
+    catch(std::exception& e) {
+        ok("two rounds happen", false, e.what());
+    }
+
+    const std::vector<std::string>& sent = server.sent();
+
+    ok("the empty response went out as an empty line",
+       sent.size() >= 3 && sent[2].empty(),
+       sent.size() >= 3 ? show(sent[2]) : "");
+}
+
+static void an_endless_challenge_is_not_endless() {
+    std::cout << "\na server that challenges forever does not hang the client:\n";
+
+    // Not a real server, but a client has no way to tell one from a broken one
+    // and "loop until the peer stops" is not a termination argument.
+    std::vector<std::string> replies;
+
+    for(int i = 0; i < 40; i++) replies.push_back("+ \r\n");
+
+    replies.push_back("A00001 BAD enough\r\n");
+
+    scripted_server server(std::move(replies));
+
+    jlib::net::Imap4 imap(url_for(server.port()));
+
+    try {
+        std::unique_ptr<jlib::sys::socketstream> sock = connect_to(imap);
+
+        int rounds = 0;
+        bool threw = false;
+
+        try {
+            imap.authenticate(*sock, "PLAIN", [&rounds](const std::string&) {
+                rounds++;
+
+                return "anything";
+            });
+        }
+        catch(std::exception&) {
+            threw = true;
+        }
+
+        ok("it gives up", threw);
+        ok("after a bounded number of rounds", rounds > 0 && rounds <= 8,
+           std::to_string(rounds));
+
+        sock->close();
+    }
+    catch(std::exception& e) {
+        ok("it gives up", false, e.what());
+    }
+
+    const std::vector<std::string>& sent = server.sent();
+
+    bool cancelled = false;
+
+    for(const std::string& line : sent) {
+        if(line == "*") cancelled = true;
+    }
+
+    ok("and cancels rather than falling silent", cancelled);
+}
+
+static void a_nul_in_a_credential_is_refused() {
+    std::cout << "\na NUL in a credential is refused before it is sent:\n";
+
+    scripted_server server({ "+ \r\n", "A00001 OK in\r\n" });
+
+    jlib::net::Imap4 imap(url_for(server.port()));
+
+    try {
+        std::unique_ptr<jlib::sys::socketstream> sock = connect_to(imap);
+
+        bool threw = false;
+
+        try {
+            // RFC 4616's fields are NUL-separated, so a NUL inside one moves
+            // where the next begins: "joe\0secret" as a username would
+            // authenticate as joe with whatever followed.
+            imap.authenticate_plain(*sock, std::string("jo\0e", 4), "secret");
+        }
+        catch(std::exception&) {
+            threw = true;
+        }
+
+        ok("it throws", threw);
+
+        sock->close();
+    }
+    catch(std::exception& e) {
+        ok("it throws", false, e.what());
+    }
+
+    ok("and nothing at all was sent", server.sent().empty(),
+       std::to_string(server.sent().size()) + " line(s)");
+}
+
+int main() {
+    std::cout << std::unitbuf;
+
+    plain_is_a_challenge_and_a_response();
+    a_rejected_login_leaves_the_connection_usable();
+    a_responder_that_gives_up_cancels();
+    a_second_challenge_is_answered();
+    an_endless_challenge_is_not_endless();
+    a_nul_in_a_credential_is_refused();
+
+    // What a green run does not establish: that a real server accepts what
+    // this sends.  The server here answers what it was scripted to answer, so
+    // it can prove the client's framing is right and cannot prove the
+    // credential is well formed -- net_imap_live_test does that half against
+    // dovecot.  Nor does it say anything about XOAUTH2 beyond the shape of the
+    // exchange: the token in the second section is the literal string "t", and
+    // no provider was asked whether the message around it is what they expect.
+    std::cout << "\n" << (failures ? "FAILED" : "PASSED") << ": " << failures
+              << " failure(s)\n";
+
+    return failures ? 1 : 0;
+}

--- a/tests/net_protocol_test.cc
+++ b/tests/net_protocol_test.cc
@@ -31,6 +31,7 @@
 #include <jlib/net/imap_response.hh>
 
 #include <iostream>
+#include <list>
 #include <sstream>
 #include <string>
 
@@ -59,6 +60,42 @@ static std::string show(const std::string& s) {
     }
 
     return out;
+}
+
+static void smtp_auth_mechanisms() {
+    std::cout << "\nwhich SASL mechanisms an EHLO reply offers:\n";
+
+    using jlib::net::smtp::has_auth_mechanism;
+
+    // The shape that was rejected outright.  RFC 4954 4 does not say the
+    // mechanisms come on one line, and a server is free to spread them; the
+    // scan here stopped at the first AUTH line and threw if PLAIN was not on
+    // that one, so this server -- which does offer PLAIN -- could not be
+    // authenticated to at all.
+    const std::list<std::string> split = { "PIPELINING", "AUTH GSSAPI",
+                                           "AUTH PLAIN LOGIN", "STARTTLS" };
+
+    ok("a mechanism on the second of two AUTH lines is found",
+       has_auth_mechanism(split, "PLAIN"));
+    ok("and one on the first still is", has_auth_mechanism(split, "GSSAPI"));
+    ok("one that is not there is not found", has_auth_mechanism(split, "CRAM-MD5") == false);
+
+    // The other half: find() matched anywhere in the line, so a mechanism
+    // whose name merely contains PLAIN counted as PLAIN.  Comparing whole
+    // tokens is the fix, and this is the case that tells the two apart.
+    ok("a longer name that contains the wanted one does not count",
+       has_auth_mechanism({ "AUTH XPLAINTEXT NTLM" }, "PLAIN") == false);
+
+    ok("the comparison ignores case",
+       has_auth_mechanism({ "auth plain" }, "PLAIN"));
+
+    // Not in the RFC; emitted for years by servers humouring a broken client
+    // of the day, and still emitted by some.  Reading it costs nothing.
+    ok("the old AUTH=PLAIN spelling is read too",
+       has_auth_mechanism({ "AUTH=PLAIN" }, "PLAIN"));
+
+    ok("a reply with no AUTH at all offers nothing",
+       has_auth_mechanism({ "PIPELINING", "STARTTLS" }, "PLAIN") == false);
 }
 
 static void smtp_transparency() {
@@ -222,6 +259,7 @@ static void imap_literals() {
 int main() {
     std::cout << std::unitbuf;
 
+    smtp_auth_mechanisms();
     smtp_transparency();
     pop3_framing();
     imap_literals();


### PR DESCRIPTION
# AUTHENTICATE, driven to completion

The second branch of the HTTP/OAuth2 work, and the one that can be finished
without any HTTP at all. OAuth2 reaches IMAP as a SASL mechanism -- XOAUTH2 --
so the exchange underneath it has to work before the token that goes through it
is worth fetching. It is also the riskiest piece, which is why it is early.

## What was there

`Imap4::authenticate(sock, name)` sent `AUTHENTICATE <name>` through
`handshake()` and **blocked forever**. `handshake()` loops until it sees a
tagged response; a `+` continuation is not one, so the first thing a server says
in this exchange is the thing that hung it. It never set `m_state` either.
Nothing in the tree called it, which is the only reason neither had been
noticed.

`command()` is no better for this: it treats a continuation as neither tagged
nor untagged and reads straight past it, which is the same hang one layer down.
So SASL needed its own driver, and this is it.

## The abort path is the point

The happy path is four lines. What makes this worth a branch is what happens
when it does not work.

The client has sent `AUTHENTICATE` and the server has answered `+`. The server
is now waiting for a line and will not say anything else until it gets one. A
client that discovers at this moment that it has no answer -- no credentials, an
expired token, a challenge it cannot parse -- and simply stops talking leaves
the connection **desynchronised**: the next command it sends is read as the
answer to the challenge, and every response after that belongs to the command
before it. That is the same bug class the literal work fixed, arrived at from
the other direction.

So the responder is a `std::function` whose *throwing* is part of the contract.
When it throws, the driver sends RFC 3501 6.2.2's `*`, reads to the tagged
completion so the socket is left at a response boundary, and then rethrows. The
caller gets its exception and a connection it can still use.

Three more things the driver has to get right, each with a section of its own:

- **A second challenge.** XOAUTH2 does not report a bad token as a tagged `NO`.
  It sends a continuation carrying a base64 JSON error, and withholds the tagged
  `NO` until the client answers it -- with an empty line. A driver written for
  exactly one round hangs there, holding a socket that looks alive.
- **A bounded number of rounds.** "Loop until the peer stops" is not a
  termination argument. Eight, then cancel.
- **The capability list.** 6.2.2: capabilities change on authentication, which
  is why the tagged `OK` may carry a new one. A client that keeps the old list
  is holding stale advertising, and `LOGINDISABLED` going stale is not cosmetic
  -- it is `login()` refusing to send a password the server would now accept.

`authenticate_plain()` sits on top for RFC 4616, and refuses a username or
password containing NUL rather than sending one: the fields are NUL-separated,
so a NUL inside one moves where the next begins, and `jo\0e` as a username would
authenticate as `jo` with whatever followed.

`state()` is new. `m_state` was written by half the commands here and readable
by nobody, which is how `authenticate()` came to not set it without anything
noticing.

## Two things fixed on the way past

**The debug masking knew about one command.** `handshake()` masked `LOGIN`'s
password and printed everything else in full -- including, had anything reached
it, `AUTHENTICATE`'s argument, which is a base64 SASL message: the password
under PLAIN and the bearer token under XOAUTH2. Both are cut to their first
argument now.

**SMTP could not authenticate to a server that offered it two ways.** The scan
in `send_tls_auth`/`send_ssl_auth` walked the EHLO reply, stopped at the *first*
line beginning `AUTH`, and threw unless that one line mentioned PLAIN. So

```
250-AUTH GSSAPI
250-AUTH PLAIN LOGIN
```

was rejected outright for not supporting a mechanism it was in the middle of
offering. It also matched with `find()`, so `AUTH XPLAINTEXT` counted as PLAIN.
It is one `has_auth_mechanism()` now, comparing whole tokens, reading every line
and understanding the old `AUTH=PLAIN` spelling; it is declared in `net.hh`
because a scan that was wrong in two ways deserves a test, and there is no way
to reach it from outside otherwise.

## Tests

**`tests/net_imap_sasl_test.cc`, new** -- against a scripted server written in
the test, on a `sys::listener`, which is why the previous branch was worth
doing. Six sections, for the shapes dovecot will not produce on demand: a
two-round challenge, a server that challenges forever, a responder that gives
up, a NUL in a credential.

The mutation that justifies it: take the `*` out of `cancel_authenticate()` and
the "responder gives up" section **deadlocks** -- the server waiting for the
line the client owes it, the client waiting for a response that will not come
until it arrives. That is the failure this branch prevents, demonstrated.

A test that hangs on regression stops `make check` instead of failing it, so the
client socket gets `set_timeout(10)` -- last branch's work, used here for the
first time. With the deadline in place the same mutation reports three failures
in ten seconds.

**`net_imap_live_test`** gains the same exchange against dovecot, with the
password that has a space, a quote and a backslash in it -- none of which means
anything inside a SASL message, since the fields are counted rather than
delimited, which is half the reason to prefer this over LOGIN. And a mechanism
the server has never heard of: dovecot answers a tagged `NO` with no
continuation at all, and the assertion is that `authenticate_plain()` then works
**on the same socket**, which is what a client trying mechanisms in order needs.

Its closing note was stale -- it said TLS was untested, which stopped being true
two branches ago -- and now says what is actually untested: XOAUTH2, and any
server that is not this one.

**`net_protocol_test`** gains seven assertions for the SMTP scan, including the
two-AUTH-line reply that was rejected and the `XPLAINTEXT` that was accepted.

**What a green run does not establish.** That a real provider accepts what this
sends. The scripted server answers what it was scripted to answer, so it proves
the client's framing and not the credential's contents; dovecot proves
AUTH=PLAIN, which is what no real account allows. XOAUTH2's *shape* is exercised
-- two rounds, an error blob, an empty final response -- with the literal string
`t` as the token and nobody asked whether the message around it is what Google
or Microsoft expects.

macOS: 47 pass, 3 skip, 0 fail. Linux container: 50 pass, 1 skip, 0 fail.
