### PR TITLE
Make util::json survive input it did not write, and give it the test it never had

### DIFF
--- a/jlib/util/json.cc
+++ b/jlib/util/json.cc
@@ -22,77 +22,334 @@
 
 #include "json.hh"
 
+#include <cerrno>
+#include <climits>
+#include <cstdlib>
+#include <sstream>
 #include <stdexcept>
 
 namespace jlib {
 namespace util {
 namespace json {
 
-proxy::proxy(json_object* obj) 
-    : m_obj(obj)
+namespace {
+
+    /** What json-c calls a type, for a message a person has to read. */
+    const char* name_of(json_object* o) {
+        if(o == 0) return "null";
+
+        switch(json_object_get_type(o)) {
+        case json_type_null:    return "null";
+        case json_type_boolean: return "a boolean";
+        case json_type_double:  return "a double";
+        case json_type_int:     return "an integer";
+        case json_type_object:  return "an object";
+        case json_type_array:   return "an array";
+        case json_type_string:  return "a string";
+        }
+
+        return "something else";
+    }
+
+    /**
+     * A whole string as an integer, or nothing.
+     *
+     * json-c's own json_object_get_int64() will coerce a string for you and
+     * returns 0 when it cannot -- so "abc" and "0" are the same answer, and an
+     * expires_in that failed to parse becomes a token that expired in 1970.
+     * strtoll with the end checked is the difference.
+     */
+    bool string_to_int64(const char* s, int64_t& out) {
+        if(s == 0 || *s == 0) return false;
+
+        errno = 0;
+
+        char* end = 0;
+        const long long v = std::strtoll(s, &end, 10);
+
+        if(errno == ERANGE) return false;
+
+        while(*end == ' ' || *end == '\t') end++;
+
+        if(*end != 0) return false;
+
+        out = v;
+
+        return true;
+    }
+
+    bool string_to_double(const char* s, double& out) {
+        if(s == 0 || *s == 0) return false;
+
+        errno = 0;
+
+        char* end = 0;
+        const double v = std::strtod(s, &end);
+
+        if(errno == ERANGE) return false;
+
+        while(*end == ' ' || *end == '\t') end++;
+
+        if(*end != 0) return false;
+
+        out = v;
+
+        return true;
+    }
+
+    bool to_int64(json_object* o, int64_t& out) {
+        switch(json_object_get_type(o)) {
+        case json_type_int:
+            out = json_object_get_int64(o);
+            return true;
+
+        case json_type_boolean:
+            out = json_object_get_boolean(o) ? 1 : 0;
+            return true;
+
+        case json_type_double: {
+            const double d = json_object_get_double(o);
+
+            // 3599.0 is the same number as 3599 and 3599.5 is not.  Truncating
+            // silently is how a count of things becomes the wrong count.
+            if(d != static_cast<double>(static_cast<int64_t>(d))) return false;
+
+            out = static_cast<int64_t>(d);
+
+            return true;
+        }
+
+        case json_type_string:
+            return string_to_int64(json_object_get_string(o), out);
+
+        default:
+            return false;
+        }
+    }
+
+    bool to_double(json_object* o, double& out) {
+        switch(json_object_get_type(o)) {
+        case json_type_double:
+            out = json_object_get_double(o);
+            return true;
+
+        case json_type_int:
+            out = static_cast<double>(json_object_get_int64(o));
+            return true;
+
+        case json_type_boolean:
+            out = json_object_get_boolean(o) ? 1.0 : 0.0;
+            return true;
+
+        case json_type_string:
+            return string_to_double(json_object_get_string(o), out);
+
+        default:
+            return false;
+        }
+    }
+
+    /**
+     * Parse, and insist that the whole input was JSON.
+     *
+     * json_tokener_parse() stops at the first complete value and says nothing
+     * about what follows, so {"access_token":"a"}{"access_token":"b"} parsed
+     * as the first of the two and `{"a":1} not json at all` parsed as {"a":1}.
+     * For a token response that is a response-splitting primitive wearing a
+     * convenience's clothes.
+     */
+    json_object* parse_whole(const std::string& data) {
+        json_tokener* tok = json_tokener_new();
+
+        if(tok == 0) throw parse_error("out of memory");
+
+        json_object* o = json_tokener_parse_ex(tok, data.data(),
+                                               static_cast<int>(data.size()));
+
+        const json_tokener_error err = json_tokener_get_error(tok);
+        const std::size_t end = json_tokener_get_parse_end(tok);
+
+        json_tokener_free(tok);
+
+        // The data is deliberately not in the message.  The first caller of
+        // this is an OAuth2 token endpoint, whose body is a bearer token, and
+        // an exception message goes to a log.  What is here is enough to find
+        // the fault -- the tokener's own description, where it stopped, and
+        // how long the input was -- and JLIB_UTIL_JSON_DEBUG adds the rest for
+        // someone debugging a config file.
+        std::ostringstream why;
+
+        if(o == 0 || err != json_tokener_success) {
+            if(o != 0) json_object_put(o);
+
+            // json_tokener_continue means "give me more input", which is what
+            // a tokener fed a whole document says when the document stops in
+            // the middle of a value.  Its error_desc for that is the word
+            // "continue", which describes the tokener's state and not the
+            // caller's problem.
+            if(err == json_tokener_continue || err == json_tokener_success) {
+                why << "the input ends in the middle of a value";
+            }
+            else {
+                why << json_tokener_error_desc(err);
+            }
+
+            why << ", at byte " << end << " of " << data.size();
+
+            if(std::getenv("JLIB_UTIL_JSON_DEBUG")) why << ": '" << data << "'";
+
+            throw parse_error(why.str());
+        }
+
+        std::size_t rest = end;
+
+        while(rest < data.size() &&
+              (data[rest] == ' ' || data[rest] == '\t' ||
+               data[rest] == '\r' || data[rest] == '\n'))
+            rest++;
+
+        if(rest < data.size()) {
+            json_object_put(o);
+
+            why << "a complete value ended at byte " << end << " and "
+                << (data.size() - rest) << " more octets follow it";
+
+            if(std::getenv("JLIB_UTIL_JSON_DEBUG")) why << ": '" << data << "'";
+
+            throw parse_error(why.str());
+        }
+
+        return o;
+    }
+
+}
+
+proxy::proxy(json_object* obj, const std::string& what)
+    : m_obj(obj),
+      m_what(what)
 {}
-    
-proxy::operator std::string() {
-    // always okay to go to string
-    //if(!json_object_is_type(m_obj, json_type_string))
-	//throw type_mismatch();
-    
-    return json_object_get_string(m_obj);
+
+void proxy::require() const {
+    if(m_obj == 0) {
+        throw missing_key(m_what.empty()
+                          ? std::string("no value")
+                          : ("no value for " + m_what));
+    }
 }
-    
-proxy::operator std::size_t() {
-    if(!json_object_is_type(m_obj, json_type_int))
-	throw type_mismatch();
-    
-    return json_object_get_int(m_obj);
+
+proxy::operator std::string() const {
+    require();
+
+    // Permissive on purpose: a number, a boolean, or a whole nested object
+    // comes back as the JSON text of it, which is what json-c does and is
+    // occasionally what a caller wants.  What is not permitted is the null
+    // that used to be handed straight to std::string's constructor.
+    const char* s = json_object_get_string(m_obj);
+
+    if(s == 0) throw type_mismatch(m_what + " is " + name_of(m_obj));
+
+    return s;
 }
-    
-proxy::operator int() {
-    if(!json_object_is_type(m_obj, json_type_int))
-	throw type_mismatch();
-    
-    return json_object_get_int(m_obj);
+
+proxy::operator int64_t() const {
+    require();
+
+    int64_t v = 0;
+
+    if(!to_int64(m_obj, v))
+        throw type_mismatch(m_what + " is " + name_of(m_obj) + ", not an integer");
+
+    return v;
 }
-    
-proxy::operator int64_t() {
-    if(!json_object_is_type(m_obj, json_type_int))
-	throw type_mismatch();
-    
-    return json_object_get_int64(m_obj);
+
+proxy::operator int() const {
+    const int64_t v = operator int64_t();
+
+    if(v < INT_MIN || v > INT_MAX)
+        throw type_mismatch(m_what + " does not fit in an int");
+
+    return static_cast<int>(v);
 }
-    
-proxy::operator bool() {
-    return (m_obj != 0);
+
+proxy::operator unsigned int() const {
+    const int64_t v = operator int64_t();
+
+    if(v < 0 || v > static_cast<int64_t>(UINT_MAX))
+        throw type_mismatch(m_what + " does not fit in an unsigned int");
+
+    return static_cast<unsigned int>(v);
 }
-    
-proxy::operator unsigned int() {
-    if(!json_object_is_type(m_obj, json_type_int))
-	throw type_mismatch();
-    
-    return json_object_get_int(m_obj);
+
+proxy::operator std::size_t() const {
+    const int64_t v = operator int64_t();
+
+    // A negative read as a size_t is not a small number, it is an enormous
+    // one, and it is usually about to be a length.
+    if(v < 0) throw type_mismatch(m_what + " is negative and was read as a size");
+
+    return static_cast<std::size_t>(v);
 }
-    
-proxy::operator double() {
-    if(!json_object_is_type(m_obj, json_type_double))
-	throw type_mismatch();
-    
-    return json_object_get_double(m_obj);
+
+proxy::operator double() const {
+    require();
+
+    double v = 0;
+
+    if(!to_double(m_obj, v))
+        throw type_mismatch(m_what + " is " + name_of(m_obj) + ", not a number");
+
+    return v;
 }
-    
-proxy::operator float() {
-    if(!json_object_is_type(m_obj, json_type_double))
-	throw type_mismatch();
-    
-    return static_cast<float>(json_object_get_double(m_obj));
+
+proxy::operator float() const {
+    return static_cast<float>(operator double());
 }
-    
-proxy::operator long double() {
-    if(!json_object_is_type(m_obj, json_type_double))
-	throw type_mismatch();
-    
-    return json_object_get_double(m_obj);
+
+proxy::operator long double() const {
+    return operator double();
 }
-    
+
+proxy::operator bool() const {
+    // This used to return m_obj != 0 -- so it answered "is the key there?"
+    // rather than "what is the value?", and {"admin":false} read as true.  It
+    // is the JSON boolean now, coerced as json-c coerces: 0, "", [] and {} are
+    // false and everything else is true.  present() is the old question, asked
+    // in a way that says what it means.
+    if(m_obj == 0) return false;
+
+    return json_object_get_boolean(m_obj) != 0;
+}
+
+std::string proxy::str_or(const std::string& dflt) const {
+    if(m_obj == 0) return dflt;
+
+    const char* s = json_object_get_string(m_obj);
+
+    return s == 0 ? dflt : std::string(s);
+}
+
+int64_t proxy::int_or(int64_t dflt) const {
+    int64_t v = 0;
+
+    if(m_obj == 0 || !to_int64(m_obj, v)) return dflt;
+
+    return v;
+}
+
+double proxy::double_or(double dflt) const {
+    double v = 0;
+
+    if(m_obj == 0 || !to_double(m_obj, v)) return dflt;
+
+    return v;
+}
+
+bool proxy::bool_or(bool dflt) const {
+    if(m_obj == 0) return dflt;
+
+    return json_object_get_boolean(m_obj) != 0;
+}
+
 object::ptr object::create() { 
     return ptr(new object());
 }
@@ -107,14 +364,9 @@ object::object()
 {}
     
 object::object(const std::string& data)
-    : m_obj(json_tokener_parse(data.data())),
+    : m_obj(parse_whole(data)),
       m_put(true)
-{
-    // json-c dropped the is_error() pointer encoding in 0.13; the tokener
-    // now simply returns null on a parse failure.
-    if(m_obj == nullptr)
-	throw std::runtime_error("data did not parse to JSON: '" + data + "'");
-}
+{}
     
 object::object(json_object* obj, bool put) 
     : m_obj(obj),
@@ -128,11 +380,28 @@ object::~object() {
 }
     
 proxy object::get(const std::string& key) const {
-    return proxy(json_object_object_get(m_obj, key.data()));
+    json_object* v = 0;
+
+    // _ex, because json-c stores a JSON null as a null pointer: without it
+    // "the key is not there" and "the key is there and is null" are the same
+    // answer, and the error message cannot tell the caller which it was.
+    const bool there = json_object_object_get_ex(m_obj, key.c_str(), &v);
+
+    std::string what = "\"" + key + "\"";
+
+    if(there && v == 0) what += ", which is null";
+
+    return proxy(v, what);
 }
-    
+
+bool object::has(const std::string& key) const {
+    return json_object_object_get_ex(m_obj, key.c_str(), 0) != 0;
+}
+
 proxy object::get(std::size_t idx) const {
-    return proxy(json_object_array_get_idx(m_obj, idx));
+    std::ostringstream o; o << "index " << idx;
+
+    return proxy(json_object_array_get_idx(m_obj, idx), o.str());
 }
     
 void object::add(const std::string& key, const std::string& val) {
@@ -144,7 +413,9 @@ void object::add(const std::string& key, int val) {
 }
     
 void object::add(const std::string& key, unsigned int val) {
-    add(key, static_cast<int>(val));
+    // Through int, this turned anything over 2^31 negative on the way out.
+    json_object_object_add(m_obj, key.data(),
+                           json_object_new_int64(static_cast<int64_t>(val)));
 }
     
 void object::add(const std::string& key, double val) {
@@ -176,7 +447,11 @@ json_object* object::obj() {
 }
     
 object::ptr object::obj(const std::string& key) {
-    json_object* o = json_object_object_get(m_obj, key.data());
+    json_object* o = 0;
+
+    if(!json_object_object_get_ex(m_obj, key.c_str(), &o) || o == 0)
+        throw missing_key("no object for \"" + key + "\"");
+
     return ptr(new object(o, false));
 }
     
@@ -186,7 +461,12 @@ object::ptr object::obj(unsigned int x) {
 }
     
 std::size_t object::size() const {
-    return json_object_array_length(m_obj);
+    // An object is not an array, and asking json-c for the array length of one
+    // is undefined -- some builds assert.  An object's size is its key count.
+    if(json_object_is_type(m_obj, json_type_array)) return json_object_array_length(m_obj);
+    if(json_object_is_type(m_obj, json_type_object)) return json_object_object_length(m_obj);
+
+    return 0;
 }
     
 bool object::is(object::type t) const {
@@ -207,13 +487,9 @@ array::array()
 {}
     
 array::array(const std::string& data)
-    : m_obj(json_tokener_parse(data.data())),
+    : m_obj(parse_whole(data)),
       m_put(true)
-{
-    // see object::object(std::string) above
-    if(m_obj == nullptr)
-	throw std::runtime_error("data did not parse to JSON: '" + data + "'");
-}
+{}
     
 array::array(json_object* obj) 
     : m_obj(obj),
@@ -235,7 +511,7 @@ void array::add(int val) {
 }
     
 void array::add(unsigned int val) {
-    add(static_cast<int>(val));
+    json_object_array_add(m_obj, json_object_new_int64(static_cast<int64_t>(val)));
 }
     
 void array::add(double val) {
@@ -257,7 +533,9 @@ void array::add(array::ptr val) {
 }
     
 proxy array::get(unsigned int x) const {
-    return proxy(json_object_array_get_idx(m_obj, x));
+    std::ostringstream o; o << "index " << x;
+
+    return proxy(json_object_array_get_idx(m_obj, x), o.str());
 }
 
 object::ptr array::obj(unsigned int x) const {

--- a/jlib/util/json.hh
+++ b/jlib/util/json.hh
@@ -23,6 +23,7 @@
 
 #include <string>
 #include <exception>
+#include <cstdint>
 
 #include <memory>
 
@@ -34,24 +35,96 @@ namespace json {
 
 class array;
 
+/**
+ * Anything this facade throws.
+ *
+ * There was no such thing before: object::create() threw std::runtime_error
+ * and proxy threw a type_mismatch whose what() was the default
+ * "std::exception", so a caller catching one learned nothing about which key,
+ * which type, or which byte.
+ */
+class exception : public std::exception {
+public:
+    exception(const std::string& msg = "") {
+        m_msg = "json exception: " + msg;
+    }
+    virtual ~exception() {}
+    virtual const char* what() const noexcept { return m_msg.c_str(); }
+protected:
+    std::string m_msg;
+};
+
+/** The value is there and is not the type that was asked for. */
+class type_mismatch : public exception {
+public:
+    type_mismatch(const std::string& msg = "") : exception("type mismatch: " + msg) {}
+};
+
+/**
+ * The value is not there at all, or is JSON null.
+ *
+ * This is the one that mattered.  A missing key produced a proxy wrapping a
+ * null pointer, and reading it as a string handed that null to std::string's
+ * constructor -- so the very first thing an OAuth2 client does with an error
+ * response, which is {"error":"invalid_grant"} and no access_token, was a
+ * segmentation fault.  Measured, not theorised.
+ */
+class missing_key : public exception {
+public:
+    missing_key(const std::string& msg = "") : exception(msg) {}
+};
+
+/** The input is not JSON, or is not only JSON. */
+class parse_error : public exception {
+public:
+    parse_error(const std::string& msg = "") : exception("parse error: " + msg) {}
+};
+
+/**
+ * One value, converted on demand.
+ *
+ * The conversions coerce across JSON types where the meaning survives -- an
+ * int read as a double, the string "3599" read as an int -- and throw where it
+ * does not.  They used to demand an exact json-c type, which is not what a
+ * real endpoint sends: Microsoft's v1 token endpoint returns expires_in as the
+ * *string* "3599", and a JSON number written 3599.0 is a double, so a client
+ * insisting on json_type_int rejects both.
+ */
 class proxy {
 public:
-    class type_mismatch : public std::exception {};
-    
-    proxy(json_object* obj);
-    
-    operator std::string();
-    operator std::size_t();
-    operator int();
-    operator unsigned int();
-    operator int64_t();
-    operator float();
-    operator double();
-    operator long double();
-    operator bool();
-    
+    /** The old spelling; jlib::util::json::type_mismatch is the same class. */
+    typedef jlib::util::json::type_mismatch type_mismatch;
+
+    /**
+     * @param obj  the value, or null for absent
+     * @param what what to call it in an error message -- a key, an index
+     */
+    proxy(json_object* obj, const std::string& what = "");
+
+    /** Whether there is a value here at all.  Never throws. */
+    bool present() const { return m_obj != 0; }
+
+    operator std::string() const;
+    operator std::size_t() const;
+    operator int() const;
+    operator unsigned int() const;
+    operator int64_t() const;
+    operator float() const;
+    operator double() const;
+    operator long double() const;
+    operator bool() const;
+
+    /** The value if it is there, and this if it is not.  Never throws. */
+    std::string str_or(const std::string& dflt) const;
+    int64_t int_or(int64_t dflt) const;
+    double double_or(double dflt) const;
+    bool bool_or(bool dflt) const;
+
 protected:
+    void require() const;
+
     json_object* m_obj;
+    std::string m_what;
 };
 
 class object {
@@ -76,6 +149,15 @@ public:
     
     proxy get(const std::string& key) const;
     proxy get(std::size_t idx) const;
+
+    /**
+     * Whether the object has this key, whatever its value.
+     *
+     * json-c stores a JSON null as a null pointer, so get() alone cannot tell
+     * an absent key from one whose value is null; this can, and it is what a
+     * caller wanting to branch rather than catch should use.
+     */
+    bool has(const std::string& key) const;
     
     ptr obj(const std::string& key);
     ptr obj(unsigned int x);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -76,6 +76,7 @@ TESTS = \
 	util_headers_fold_test \
 	util_headers_angie_test \
 	util_xml_test \
+	util_json_test \
 	util_abnf_test \
 	util_abnf_compile_test \
  \
@@ -175,6 +176,9 @@ sys_sync_test_LDADD   = $(JSYS_LA)
 
 sys_socket_test_SOURCES = sys_socket_test.cc
 sys_socket_test_LDADD   = $(JSYS_LA)
+
+util_json_test_SOURCES = util_json_test.cc
+util_json_test_LDADD   = $(JUTIL_LA) $(JSYS_LA) $(JSONC_LIBS)
 
 util_test_SOURCES = util_test.cc
 util_test_LDADD   = $(JUTIL_LA)

--- a/tests/util_json_test.cc
+++ b/tests/util_json_test.cc
@@ -1,0 +1,336 @@
+/* -*- mode: C++ c-basic-offset: 4 -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// jlib::util::json, which had no test at all.
+//
+// It has been in the tree since 2010 and the neural-net apps have been reading
+// their weights through it for as long, so it works for the input it was
+// written against: a file this program wrote itself.  What it had never seen
+// is input from somewhere else, and the next caller is an OAuth2 token
+// endpoint -- a stranger, answering over the network, whose error responses
+// are the normal case rather than the exceptional one.
+//
+// Every section below is a thing that endpoint does on an ordinary day.  The
+// first one used to be a segmentation fault.
+
+#include <jlib/util/json.hh>
+
+#include <iostream>
+#include <string>
+
+namespace json = jlib::util::json;
+
+static int failures = 0;
+
+static void ok(const std::string& what, bool good, const std::string& detail = "") {
+    if(!good) ++failures;
+    std::cout << (good ? "  ok   " : "  FAIL ") << what;
+    if(!detail.empty()) std::cout << ": " << detail;
+    std::cout << "\n";
+}
+
+static void a_key_that_is_not_there() {
+    std::cout << "\na key that is not there:\n";
+
+    // The body of a failed token request.  There is no access_token in it --
+    // that is the whole message -- and reading one used to hand json-c's null
+    // to std::string's constructor and take the process down.  A client cannot
+    // check for the key first, because until has() there was nothing to check
+    // with: proxy's operator bool answered "is it there", but only after the
+    // conversion that crashed.
+    json::object::ptr o = json::object::create("{\"error\":\"invalid_grant\"}");
+
+    ok("the error is readable", std::string(o->get("error")) == "invalid_grant");
+
+    ok("has() says the key is not there", !o->has("access_token"));
+    ok("and present() agrees", !o->get("access_token").present());
+
+    bool threw = false;
+    std::string message;
+
+    try {
+        std::string token = o->get("access_token");
+
+        ok("reading it throws rather than crashing", false, "got '" + token + "'");
+    }
+    catch(json::missing_key& e) {
+        threw = true;
+        message = e.what();
+    }
+
+    ok("reading it throws rather than crashing", threw);
+    ok("and the message names the key",
+       message.find("access_token") != std::string::npos, message);
+
+    // The other half of the same problem: json-c stores a JSON null as a null
+    // pointer, so an explicit null and an absent key are the same value.  Only
+    // has() can tell them apart.
+    json::object::ptr n = json::object::create("{\"refresh_token\":null}");
+
+    ok("an explicit null is distinguishable from an absent key",
+       n->has("refresh_token") && !n->has("nothing"));
+
+    ok("but reading it still throws", [&n] {
+        try { std::string s = n->get("refresh_token"); return false; }
+        catch(json::missing_key&) { return true; }
+    }());
+
+    // And the accessor for a caller that would rather branch than catch.
+    ok("str_or gives the default", o->get("access_token").str_or("none") == "none");
+    ok("and the value when there is one", o->get("error").str_or("none") == "invalid_grant");
+}
+
+static void numbers_as_a_server_writes_them() {
+    std::cout << "\nnumbers, as a server actually writes them:\n";
+
+    // Microsoft's v1 token endpoint returns expires_in as a *string*.  Google's
+    // returns it as a number.  A JSON number written 3599.0 is a double.  The
+    // old code demanded json_type_int exactly and threw on two of the three.
+    json::object::ptr o = json::object::create(
+        "{\"a\":3599,\"b\":\"3599\",\"c\":3599.0,\"d\":3599.5,\"e\":\"soon\"}");
+
+    ok("an integer reads as an integer", static_cast<int>(o->get("a")) == 3599);
+    ok("a string of digits reads as an integer", static_cast<int>(o->get("b")) == 3599);
+    ok("a whole double reads as an integer", static_cast<int>(o->get("c")) == 3599);
+
+    // Where the coercion would lose something, it does not happen silently.
+    ok("a fractional double does not", [&o] {
+        try { int x = o->get("d"); (void)x; return false; }
+        catch(json::type_mismatch&) { return true; }
+    }());
+
+    // json-c's own json_object_get_int64() coerces a string and returns 0 when
+    // it cannot, so "soon" and "0" would be the same answer -- and an
+    // expires_in that failed to parse becomes a token that expired in 1970.
+    ok("and a word that is not a number does not read as zero", [&o] {
+        try { int x = o->get("e"); (void)x; return false; }
+        catch(json::type_mismatch&) { return true; }
+    }());
+
+    ok("an integer reads as a double", static_cast<double>(o->get("a")) == 3599.0);
+    ok("and a double reads as a double", static_cast<double>(o->get("d")) == 3599.5);
+
+    // Ranges.  These used to truncate through int without a word.
+    json::object::ptr big = json::object::create(
+        "{\"big\":4294967296,\"neg\":-1}");
+
+    ok("a value too large for an int throws", [&big] {
+        try { int x = big->get("big"); (void)x; return false; }
+        catch(json::type_mismatch&) { return true; }
+    }());
+
+    ok("and reads fine as an int64",
+       static_cast<int64_t>(big->get("big")) == 4294967296LL);
+
+    // A negative read as a size_t is not a small number, it is an enormous
+    // one, and it is usually about to be a length.
+    ok("a negative read as a size throws", [&big] {
+        try { std::size_t x = big->get("neg"); (void)x; return false; }
+        catch(json::type_mismatch&) { return true; }
+    }());
+
+    ok("int_or gives the default for something unreadable",
+       o->get("e").int_or(-1) == -1 && o->get("a").int_or(-1) == 3599);
+}
+
+static void a_boolean_means_the_value() {
+    std::cout << "\na boolean means the value, not whether the key is there:\n";
+
+    json::object::ptr o = json::object::create("{\"yes\":true,\"no\":false}");
+
+    ok("true is true", static_cast<bool>(o->get("yes")));
+
+    // This is the one that was wrong: operator bool returned m_obj != 0, so it
+    // answered "is the key present" and {"no":false} read as true.  Anything
+    // that branched on a JSON boolean took the wrong branch, every time,
+    // whenever the answer was false.
+    ok("and false is false", !static_cast<bool>(o->get("no")));
+
+    ok("a missing key is false", !static_cast<bool>(o->get("neither")));
+    ok("and present() is what asks the old question",
+       o->get("no").present() && !o->get("neither").present());
+}
+
+static void the_whole_input_has_to_be_json() {
+    std::cout << "\nthe whole input has to be JSON:\n";
+
+    // json_tokener_parse() stops at the first complete value and says nothing
+    // about the rest, so a body with two objects in it parsed as the first and
+    // the second went unmentioned.  For a token response that is a
+    // response-splitting primitive: whatever appends the second object decides
+    // nothing, and whatever appends the first decides everything.
+    ok("two objects is an error", [] {
+        try {
+            json::object::ptr o = json::object::create(
+                "{\"access_token\":\"a\"}{\"access_token\":\"b\"}");
+
+            return false;
+        }
+        catch(json::parse_error&) { return true; }
+    }());
+
+    ok("and so is trailing rubbish", [] {
+        try {
+            json::object::ptr o = json::object::create("{\"a\":1} and then some");
+
+            return false;
+        }
+        catch(json::parse_error&) { return true; }
+    }());
+
+    // Whitespace after a value is not rubbish; a server is entitled to a
+    // trailing newline and refusing one would be its own bug.
+    ok("but trailing whitespace is not", [] {
+        try {
+            json::object::ptr o = json::object::create("{\"a\":1}\r\n\r\n");
+
+            return static_cast<int>(o->get("a")) == 1;
+        }
+        catch(std::exception&) { return false; }
+    }());
+
+    ok("a truncated object is an error", [] {
+        try {
+            json::object::ptr o = json::object::create("{\"a\":1");
+
+            return false;
+        }
+        catch(json::parse_error&) { return true; }
+    }());
+}
+
+static void an_exception_does_not_carry_the_payload() {
+    std::cout << "\nan exception does not carry the payload:\n";
+
+    // The message used to be "data did not parse to JSON: '" + data + "'".
+    // The data, in the caller this branch exists for, is a bearer token; the
+    // message goes to a log, which is a longer-lived and less careful place
+    // than a process's memory.  The description and the offset are enough to
+    // find the fault.
+    const std::string secret = "{\"access_token\":\"ya29.SUPERSECRET\" ";
+
+    std::string message;
+
+    try {
+        json::object::ptr o = json::object::create(secret);
+    }
+    catch(std::exception& e) {
+        message = e.what();
+    }
+
+    ok("it threw", !message.empty());
+    ok("and the token is not in the message",
+       message.find("SUPERSECRET") == std::string::npos, message);
+    ok("but it says where and why", message.find("byte") != std::string::npos, message);
+
+    // A type_mismatch used to be a bare std::exception, whose what() is the
+    // string "std::exception" -- which breaks the house rule and tells a
+    // caller nothing at all.
+    json::object::ptr o = json::object::create("{\"n\":\"words\"}");
+
+    std::string mismatch;
+
+    try {
+        int x = o->get("n");
+        (void)x;
+    }
+    catch(std::exception& e) {
+        mismatch = e.what();
+    }
+
+    ok("a type mismatch says what was wrong",
+       mismatch.find("\"n\"") != std::string::npos &&
+       mismatch.find("string") != std::string::npos, mismatch);
+}
+
+static void what_it_could_already_do_it_still_does() {
+    std::cout << "\nwhat it could already do, it still does:\n";
+
+    // The neural nets read their weights through this, so the building and
+    // round-tripping half has to keep working exactly as it did.
+    json::object::ptr o = json::object::create();
+
+    o->add("name", std::string("net"));
+    o->add("layers", 3);
+    o->add("rate", 0.25);
+
+    json::array::ptr a = json::array::create();
+
+    a->add(1);
+    a->add(2);
+    a->add(3);
+
+    o->add("hidden", a);
+
+    json::object::ptr back = json::object::create(o->str());
+
+    ok("a string round trips", std::string(back->get("name")) == "net");
+    ok("an int round trips", static_cast<int>(back->get("layers")) == 3);
+    ok("a double round trips", static_cast<double>(back->get("rate")) == 0.25);
+    ok("an object knows it is one", back->is(json::object::type_object));
+
+    json::array::ptr h = json::array::create(back->obj("hidden")->str());
+
+    ok("an array round trips", h->size() == 3 &&
+       static_cast<int>(h->get(0)) == 1 && static_cast<int>(h->get(2)) == 3);
+
+    // size() on an object used to call json_object_array_length on it, which
+    // is undefined for a non-array and asserts in some builds.
+    ok("an object's size is its key count", back->size() == 4,
+       std::to_string(back->size()));
+
+    // An unsigned value over 2^31 went out through int and came back negative.
+    json::object::ptr u = json::object::create();
+
+    u->add("u", static_cast<unsigned int>(4000000000u));
+
+    ok("a large unsigned survives the round trip",
+       static_cast<int64_t>(json::object::create(u->str())->get("u")) == 4000000000LL,
+       u->str());
+}
+
+int main() {
+    std::cout << std::unitbuf;
+
+    a_key_that_is_not_there();
+    numbers_as_a_server_writes_them();
+    a_boolean_means_the_value();
+    the_whole_input_has_to_be_json();
+    an_exception_does_not_carry_the_payload();
+    what_it_could_already_do_it_still_does();
+
+    // What a green run does not establish.
+    //
+    // Not that the facade is safe to use on hostile input generally.  It is
+    // json-c underneath and json-c is the thing that has been audited; what is
+    // tested here is the thin layer above it, which is where all of the faults
+    // were.  Nothing here feeds it a deeply nested document, a hundred
+    // megabytes, or invalid UTF-8, and nothing here sets a depth limit --
+    // json-c has one, JSON_TOKENER_DEFAULT_DEPTH, and this code does not
+    // choose it.
+    //
+    // Not the ownership rules.  object::add(ptr) transfers the underlying
+    // json_object and clears the child's m_put, so using a child after adding
+    // it to a parent is a question with an answer nobody has written down, and
+    // no assertion here asks it.
+    std::cout << "\n" << (failures ? "FAILED" : "PASSED") << ": " << failures
+              << " failure(s)\n";
+
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
# json, hardened against input it did not write

Third branch of the HTTP/OAuth2 work. A token endpoint answers in JSON, so this
has to be right before there is any point fetching one.

`jlib::util::json` has been in the tree since 2010 and had **no test at all**.
That is not as surprising as it sounds: the only callers are the neural-net
apps, reading back weight files this same code wrote, so it has been exercised
for fifteen years against input it produced itself. The next caller is a
stranger answering over a network, whose *error* responses are the ordinary
case rather than the exceptional one -- and against that, six things were
wrong. All six were measured before being fixed, not inferred from reading.

## What a token endpoint does on an ordinary day

**A missing key was a segmentation fault.** `get()` on an absent key returns a
proxy wrapping json-c's null, and `operator std::string()` handed that null
straight to `std::string`'s constructor. The body of a failed token request is
`{"error":"invalid_grant"}` with no `access_token` in it -- so the very first
thing an OAuth2 client does when something goes wrong took the process down.
Confirmed: exit 139.

There was also no way to check first. `has()` did not exist, and proxy's
`operator bool` looked like it would answer the question but did not (below).

**A boolean answered the wrong question.** `operator bool()` returned
`m_obj != 0` -- "is the key there" -- so `{"admin":false}` read as **true**.
Anything branching on a JSON boolean took the wrong branch every time the answer
was false. It is `json_object_get_boolean` now, and `present()` is the old
question asked in a way that says what it means.

**The numeric conversions demanded an exact json-c type.** Microsoft's v1 token
endpoint returns `expires_in` as the *string* `"3599"`; a number written
`3599.0` is a double; `operator int` insisted on `json_type_int` and threw on
both. They coerce now where the meaning survives and throw where it does not --
`3599.5` as an int is a mismatch, not a truncation.

Coercion had to be written out rather than delegated: json-c's own
`json_object_get_int64()` will coerce a string for you and returns **0** when it
cannot, so `"soon"` and `"0"` are the same answer, and an `expires_in` that
failed to parse becomes a token that expired in 1970. `strtoll` with the end
checked is the difference.

Ranges are checked too. `operator int` from a value that does not fit throws
instead of truncating, and a negative read as `std::size_t` throws -- that is
not a small number, it is an enormous one, and it is usually about to be a
length.

**Trailing input was ignored.** `json_tokener_parse()` stops at the first
complete value and says nothing about the rest, so
`{"access_token":"a"}{"access_token":"b"}` parsed as the first and
`{"a":1} and then some` parsed as `{"a":1}`. For a token response that is a
response-splitting primitive wearing a convenience's clothes. It goes through
`json_tokener_parse_ex` now with `json_tokener_get_parse_end()` checked, and
only whitespace may follow -- a server is entitled to a trailing newline.

**The exception carried the payload.** The message was
`"data did not parse to JSON: '" + data + "'"`. The data, for the caller this
branch exists for, is a bearer token; the message goes to a log, which is a
longer-lived and less careful place than a process's memory. What is there now
is the tokener's own description, the byte it stopped at, and the input's
length. `JLIB_UTIL_JSON_DEBUG` adds the rest, for someone debugging a config
file -- the house pattern.

**`type_mismatch` had no `what()`**, so it printed the string `"std::exception"`
and told a caller nothing about which key or which type. There is a
`json::exception` base with `m_msg` now, per the house rule, with
`type_mismatch`, `missing_key` and `parse_error` under it. `proxy::type_mismatch`
still names the same class, and all of them still derive from `std::exception`,
so existing `catch` sites are unaffected.

Three smaller things found while in here: `object::size()` called
`json_object_array_length` on an object, which is undefined for a non-array and
asserts in some builds -- it is the key count now; `object::obj(key)` on a
missing key produced an `object` wrapping null that crashed later rather than
there; and `add(key, unsigned int)` went through `int`, so anything over 2^31
came back negative.

## Tests

`tests/util_json_test.cc`, new -- six sections, one per fault above, each
written as what an endpoint actually sends. The `missing_key` section is the
one that used to be a crash rather than a failure.

Also `str_or`, `int_or`, `double_or` and `bool_or`, for the caller that would
rather branch than catch, and a section asserting that the building and
round-tripping half the neural nets depend on is untouched.

**What a green run does not establish.** Not that the facade is safe on hostile
input generally -- json-c is underneath and json-c is the thing that has been
audited; what is tested here is the thin layer above it, which is where all the
faults were. Nothing feeds it a deeply nested document, a hundred megabytes, or
invalid UTF-8, and nothing here chooses a depth limit; json-c has one and this
code does not set it. And not the ownership rules: `object::add(ptr)` transfers
the underlying `json_object` and clears the child's `m_put`, so using a child
after adding it to a parent is a question with an answer nobody has written
down, and no assertion here asks it.

macOS: 48 pass, 3 skip, 0 fail. Linux container (json-c 0.17, against 0.19 on
macOS): 51 pass, 1 skip, 0 fail.
