### PR TITLE
Read an HTTP response head against RFC 9112's grammar, and put the proxy on the same reader

### DIFF
--- a/jlib/sys/proxystream.hh
+++ b/jlib/sys/proxystream.hh
@@ -22,10 +22,12 @@
 #define JLIB_SYS_PROXYSTREAM_HH
 
 #include <jlib/sys/socketstream.hh>
+#include <jlib/util/http.hh>
 #include <jlib/util/util.hh>
 
 #include <openssl/ssl.h>
 
+#include <istream>
 #include <sstream>
 
 namespace jlib {
@@ -83,49 +85,49 @@ protected:
         // gets this->sputn right, so someone knew and missed one.
         this->sync();
 
-        // The whole of the response head, to the blank line.  What was here
-        // read until it had seen two '\n' characters and then threw the result
-        // away -- so a proxy that sends any headers of its own (most do:
-        // Proxy-agent, Connection) left the rest of them in the stream to be
-        // read as protocol data, and a proxy that refused the tunnel was
-        // indistinguishable from one that granted it.
-        std::string head;
+        // The whole of the response head, to the blank line, read and parsed
+        // by util::http.
+        //
+        // This used to be twenty lines here: read until two '\n' have gone by,
+        // then find(' ') and look at the character after it.  Two things were
+        // wrong with the version before *that* -- it threw the head away, so a
+        // proxy sending headers of its own (most do: Proxy-agent, Connection)
+        // left the rest of them in the stream to be read as protocol data, and
+        // a refused tunnel was indistinguishable from a granted one.  Both were
+        // fixed here, and then the same reader had to be written again for the
+        // HTTP client, which is one too many.
+        //
+        // An istream over this streambuf, because read_head() takes a stream
+        // and this *is* the stream -- nothing is copied, and there is no second
+        // buffer to get out of step with the first.
+        std::istream is(this);
 
-        while(head.find("\r\n\r\n") == std::string::npos &&
-              head.find("\n\n") == std::string::npos) {
-            const int c = this->sbumpc();
+        util::http::Response answer;
 
-            if(c == traits_type::eof()) {
-                throw typename basic_socketbuf<charT,traitT>::exception(
-                    "the proxy closed the connection before answering CONNECT: "
-                    "read \"" + head + "\"");
-            }
-
-            head.append(1, static_cast<char>(c));
-
-            if(head.size() > 8192) {
-                throw typename basic_socketbuf<charT,traitT>::exception(
-                    "the proxy's answer to CONNECT has no end to its headers");
-            }
+        try {
+            // A 2xx answer to CONNECT has no body whatever its fields say
+            // (9110 9.3.6): what follows the blank line is the tunnel.  Saying
+            // so here means a Content-Length the proxy had no business sending
+            // cannot make anything try to read one.
+            answer = util::http::parse_head(util::http::read_head(is), true);
+        }
+        catch(util::http::error& e) {
+            throw typename basic_socketbuf<charT,traitT>::exception(
+                std::string("the proxy's answer to CONNECT: ") + e.what());
         }
 
         if(getenv("JLIB_SYS_PROXY_DEBUG"))
-            std::cerr << head << std::flush;
+            std::cerr << answer.status() << " " << answer.reason() << std::endl;
 
         // RFC 9110 9.3.6: any 2xx means the tunnel is up, and anything else
         // means it is not.  "HTTP/1.1 200 Connection established".
-        const std::string::size_type sp = head.find(' ');
+        if(!answer.ok()) {
+            std::ostringstream why;
 
-        if(sp == std::string::npos || head.compare(0, 5, "HTTP/") != 0) {
-            throw typename basic_socketbuf<charT,traitT>::exception(
-                "the proxy did not answer CONNECT with a status line: " + head);
-        }
+            why << "the proxy refused CONNECT: " << answer.status()
+                << " " << answer.reason();
 
-        if(head[sp + 1] != '2') {
-            const std::string::size_type nl = head.find_first_of("\r\n");
-
-            throw typename basic_socketbuf<charT,traitT>::exception(
-                "the proxy refused CONNECT: " + head.substr(0, nl));
+            throw typename basic_socketbuf<charT,traitT>::exception(why.str());
         }
     }
 

--- a/jlib/util/Makefile.am
+++ b/jlib/util/Makefile.am
@@ -2,7 +2,7 @@ AM_CPPFLAGS = -I$(top_srcdir) $(JSONC_CFLAGS)
 
 lib_LTLIBRARIES = libjutil.la
 libjutil_la_SOURCES = abnf.cc Regex.cc MimeType.cc util.cc Date.cc xml.cc \
-                      URL.cc Headers.cc Timer.cc json.cc content_type.cc \
+                      URL.cc Headers.cc Timer.cc json.cc content_type.cc http.cc \
                       encoded_word.cc
 libjutil_la_LDFLAGS = -version-info $(LIBJ_SO_VERSION) -release $(JLIB_RELEASE) -no-undefined
 libjutil_la_LIBADD = $(top_builddir)/jlib/sys/libjsys.la $(JSONC_LIBS)
@@ -10,5 +10,5 @@ libjutil_la_LIBADD = $(top_builddir)/jlib/sys/libjsys.la $(JSONC_LIBS)
 libjutilincludedir = $(includedir)/jlib-1.2/jlib/util
 libjutilinclude_HEADERS = abnf.hh Regex.hh MimeType.hh util.hh Date.hh xml.hh \
                           URL.hh Headers.hh Timer.hh json.hh \
-                          content_type.hh rfc2045.hh rfc5322.hh \
-                          encoded_word.hh rfc2047.hh rfc3986.hh
+                          content_type.hh rfc2045.hh rfc5322.hh http.hh \
+                          encoded_word.hh rfc2047.hh rfc3986.hh rfc9110.hh rfc9112.hh

--- a/jlib/util/URL.cc
+++ b/jlib/util/URL.cc
@@ -84,6 +84,14 @@ namespace jlib {
         }
         
         void URL::parse(const std::string& url) {
+            parse(url, "URI");
+        }
+
+        void URL::parse_reference(const std::string& url) {
+            parse(url, "URI-reference");
+        }
+
+        void URL::parse(const std::string& url, const char* start) {
             if(std::getenv("JLIB_UTIL_URL_DEBUG"))
                 std::cerr << "jlib::util::URL::parse(\""<<url<<"\")"<<std::endl;
 
@@ -96,7 +104,14 @@ namespace jlib {
             abnf::match m;
 
             try {
-                m = uri_grammar().at("URI").parse(text, parse_options());
+                // "URI" or "URI-reference" -- see parse_reference().  The
+                // latter is URI / relative-ref, so an absolute URL takes the
+                // same branch either way and everything below is unchanged.
+                //
+                // relative-ref could not be asked for at all until this
+                // branch: the first version of rfc3986.hh pasted only the
+                // rules URL::parse needed, and that was not one of them.
+                m = uri_grammar().at(start).parse(text, parse_options());
             }
             catch(abnf::budget_exceeded& e) {
                 throw exception(std::string("gave up reading a URL: ") + e.what());
@@ -110,7 +125,9 @@ namespace jlib {
             // RFC 3986 6.2.2.1: the scheme and the host are case insensitive,
             // and lower case is the canonical form.  Every caller in jlib was
             // doing this for itself, with util::lower, at every comparison.
-            m_protocol = lower(m["scheme"].str());
+            // A relative reference has no scheme, and get_protocol() being
+            // empty is how a caller tells the two apart.
+            m_protocol = m["scheme"] ? lower(m["scheme"].str()) : std::string();
 
             m_authority = static_cast<bool>(m["authority"]);
 
@@ -140,7 +157,11 @@ namespace jlib {
 
             m_host_literal = static_cast<bool>(m["IP-literal"]);
 
-            if(m_host_literal) {
+            if(!host) {
+                m_host.clear();
+                m_host_literal = false;
+            }
+            else if(m_host_literal) {
                 // Without the brackets: they delimit the literal, they are not
                 // part of the address, and getaddrinfo does not want them.
                 const std::string text = host.str();
@@ -157,7 +178,8 @@ namespace jlib {
             // took, and exactly one of the three can be present.
             m_path.clear();
 
-            for(const char* n : { "path-abempty", "path-absolute", "path-rootless" }) {
+            for(const char* n : { "path-abempty", "path-absolute", "path-rootless",
+                                  "path-noscheme" }) {
                 if(const abnf::match p = m[n]) {
                     m_path = p.str();
                     break;
@@ -172,6 +194,17 @@ namespace jlib {
         bool URL::valid(const std::string& url) {
             try {
                 URL u(url);
+                return true;
+            }
+            catch(exception&) {
+                return false;
+            }
+        }
+
+        bool URL::valid_reference(const std::string& url) {
+            try {
+                URL u;
+                u.parse_reference(url);
                 return true;
             }
             catch(exception&) {

--- a/jlib/util/URL.hh
+++ b/jlib/util/URL.hh
@@ -85,8 +85,34 @@ namespace jlib {
              */
             void parse(const std::string& url);
 
-            /** Would it parse?  The way to ask without catching. */
+            /**
+             * Parse an RFC 3986 4.1 URI-reference: a URI, or a relative one.
+             *
+             * Separate from parse() on purpose, rather than parse() being
+             * widened.  A mail URL with a typo in it -- "imap:/host", say --
+             * is a perfectly good relative reference, so a parse() that
+             * accepted one would stop throwing on it and start returning
+             * something with no scheme and no host, which Imap4 would then try
+             * to connect to.  Refusing at the point of parse is worth keeping.
+             *
+             * What wants this is HTTP: RFC 9110 makes Location a
+             * URI-reference, and a 302 pointing at "/signin" is the ordinary
+             * case rather than the exotic one.
+             *
+             * Nothing here resolves a reference against a base.  RFC 3986 5.3
+             * is an algorithm of its own and no caller has needed it yet;
+             * relative() is how to find out that you have one.
+             */
+            void parse_reference(const std::string& url);
+
+            /** Would it parse as a URI?  The way to ask without catching. */
             static bool valid(const std::string& url);
+
+            /** Would it parse as a URI-reference? */
+            static bool valid_reference(const std::string& url);
+
+            /** No scheme: this came from parse_reference() and is relative. */
+            bool relative() const { return m_protocol.empty(); }
 
             /**
              * Split a query string into its pairs, percent-decoding both
@@ -181,6 +207,10 @@ namespace jlib {
 
             std::string m_delim;
             std::map<std::string,std::string> m_qs_hash;
+
+        protected:
+            void parse(const std::string& url, const char* start);
+
         };
         
     }

--- a/jlib/util/http.cc
+++ b/jlib/util/http.cc
@@ -1,0 +1,452 @@
+/* -*- mode: C++ c-basic-offset: 4 -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <jlib/util/http.hh>
+
+#include <jlib/util/rfc3986.hh>
+#include <jlib/util/rfc9110.hh>
+#include <jlib/util/rfc9112.hh>
+
+#include <algorithm>
+#include <cctype>
+#include <istream>
+#include <sstream>
+
+namespace jlib {
+namespace util {
+namespace http {
+
+std::string fold(std::string_view s) {
+    std::string out;
+
+    out.reserve(s.size());
+
+    for(char c : s) {
+        out += static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+    }
+
+    return out;
+}
+
+const abnf::grammar& grammar() {
+    // On first use, not at namespace scope: a grammar built while the library
+    // loads runs before main(), which is the mistake crypt/curve.hh documents
+    // at length.  content_type.cc builds its grammar the same way.
+    static const abnf::grammar g = [] {
+        abnf::grammar built = abnf::compile(std::string(rfc3986::URI_GRAMMAR) +
+                                            rfc9110::SEMANTICS +
+                                            rfc9112::MESSAGING);
+
+        built.check();
+
+        return built;
+    }();
+
+    return g;
+}
+
+// ------------------------------------------------------------------- fields
+
+void fields::add(std::string name, std::string value) {
+    m_fields.emplace_back(std::move(name), std::move(value));
+}
+
+bool fields::has(std::string_view name) const {
+    return count(name) != 0;
+}
+
+std::string fields::get(std::string_view name) const {
+    const std::string want = fold(name);
+
+    for(const value_type& f : m_fields) {
+        if(fold(f.first) == want) return f.second;
+    }
+
+    return std::string();
+}
+
+std::vector<std::string> fields::all(std::string_view name) const {
+    const std::string want = fold(name);
+    std::vector<std::string> out;
+
+    for(const value_type& f : m_fields) {
+        if(fold(f.first) == want) out.push_back(f.second);
+    }
+
+    return out;
+}
+
+fields::size_type fields::count(std::string_view name) const {
+    const std::string want = fold(name);
+    size_type n = 0;
+
+    for(const value_type& f : m_fields) {
+        if(fold(f.first) == want) n++;
+    }
+
+    return n;
+}
+
+// ---------------------------------------------------------------- read_head
+
+std::string read_head(std::istream& is, std::size_t cap) {
+    std::string head;
+
+    // One octet at a time, looking for the blank line.  Not getline: a bare LF
+    // in the middle of the section is something this has to be able to see and
+    // refuse, and getline would silently make it a line ending.
+    //
+    // "\n\n" is accepted as an end as well as "\r\n\r\n" only so that a head
+    // sent with bare LFs is *read* and then *rejected* by the grammar, with a
+    // message saying what was wrong, rather than read until the cap runs out.
+    while(head.size() < 4 ||
+          (head.compare(head.size() - 4, 4, "\r\n\r\n") != 0 &&
+           head.compare(head.size() - 2, 2, "\n\n") != 0)) {
+        const int c = is.get();
+
+        if(c == std::char_traits<char>::eof()) {
+            throw error("the connection closed before the response head ended, "
+                        "after " + std::to_string(head.size()) + " octets");
+        }
+
+        head += static_cast<char>(c);
+
+        if(head.size() > cap) {
+            throw error("no end to the response head within " +
+                        std::to_string(cap) + " octets");
+        }
+    }
+
+    return head;
+}
+
+// --------------------------------------------------------------- parse_head
+
+namespace {
+
+    /**
+     * Split a head into lines on CRLF, refusing anything else.
+     *
+     * RFC 9112 2.2 lets a recipient accept a bare LF as a line terminator and
+     * says it MUST NOT accept a bare CR.  jlib accepts neither, because the
+     * whole reason to care is that a recipient which disagrees with the one in
+     * front of it about where a line ends is how one message becomes two --
+     * and the only way to disagree with nobody is to insist on CRLF.
+     */
+    std::vector<std::string> split_lines(std::string_view head) {
+        std::vector<std::string> lines;
+        std::size_t i = 0;
+
+        while(i < head.size()) {
+            const std::size_t nl = head.find("\r\n", i);
+
+            if(nl == std::string_view::npos)
+                throw error("the response head does not end in CRLF");
+
+            const std::string_view line = head.substr(i, nl - i);
+
+            if(line.find('\r') != std::string_view::npos ||
+               line.find('\n') != std::string_view::npos) {
+                throw error("a bare CR or LF inside the response head");
+            }
+
+            if(line.empty()) {
+                // The blank line.  Anything after it is the body's business.
+                return lines;
+            }
+
+            lines.emplace_back(line);
+            i = nl + 2;
+        }
+
+        throw error("the response head has no blank line at the end of it");
+    }
+
+    bool all_digits(const std::string& s) {
+        if(s.empty()) return false;
+
+        for(char c : s) {
+            if(c < '0' || c > '9') return false;
+        }
+
+        return true;
+    }
+
+}
+
+Response parse_head(std::string_view head, bool head_request) {
+    const std::vector<std::string> lines = split_lines(head);
+
+    if(lines.empty()) throw error("the response head is empty");
+
+    Response r;
+
+    {
+        const abnf::rule status = grammar().at("status-line");
+
+        abnf::parse_result p = status.try_parse(lines[0]);
+
+        if(!p) {
+            // RFC 9112 4 writes status-line = HTTP-version SP status-code SP
+            // [ reason-phrase ] -- the second SP is required even when the
+            // reason is empty.  Servers do omit it.  This is a deliberate
+            // leniency and it is narrow: only a line that is otherwise exactly
+            // a status line, with the trailing SP supplied.
+            p = status.try_parse(std::string(lines[0]) + " ");
+
+            if(!p) throw error("not a status line: \"" + lines[0] + "\"");
+        }
+
+        const abnf::match m = p.root();
+
+        r.m_version = m["HTTP-version"].str();
+        r.m_status = std::stoi(m["status-code"].str());
+
+        const abnf::match reason = m["reason-phrase"];
+
+        if(reason) r.m_reason = reason.str();
+    }
+
+    {
+        const abnf::rule field = grammar().at("field-line");
+
+        for(std::size_t i = 1; i < lines.size(); i++) {
+            // obs-fold: a line beginning with SP or HTAB continues the one
+            // before it.  RFC 9112 5.2 says a recipient of a message that is
+            // not a message/http payload must either reject it or replace the
+            // fold with a space; rejecting is the safe half of that choice,
+            // and nothing has sent jlib one since HTTP/1.0.
+            if(lines[i][0] == ' ' || lines[i][0] == '\t') {
+                throw error("obs-fold, an obsolete line continuation, in the "
+                            "response head: \"" + lines[i] + "\"");
+            }
+
+            const abnf::parse_result p = field.try_parse(lines[i]);
+
+            if(!p) throw error("not a header field: \"" + lines[i] + "\"");
+
+            const abnf::match m = p.root();
+
+            // The value comes from the match, not from find(':'), which is the
+            // point of having the grammar: field-line puts the OWS outside
+            // field-value, so what is captured is already trimmed at both ends.
+            r.m_fields.add(m["field-name"].str(), m["field-value"].str());
+        }
+    }
+
+    // ------------------------------------------------------ RFC 9112 6.3
+
+    const bool no_body = head_request ||
+                         (r.m_status >= 100 && r.m_status < 200) ||
+                         r.m_status == 204 ||
+                         r.m_status == 304;
+
+    const bool has_te = r.m_fields.has("Transfer-Encoding");
+    const bool has_cl = r.m_fields.has("Content-Length");
+
+    if(has_te && has_cl) {
+        // The request-smuggling primitive.  RFC 9112 6.1: a message with both
+        // "ought to be handled as an error"; the reason it is an error rather
+        // than a preference is that a proxy in front of us may pick the other
+        // one, and then the tail of this message is the head of the next
+        // request as far as one of us is concerned.
+        throw error("both Content-Length and Transfer-Encoding are present; "
+                    "where this message ends depends on who is reading it");
+    }
+
+    if(has_cl) {
+        const std::vector<std::string> all = r.m_fields.all("Content-Length");
+
+        for(const std::string& v : all) {
+            if(!all_digits(v))
+                throw error("Content-Length is not a number: \"" + v + "\"");
+
+            if(v != all[0])
+                throw error("two Content-Length fields that do not agree: \"" +
+                            all[0] + "\" and \"" + v + "\"");
+        }
+
+        try {
+            r.m_length = static_cast<std::size_t>(std::stoull(all[0]));
+        }
+        catch(std::exception&) {
+            throw error("Content-Length does not fit: \"" + all[0] + "\"");
+        }
+
+        r.m_framing = framing::length;
+    }
+    else if(has_te) {
+        // 6.1: chunked must be the final coding, and if it is not there the
+        // message ends at the close of the connection.
+        const std::string te = fold(r.m_fields.get("Transfer-Encoding"));
+        const std::size_t last = te.find_last_of(',');
+        const std::string final = last == std::string::npos
+                                  ? te : te.substr(last + 1);
+
+        std::string trimmed;
+
+        for(char c : final) {
+            if(c != ' ' && c != '\t') trimmed += c;
+        }
+
+        r.m_framing = trimmed == "chunked" ? framing::chunked : framing::until_close;
+    }
+
+    if(no_body) {
+        r.m_framing = framing::none;
+        r.m_length = 0;
+    }
+
+    return r;
+}
+
+Response read_response_head(std::istream& is, bool head_request, std::size_t cap) {
+    return parse_head(read_head(is, cap), head_request);
+}
+
+// --------------------------------------------------------------- read_body
+
+namespace {
+
+    std::string read_exactly(std::istream& is, std::size_t n, std::size_t cap) {
+        if(n > cap) {
+            throw error("the body claims " + std::to_string(n) +
+                        " octets and the most that will be read is " +
+                        std::to_string(cap));
+        }
+
+        std::string out(n, '\0');
+
+        is.read(&out[0], static_cast<std::streamsize>(n));
+
+        if(static_cast<std::size_t>(is.gcount()) != n) {
+            throw error("the connection closed " +
+                        std::to_string(n - is.gcount()) +
+                        " octets short of the body it promised");
+        }
+
+        return out;
+    }
+
+    void eat_crlf(std::istream& is) {
+        const int a = is.get();
+        const int b = is.get();
+
+        if(a != '\r' || b != '\n')
+            throw error("a chunk is not followed by CRLF");
+    }
+
+    std::string read_line(std::istream& is, std::size_t cap) {
+        std::string line;
+
+        for(;;) {
+            const int c = is.get();
+
+            if(c == std::char_traits<char>::eof())
+                throw error("the connection closed in the middle of a chunked body");
+
+            if(c == '\n') {
+                if(line.empty() || line.back() != '\r')
+                    throw error("a bare LF in a chunked body");
+
+                line.pop_back();
+
+                return line;
+            }
+
+            line += static_cast<char>(c);
+
+            if(line.size() > cap)
+                throw error("a chunked body's line has no end to it");
+        }
+    }
+
+}
+
+std::string read_body(std::istream& is, const Response& head, std::size_t cap) {
+    switch(head.body_framing()) {
+    case framing::none:
+        return std::string();
+
+    case framing::length:
+        return read_exactly(is, head.content_length(), cap);
+
+    case framing::chunked: {
+        std::string body;
+
+        for(;;) {
+            // chunk-size [ chunk-ext ] CRLF -- the extension is parsed off and
+            // thrown away, which is what RFC 9112 7.1.1 says to do with one
+            // that is not recognised, and none is.
+            const std::string line = read_line(is, 4096);
+            const std::size_t semi = line.find(';');
+            const std::string size_text = line.substr(0, semi);
+
+            if(!grammar().at("chunk-size").try_parse(size_text))
+                throw error("not a chunk size: \"" + size_text + "\"");
+
+            const std::size_t n = std::stoull(size_text, 0, 16);
+
+            if(n == 0) {
+                // The trailer section, read and discarded.  Something has to
+                // consume it or the connection is not at a message boundary,
+                // and a caller reusing it reads a trailer as a status line.
+                for(;;) {
+                    const std::string trailer = read_line(is, 4096);
+
+                    if(trailer.empty()) break;
+                }
+
+                return body;
+            }
+
+            if(body.size() + n > cap) {
+                throw error("a chunked body is larger than the " +
+                            std::to_string(cap) + " octets that will be read");
+            }
+
+            body += read_exactly(is, n, cap);
+
+            eat_crlf(is);
+        }
+    }
+
+    case framing::until_close: {
+        std::string body;
+        char buf[4096];
+
+        while(is.read(buf, sizeof buf) || is.gcount() > 0) {
+            if(body.size() + is.gcount() > cap) {
+                throw error("a body read to end of stream passed the " +
+                            std::to_string(cap) + " octets that will be read");
+            }
+
+            body.append(buf, is.gcount());
+        }
+
+        return body;
+    }
+    }
+
+    return std::string();
+}
+
+}
+}
+}

--- a/jlib/util/http.hh
+++ b/jlib/util/http.hh
@@ -1,0 +1,245 @@
+/* -*- mode: C++ c-basic-offset: 4 -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef JLIB_UTIL_HTTP_HH
+#define JLIB_UTIL_HTTP_HH
+
+#include <jlib/util/abnf.hh>
+
+#include <cstddef>
+#include <iosfwd>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace jlib {
+namespace util {
+
+/**
+ * Reading an HTTP/1.1 response, against RFC 9112's grammar.
+ *
+ * The message layer only: a status line, a field section, and how the body
+ * that follows them is delimited.  Making the request and choosing a transport
+ * is a client's job and lives above this.
+ *
+ * ## Why this is in util and not net
+ *
+ * Because sys/proxystream.hh needs it.  basic_proxybuf::open_proxy() reads an
+ * HTTP response head -- the answer to CONNECT -- and it was the only correct
+ * head reader in the tree: it capped the length, it insisted on a status line,
+ * and it read to the blank line rather than throwing the proxy's own headers
+ * into the protocol stream.  Having a second one in net would leave two, which
+ * is what this branch exists to avoid.  jlib::sys is below jlib::net and may
+ * not include it; it already includes jlib/util/util.hh, so this is the same
+ * seam rather than a new one.
+ *
+ * It is also where the other RFC readers live -- URL for 3986, content_type
+ * for 2045, encoded_word for 2047 -- and rfc9110.hh and rfc9112.hh compose
+ * onto rfc3986.hh, which is next door.
+ *
+ * ## What this deliberately does not do
+ *
+ * No cookies, no keep-alive, no content negotiation, no compression, no
+ * HTTP/2.  The client this serves fetches an OAuth2 token, and the way a
+ * narrow thing becomes a broad one is by nobody writing down that it was meant
+ * to be narrow.
+ */
+namespace http {
+
+class error : public std::exception {
+public:
+    error(const std::string& msg = "") { m_msg = "http error: " + msg; }
+    virtual ~error() {}
+    virtual const char* what() const noexcept { return m_msg.c_str(); }
+protected:
+    std::string m_msg;
+};
+
+/**
+ * A field section: names to values, in the order they arrived.
+ *
+ * **Not util::Headers**, and that is a decision rather than an oversight.
+ * Headers is an RFC 5322 header set: it RFC 2047-decodes every value it is
+ * given, unconditionally, folds continuation lines, and compares names with
+ * case.  HTTP field names are case-insensitive (RFC 9110 5.1), HTTP has no
+ * encoded words at all, and an HTTP field value that happens to contain
+ * "=?utf-8?q?..." means those characters and nothing else.  Handing one to the
+ * other would decode a value nobody asked to have decoded.
+ *
+ * A field may appear more than once and the repeats are not interchangeable
+ * -- two Content-Lengths that disagree is an attack, not a formatting choice
+ * -- so nothing here collapses them.
+ */
+class fields {
+public:
+    typedef std::pair<std::string, std::string> value_type;
+    typedef std::vector<value_type> rep_type;
+    typedef rep_type::const_iterator const_iterator;
+    typedef rep_type::size_type size_type;
+
+    void add(std::string name, std::string value);
+
+    /** Case-insensitively, per RFC 9110 5.1. */
+    bool has(std::string_view name) const;
+
+    /** The first value, or "" -- which is also what an empty field gives. */
+    std::string get(std::string_view name) const;
+
+    /** Every value under that name, in the order received. */
+    std::vector<std::string> all(std::string_view name) const;
+
+    /** How many times that name appears. */
+    size_type count(std::string_view name) const;
+
+    const_iterator begin() const { return m_fields.begin(); }
+    const_iterator end() const { return m_fields.end(); }
+    size_type size() const { return m_fields.size(); }
+    bool empty() const { return m_fields.empty(); }
+
+private:
+    rep_type m_fields;
+};
+
+/** How the body after a response head is delimited.  RFC 9112 6.3. */
+enum class framing {
+    none,          ///< there is no body: 1xx, 204, 304, or a response to HEAD
+    length,        ///< Content-Length octets
+    chunked,       ///< Transfer-Encoding ends in chunked
+    until_close    ///< to end of stream, which is the last resort
+};
+
+/** One response: its head, and its body once something has read one. */
+class Response {
+public:
+    Response() = default;
+
+    /** The three-digit code as a number.  Not a string to be compared. */
+    int status() const { return m_status; }
+
+    /** "HTTP/1.1". */
+    const std::string& version() const { return m_version; }
+
+    /** The reason phrase, which may be empty and means nothing to a program. */
+    const std::string& reason() const { return m_reason; }
+
+    const http::fields& fields() const { return m_fields; }
+
+    const std::string& body() const { return m_body; }
+    void set_body(std::string body) { m_body = std::move(body); }
+
+    /**
+     * 2xx.
+     *
+     * A non-2xx is not an exception here and must not become one.  An OAuth2
+     * token endpoint answers 400 with a JSON body that says whether the
+     * refresh token was revoked or the server merely hiccuped, and a client
+     * that throws away the body of anything it does not like cannot tell those
+     * apart.
+     */
+    bool ok() const { return m_status >= 200 && m_status < 300; }
+
+    http::framing body_framing() const { return m_framing; }
+
+    /** Meaningful only when body_framing() is framing::length. */
+    std::size_t content_length() const { return m_length; }
+
+    friend Response parse_head(std::string_view head, bool head_request);
+
+private:
+    int m_status = 0;
+    std::string m_version;
+    std::string m_reason;
+    http::fields m_fields;
+    std::string m_body;
+    http::framing m_framing = framing::until_close;
+    std::size_t m_length = 0;
+};
+
+/**
+ * The composed grammar: RFC 3986, then RFC 9110, then RFC 9112.
+ *
+ * Built once, on first use.  Exposed so a test can ask it what it knows --
+ * which rules are still prose, whether it passes check() -- without going
+ * through a parse.
+ */
+const abnf::grammar& grammar();
+
+/**
+ * Read a response head from a stream, to and including the blank line.
+ *
+ * Returns everything read, CRLFs and all.  Framing is procedural here for the
+ * reason written down in rfc9112.hh: abnf::rule::parse takes a string_view, so
+ * a grammar cannot ask for more input.  imap::read() frames an IMAP literal
+ * the same way.
+ *
+ * @param cap  the most octets to read before giving up.  A head with no end
+ *             to it is otherwise an unbounded read from a stranger.
+ *
+ * @throw error if the stream ends first, or the cap is reached.
+ */
+std::string read_head(std::istream& is, std::size_t cap = 8192);
+
+/**
+ * Parse a response head against the grammar.
+ *
+ * @param head_request  true if this answers a HEAD, which has no body however
+ *                      the fields are written (RFC 9112 6.3)
+ *
+ * Refuses, per RFC 9112 6:
+ *
+ * - both Content-Length and Transfer-Encoding, which is the request-smuggling
+ *   primitive: two recipients disagreeing about where a message ends is how
+ *   one request becomes two;
+ * - two Content-Lengths that do not agree, which is the same thing spelled
+ *   differently;
+ * - a Content-Length that is not a run of digits;
+ * - obs-fold, the continuation line, which 9112 5.2 says a recipient must
+ *   reject or replace;
+ * - whitespace before the colon, and a bare CR or LF anywhere in the section,
+ *   both of which the grammar refuses on its own.
+ */
+Response parse_head(std::string_view head, bool head_request = false);
+
+/** read_head() then parse_head(). */
+Response read_response_head(std::istream& is, bool head_request = false,
+                            std::size_t cap = 8192);
+
+/**
+ * Read a body, however the head says it is delimited.
+ *
+ * @param cap  the most octets to keep.  A Content-Length arriving from a
+ *             stranger decides an allocation; a token response is a few
+ *             hundred octets and anything claiming a gigabyte is not one.
+ *
+ * Chunked is read the size line, read that many octets, eat the CRLF, repeat
+ * -- and the trailer section after the last chunk is read and discarded, since
+ * something has to consume it for the connection to be at a boundary.
+ */
+std::string read_body(std::istream& is, const Response& head,
+                      std::size_t cap = 1 << 20);
+
+/** Lower-cased ASCII, for comparing a field name or a token. */
+std::string fold(std::string_view s);
+
+}
+}
+}
+
+#endif // JLIB_UTIL_HTTP_HH

--- a/jlib/util/rfc3986.hh
+++ b/jlib/util/rfc3986.hh
@@ -81,6 +81,14 @@ namespace util {
  * **A rule per path shape is what hier-part already had.**  No change; noted
  * because a reader will look for one name and find four.
  *
+ * ## What was missing, and is here now
+ *
+ * URI-reference, absolute-URI, relative-ref, relative-part, path-noscheme and
+ * segment-nz-nc are all in Appendix A and none of them had been pasted -- the
+ * first draft of this header took only what URL::parse needed, which is why
+ * URL::parse refused a relative reference: there was no rule for one.  RFC
+ * 9110 imports four of the six by name, which is what turned the omission up.
+ *
  * ## What the grammar does not decide
  *
  * Not whether the URI means anything.  "imap://-b.example/" parses and no
@@ -103,6 +111,17 @@ URI             =  scheme ":" hier-part [ "?" query ] [ "#" fragment ]
 hier-part       =  ( "//" authority path-abempty )
                 /  path-absolute
                 /  path-rootless
+                /  path-empty
+
+URI-reference   =  URI / relative-ref
+
+absolute-URI    =  scheme ":" hier-part [ "?" query ]
+
+relative-ref    =  relative-part [ "?" query ] [ "#" fragment ]
+
+relative-part   =  ( "//" authority path-abempty )
+                /  path-absolute
+                /  path-noscheme
                 /  path-empty
 
 scheme          =  ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )
@@ -146,12 +165,14 @@ reg-name        =  *( unreserved / pct-encoded / sub-delims )
 
 path-abempty    =  *( "/" segment )
 path-absolute   =  "/" [ segment-nz *( "/" segment ) ]
+path-noscheme   =  segment-nz-nc *( "/" segment )
 path-rootless   =  segment-nz *( "/" segment )
 path-empty      =  ""                   ; jlib: the RFC writes 0<pchar>, which
                                         ; is its notation for "nothing"
 
 segment         =  *pchar
 segment-nz      =  1*pchar
+segment-nz-nc   =  1*( unreserved / pct-encoded / sub-delims / "@" )
 pchar           =  unreserved / pct-encoded / sub-delims / ":" / "@"
 
 query           =  *( pchar / "/" / "?" )

--- a/jlib/util/rfc9110.hh
+++ b/jlib/util/rfc9110.hh
@@ -1,0 +1,366 @@
+/* -*- mode: C++ c-basic-offset: 4 -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef JLIB_UTIL_RFC9110_HH
+#define JLIB_UTIL_RFC9110_HH
+
+namespace jlib {
+namespace util {
+
+/**
+ * RFC 9110 Appendix A, the HTTP semantics grammar, as ABNF.
+ *
+ * Pasted whole -- all 142 rules, not the dozen the client happens to use.  The
+ * point of pasting an RFC is that a reader can check it against the document,
+ * and a subset breaks that: you would have to take it on trust that what was
+ * left out did not matter.  Unreferenced rules cost nothing at runtime.
+ * compile() makes the slots and only check() walks them, once.
+ *
+ * Composed, not standalone.  Concatenate it after rfc3986::URI_GRAMMAR:
+ *
+ *     grammar g = abnf::compile(std::string(rfc3986::URI_GRAMMAR) +
+ *                               rfc9110::SEMANTICS +
+ *                               rfc9112::MESSAGING);
+ *
+ * ## Where this departs from the published text
+ *
+ * **The imports from RFC 3986 are commented out, not deleted.**  RFC 9110
+ * writes nine of its rules as a prose-val pointing at the URI RFC --
+ *
+ *     absolute-URI = <absolute-URI, see [URI], Section 4.3>
+ *
+ * -- and RFC 3986 is pasted immediately above in the composed text, so
+ * defining it again here would be a redefinition error.  Each such line is
+ * still here with a "; jlib:" in front of it, so a reader sees every published
+ * line in its published order and can see exactly what was done to it.
+ * uri-host is the one that needed more than commenting: RFC 3986 spells that
+ * rule "host", so the import is written out as an alias.
+ *
+ * **Host is commented out, and it is not an import.**  RFC 5234 2.1 makes
+ * rulenames case-insensitive, so RFC 9110's `Host` field is the same
+ * rule as RFC 3986's `host` production -- which is why RFC 9110 imports that
+ * production under the name `uri-host` rather than under its own.  A composed
+ * grammar cannot hold both.  Nothing is lost: a Host field is
+ * `uri-host [ ":" port ]`, and RFC 3986's `authority` already accepts exactly
+ * that.
+ *
+ * **field-content is restructured**, and it is the only rule here whose text
+ * changed.  As published:
+ *
+ *     field-content = field-vchar [ 1*( SP / HTAB / field-vchar ) field-vchar ]
+ *
+ * Under possessive repetition the 1*( ... ) eats the trailing field-vchar that
+ * the rule then requires, so the optional group always fails and field-content
+ * matches exactly one character.  field-value = *field-content then stops at
+ * the first space: a Date: header would read as "Mon,".  The form here --
+ * field-vchar *( *( SP / HTAB ) field-vchar ) -- accepts the same language and
+ * ends every iteration on a field-vchar, so nothing has to be given back.
+ *
+ * ## The three rules that are still prose
+ *
+ * language-range (RFC 4647), Language-Tag (RFC 5646) and mailbox (RFC 5322)
+ * are left exactly as the RFC writes them.  jlib has an RFC 5322 mailbox
+ * grammar, in jlib/net/rfc5322.hh, and it is deliberately *not* composed in:
+ * RFC 5322 and RFC 9110 both define comment, ctext, quoted-pair and
+ * quoted-string and they do not agree, so pasting one over the other would
+ * quietly change the meaning of four rules to get one.
+ *
+ * So compile() leaves them as prose, grammar::prose_rules() reports them, and
+ * a parse that reaches one fails with a position naming the rule.  Inventing a
+ * grammar for them would look complete and be wrong, which is worse.
+ *
+ * ## What a compiling grammar does not prove
+ *
+ * check() finds undefined references, left recursion, and repetition of
+ * something nullable.  It does **not** find an alternation that commits to the
+ * wrong branch -- which is the failure mode every grammar in this tree has
+ * actually had.  dec-octet, IPv6address, RFC 5234's own defined-as and repeat,
+ * five of RFC 5322's, and field-content above were all found by *running*
+ * them, never by reading them.
+ *
+ * So the rules this code exercises are right because they are tested, and the
+ * rest are well-formed and unverified.  What is exercised, as of this branch:
+ * status-line, HTTP-version, status-code, reason-phrase, field-line,
+ * field-name, field-value, token, OWS, and the RFC 3986 rules underneath
+ * absolute-URI and URI-reference.
+ *
+ * Two known-wrong-under-PEG rules that nothing here exercises, written down so
+ * the next caller does not have to find them again:
+ *
+ * - credentials and challenge put token68 before the auth-param list, and
+ *   token68 ends in *"=", so `Digest username="x"` matches token68 as
+ *   `username=` and the rest is left over.  Whatever implements #104 will have
+ *   to reorder those two.
+ * - chunk has chunk-data = 1*OCTET, which is greedy and consumes the rest of
+ *   the input, so chunked-body cannot frame anything.  That is expected:
+ *   chunked framing is procedural, exactly as imap::read() frames a literal.
+ */
+namespace rfc9110 {
+
+inline const char* const SEMANTICS = R"ABNF(
+Accept = [ ( media-range [ weight ] ) *( OWS "," OWS ( media-range [
+ weight ] ) ) ]
+Accept-Charset = [ ( ( token / "*" ) [ weight ] ) *( OWS "," OWS ( (
+ token / "*" ) [ weight ] ) ) ]
+Accept-Encoding = [ ( codings [ weight ] ) *( OWS "," OWS ( codings [
+ weight ] ) ) ]
+Accept-Language = [ ( language-range [ weight ] ) *( OWS "," OWS (
+ language-range [ weight ] ) ) ]
+Accept-Ranges = acceptable-ranges
+Allow = [ method *( OWS "," OWS method ) ]
+Authentication-Info = [ auth-param *( OWS "," OWS auth-param ) ]
+Authorization = credentials
+
+BWS = OWS
+
+Connection = [ connection-option *( OWS "," OWS connection-option )
+ ]
+Content-Encoding = [ content-coding *( OWS "," OWS content-coding )
+ ]
+Content-Language = [ language-tag *( OWS "," OWS language-tag ) ]
+Content-Length = 1*DIGIT
+Content-Location = absolute-URI / partial-URI
+Content-Range = range-unit SP ( range-resp / unsatisfied-range )
+Content-Type = media-type
+
+Date = HTTP-date
+
+ETag = entity-tag
+Expect = [ expectation *( OWS "," OWS expectation ) ]
+
+From = mailbox
+
+GMT = %x47.4D.54 ; GMT
+
+HTTP-date = IMF-fixdate / obs-date
+; jlib: Host = uri-host [ ":" port ]
+;
+; Commented out, and this one is not an import.  RFC 5234 2.1 makes
+; rulenames case-insensitive, so RFC 9110's Host field is the same rule
+; as RFC 3986's host production -- which is exactly why RFC 9110 imports
+; that production under the name uri-host rather than its own.  A
+; composed grammar cannot hold both, and the URI one is the one
+; everything else here reaches through.  Nothing is lost: a Host field
+; is uri-host [ ":" port ], and RFC 3986's authority already accepts
+; precisely that and a userinfo besides.
+
+IMF-fixdate = day-name "," SP date1 SP time-of-day SP GMT
+If-Match = "*" / [ entity-tag *( OWS "," OWS entity-tag ) ]
+If-Modified-Since = HTTP-date
+If-None-Match = "*" / [ entity-tag *( OWS "," OWS entity-tag ) ]
+If-Range = entity-tag / HTTP-date
+If-Unmodified-Since = HTTP-date
+
+Last-Modified = HTTP-date
+Location = URI-reference
+
+Max-Forwards = 1*DIGIT
+
+OWS = *( SP / HTAB )
+
+Proxy-Authenticate = [ challenge *( OWS "," OWS challenge ) ]
+Proxy-Authentication-Info = [ auth-param *( OWS "," OWS auth-param )
+ ]
+Proxy-Authorization = credentials
+
+RWS = 1*( SP / HTAB )
+Range = ranges-specifier
+Referer = absolute-URI / partial-URI
+Retry-After = HTTP-date / delay-seconds
+
+Server = product *( RWS ( product / comment ) )
+
+TE = [ t-codings *( OWS "," OWS t-codings ) ]
+Trailer = [ field-name *( OWS "," OWS field-name ) ]
+
+; jlib: URI-reference = <URI-reference, see [URI], Section 4.1>
+Upgrade = [ protocol *( OWS "," OWS protocol ) ]
+User-Agent = product *( RWS ( product / comment ) )
+
+Vary = [ ( "*" / field-name ) *( OWS "," OWS ( "*" / field-name ) )
+ ]
+Via = [ ( received-protocol RWS received-by [ RWS comment ] ) *( OWS
+ "," OWS ( received-protocol RWS received-by [ RWS comment ] ) ) ]
+
+WWW-Authenticate = [ challenge *( OWS "," OWS challenge ) ]
+
+; jlib: absolute-URI = <absolute-URI, see [URI], Section 4.3>
+absolute-path = 1*( "/" segment )
+acceptable-ranges = range-unit *( OWS "," OWS range-unit )
+asctime-date = day-name SP date3 SP time-of-day SP year
+auth-param = token BWS "=" BWS ( token / quoted-string )
+auth-scheme = token
+; jlib: authority = <authority, see [URI], Section 3.2>
+
+challenge = auth-scheme [ 1*SP ( token68 / [ auth-param *( OWS ","
+ OWS auth-param ) ] ) ]
+codings = content-coding / "identity" / "*"
+comment = "(" *( ctext / quoted-pair / comment ) ")"
+complete-length = 1*DIGIT
+connection-option = token
+content-coding = token
+credentials = auth-scheme [ 1*SP ( token68 / [ auth-param *( OWS ","
+ OWS auth-param ) ] ) ]
+ctext = HTAB / SP / %x21-27 ; '!'-'''
+ / %x2A-5B ; '*'-'['
+ / %x5D-7E ; ']'-'~'
+ / obs-text
+
+date1 = day SP month SP year
+date2 = day "-" month "-" 2DIGIT
+date3 = month SP ( 2DIGIT / ( SP DIGIT ) )
+day = 2DIGIT
+day-name = %x4D.6F.6E ; Mon
+ / %x54.75.65 ; Tue
+ / %x57.65.64 ; Wed
+ / %x54.68.75 ; Thu
+ / %x46.72.69 ; Fri
+ / %x53.61.74 ; Sat
+ / %x53.75.6E ; Sun
+day-name-l = %x4D.6F.6E.64.61.79 ; Monday
+ / %x54.75.65.73.64.61.79 ; Tuesday
+ / %x57.65.64.6E.65.73.64.61.79 ; Wednesday
+ / %x54.68.75.72.73.64.61.79 ; Thursday
+ / %x46.72.69.64.61.79 ; Friday
+ / %x53.61.74.75.72.64.61.79 ; Saturday
+ / %x53.75.6E.64.61.79 ; Sunday
+delay-seconds = 1*DIGIT
+
+entity-tag = [ weak ] opaque-tag
+etagc = "!" / %x23-7E ; '#'-'~'
+ / obs-text
+expectation = token [ "=" ( token / quoted-string ) parameters ]
+
+; jlib: field-content = field-vchar [ 1*( SP / HTAB / field-vchar )
+;                       field-vchar ]
+;
+; The published rule cannot work under possessive repetition: the
+; 1*( SP / HTAB / field-vchar ) eats the trailing field-vchar the rule
+; then requires, so the optional group always fails and field-content
+; matches one character.  field-value = *field-content then stops at
+; the first space -- a Date: would read as "Mon,".  Same language,
+; written so that every iteration ends on a field-vchar:
+field-content = field-vchar *( *( SP / HTAB ) field-vchar )
+field-name = token
+field-value = *field-content
+field-vchar = VCHAR / obs-text
+first-pos = 1*DIGIT
+
+hour = 2DIGIT
+http-URI = "http://" authority path-abempty [ "?" query ]
+https-URI = "https://" authority path-abempty [ "?" query ]
+
+incl-range = first-pos "-" last-pos
+int-range = first-pos "-" [ last-pos ]
+
+language-range = <language-range, see [RFC4647], Section 2.1>
+language-tag = <Language-Tag, see [RFC5646], Section 2.1>
+last-pos = 1*DIGIT
+
+mailbox = <mailbox, see [RFC5322], Section 3.4>
+media-range = ( "*/*" / ( type "/*" ) / ( type "/" subtype ) )
+ parameters
+media-type = type "/" subtype parameters
+method = token
+minute = 2DIGIT
+month = %x4A.61.6E ; Jan
+ / %x46.65.62 ; Feb
+ / %x4D.61.72 ; Mar
+ / %x41.70.72 ; Apr
+ / %x4D.61.79 ; May
+ / %x4A.75.6E ; Jun
+ / %x4A.75.6C ; Jul
+ / %x41.75.67 ; Aug
+ / %x53.65.70 ; Sep
+ / %x4F.63.74 ; Oct
+ / %x4E.6F.76 ; Nov
+ / %x44.65.63 ; Dec
+
+obs-date = rfc850-date / asctime-date
+obs-text = %x80-FF
+opaque-tag = DQUOTE *etagc DQUOTE
+other-range = 1*( %x21-2B ; '!'-'+'
+ / %x2D-7E ; '-'-'~'
+ )
+
+parameter = parameter-name "=" parameter-value
+parameter-name = token
+parameter-value = ( token / quoted-string )
+parameters = *( OWS ";" OWS [ parameter ] )
+partial-URI = relative-part [ "?" query ]
+; jlib: path-abempty = <path-abempty, see [URI], Section 3.3>
+; jlib: port = <port, see [URI], Section 3.2.3>
+product = token [ "/" product-version ]
+product-version = token
+protocol = protocol-name [ "/" protocol-version ]
+protocol-name = token
+protocol-version = token
+pseudonym = token
+
+qdtext = HTAB / SP / "!" / %x23-5B ; '#'-'['
+ / %x5D-7E ; ']'-'~'
+ / obs-text
+; jlib: query = <query, see [URI], Section 3.4>
+quoted-pair = "\" ( HTAB / SP / VCHAR / obs-text )
+quoted-string = DQUOTE *( qdtext / quoted-pair ) DQUOTE
+qvalue = ( "0" [ "." *3DIGIT ] ) / ( "1" [ "." *3"0" ] )
+
+range-resp = incl-range "/" ( complete-length / "*" )
+range-set = range-spec *( OWS "," OWS range-spec )
+range-spec = int-range / suffix-range / other-range
+range-unit = token
+ranges-specifier = range-unit "=" range-set
+received-by = pseudonym [ ":" port ]
+received-protocol = [ protocol-name "/" ] protocol-version
+; jlib: relative-part = <relative-part, see [URI], Section 4.2>
+rfc850-date = day-name-l "," SP date2 SP time-of-day SP GMT
+
+second = 2DIGIT
+; jlib: segment = <segment, see [URI], Section 3.3>
+subtype = token
+suffix-length = 1*DIGIT
+suffix-range = "-" suffix-length
+
+t-codings = "trailers" / ( transfer-coding [ weight ] )
+tchar = "!" / "#" / "$" / "%" / "&" / "'" / "*" / "+" / "-" / "." /
+ "^" / "_" / "`" / "|" / "~" / DIGIT / ALPHA
+time-of-day = hour ":" minute ":" second
+token = 1*tchar
+token68 = 1*( ALPHA / DIGIT / "-" / "." / "_" / "~" / "+" / "/" )
+ *"="
+transfer-coding = token *( OWS ";" OWS transfer-parameter )
+transfer-parameter = token BWS "=" BWS ( token / quoted-string )
+type = token
+
+unsatisfied-range = "*/" complete-length
+; jlib: uri-host = <host, see [URI], Section 3.2.2>
+uri-host      = host   ; jlib: that import, written out --
+                       ; RFC 3986 spells the rule "host"
+
+weak = %x57.2F ; W/
+weight = OWS ";" OWS "q=" qvalue
+
+year = 4DIGIT
+)ABNF";
+
+}
+}
+}
+
+#endif // JLIB_UTIL_RFC9110_HH

--- a/jlib/util/rfc9112.hh
+++ b/jlib/util/rfc9112.hh
@@ -1,0 +1,126 @@
+/* -*- mode: C++ c-basic-offset: 4 -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef JLIB_UTIL_RFC9112_HH
+#define JLIB_UTIL_RFC9112_HH
+
+namespace jlib {
+namespace util {
+
+/**
+ * RFC 9112 Appendix A, the HTTP/1.1 message grammar, as ABNF.
+ *
+ * Pasted whole, and composed after rfc3986::URI_GRAMMAR and
+ * rfc9110::SEMANTICS -- see the note in rfc9110.hh, which applies here in full
+ * and is not repeated.
+ *
+ * ## Where this departs from the published text
+ *
+ * **Imports are commented out rather than deleted**, as in rfc9110.hh: fifteen
+ * prose-val lines pointing at [HTTP] and [URI], both of which are pasted above
+ * in the composed text.
+ *
+ * **method = token is commented out.**  RFC 9110 defines it identically and a
+ * second "=" would be a redefinition error.  This is the only rule the two
+ * documents both spell out.
+ *
+ * ## What this grammar can and cannot frame
+ *
+ * A response head, yes: HTTP-message's start-line and field-line are what
+ * http::read_head() checks its input against.
+ *
+ * A body, no, and not because of anything jlib did.  rule::parse takes a
+ * std::string_view, so a grammar can only see bytes that have already been
+ * read -- and chunk-data is 1*OCTET, which is greedy.  Framing a chunked body
+ * means reading the size line, reading that many octets, and going round
+ * again, which is procedural and is what http::read_body() does.  imap::read()
+ * frames an IMAP literal the same way and for the same reason.
+ */
+namespace rfc9112 {
+
+inline const char* const MESSAGING = R"ABNF(
+; jlib: BWS = <BWS, see [HTTP], Section 5.6.3>
+
+HTTP-message = start-line CRLF *( field-line CRLF ) CRLF [
+ message-body ]
+HTTP-name = %x48.54.54.50 ; HTTP
+HTTP-version = HTTP-name "/" DIGIT "." DIGIT
+
+; jlib: OWS = <OWS, see [HTTP], Section 5.6.3>
+
+; jlib: RWS = <RWS, see [HTTP], Section 5.6.3>
+
+Transfer-Encoding = [ transfer-coding *( OWS "," OWS transfer-coding
+ ) ]
+
+; jlib: absolute-URI = <absolute-URI, see [URI], Section 4.3>
+absolute-form = absolute-URI
+; jlib: absolute-path = <absolute-path, see [HTTP], Section 4.1>
+asterisk-form = "*"
+; jlib: authority = <authority, see [URI], Section 3.2>
+authority-form = uri-host ":" port
+
+chunk = chunk-size [ chunk-ext ] CRLF chunk-data CRLF
+chunk-data = 1*OCTET
+chunk-ext = *( BWS ";" BWS chunk-ext-name [ BWS "=" BWS chunk-ext-val
+ ] )
+chunk-ext-name = token
+chunk-ext-val = token / quoted-string
+chunk-size = 1*HEXDIG
+chunked-body = *chunk last-chunk trailer-section CRLF
+
+field-line = field-name ":" OWS field-value OWS
+; jlib: field-name = <field-name, see [HTTP], Section 5.1>
+; jlib: field-value = <field-value, see [HTTP], Section 5.5>
+
+last-chunk = 1*"0" [ chunk-ext ] CRLF
+
+message-body = *OCTET
+; jlib: method = token   ; RFC 9110 defines it identically, above
+
+obs-fold = OWS CRLF RWS
+; jlib: obs-text = <obs-text, see [HTTP], Section 5.6.4>
+origin-form = absolute-path [ "?" query ]
+
+; jlib: port = <port, see [URI], Section 3.2.3>
+
+; jlib: query = <query, see [URI], Section 3.4>
+; jlib: quoted-string = <quoted-string, see [HTTP], Section 5.6.4>
+
+reason-phrase = 1*( HTAB / SP / VCHAR / obs-text )
+request-line = method SP request-target SP HTTP-version
+request-target = origin-form / absolute-form / authority-form /
+ asterisk-form
+
+start-line = request-line / status-line
+status-code = 3DIGIT
+status-line = HTTP-version SP status-code SP [ reason-phrase ]
+
+; jlib: token = <token, see [HTTP], Section 5.6.2>
+trailer-section = *( field-line CRLF )
+; jlib: transfer-coding = <transfer-coding, see [HTTP], Section 10.1.4>
+
+; jlib: uri-host = <host, see [URI], Section 3.2.2>
+)ABNF";
+
+}
+}
+}
+
+#endif // JLIB_UTIL_RFC9112_HH

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -77,6 +77,7 @@ TESTS = \
 	util_headers_angie_test \
 	util_xml_test \
 	util_json_test \
+	util_http_test \
 	util_abnf_test \
 	util_abnf_compile_test \
  \
@@ -145,7 +146,7 @@ net_pop3_live_test_SOURCES      = net_pop3_live_test.cc
 net_pop3_live_test_LDADD        = $(JNET_LA) $(JUTIL_LA) $(JSYS_LA) $(OPENSSL_LIBS)
 
 sys_proxy_live_test_SOURCES     = sys_proxy_live_test.cc
-sys_proxy_live_test_LDADD       = $(JSYS_LA) $(JUTIL_LA) $(OPENSSL_LIBS)
+sys_proxy_live_test_LDADD       = $(JUTIL_LA) $(JSYS_LA) $(OPENSSL_LIBS)
 
 net_imap_live_test_SOURCES      = net_imap_live_test.cc
 net_imap_live_test_LDADD        = $(JNET_LA) $(JUTIL_LA) $(JSYS_LA) $(OPENSSL_LIBS)
@@ -179,6 +180,9 @@ sys_socket_test_LDADD   = $(JSYS_LA)
 
 util_json_test_SOURCES = util_json_test.cc
 util_json_test_LDADD   = $(JUTIL_LA) $(JSYS_LA) $(JSONC_LIBS)
+
+util_http_test_SOURCES = util_http_test.cc
+util_http_test_LDADD   = $(JUTIL_LA) $(JSYS_LA)
 
 util_test_SOURCES = util_test.cc
 util_test_LDADD   = $(JUTIL_LA)

--- a/tests/util_http_test.cc
+++ b/tests/util_http_test.cc
@@ -1,0 +1,402 @@
+/* -*- mode: C++ c-basic-offset: 4 -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// An HTTP/1.1 response head, read against RFC 9112's grammar.
+//
+// No server here: read_head() takes an std::istream, so an istringstream is
+// the whole harness, and the awkward cases -- a head with no end, both framing
+// fields at once, a chunk whose data looks like a chunk header -- can be
+// written down exactly rather than coaxed out of something real.
+//
+// sys_proxy_live_test is the other half: it drives the same reader against a
+// real tinyproxy, because a server nobody wrote produces responses nobody
+// thought of.
+
+#include <jlib/util/http.hh>
+#include <jlib/util/URL.hh>
+#include <jlib/util/abnf.hh>
+
+#include <iostream>
+#include <sstream>
+#include <string>
+
+namespace http = jlib::util::http;
+
+using jlib::util::URL;
+
+static int failures = 0;
+
+static void ok(const std::string& what, bool good, const std::string& detail = "") {
+    if(!good) ++failures;
+    std::cout << (good ? "  ok   " : "  FAIL ") << what;
+    if(!detail.empty()) std::cout << ": " << detail;
+    std::cout << "\n";
+}
+
+/** Did parsing this head throw? */
+static bool refused(const std::string& head) {
+    try {
+        http::parse_head(head);
+
+        return false;
+    }
+    catch(http::error&) {
+        return true;
+    }
+}
+
+static void the_grammar_is_the_whole_rfc() {
+    std::cout << "\nthe grammar is the whole of both RFCs:\n";
+
+    const jlib::util::abnf::grammar& g = http::grammar();
+
+    // 3986 + 9110 + 9112, pasted whole rather than the dozen rules the client
+    // uses.  If this number moves, a rule was added or lost and the reader
+    // checking this file against the RFCs deserves to know.
+    ok("it compiles, and has every rule in it", g.rules().size() == 194,
+       std::to_string(g.rules().size()));
+
+    ok("nothing is referenced and undefined", g.undefined().empty());
+
+    // check() finds undefined references, left recursion and nullable
+    // repetition.  It does NOT find an alternation that commits to the wrong
+    // branch, which is the failure every grammar in this tree has actually
+    // had -- so this passing is necessary and a long way from sufficient.
+    bool checked = true;
+
+    try { g.check(); } catch(std::exception&) { checked = false; }
+
+    ok("and it passes check()", checked);
+
+    // Exactly three rules are still prose, and they are the three RFC 9110
+    // imports from documents jlib does not have: RFC 4647, RFC 5646, RFC 5322.
+    // Anything else appearing here means an import was missed and a rule that
+    // looks defined will fail at parse time.
+    const std::vector<std::string> prose = g.prose_rules();
+
+    ok("three rules are still prose, and only three", prose.size() == 3,
+       std::to_string(prose.size()));
+
+    bool expected = prose.size() == 3;
+
+    for(const std::string& p : prose) {
+        if(p != "language-range" && p != "language-tag" && p != "mailbox")
+            expected = false;
+    }
+
+    ok("and they are the ones from RFCs jlib has not pasted", expected);
+}
+
+static void a_status_line_and_a_field_section() {
+    std::cout << "\na status line and a field section:\n";
+
+    const http::Response r = http::parse_head(
+        "HTTP/1.1 200 OK\r\n"
+        "Content-Type: text/html; charset=utf-8\r\n"
+        "Date: Mon, 01 Jan 2024 00:00:00 GMT\r\n"
+        "Content-Length: 12\r\n"
+        "\r\n");
+
+    // A number, not a string.  http::get() compared the status against the
+    // string "200" and treated everything else as an error, which is why it
+    // could neither follow a redirect nor read the body of a 400.
+    ok("the status is a number", r.status() == 200, std::to_string(r.status()));
+    ok("the version is there", r.version() == "HTTP/1.1", r.version());
+    ok("and the reason phrase", r.reason() == "OK", r.reason());
+    ok("2xx is ok()", r.ok());
+
+    // The field value comes out of the match, and field-line puts the OWS
+    // outside field-value, so it arrives trimmed without anyone trimming it.
+    ok("a field value has no leading space",
+       r.fields().get("Content-Type") == "text/html; charset=utf-8",
+       "\"" + r.fields().get("Content-Type") + "\"");
+
+    // RFC 9110 5.1: field names are case-insensitive.
+    ok("names are matched without case",
+       r.fields().has("content-type") && r.fields().has("CONTENT-TYPE"));
+
+    // The one that proves the field-content fix.  As RFC 9110 publishes it,
+    // field-content cannot match past a space under possessive repetition, and
+    // this value would have read as "Mon,".
+    ok("a value with spaces in it survives",
+       r.fields().get("Date") == "Mon, 01 Jan 2024 00:00:00 GMT",
+       "\"" + r.fields().get("Date") + "\"");
+
+    ok("Content-Length gives length framing",
+       r.body_framing() == http::framing::length && r.content_length() == 12,
+       std::to_string(r.content_length()));
+
+    // RFC 9112 4: the second SP is required even with no reason phrase.
+    // Servers omit it, so this is a deliberate and narrow leniency.
+    const http::Response bare = http::parse_head("HTTP/1.1 204\r\n\r\n");
+
+    ok("a status line with no trailing space is read anyway",
+       bare.status() == 204 && bare.reason().empty());
+
+    // 204 has no body however the fields are written (9112 6.3).
+    ok("and a 204 has no body", bare.body_framing() == http::framing::none);
+
+    const http::Response err = http::parse_head(
+        "HTTP/1.1 400 Bad Request\r\nContent-Length: 27\r\n\r\n");
+
+    // A non-2xx is not an exception.  A token endpoint answers 400 with a body
+    // saying whether the refresh token was revoked or the server hiccuped.
+    ok("a 400 parses, with its body still to come",
+       err.status() == 400 && !err.ok() && err.content_length() == 27);
+}
+
+static void what_rfc_9112_section_6_refuses() {
+    std::cout << "\nwhat RFC 9112 section 6 refuses:\n";
+
+    // The request-smuggling primitive.  Two recipients disagreeing about where
+    // a message ends is how one request becomes two.
+    ok("both Content-Length and Transfer-Encoding",
+       refused("HTTP/1.1 200 OK\r\n"
+               "Content-Length: 5\r\n"
+               "Transfer-Encoding: chunked\r\n\r\n"));
+
+    ok("two Content-Lengths that disagree",
+       refused("HTTP/1.1 200 OK\r\nContent-Length: 5\r\nContent-Length: 6\r\n\r\n"));
+
+    // Two that agree are redundant rather than dangerous, and 9112 6.3 says to
+    // take the value.
+    bool agreed = false;
+
+    try {
+        const http::Response r = http::parse_head(
+            "HTTP/1.1 200 OK\r\nContent-Length: 5\r\nContent-Length: 5\r\n\r\n");
+
+        agreed = r.content_length() == 5;
+    }
+    catch(http::error&) {}
+
+    ok("but two that agree are allowed", agreed);
+
+    ok("a Content-Length that is not a number",
+       refused("HTTP/1.1 200 OK\r\nContent-Length: 5, 6\r\n\r\n"));
+
+    // The grammar refuses these on its own -- field-line is
+    // field-name ":" OWS field-value OWS and field-name is a token.
+    ok("whitespace before the colon",
+       refused("HTTP/1.1 200 OK\r\nContent-Length : 5\r\n\r\n"));
+
+    ok("a field name that is not a token",
+       refused("HTTP/1.1 200 OK\r\nCon tent: 5\r\n\r\n"));
+
+    // 9112 5.2: obs-fold must be rejected or replaced by a recipient.
+    ok("obs-fold, the obsolete continuation line",
+       refused("HTTP/1.1 200 OK\r\nX-Long: one\r\n  two\r\n\r\n"));
+
+    // 9112 2.2 permits accepting a bare LF as a terminator and forbids a bare
+    // CR.  jlib accepts neither: the only way not to disagree with the
+    // recipient in front of you is to insist on CRLF.
+    ok("a bare LF as a line ending", refused("HTTP/1.1 200 OK\nX: 1\n\n"));
+
+    ok("a bare CR inside a field value",
+       refused("HTTP/1.1 200 OK\r\nX: one\rtwo\r\n\r\n"));
+
+    ok("something that is not a status line at all",
+       refused("220 mail.example.com ESMTP\r\n\r\n"));
+
+    ok("and a status code that is not three digits",
+       refused("HTTP/1.1 20 OK\r\n\r\n"));
+}
+
+static void reading_a_head_off_a_stream() {
+    std::cout << "\nreading a head off a stream:\n";
+
+    std::istringstream is("HTTP/1.1 200 OK\r\nX: 1\r\n\r\nbody goes here");
+
+    const std::string head = http::read_head(is);
+
+    ok("it stops at the blank line", head == "HTTP/1.1 200 OK\r\nX: 1\r\n\r\n",
+       std::to_string(head.size()) + " octets");
+
+    std::string rest;
+    std::getline(is, rest);
+
+    ok("and leaves the body in the stream", rest == "body goes here", rest);
+
+    // A head with no end to it is an unbounded read from a stranger.  This is
+    // the cap open_proxy() had and the reason its reader was worth keeping.
+    std::string endless = "HTTP/1.1 200 OK\r\n";
+
+    for(int i = 0; i < 500; i++) endless += "X-Padding: aaaaaaaaaaaaaaaaaaaa\r\n";
+
+    std::istringstream big(endless);
+    bool capped = false;
+
+    try { http::read_head(big, 4096); }
+    catch(http::error&) { capped = true; }
+
+    ok("a head with no end is given up on", capped);
+
+    std::istringstream cut("HTTP/1.1 200 OK\r\nX: 1\r\n");
+    bool truncated = false;
+
+    try { http::read_head(cut); }
+    catch(http::error&) { truncated = true; }
+
+    ok("and so is one the connection cut short", truncated);
+}
+
+static void reading_a_body() {
+    std::cout << "\nreading a body:\n";
+
+    {
+        std::istringstream is("HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nhelloAND MORE");
+
+        const http::Response head = http::read_response_head(is);
+
+        ok("Content-Length octets, and no more",
+           http::read_body(is, head) == "hello");
+    }
+
+    {
+        // The case that catches a chunked reader written with find(): the
+        // chunk data contains a line that looks exactly like a chunk header.
+        // Framing by the counts is what makes this work, and framing by
+        // searching is what does not.
+        const std::string trap = "5\r\nnope\r\n";
+
+        std::ostringstream o;
+
+        o << "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n"
+          << std::hex << trap.size() << "\r\n" << trap << "\r\n"
+          << "3\r\nend\r\n"
+          << "0\r\n\r\n";
+
+        std::istringstream is(o.str());
+
+        const http::Response head = http::read_response_head(is);
+
+        ok("Transfer-Encoding: chunked gives chunked framing",
+           head.body_framing() == http::framing::chunked);
+
+        const std::string body = http::read_body(is, head);
+
+        ok("a chunk whose data looks like a chunk header reassembles",
+           body == trap + "end", body);
+    }
+
+    {
+        // A chunk extension is parsed off and discarded, and so is the trailer
+        // section -- something has to consume the trailer or the connection is
+        // not at a message boundary and the next reader takes it for a status
+        // line.
+        std::istringstream is(
+            "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n"
+            "4;name=value\r\nabcd\r\n"
+            "0\r\nX-Checksum: 1234\r\n\r\n"
+            "HTTP/1.1 200 OK\r\n\r\n");
+
+        const http::Response head = http::read_response_head(is);
+
+        ok("a chunk extension is ignored", http::read_body(is, head) == "abcd");
+
+        // And the proof that the trailer was consumed: what is left is the
+        // next message, starting exactly where it should.
+        const http::Response next = http::read_response_head(is);
+
+        ok("and the trailer section is consumed", next.status() == 200);
+    }
+
+    {
+        std::istringstream is("HTTP/1.1 200 OK\r\nX: 1\r\n\r\nall of this");
+
+        const http::Response head = http::read_response_head(is);
+
+        ok("with no framing fields the body runs to end of stream",
+           head.body_framing() == http::framing::until_close &&
+           http::read_body(is, head) == "all of this");
+    }
+
+    {
+        // A Content-Length from a stranger decides an allocation.
+        std::istringstream is("HTTP/1.1 200 OK\r\nContent-Length: 999999999\r\n\r\nx");
+
+        const http::Response head = http::read_response_head(is);
+        bool capped = false;
+
+        try { http::read_body(is, head, 1024); }
+        catch(http::error&) { capped = true; }
+
+        ok("an enormous Content-Length is refused rather than allocated", capped);
+    }
+}
+
+static void a_relative_reference_parses_now() {
+    std::cout << "\na relative reference parses now:\n";
+
+    // RFC 9110 makes Location a URI-reference, and a 302 pointing at "/signin"
+    // is the ordinary case.  relative-ref was simply not in the pasted grammar
+    // -- the first version of rfc3986.hh took only the rules URL::parse needed.
+    ok("a path-only reference", URL::valid_reference("/signin?next=/inbox"));
+    ok("a reference with no leading slash", URL::valid_reference("next/page"));
+    ok("and one beginning with //", URL::valid_reference("//example.com/x"));
+
+    URL u;
+    u.parse_reference("/signin?next=%2Finbox");
+
+    ok("it has no scheme, and says so", u.relative() && u.get_protocol().empty());
+    ok("and the path is there", u.get_path() == "/signin", u.get_path());
+
+    // parse() is deliberately NOT widened.  "imap:/host" is a typo and also a
+    // perfectly good relative reference; a parse() that accepted it would stop
+    // throwing and start handing Imap4 something with no host to connect to.
+    ok("but parse() still refuses a relative reference",
+       !URL::valid("example.com/x"));
+
+    ok("and an absolute URL goes through either", URL::valid_reference("https://x/y") &&
+       URL::valid("https://x/y"));
+}
+
+int main() {
+    std::cout << std::unitbuf;
+
+    the_grammar_is_the_whole_rfc();
+    a_status_line_and_a_field_section();
+    what_rfc_9112_section_6_refuses();
+    reading_a_head_off_a_stream();
+    reading_a_body();
+    a_relative_reference_parses_now();
+
+    // What a green run does not establish.
+    //
+    // That the rules nothing here exercises are right.  RFC 9110 and RFC 9112
+    // are pasted whole and this uses a fraction of them; check() proves they
+    // are well-formed, not that each alternation commits to the branch the RFC
+    // meant.  Every grammar in this tree that needed reordering -- dec-octet,
+    // IPv6address, RFC 5234's own defined-as and repeat, five of RFC 5322's,
+    // and field-content on this branch -- was found by running it, never by
+    // reading it.  Two are known wrong and written down in rfc9110.hh:
+    // credentials/challenge, and chunk.
+    //
+    // That a real server sends what this expects.  Everything here is an
+    // istringstream, which produces exactly the responses somebody thought of.
+    // sys_proxy_live_test runs the same reader against tinyproxy, which is one
+    // real server and not a survey.
+    //
+    // Anything about requests.  read_head parses a response; request-line and
+    // the four request-target forms compile and are unexercised.
+    std::cout << "\n" << (failures ? "FAILED" : "PASSED") << ": " << failures
+              << " failure(s)\n";
+
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
# An HTTP response head, read against the RFC

Fourth branch of the HTTP/OAuth2 work: the message layer. No client yet -- that
is next -- but everything that decides what a response *is*.

## The grammars, pasted whole

`jlib/util/rfc9110.hh` and `jlib/util/rfc9112.hh` are RFC 9110 Appendix A and
RFC 9112 Appendix A, complete: all 142 rules and all 42, not the dozen the
client happens to use. The point of pasting an RFC is that a reader can check
it against the document; a subset breaks that, because you would have to take
on trust that what was left out did not matter. Unreferenced rules cost nothing
-- `compile()` makes the slots and only `check()` walks them, once.

They compose onto `jlib/util/rfc3986.hh` by concatenation, as `rfc2045.hh`
already composes onto `rfc5322::LEXICAL`. 194 rules, `check()` passes, nothing
undefined.

RFC 3986 gained the six rules that were never pasted: `URI-reference`,
`absolute-URI`, `relative-ref`, `relative-part`, `path-noscheme` and
`segment-nz-nc`. The first version of that header took only what `URL::parse`
needed, and RFC 9110 importing four of the six by name is what turned the
omission up.

### The three departures, each marked "; jlib:"

**Imports are commented out, not deleted.** RFC 9110 writes nine of its rules
and RFC 9112 fifteen as a prose-val pointing elsewhere --
`absolute-URI = <absolute-URI, see [URI], Section 4.3>` -- and the referent is
now pasted above in the same text, so defining it twice is a redefinition
error. Each line is still there with a `; jlib:` in front of it, so a reader
sees every published line in its published order and can see exactly what
happened to it.

**`Host` is commented out, and this one is not an import.** RFC 5234 2.1 makes
rulenames case-insensitive, so RFC 9110's `Host` *field* is the same rule as
RFC 3986's `host` *production* -- which is precisely why RFC 9110 imports that
production under the name `uri-host` rather than its own. A composed grammar
cannot hold both. Nothing is lost: a Host field is `uri-host [ ":" port ]` and
RFC 3986's `authority` already accepts exactly that.

**`field-content` is restructured**, and it is the only rule whose text
changed. As published:

```
field-content = field-vchar [ 1*( SP / HTAB / field-vchar ) field-vchar ]
```

Under possessive repetition the `1*( ... )` eats the trailing `field-vchar` the
rule then requires, so the optional group always fails and `field-content`
matches exactly one character. `field-value = *field-content` then stops at the
first space: a `Date:` header would read as `"Mon,"`. The form here --
`field-vchar *( *( SP / HTAB ) field-vchar )` -- accepts the same language and
ends every iteration on a `field-vchar`, so nothing has to be given back. There
is a test asserting the full Date value survives.

That is the fourth grammar in this tree to need reordering, after `dec-octet`,
`IPv6address`, RFC 5234's own `defined-as` and `repeat`, and five of RFC 5322's
-- and like all of them it was found by *running* it.

### Three rules are still prose, on purpose

`language-range` (RFC 4647), `Language-Tag` (RFC 5646) and `mailbox` (RFC 5322)
are left exactly as the RFC writes them. jlib *has* an RFC 5322 mailbox
grammar and it is deliberately not composed in: RFC 5322 and RFC 9110 both
define `comment`, `ctext`, `quoted-pair` and `quoted-string` and they do not
agree, so pasting one over the other would quietly change four rules to get
one. `compile()` leaves them as prose, `prose_rules()` reports them, and a
parse that reaches one fails with a position naming it. Inventing a grammar for
them would look complete and be wrong.

The test asserts `prose_rules()` is exactly those three -- so a missed import,
which would leave a rule looking defined and failing at parse time, fails the
build instead.

## One head reader, not two

`basic_proxybuf::open_proxy()` had the only correct one in the tree: it capped
the length, insisted on a status line, and read to the blank line rather than
leaving the proxy's own headers in the stream as protocol data. Writing a
second one for the client would leave two, so `open_proxy` is rewritten onto
this one -- an `std::istream` over the streambuf itself, so nothing is copied
and there is no second buffer to get out of step with the first.

`sys_proxy_live_test` is its regression test, and still passes against a real
tinyproxy in the container. The error messages got better on the way:
"the proxy refused CONNECT: 403 Access violation" is now a parsed status and
reason rather than a substring up to the first newline.

**Which is why this is in `util` and not `net`.** `jlib::sys` is below
`jlib::net` and may not include it; `sys/proxystream.hh` already includes
`jlib/util/util.hh`, so this is the same seam rather than a new one. It is also
where the other RFC readers live -- `URL` for 3986, `content_type` for 2045,
`encoded_word` for 2047 -- and next door to the grammar it composes onto. The
client, which chooses a transport and makes a request, will be `jlib::net`.

## What the reader does

`http::Response` carries status as a **number**. `http::get()` compared it
against the string `"200"` and treated everything else as an error, which is
why it could neither follow a redirect nor read the body of a 400 -- and a 400
with a body is exactly what a token endpoint answers with when it has something
to tell you.

`http::fields` is **not** `util::Headers`, and that is a decision. Headers is
an RFC 5322 header set: it RFC 2047-decodes every value unconditionally, folds
continuation lines, and compares names with case. HTTP field names are
case-insensitive, HTTP has no encoded words, and an HTTP value containing
`=?utf-8?q?...` means those characters. Repeats are kept in order and never
collapsed -- two Content-Lengths that disagree is an attack, not a formatting
choice.

Refused at parse time, per RFC 9112 6: both `Content-Length` and
`Transfer-Encoding` (the request-smuggling primitive -- two recipients
disagreeing about where a message ends is how one request becomes two);
disagreeing duplicate Content-Lengths; a Content-Length that is not digits;
`obs-fold`; whitespace before the colon; a bare CR or LF anywhere in the
section. jlib accepts neither a bare LF nor a bare CR as a terminator, though
9112 2.2 permits the former: the only way not to disagree with the recipient in
front of you is to insist on CRLF.

`read_body()` handles all four framings. Chunked is procedural -- read the size
line, read that many octets, eat the CRLF -- for the reason written down in
`rfc9112.hh`: `abnf::rule::parse` takes a `string_view`, so a grammar cannot
ask for more input, and `chunk-data = 1*OCTET` is greedy besides. `imap::read()`
frames an IMAP literal the same way. The trailer section after the last chunk
is read and discarded, because something has to consume it or the connection is
not at a message boundary and the next reader takes a trailer for a status line.

## `URL::parse_reference`, and why `parse` was not widened

The plan for this branch said "URL::parse now takes a relative reference". It
does not, and it should not. `imap:/host` is a typo and also a perfectly good
relative reference, so a widened `parse()` would stop throwing on it and start
handing `Imap4` something with no scheme and no host to connect to. It is an
additive `parse_reference()` instead, with `valid_reference()` and
`relative()`. `Location` being a URI-reference is an HTTP concern and HTTP can
ask for it by name.

Nothing resolves a reference against a base; RFC 3986 5.3 is an algorithm of
its own and no caller has needed it.

## Tests

`tests/util_http_test.cc`, new -- six sections, no server. `read_head()` takes
an `std::istream`, so an `istringstream` is the whole harness and the awkward
cases can be written down exactly: a head with no end, both framing fields at
once, a chunk whose data contains a line that looks exactly like a chunk
header, a trailer section that has to be consumed before the next message can
be read off the same stream.

**What a green run does not establish.** That the rules nothing exercises are
right. `check()` proves they are well-formed, not that each alternation commits
to the branch the RFC meant. Two are known wrong under ordered choice and are
written down in `rfc9110.hh` rather than left to be rediscovered:
`credentials`/`challenge` put `token68` before the auth-param list and
`token68` ends in `*"="`, so `Digest username="x"` matches `username=` and
strands the rest -- whatever implements #104 will have to reorder them; and
`chunk`'s `chunk-data = 1*OCTET` is greedy, so `chunked-body` cannot frame
anything, which is why chunked is procedural.

And: that a real server sends what this expects. Everything in the new test is
an `istringstream`, which produces exactly the responses somebody thought of.
tinyproxy is one real server and not a survey.

macOS: 49 pass, 3 skip, 0 fail. Linux container: 52 pass, 1 skip, 0 fail.
