### PR TITLE
An HTTP client narrow enough to be safe: no redirects, no keep-alive, and one place that reads a proxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,16 @@
 # server on high ports with a seeded Maildir and drive jlib::net::Imap4 and
 # jlib::net::Pop3 against it.  tinyproxy is for the same reason one layer out:
 # jlib can reach a server through an HTTP CONNECT proxy, and until there was a
-# proxy to test against, that path had never run.  It is the only way to exercise the literal handling end to end:
-# a std::istringstream can be made to produce any response, but only a server
-# decides when to send a literal.
+# proxy to test against, that path had never run.  It is the only way to
+# exercise the literal handling end to end: a std::istringstream can be made to
+# produce any response, but only a server decides when to send a literal.
+#
+# nginx is here for tests/net_http_live_test, and for the same reason.  The
+# HTTP client is tested against a server written in the test as well, because
+# that is the only way to get a chunked body whose data looks like its own
+# framing -- but a server somebody else wrote sends a Date and a Server and an
+# ETag and a 404 body nobody here thought of, and those are what an in-process
+# server can never provide.
 
 FROM ubuntu:24.04
 
@@ -50,6 +57,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         dovecot-imapd \
         dovecot-pop3d \
         tinyproxy \
+        nginx-light \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /src/jlib

--- a/jlib/net/Imap4.cc
+++ b/jlib/net/Imap4.cc
@@ -433,19 +433,18 @@ namespace jlib {
             while(i<MAX_CONNECT_ATTEMPTS && sock == 0) {
                 try {
                     std::string phost;
-                    u_int pport;
+                    unsigned int pport = 0;
 
-                    if(m_url["proxy"] != "") {
-                        std::vector<std::string> pvec = 
-                            util::tokenize(m_url["proxy"], ":");
-                        phost = pvec[0];
-                        pport = util::int_value(pvec[1]);
-                        if(getenv("JLIB_NET_PROXY_DEBUG")) 
-                            std::cout << "proxy "<<phost<<" on port "<<pport<<std::endl;
-                    }
+                    // proxy_of(), not tokenize on ":".  What was here indexed
+                    // pvec[1] without checking size(), so "?proxy=host" with
+                    // no port read off the end of the vector.
+                    const bool proxied = proxy_of(m_url, phost, pport);
+
+                    if(proxied && getenv("JLIB_NET_PROXY_DEBUG"))
+                        std::cout << "proxy "<<phost<<" on port "<<pport<<std::endl;
 
                     if(is_secure()) {
-                        if(m_url["proxy"] != "") {
+                        if(proxied) {
                             sock = new sys::sslproxystream(m_host,
                                                                  m_port,
                                                                  phost, 
@@ -464,7 +463,7 @@ namespace jlib {
                         // The proxy variant exists now that both sit on one
                         // buffer; it used to throw here for want of a
                         // tlsproxystream.
-                        if(m_url["proxy"] != "") {
+                        if(proxied) {
                             sock = new sys::tlsproxystream(m_host, m_port,
                                                            phost, pport, true);
                         } else {
@@ -472,7 +471,7 @@ namespace jlib {
                         }
                     }
                     else {
-                        if(m_url["proxy"] != "") {
+                        if(proxied) {
                             sock = new sys::proxystream(m_host,
                                                               m_port,
                                                               phost, 

--- a/jlib/net/Makefile.am
+++ b/jlib/net/Makefile.am
@@ -4,7 +4,7 @@ lib_LTLIBRARIES = libjnet.la
 libjnet_la_SOURCES = Email.cc MailBox.cc Imap4Box.cc Pop3.cc MBox.cc \
                      Imap4.cc Imap4Fetch.cc net.cc MFolder.cc Imap4Folder.cc \
                      MailFolder.cc ASMailBox.cc ASImapBox.cc ASMBox.cc \
-                     address.cc imap_response.cc
+                     address.cc imap_response.cc http.cc
 libjnet_la_LDFLAGS = -version-info $(LIBJ_SO_VERSION) -release $(JLIB_RELEASE) -no-undefined
 libjnet_la_LIBADD = $(top_builddir)/jlib/sys/libjsys.la \
                     $(top_builddir)/jlib/util/libjutil.la \
@@ -16,4 +16,4 @@ libjnetinclude_HEADERS = Imap4Box.hh Pop3.hh MBox.hh Email.hh \
                          Imap4.hh Imap4Fetch.hh net.hh MFolder.hh \
                          Imap4Folder.hh MailBox.hh MailFetch.hh MailFolder.hh \
                          ASMailBox.hh ASImapBox.hh ASMBox.hh address.hh rfc5322.hh \
-                         imap_response.hh rfc3501.hh
+                         imap_response.hh rfc3501.hh http.hh

--- a/jlib/net/Pop3.cc
+++ b/jlib/net/Pop3.cc
@@ -23,6 +23,7 @@
 
 #include <jlib/sys/sys.hh>
 #include <jlib/sys/sslstream.hh>
+#include <jlib/sys/sslproxystream.hh>
 
 #include <jlib/util/util.hh>
 
@@ -215,22 +216,56 @@ namespace jlib {
         
         jlib::sys::socketstream* Pop3::connect() {
             jlib::sys::socketstream* sock;
+
+            // The URL's ?proxy= parameter, which this read nowhere at all: it
+            // was accepted by the URL parser, stored, and silently ignored, so
+            // pop3s://host/?proxy=p:3128 connected direct.  A caller asking to
+            // go through a proxy may be doing so because it is the only route
+            // out; giving them a direct connection instead is the worst of the
+            // three things that could happen.  Imap4 had the three branches
+            // and this had none (#103).
+            std::string phost;
+            unsigned int pport = 0;
+
+            const bool proxied = proxy_of(m_url, phost, pport);
+
             // The constructor already refused a scheme that is neither, so
             // there is no third case to fall through to -- and the one that
             // used to be here tested find("pop"), which is how "pop3s" ended
             // up on a plain socket.
             if(is_secure(m_url)) {
-                sock = new jlib::sys::sslstream(m_url.get_host(), m_url.get_port_val());
+                if(proxied) {
+                    sock = new jlib::sys::tlsproxystream(m_url.get_host(),
+                                                         m_url.get_port_val(),
+                                                         phost, pport);
+                }
+                else {
+                    sock = new jlib::sys::sslstream(m_url.get_host(), m_url.get_port_val());
+                }
             }
             else if(use_starttls(m_url)) {
                 // A tlsstream with delay set connects without handshaking;
                 // start() does the handshake in place once STLS has been
                 // negotiated.  The primitive smtp::send_tls has used all along.
-                sock = new jlib::sys::tlsstream(m_url.get_host(),
-                                                m_url.get_port_val(), true);
+                if(proxied) {
+                    sock = new jlib::sys::tlsproxystream(m_url.get_host(),
+                                                         m_url.get_port_val(),
+                                                         phost, pport, true);
+                }
+                else {
+                    sock = new jlib::sys::tlsstream(m_url.get_host(),
+                                                    m_url.get_port_val(), true);
+                }
             }
             else {
-                sock = new jlib::sys::socketstream(m_url.get_host(), m_url.get_port_val());
+                if(proxied) {
+                    sock = new jlib::sys::proxystream(m_url.get_host(),
+                                                      m_url.get_port_val(),
+                                                      phost, pport);
+                }
+                else {
+                    sock = new jlib::sys::socketstream(m_url.get_host(), m_url.get_port_val());
+                }
             }
 
 

--- a/jlib/net/http.cc
+++ b/jlib/net/http.cc
@@ -1,0 +1,367 @@
+/* -*- mode: C++ c-basic-offset: 4 -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <jlib/net/http.hh>
+#include <jlib/net/net.hh>
+
+#include <jlib/sys/proxystream.hh>
+#include <jlib/sys/socketstream.hh>
+#include <jlib/sys/sslproxystream.hh>
+#include <jlib/sys/sslstream.hh>
+
+#include <jlib/util/abnf.hh>
+#include <jlib/util/util.hh>
+
+#include <cstdlib>
+#include <memory>
+#include <sstream>
+
+namespace jlib {
+namespace net {
+namespace http {
+
+namespace {
+
+    const char* const HEX = "0123456789ABCDEF";
+
+    bool debug() { return std::getenv("JLIB_NET_HTTP_DEBUG") != 0; }
+
+    /** Whether a caller's field name and value can safely go on the wire. */
+    void check_field(const std::string& name, const std::string& value) {
+        // Against the grammar, not against a list of bad characters.  What
+        // this is really stopping is a CR or an LF in a value, because that is
+        // how one request becomes two -- but field-name being a token and
+        // field-value being field-content are the rules that say so, and
+        // checking them is both stricter and easier to defend than a blocklist.
+        const std::string line = name + ": " + value;
+
+        if(!util::http::grammar().at("field-line").try_parse(line))
+            throw error("not a header field: \"" + line + "\"");
+    }
+
+    /** The Host field: authority without userinfo, port only when it is not the default. */
+    std::string host_field(const util::URL& url, unsigned int port, bool tls) {
+        std::ostringstream o;
+
+        // A literal goes back in its brackets: RFC 9110 4.1 writes uri-host,
+        // and an IPv6 address without them is ambiguous with the port.
+        if(url.get_host().find(':') != std::string::npos)
+            o << "[" << url.get_host() << "]";
+        else
+            o << url.get_host();
+
+        if(port != (tls ? 443u : 80u)) o << ":" << port;
+
+        return o.str();
+    }
+
+    /**
+     * The request-target: origin-form, per RFC 9112 3.2.1.
+     *
+     * get_path() alone is not it.  URL keeps the path and the query apart, so
+     * a target built from the path drops "?code=..." -- which is the whole
+     * message for half the requests this client makes.  And an empty path goes
+     * out as "/": RFC 9112 3.2.1 says so explicitly, and a request line
+     * reading "GET  HTTP/1.1" is not a request line at all.
+     *
+     * The fragment is never sent (RFC 9110 7.1).  It is the client's, not the
+     * server's.
+     */
+    std::string request_target(const util::URL& url) {
+        std::string target = url.get_path();
+
+        if(target.empty()) target = "/";
+
+        const std::string qs = url.get_qs();
+
+        if(!qs.empty()) target += "?" + qs;
+
+        return target;
+    }
+
+    std::unique_ptr<sys::socketstream> transport(const util::URL& url,
+                                                 unsigned int port,
+                                                 bool tls,
+                                                 const options& o)
+    {
+        std::string phost;
+        unsigned int pport = 0;
+
+        const bool proxied = proxy_of(url, phost, pport);
+
+        std::unique_ptr<sys::socketstream> sock;
+
+        if(proxied) {
+            if(tls) sock.reset(new sys::tlsproxystream(url.get_host(), port, phost, pport));
+            else    sock.reset(new sys::proxystream(url.get_host(), port, phost, pport));
+        }
+        else {
+            if(tls) sock.reset(new sys::tlsstream(url.get_host(), port));
+            else    sock.reset(new sys::socketstream(url.get_host(), port));
+        }
+
+        // The library default is no read timeout, for the reason written down
+        // in sys.hh: Imap4::idle() is supposed to sit on a quiet socket for
+        // half an hour.  An HTTP client is not, and this is the caller that
+        // knows its own timing.
+        if(o.timeout > 0) sock->set_timeout(o.timeout);
+
+        return sock;
+    }
+
+    Response once(const std::string& method,
+                  const util::URL& url,
+                  const fields& send,
+                  const std::string& body,
+                  const options& o)
+    {
+        if(!util::http::grammar().at("method").try_parse(method))
+            throw error("not an HTTP method: \"" + method + "\"");
+
+        const std::string scheme = url.get_protocol();
+        const bool tls = scheme == "https";
+
+        if(scheme != "http" && !tls)
+            throw error("not an HTTP URL: \"" + url.coagulate() + "\"");
+
+        if(url.get_host().empty())
+            throw error("an HTTP URL with no host: \"" + url.coagulate() + "\"");
+
+        const unsigned int port = url.get_port().empty()
+                                  ? (tls ? 443u : 80u)
+                                  : url.get_port_val();
+
+        std::unique_ptr<sys::socketstream> sock = transport(url, port, tls, o);
+
+        std::ostringstream head;
+
+        head << method << " " << request_target(url) << " HTTP/1.1\r\n";
+
+        // Supplied unless the caller said otherwise.
+        //
+        // Connection: close is not politeness.  It ends the message at the end
+        // of the connection and takes every keep-alive framing question off the
+        // table -- and those questions are exactly where request smuggling
+        // lives.  One request per connection is also all this client needs.
+        //
+        // Accept-Encoding: identity, because RFC 9110 12.5.3 lets a server
+        // send any coding to a client that sends no Accept-Encoding at all.
+        // Nothing here can inflate a gzip body, so asking for one and then
+        // handing the caller compressed bytes it will try to parse as JSON is
+        // a failure worth ruling out rather than diagnosing later.
+        fields out;
+
+        out.add("Host", host_field(url, port, tls));
+        out.add("User-Agent", o.user_agent);
+        out.add("Connection", "close");
+        out.add("Accept-Encoding", "identity");
+
+        if(!body.empty()) out.add("Content-Length", std::to_string(body.size()));
+
+        for(const fields::value_type& f : out) {
+            if(!send.has(f.first)) head << f.first << ": " << f.second << "\r\n";
+        }
+
+        for(const fields::value_type& f : send) {
+            check_field(f.first, f.second);
+
+            head << f.first << ": " << f.second << "\r\n";
+        }
+
+        head << "\r\n";
+
+        if(debug()) std::cerr << head.str() << std::flush;
+
+        *sock << head.str() << body << std::flush;
+
+        if(!*sock) throw error("the connection failed while sending the request");
+
+        // HEAD has no body however the fields are written (RFC 9112 6.3), and
+        // this is the only place that knows which method was sent.
+        Response r = util::http::read_response_head(*sock, method == "HEAD");
+
+        r.set_body(util::http::read_body(*sock, r, o.max_body));
+
+        if(debug())
+            std::cerr << r.status() << " " << r.reason()
+                      << ", " << r.body().size() << " octets of body" << std::endl;
+
+        return r;
+    }
+
+}
+
+std::string form_encode(const std::map<std::string, std::string>& form) {
+    std::string out;
+
+    for(const std::pair<const std::string, std::string>& kv : form) {
+        if(!out.empty()) out += "&";
+
+        for(int half = 0; half < 2; half++) {
+            const std::string& s = half == 0 ? kv.first : kv.second;
+
+            for(unsigned char c : s) {
+                // The unreserved set of RFC 3986 2.3, which is also what this
+                // encoding leaves alone.
+                if((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') ||
+                   (c >= '0' && c <= '9') ||
+                   c == '-' || c == '.' || c == '_' || c == '~') {
+                    out += static_cast<char>(c);
+                }
+                else if(c == ' ') {
+                    // The one difference from uri::encode, and the reason this
+                    // exists: HTML's form encoding spells a space "+".  A "+"
+                    // in the data therefore has to be escaped, which is the
+                    // case that bites -- base64 produces them constantly, and
+                    // a token sent through the wrong encoder arrives with
+                    // spaces in it and does not match.
+                    out += '+';
+                }
+                else {
+                    out += '%';
+                    out += HEX[c >> 4];
+                    out += HEX[c & 0x0f];
+                }
+            }
+
+            if(half == 0) out += "=";
+        }
+    }
+
+    return out;
+}
+
+Response request(const std::string& method,
+                 const util::URL& url,
+                 const fields& send,
+                 const std::string& body,
+                 const options& o)
+{
+    util::URL target = url;
+    std::string verb = method;
+    std::string payload = body;
+    fields carry = send;
+
+    for(unsigned int hop = 0; ; hop++) {
+        const Response r = once(verb, target, carry, payload, o);
+
+        if(hop >= o.redirects) return r;
+
+        const bool redirect = r.status() == 301 || r.status() == 302 ||
+                              r.status() == 303 || r.status() == 307 ||
+                              r.status() == 308;
+
+        if(!redirect || !r.fields().has("Location")) return r;
+
+        // A 303 says "go and GET this instead" and drops the body; 307 and 308
+        // say "same request, elsewhere".  RFC 9110 15.4.4.
+        if(r.status() == 303) {
+            verb = "GET";
+            payload.clear();
+        }
+
+        // Anything else is not followed, and this is the important half.
+        // Re-sending a POST body to a host named by the response is not a
+        // redirect, it is handing the request to whoever wrote the Location --
+        // and for the request this client exists to make, the body is a
+        // client_secret and a refresh_token.
+        if(verb != "GET" && verb != "HEAD") return r;
+
+        util::URL next;
+
+        try {
+            next.parse_reference(util::trim(r.fields().get("Location")));
+        }
+        catch(std::exception&) {
+            throw error("a redirect to something that is not a URI reference: \"" +
+                        r.fields().get("Location") + "\"");
+        }
+
+        if(next.relative()) {
+            // No RFC 3986 5.3 here, and inventing half of it would be worse
+            // than not having it.  An absolute path against the same origin is
+            // the case that resolves without an algorithm, and it is the one
+            // servers actually send.
+            if(next.get_path().empty() || next.get_path()[0] != '/') {
+                throw error("a relative redirect that is not an absolute path: \"" +
+                            r.fields().get("Location") + "\"");
+            }
+
+            util::URL resolved(target);
+
+            resolved.set_path(next.get_path());
+            resolved.set_qs(next.get_qs());
+            resolved.set_fragment("");
+
+            next = resolved;
+        }
+
+        // Origin: scheme, host and port together.  Authorization is scoped to
+        // one of those and to no other, so it comes off whenever any of the
+        // three changes -- which is what stops a redirect from being a way to
+        // read somebody's bearer token.
+        const bool same_origin = next.get_protocol() == target.get_protocol() &&
+                                 next.get_host() == target.get_host() &&
+                                 next.get_port() == target.get_port();
+
+        if(!same_origin) {
+            fields kept;
+
+            for(const fields::value_type& f : carry) {
+                if(util::http::fold(f.first) != "authorization" &&
+                   util::http::fold(f.first) != "cookie")
+                    kept.add(f.first, f.second);
+            }
+
+            carry = kept;
+        }
+
+        // The proxy parameter travels with the request rather than with the
+        // URL: a Location: names a resource, not a route to it.
+        if(!target["proxy"].empty()) {
+            std::map<std::string, std::string> qs = next.get_qs_hash();
+
+            qs["proxy"] = target["proxy"];
+            next.set_qs(qs);
+        }
+
+        target = next;
+    }
+}
+
+Response get(const util::URL& url, const fields& send, const options& o) {
+    return request("GET", url, send, "", o);
+}
+
+Response post_form(const util::URL& url,
+                   const std::map<std::string, std::string>& form,
+                   const fields& send,
+                   const options& o)
+{
+    fields with = send;
+
+    if(!with.has("Content-Type"))
+        with.add("Content-Type", "application/x-www-form-urlencoded");
+
+    return request("POST", url, with, form_encode(form), o);
+}
+
+}
+}
+}

--- a/jlib/net/http.cc
+++ b/jlib/net/http.cc
@@ -147,6 +147,12 @@ namespace {
                                   ? (tls ? 443u : 80u)
                                   : url.get_port_val();
 
+        // The caller's fields are checked before anything is connected.  They
+        // cannot become a valid request however the socket goes, so opening
+        // one first only means a connection the server has to notice, time out
+        // and clean up on behalf of a request that was never going to be sent.
+        for(const fields::value_type& f : send) check_field(f.first, f.second);
+
         std::unique_ptr<sys::socketstream> sock = transport(url, port, tls, o);
 
         std::ostringstream head;
@@ -179,8 +185,6 @@ namespace {
         }
 
         for(const fields::value_type& f : send) {
-            check_field(f.first, f.second);
-
             head << f.first << ": " << f.second << "\r\n";
         }
 

--- a/jlib/net/http.hh
+++ b/jlib/net/http.hh
@@ -1,0 +1,150 @@
+/* -*- mode: C++ c-basic-offset: 4 -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef JLIB_NET_HTTP_HH
+#define JLIB_NET_HTTP_HH
+
+#include <jlib/util/URL.hh>
+#include <jlib/util/http.hh>
+
+#include <map>
+#include <string>
+
+namespace jlib {
+namespace net {
+
+/**
+ * An HTTP/1.1 client.
+ *
+ * ## Narrow, and closed
+ *
+ * What an OAuth2 token exchange needs and nothing else: GET, POST, a form
+ * body, Content-Length and chunked responses, TLS, and a CONNECT proxy.  No
+ * cookies, no keep-alive, no compression, no content negotiation, no HTTP/2,
+ * no connection pool.
+ *
+ * That list is here so it stays true.  Nothing in this tree has ever called
+ * the old jlib::net::http -- it declared a Request and a Response that were
+ * never defined anywhere, and a get() that was HTTP/1.0 and treated any status
+ * but 200 as an error -- so there is no existing user pulling this wider, and
+ * the way a narrow thing becomes a broad one is by nobody writing down that it
+ * was meant to be narrow.
+ *
+ * ## Two halves in two libraries
+ *
+ * Reading a response is jlib::util::http, because jlib::sys needs it:
+ * basic_proxybuf reads the answer to CONNECT and jlib::sys may not include
+ * jlib::net.  The names are pulled through below, so a caller says
+ * net::http::Response and gets the same class either way.
+ */
+namespace http {
+
+using jlib::util::http::error;
+using jlib::util::http::fields;
+using jlib::util::http::framing;
+using jlib::util::http::Response;
+
+/** How to make a request. */
+struct options {
+    /**
+     * Seconds to allow the connect, and each read afterwards.  Zero waits.
+     *
+     * A default rather than the library's, which is off: a mail client is
+     * supposed to sit on a quiet IMAP connection and an HTTP client is not.
+     */
+    double timeout = 30;
+
+    /** The most body octets to read.  A token response is a few hundred. */
+    std::size_t max_body = 1 << 20;
+
+    /**
+     * How many 3xx to follow.  **Zero, and that is not timidity.**
+     *
+     * Following a redirect means sending the request again to a host named by
+     * the response.  For the call this client exists to make that request
+     * carries a client_secret and a refresh_token, and a Location: is
+     * attacker-controlled the moment anything upstream is.  Turning it on is a
+     * decision a caller makes for a particular request, which is why it is
+     * here and not a default.
+     *
+     * Even switched on: only GET and HEAD are followed, because re-sending a
+     * POST body somewhere else is not a redirect; a 303 becomes a GET, as RFC
+     * 9110 15.4.4 says; and Authorization is dropped whenever the origin
+     * changes.
+     */
+    unsigned int redirects = 0;
+
+    std::string user_agent = "jlib/1.2";
+};
+
+/**
+ * Make one request and read the whole response.
+ *
+ * @param method  "GET", "POST", ...  Must be a token.
+ * @param url     http or https.  The query string is part of the target; the
+ *                fragment is not sent, per RFC 9110 7.1.
+ * @param send    fields to add.  Host, User-Agent, Connection, Content-Length
+ *                and Accept-Encoding are supplied and may be overridden.
+ * @param body    the request body, sent with a Content-Length.
+ *
+ * **A non-2xx is a Response, not an exception.**  An OAuth2 token endpoint
+ * answers 400 with a JSON body saying whether the refresh token was revoked or
+ * the server merely hiccuped, and a client that throws away the body of
+ * anything it does not like cannot tell those apart.  What throws is a failure
+ * to complete an exchange at all: no connection, a malformed head, a body that
+ * ends early or runs past max_body.
+ *
+ * Field names and values from a caller are checked against the grammar before
+ * they go out.  A CR or LF in a value is how one request becomes two.
+ */
+Response request(const std::string& method,
+                 const jlib::util::URL& url,
+                 const fields& send = fields(),
+                 const std::string& body = "",
+                 const options& o = options());
+
+Response get(const jlib::util::URL& url,
+             const fields& send = fields(),
+             const options& o = options());
+
+/**
+ * POST an application/x-www-form-urlencoded body.
+ *
+ * Which is how every OAuth2 token request is made (RFC 6749 4.1.3).
+ */
+Response post_form(const jlib::util::URL& url,
+                   const std::map<std::string, std::string>& form,
+                   const fields& send = fields(),
+                   const options& o = options());
+
+/**
+ * application/x-www-form-urlencoded.
+ *
+ * **Not uri::encode.**  This encoding is HTML's, not RFC 3986's: a space is
+ * "+" here and "%20" there, and "+" itself therefore has to be escaped.  A
+ * token containing a "+" -- base64 produces them constantly -- sent through
+ * the wrong encoder arrives as a space and does not match.
+ */
+std::string form_encode(const std::map<std::string, std::string>& form);
+
+}
+}
+}
+
+#endif // JLIB_NET_HTTP_HH

--- a/jlib/net/net.cc
+++ b/jlib/net/net.cc
@@ -821,56 +821,42 @@ namespace jlib {
         }
 
 
-        namespace http {
+        bool proxy_of(const util::URL& url, std::string& host, unsigned int& port) {
+            const std::string p = url["proxy"];
 
-            std::string get(util::URL url) {
-                std::string endl = "\r\n";
-                std::string dendl = endl+endl;
-                std::string buf;
-                std::string ret;
-                std::ostringstream o;
-                unsigned int port = 80;
+            if(p.empty()) return false;
 
-                if(url.get_protocol() != "http") {
-                    throw net::exception("error in net::http::get(): bad protocol: "+
-                                               url.get_protocol());
-                }
+            // Rightmost colon, not the first: an IPv6 literal proxy is written
+            // [::1]:3128 and tokenize on ":" would hand back "[" as the host.
+            const std::string::size_type colon = p.rfind(':');
 
-                if(url.get_port() != "") {
-                    port = url.get_port_val();
-                }
-
-                o << "GET "<<url.get_path()<<" HTTP/1.0"<<endl
-                  << "Host: "<<url.get_host()<<endl
-                  << endl;
-
-                sys::socketstream sock(url.get_host(), port);
-                sock << o.str() << std::flush;
-                
-                std::getline(sock,buf);
-
-                std::vector<std::string> response = util::tokenize(buf);
-                if(response.size() < 3) {
-                    throw net::exception("error in net::http::get(): bad response: "+
-                                               buf);
-                }
-                
-                if(response[1] != "200") {
-                    std::ostringstream err;
-                    err << "error in net::http::get(): error code "<<response[1]<<": ";
-                    for(unsigned int j=2;j<response.size();j++)
-                        err << response[j]<< " ";
-                        
-                    throw net::exception(err.str());
-                }
-
-                sys::getstring(sock,buf);
-                std::string::size_type p = buf.find(dendl);
-                ret = buf.substr(p+dendl.length());
-
-                return ret;
+            if(colon == std::string::npos || colon == 0 || colon + 1 == p.length()) {
+                throw exception("the proxy parameter \"" + p + "\" is not "
+                                "host:port");
             }
 
+            const std::string h = p.substr(0, colon);
+            const std::string s = p.substr(colon + 1);
+
+            for(char c : s) {
+                if(c < '0' || c > '9')
+                    throw exception("the proxy parameter \"" + p + "\" has a "
+                                    "port that is not a number");
+            }
+
+            const unsigned long n = std::stoul(s);
+
+            if(n == 0 || n > 65535)
+                throw exception("the proxy parameter \"" + p + "\" has a port "
+                                "outside 1-65535");
+
+            // The brackets delimit an IPv6 literal; they are not part of the
+            // address and getaddrinfo does not want them.
+            host = (h.length() > 2 && h.front() == '[' && h.back() == ']')
+                   ? h.substr(1, h.length() - 2) : h;
+            port = static_cast<unsigned int>(n);
+
+            return true;
         }
 
         namespace html {

--- a/jlib/net/net.hh
+++ b/jlib/net/net.hh
@@ -152,6 +152,30 @@ namespace jlib {
             void append(const std::string& path, Email e);
         }
 
+        /**
+         * The host and port of a URL's "?proxy=" parameter.
+         *
+         * @return false when there is no proxy parameter, leaving host and
+         *         port untouched
+         * @throw exception when there is one and it cannot be read.  Silently
+         *        connecting direct is the one behaviour that must not happen:
+         *        a caller has asked to go through a proxy, possibly because it
+         *        is the only route out, and telling them nothing is worse than
+         *        failing.
+         *
+         * One function because there were nearly two.  Imap4::connect had
+         *
+         *     std::vector<std::string> pvec = util::tokenize(m_url["proxy"], ":");
+         *     phost = pvec[0];
+         *     pport = util::int_value(pvec[1]);
+         *
+         * which indexes pvec[1] with no size check, so "?proxy=host" with no
+         * port read off the end of the vector.  Pop3::connect did not read the
+         * parameter at all -- it was accepted by the URL parser, stored, and
+         * ignored, so pop3s://host/?proxy=p:3128 connected direct.
+         */
+        bool proxy_of(const jlib::util::URL& url, std::string& host, unsigned int& port);
+
         namespace smtp {
             void send(const std::string& mail, const std::string& rcpt, const std::string& data, const std::string& host, unsigned int port);
 
@@ -176,23 +200,11 @@ namespace jlib {
             bool has_auth_mechanism(const std::list<std::string>& lines, const std::string& want);
         }
 
-        namespace http {
-            // Request, Response and request() were declared here and defined
-            // nowhere -- no constructor, no get_text(), no request(), in any
-            // file in the tree.  Twenty-odd years of a header promising an HTTP
-            // client that did not exist; the only thing here that ever ran is
-            // get(), below.  They are gone rather than kept as a sketch,
-            // because the sketch had already started to constrain the real
-            // thing: Request held a util::Headers, which is an RFC 5322 header
-            // set that decodes encoded-words, and HTTP fields are not that.
-            //
-            // get() is HTTP/1.0, plaintext-only, and treats any status but 200
-            // as an error, so it cannot follow a redirect or read the body of a
-            // 400 -- which is precisely what an OAuth2 token endpoint answers
-            // with when it has something to tell you.  Nothing in the tree
-            // calls it.  It goes when there is something to replace it with.
-            std::string get(jlib::util::URL url);
-        }
+        // namespace http was here.  Request, Response and request() were
+        // declared and never defined, in any file in the tree; get() was
+        // HTTP/1.0, plaintext-only, and treated any status but 200 as an
+        // error, so it could neither follow a redirect nor read the body of a
+        // 400.  Nothing called it.  jlib/net/http.hh is what replaced it.
 
         namespace html {
             std::string render(const std::string& s);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -3,7 +3,7 @@
 AM_CPPFLAGS = -I$(top_srcdir) \
 	$(GPGME_CFLAGS) $(GPGERROR_CFLAGS) $(SODIUM_CFLAGS) $(OPENSSL_CFLAGS) $(JSONC_CFLAGS) $(PORTAUDIO_CFLAGS)
 
-EXTRA_DIST = audio_test.hh certificate.hh mailserver.hh
+EXTRA_DIST = audio_test.hh certificate.hh mailserver.hh httpserver.hh
 
 JSYS_LA   = $(top_builddir)/jlib/sys/libjsys.la
 JUTIL_LA  = $(top_builddir)/jlib/util/libjutil.la
@@ -56,6 +56,8 @@ TESTS = \
 	net_protocol_test \
 	net_imap_test \
 	net_imap_sasl_test \
+	net_http_test \
+	net_http_live_test \
 	net_imap_live_test \
 	sys_proxy_live_test \
 	net_pop3_live_test \
@@ -146,13 +148,19 @@ net_pop3_live_test_SOURCES      = net_pop3_live_test.cc
 net_pop3_live_test_LDADD        = $(JNET_LA) $(JUTIL_LA) $(JSYS_LA) $(OPENSSL_LIBS)
 
 sys_proxy_live_test_SOURCES     = sys_proxy_live_test.cc
-sys_proxy_live_test_LDADD       = $(JUTIL_LA) $(JSYS_LA) $(OPENSSL_LIBS)
+sys_proxy_live_test_LDADD       = $(JNET_LA) $(JUTIL_LA) $(JSYS_LA) $(OPENSSL_LIBS)
 
 net_imap_live_test_SOURCES      = net_imap_live_test.cc
 net_imap_live_test_LDADD        = $(JNET_LA) $(JUTIL_LA) $(JSYS_LA) $(OPENSSL_LIBS)
 
 net_imap_test_SOURCES           = net_imap_test.cc
 net_imap_test_LDADD             = $(JNET_LA) $(JUTIL_LA)
+
+net_http_live_test_SOURCES      = net_http_live_test.cc
+net_http_live_test_LDADD        = $(JNET_LA) $(JUTIL_LA) $(JSYS_LA) $(OPENSSL_LIBS)
+
+net_http_test_SOURCES           = net_http_test.cc
+net_http_test_LDADD             = $(JNET_LA) $(JUTIL_LA) $(JSYS_LA) $(OPENSSL_LIBS)
 
 net_imap_sasl_test_SOURCES      = net_imap_sasl_test.cc
 net_imap_sasl_test_LDADD        = $(JNET_LA) $(JUTIL_LA) $(JSYS_LA) $(OPENSSL_LIBS)

--- a/tests/httpserver.hh
+++ b/tests/httpserver.hh
@@ -33,6 +33,13 @@
 // Authorization came off across an origin change, that a POST body was not
 // re-sent to a redirect.
 //
+// It speaks TLS when handed a certificate, which is the only way jlib gets an
+// HTTPS test that runs on a developer's machine: net_http_live_test needs an
+// nginx and there is not one outside the build container.  Server-side TLS is
+// raw OpenSSL here rather than jlib's own -- basic_tlsbuf calls SSL_connect and
+// there is no server-side counterpart in the library, which is a gap this test
+// works around rather than one it fixes.
+//
 // It is not a substitute for a real server and net_http_live_test is the other
 // half: a server nobody wrote sends responses nobody thought of.  This one
 // sends exactly what somebody thought of, which is the point of it and also
@@ -43,11 +50,19 @@
 
 #include <jlib/util/http.hh>
 
+#include <openssl/err.h>
+#include <openssl/ssl.h>
+
+#include <unistd.h>
+
+#include <algorithm>
 #include <atomic>
+#include <cctype>
 #include <functional>
 #include <istream>
 #include <memory>
 #include <mutex>
+#include <stdexcept>
 #include <string>
 #include <thread>
 #include <vector>
@@ -65,22 +80,64 @@ public:
     /** Given the request, return the raw octets to send back. */
     typedef std::function<std::string(const request&)> handler;
 
-    explicit server(handler h)
+    /**
+     * @param h     what to answer with
+     * @param cert  a PEM certificate, or "" for a plaintext server
+     * @param key   its private key
+     *
+     * With a certificate this speaks TLS, and the client is expected to
+     * verify it for real -- point SSL_CERT_FILE at the same file and connect
+     * to a name the certificate covers.  Nothing here weakens verification;
+     * the handshake succeeds because the certificate is genuinely trusted for
+     * the run, which is the pattern mailserver.hh and sys_tls_sigpipe_test
+     * both use.
+     */
+    explicit server(handler h,
+                    const std::string& cert = std::string(),
+                    const std::string& key = std::string())
         : m_listener(),
           m_handler(std::move(h))
     {
+        if(!cert.empty()) {
+            m_ctx = SSL_CTX_new(TLS_server_method());
+
+            if(!m_ctx ||
+               SSL_CTX_use_certificate_file(m_ctx, cert.c_str(), SSL_FILETYPE_PEM) != 1 ||
+               SSL_CTX_use_PrivateKey_file(m_ctx, key.c_str(), SSL_FILETYPE_PEM) != 1) {
+                if(m_ctx) SSL_CTX_free(m_ctx);
+
+                m_ctx = 0;
+
+                throw std::runtime_error("could not set up a TLS test server");
+            }
+        }
+
         m_thread = std::thread([this] { run(); });
     }
 
-    ~server() { stop(); }
+    ~server() {
+        stop();
+
+        if(m_ctx) SSL_CTX_free(m_ctx);
+    }
 
     server(const server&) = delete;
     server& operator=(const server&) = delete;
 
     unsigned short port() const { return m_listener.port(); }
 
+    bool tls() const { return m_ctx != 0; }
+
+    /**
+     * Where to reach it.
+     *
+     * The TLS form says "localhost" rather than 127.0.0.1, because that is the
+     * name the generated certificate covers and jlib checks it with
+     * SSL_set1_host.
+     */
     std::string url(const std::string& path = "/") const {
-        return "http://127.0.0.1:" + std::to_string(m_listener.port()) + path;
+        return (m_ctx ? "https://localhost:" : "http://127.0.0.1:") +
+               std::to_string(m_listener.port()) + path;
     }
 
     /** Every request served so far. */
@@ -99,25 +156,134 @@ public:
     }
 
 private:
+    /**
+     * One accepted connection, plain or TLS.
+     *
+     * A pair of read/write calls rather than a streambuf, because there is no
+     * server-side one in jlib to reach for and writing one to serve a test
+     * would be the tail wagging the dog.
+     */
+    class conn {
+    public:
+        conn(int fd, SSL_CTX* ctx) : m_fd(fd) {
+            if(!ctx) return;
+
+            m_ssl = SSL_new(ctx);
+
+            if(!m_ssl || SSL_set_fd(m_ssl, fd) != 1 || SSL_accept(m_ssl) != 1) {
+                if(m_ssl) { SSL_free(m_ssl); m_ssl = 0; }
+
+                // Closed here, not left to the destructor: a constructor that
+                // throws does not get one, and the descriptor would leak once
+                // per failed handshake.
+                ::close(m_fd);
+                m_fd = -1;
+
+                throw std::runtime_error("the TLS handshake failed");
+            }
+        }
+
+        ~conn() {
+            if(m_ssl) {
+                SSL_shutdown(m_ssl);
+                SSL_free(m_ssl);
+            }
+
+            if(m_fd >= 0) ::close(m_fd);
+        }
+
+        conn(const conn&) = delete;
+        conn& operator=(const conn&) = delete;
+
+        /** Bytes read, 0 at end of stream. */
+        std::size_t read(char* buf, std::size_t n) {
+            const int got = m_ssl ? SSL_read(m_ssl, buf, static_cast<int>(n))
+                                  : static_cast<int>(::read(m_fd, buf, n));
+
+            return got > 0 ? static_cast<std::size_t>(got) : 0;
+        }
+
+        void write(const std::string& s) {
+            std::size_t sent = 0;
+
+            while(sent < s.size()) {
+                const int n = m_ssl
+                    ? SSL_write(m_ssl, s.data() + sent, static_cast<int>(s.size() - sent))
+                    : static_cast<int>(::write(m_fd, s.data() + sent, s.size() - sent));
+
+                if(n <= 0) return;
+
+                sent += static_cast<std::size_t>(n);
+            }
+        }
+
+    private:
+        int m_fd = -1;
+        SSL* m_ssl = 0;
+    };
+
+    /** Exactly n octets, or fewer if the peer stopped. */
+    static std::string take(conn& c, std::size_t n) {
+        std::string out;
+
+        while(out.size() < n) {
+            char buf[4096];
+            const std::size_t want = std::min(sizeof buf, n - out.size());
+            const std::size_t got = c.read(buf, want);
+
+            if(!got) break;
+
+            out.append(buf, got);
+        }
+
+        return out;
+    }
+
     void run() {
         while(!m_stop) {
-            std::unique_ptr<jlib::sys::socketstream> peer;
+            int fd = -1;
 
             try {
                 // A short deadline rather than a blocking accept, so that
                 // stopping does not depend on one more client turning up.
-                peer = m_listener.accept_stream(0.2);
+                fd = m_listener.accept(0.2);
             }
             catch(std::exception&) {
                 return;
             }
 
-            if(!peer) continue;
+            if(fd < 0) continue;
 
             try {
+                conn c(fd, m_ctx);
+
                 request r;
 
-                r.head = jlib::util::http::read_head(*peer, 65536);
+                // A byte at a time to the blank line.  util::http::read_head()
+                // does this over an istream and there is not one here; the
+                // duplication is four lines and the alternative is a
+                // server-side streambuf nothing else would use.
+                while(r.head.size() < 4 ||
+                      r.head.compare(r.head.size() - 4, 4, "\r\n\r\n") != 0) {
+                    char one;
+
+                    if(!c.read(&one, 1)) break;
+
+                    r.head += one;
+
+                    if(r.head.size() > 65536) break;
+                }
+
+                // A connection that carried no complete head is not a
+                // request and must not be recorded as one.  read_head(), which
+                // this replaced, threw on end of stream and so never got here;
+                // the loop above just stops, and recording what it had made a
+                // client that connected and thought better of it look exactly
+                // like one that asked for something.
+                if(r.head.size() < 4 ||
+                   r.head.compare(r.head.size() - 4, 4, "\r\n\r\n") != 0) {
+                    continue;
+                }
 
                 // Only what a test sends: a Content-Length body, or none.
                 const std::string::size_type at = find_ci(r.head, "\r\ncontent-length:");
@@ -125,14 +291,9 @@ private:
                 if(at != std::string::npos) {
                     const std::string::size_type eol = r.head.find("\r\n", at + 2);
                     const std::string value = r.head.substr(at + 17, eol - at - 17);
-                    const std::size_t n = std::stoul(value);
 
-                    r.body.resize(n);
-
-                    if(n) peer->read(&r.body[0], static_cast<std::streamsize>(n));
+                    r.body = take(c, std::stoul(value));
                 }
-
-                std::string reply;
 
                 {
                     std::lock_guard<std::mutex> lock(m_lock);
@@ -140,18 +301,16 @@ private:
                     m_requests.push_back(r);
                 }
 
-                reply = m_handler(r);
-
-                *peer << reply << std::flush;
+                // The client sends Connection: close and so does this; conn's
+                // destructor closing is what ends a body with no framing
+                // fields on it.
+                c.write(m_handler(r));
             }
             catch(std::exception&) {
-                // A client that hung up mid-request is a case some tests
-                // create on purpose.
+                // A client that hung up mid-request, or a handshake that did
+                // not complete, are both cases some tests create on purpose.
+                // conn closes the descriptor either way.
             }
-
-            // The client sends Connection: close and so does this; closing
-            // here is what ends a body with no framing fields on it.
-            peer->close();
         }
     }
 
@@ -165,6 +324,7 @@ private:
 
     jlib::sys::listener m_listener;
     handler m_handler;
+    SSL_CTX* m_ctx = 0;
     mutable std::mutex m_lock;
     std::vector<request> m_requests;
     std::atomic<bool> m_stop{false};

--- a/tests/httpserver.hh
+++ b/tests/httpserver.hh
@@ -1,0 +1,187 @@
+/* -*- mode: C++ c-basic-offset: 4 -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef JLIB_TESTS_HTTPSERVER_HH
+#define JLIB_TESTS_HTTPSERVER_HH
+
+// An HTTP server that answers whatever it is told to, in this process.
+//
+// For the cases a real server will not produce on request: a chunked body
+// whose chunk data contains a line that looks like a chunk header, a response
+// carrying both Content-Length and Transfer-Encoding, a Location: pointing
+// somewhere it must not be followed to.  Those are the shapes that break a
+// client, and no amount of asking nginx nicely will get them.
+//
+// It also records every request it was sent, which is how a test asserts what
+// the *client* did -- that the query string reached the request-target, that
+// Authorization came off across an origin change, that a POST body was not
+// re-sent to a redirect.
+//
+// It is not a substitute for a real server and net_http_live_test is the other
+// half: a server nobody wrote sends responses nobody thought of.  This one
+// sends exactly what somebody thought of, which is the point of it and also
+// its whole limitation.
+
+#include <jlib/sys/listener.hh>
+#include <jlib/sys/socketstream.hh>
+
+#include <jlib/util/http.hh>
+
+#include <atomic>
+#include <functional>
+#include <istream>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace httpserver {
+
+/** One request as it arrived. */
+struct request {
+    std::string head;   ///< the request line and fields, CRLFs and all
+    std::string body;
+};
+
+class server {
+public:
+    /** Given the request, return the raw octets to send back. */
+    typedef std::function<std::string(const request&)> handler;
+
+    explicit server(handler h)
+        : m_listener(),
+          m_handler(std::move(h))
+    {
+        m_thread = std::thread([this] { run(); });
+    }
+
+    ~server() { stop(); }
+
+    server(const server&) = delete;
+    server& operator=(const server&) = delete;
+
+    unsigned short port() const { return m_listener.port(); }
+
+    std::string url(const std::string& path = "/") const {
+        return "http://127.0.0.1:" + std::to_string(m_listener.port()) + path;
+    }
+
+    /** Every request served so far. */
+    std::vector<request> requests() const {
+        std::lock_guard<std::mutex> lock(m_lock);
+
+        return m_requests;
+    }
+
+    void stop() {
+        m_stop = true;
+
+        if(m_thread.joinable()) m_thread.join();
+
+        m_listener.close();
+    }
+
+private:
+    void run() {
+        while(!m_stop) {
+            std::unique_ptr<jlib::sys::socketstream> peer;
+
+            try {
+                // A short deadline rather than a blocking accept, so that
+                // stopping does not depend on one more client turning up.
+                peer = m_listener.accept_stream(0.2);
+            }
+            catch(std::exception&) {
+                return;
+            }
+
+            if(!peer) continue;
+
+            try {
+                request r;
+
+                r.head = jlib::util::http::read_head(*peer, 65536);
+
+                // Only what a test sends: a Content-Length body, or none.
+                const std::string::size_type at = find_ci(r.head, "\r\ncontent-length:");
+
+                if(at != std::string::npos) {
+                    const std::string::size_type eol = r.head.find("\r\n", at + 2);
+                    const std::string value = r.head.substr(at + 17, eol - at - 17);
+                    const std::size_t n = std::stoul(value);
+
+                    r.body.resize(n);
+
+                    if(n) peer->read(&r.body[0], static_cast<std::streamsize>(n));
+                }
+
+                std::string reply;
+
+                {
+                    std::lock_guard<std::mutex> lock(m_lock);
+
+                    m_requests.push_back(r);
+                }
+
+                reply = m_handler(r);
+
+                *peer << reply << std::flush;
+            }
+            catch(std::exception&) {
+                // A client that hung up mid-request is a case some tests
+                // create on purpose.
+            }
+
+            // The client sends Connection: close and so does this; closing
+            // here is what ends a body with no framing fields on it.
+            peer->close();
+        }
+    }
+
+    static std::string::size_type find_ci(const std::string& hay, const std::string& needle) {
+        std::string lower;
+
+        for(char c : hay) lower += static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+
+        return lower.find(needle);
+    }
+
+    jlib::sys::listener m_listener;
+    handler m_handler;
+    mutable std::mutex m_lock;
+    std::vector<request> m_requests;
+    std::atomic<bool> m_stop{false};
+    std::thread m_thread;
+};
+
+/** A minimal well-formed response. */
+inline std::string reply(int status, const std::string& reason,
+                         const std::string& body = "",
+                         const std::string& extra = "")
+{
+    return "HTTP/1.1 " + std::to_string(status) + " " + reason + "\r\n" +
+           "Content-Length: " + std::to_string(body.size()) + "\r\n" +
+           extra +
+           "\r\n" + body;
+}
+
+}
+
+#endif // JLIB_TESTS_HTTPSERVER_HH

--- a/tests/net_http_live_test.cc
+++ b/tests/net_http_live_test.cc
@@ -1,0 +1,398 @@
+/* -*- mode: C++ c-basic-offset: 4 -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// The HTTP client against a server nobody here wrote.
+//
+// net_http_test drives it against a server written in the test, which is the
+// only way to get the awkward shapes -- a chunked body whose data looks like
+// its own framing, both framing fields at once -- and which for that same
+// reason can only ever send what somebody thought of.  nginx sends a Date and
+// a Server and an ETag and a 404 body that nobody here chose, in an order
+// nobody here chose, and that is the whole point of it.
+//
+// And through tinyproxy, which is already in the image for the mail tests: the
+// CONNECT path and the plaintext proxy path are different code, and neither
+// had ever carried an HTTP request.
+//
+// SKIP (77) where there is no nginx, which is every machine that is not the
+// build container.
+
+#include <jlib/net/http.hh>
+#include <jlib/net/net.hh>
+
+#include <jlib/sys/socketstream.hh>
+#include <jlib/sys/sys.hh>
+
+#include <jlib/util/URL.hh>
+
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <unistd.h>
+
+namespace fs = std::filesystem;
+namespace http = jlib::net::http;
+
+using jlib::util::URL;
+
+static int failures = 0;
+
+static void ok(const std::string& what, bool good, const std::string& detail = "") {
+    if(!good) ++failures;
+    std::cout << (good ? "  ok   " : "  FAIL ") << what;
+    if(!detail.empty()) std::cout << ": " << detail;
+    std::cout << "\n";
+}
+
+/** nginx and tinyproxy, started for this test and stopped after it. */
+struct site {
+    fs::path dir;
+    unsigned int port = 0;
+    unsigned int proxy_port = 0;
+    bool running = false;
+    bool proxied = false;
+
+    ~site() { stop(); }
+
+    bool start() {
+        std::string out, err;
+
+        try {
+            if(jlib::sys::run({ "nginx", "-v" }, out, err) != 0) return false;
+        }
+        catch(std::exception&) {
+            return false;
+        }
+
+        // Derived from the pid, so two builds on one machine do not collide.
+        port = 16000 + static_cast<unsigned int>(::getpid() % 900);
+        proxy_port = port + 1000;
+
+        dir = fs::temp_directory_path() / ("jlib-http-" + std::to_string(::getpid()));
+
+        fs::remove_all(dir);
+        fs::create_directories(dir / "www");
+        fs::create_directories(dir / "logs");
+        fs::create_directories(dir / "tmp");
+
+        {
+            std::ofstream f(dir / "www" / "hello.txt");
+            f << "hello from nginx\n";
+        }
+
+        {
+            std::ofstream f(dir / "nginx.conf");
+
+            f << "daemon on;\n"
+              << "worker_processes 1;\n"
+              << "pid " << (dir / "nginx.pid").string() << ";\n"
+              << "error_log " << (dir / "logs" / "error.log").string() << ";\n"
+              << "events { worker_connections 64; }\n"
+              << "http {\n"
+              << "  access_log " << (dir / "logs" / "access.log").string() << ";\n"
+              << "  client_body_temp_path " << (dir / "tmp").string() << ";\n"
+              << "  proxy_temp_path " << (dir / "tmp").string() << ";\n"
+              << "  fastcgi_temp_path " << (dir / "tmp").string() << ";\n"
+              << "  uwsgi_temp_path " << (dir / "tmp").string() << ";\n"
+              << "  scgi_temp_path " << (dir / "tmp").string() << ";\n"
+              << "  default_type application/octet-stream;\n"
+              << "  server {\n"
+              << "    listen 127.0.0.1:" << port << ";\n"
+              << "    root " << (dir / "www").string() << ";\n"
+              << "    location = /echo {\n"
+              << "      return 200 \"$request_method $args\";\n"
+              << "    }\n"
+              << "    location = /moved {\n"
+              << "      return 302 \"/hello.txt\";\n"
+              << "    }\n"
+              << "    location = /teapot {\n"
+              << "      return 418 \"short and stout\";\n"
+              << "    }\n"
+              << "  }\n"
+              << "}\n";
+        }
+
+        if(jlib::sys::run({ "nginx", "-c", (dir / "nginx.conf").string(),
+                            "-p", dir.string() }, out, err) != 0) {
+            std::cerr << "nginx would not start: " << err << out << "\n";
+
+            return false;
+        }
+
+        running = true;
+
+        for(int i = 0; i < 100; i++) {
+            try {
+                jlib::sys::socketstream probe("127.0.0.1", port);
+
+                return true;
+            }
+            catch(std::exception&) {
+                ::usleep(50000);
+            }
+        }
+
+        std::cerr << "nginx did not come up on " << port << "\n";
+
+        return false;
+    }
+
+    bool start_proxy() {
+        std::string out, err;
+
+        try {
+            if(jlib::sys::run({ "tinyproxy", "-v" }, out, err) != 0) return false;
+        }
+        catch(std::exception&) {
+            return false;
+        }
+
+        {
+            std::ofstream f(dir / "proxy.conf");
+
+            f << "Port " << proxy_port << "\n"
+              << "Listen 127.0.0.1\n"
+              << "Timeout 60\n"
+              << "LogFile \"" << (dir / "logs" / "proxy.log").string() << "\"\n"
+              << "LogLevel Info\n"
+              << "MaxClients 20\n"
+              << "Allow 127.0.0.1\n"
+              << "ConnectPort " << port << "\n";
+        }
+
+        if(jlib::sys::run({ "tinyproxy", "-c", (dir / "proxy.conf").string() },
+                          out, err) != 0) {
+            std::cerr << "tinyproxy would not start: " << err << out << "\n";
+
+            return false;
+        }
+
+        proxied = true;
+
+        for(int i = 0; i < 100; i++) {
+            try {
+                jlib::sys::socketstream probe("127.0.0.1", proxy_port);
+
+                return true;
+            }
+            catch(std::exception&) {
+                ::usleep(50000);
+            }
+        }
+
+        return false;
+    }
+
+    void stop() {
+        std::string out, err;
+
+        if(running) {
+            try {
+                jlib::sys::run({ "nginx", "-c", (dir / "nginx.conf").string(),
+                                 "-p", dir.string(), "-s", "quit" }, out, err);
+            }
+            catch(std::exception&) {}
+
+            running = false;
+        }
+
+        if(proxied) {
+            try { jlib::sys::run({ "pkill", "-f", (dir / "proxy.conf").string() }, out, err); }
+            catch(std::exception&) {}
+
+            proxied = false;
+        }
+
+        if(!dir.empty()) {
+            std::error_code e;
+            fs::remove_all(dir, e);
+        }
+    }
+
+    std::string url(const std::string& path) const {
+        return "http://127.0.0.1:" + std::to_string(port) + path;
+    }
+
+    std::string through_proxy(const std::string& path) const {
+        return url(path) + "?proxy=127.0.0.1:" + std::to_string(proxy_port);
+    }
+};
+
+int main() {
+    std::cout << std::unitbuf;
+
+    site s;
+
+    if(!s.start()) {
+        std::cerr << "no nginx here; skipping\n";
+
+        return 77;
+    }
+
+    std::cout << "nginx on 127.0.0.1:" << s.port << "\n";
+
+    std::cout << "\nagainst a real server:\n";
+
+    try {
+        const http::Response r = http::get(URL(s.url("/hello.txt")));
+
+        ok("a GET of a static file", r.status() == 200 &&
+           r.body() == "hello from nginx\n", r.body());
+
+        // Fields nobody here chose, in an order nobody here chose.  An
+        // in-process server sends the two or three a test thought of.
+        ok("the fields a real server sends are all read",
+           r.fields().has("Server") && r.fields().has("Date") &&
+           r.fields().has("Content-Type") && r.fields().has("Last-Modified") &&
+           r.fields().has("ETag"),
+           std::to_string(r.fields().size()) + " fields");
+
+        ok("and Content-Length framed the body",
+           r.body_framing() == http::framing::length &&
+           r.content_length() == r.body().size());
+    }
+    catch(std::exception& e) {
+        ok("a GET of a static file", false, e.what());
+    }
+
+    try {
+        const http::Response r = http::get(URL(s.url("/nothing-here")));
+
+        // A 404 is a response with a body, not an error.  http::get() compared
+        // the status against the string "200" and threw everything else away.
+        ok("a 404 is a response with a body", r.status() == 404 &&
+           !r.ok() && !r.body().empty(),
+           std::to_string(r.body().size()) + " octets");
+    }
+    catch(std::exception& e) {
+        ok("a 404 is a response with a body", false, e.what());
+    }
+
+    try {
+        const http::Response r = http::get(URL(s.url("/teapot")));
+
+        ok("and so is a status nobody has a branch for",
+           r.status() == 418 && r.body() == "short and stout", r.body());
+    }
+    catch(std::exception& e) {
+        ok("and so is a status nobody has a branch for", false, e.what());
+    }
+
+    try {
+        // The query string has to reach the request-target: nginx echoes $args
+        // back, which is what it parsed out of the request line this client
+        // built.
+        const http::Response r = http::get(URL(s.url("/echo?a=1&b=two")));
+
+        ok("the query string arrives at the server",
+           r.body() == "GET a=1&b=two", r.body());
+    }
+    catch(std::exception& e) {
+        ok("the query string arrives at the server", false, e.what());
+    }
+
+    try {
+        const http::Response off = http::get(URL(s.url("/moved")));
+
+        ok("a redirect is handed back by default", off.status() == 302 &&
+           off.fields().has("Location"), off.fields().get("Location"));
+
+        http::options o;
+        o.redirects = 3;
+
+        const http::Response on = http::get(URL(s.url("/moved")), http::fields(), o);
+
+        ok("and followed when asked", on.status() == 200 &&
+           on.body() == "hello from nginx\n", on.body());
+    }
+    catch(std::exception& e) {
+        ok("a redirect is handed back by default", false, e.what());
+    }
+
+    try {
+        const http::Response r = http::post_form(URL(s.url("/echo")),
+                                                 { { "grant_type", "refresh_token" } });
+
+        ok("a POST with a form body reaches it", r.status() == 200 &&
+           r.body().substr(0, 4) == "POST", r.body());
+    }
+    catch(std::exception& e) {
+        ok("a POST with a form body reaches it", false, e.what());
+    }
+
+    if(s.start_proxy()) {
+        std::cout << "\nthrough a real proxy on " << s.proxy_port << ":\n";
+
+        try {
+            const http::Response r = http::get(URL(s.through_proxy("/hello.txt")));
+
+            ok("a request through a CONNECT proxy", r.status() == 200 &&
+               r.body() == "hello from nginx\n", r.body());
+        }
+        catch(std::exception& e) {
+            ok("a request through a CONNECT proxy", false, e.what());
+        }
+
+        try {
+            // tinyproxy is configured to allow CONNECT only to nginx's port,
+            // so this is refused -- and the refusal has to reach the caller
+            // rather than becoming a mysterious connection failure.
+            bool threw = false;
+            std::string why;
+
+            try {
+                http::get(URL("http://127.0.0.1:9/x?proxy=127.0.0.1:" +
+                              std::to_string(s.proxy_port)));
+            }
+            catch(std::exception& e) {
+                threw = true;
+                why = e.what();
+            }
+
+            ok("and a proxy that refuses the tunnel says so", threw, why);
+        }
+        catch(std::exception& e) {
+            ok("and a proxy that refuses the tunnel says so", false, e.what());
+        }
+    }
+    else {
+        std::cout << "\n  skip  no tinyproxy; the proxy path is untested here\n";
+    }
+
+    // What a green run does not establish.
+    //
+    // Not TLS.  nginx here is plaintext; https:// goes through sys::tlsstream,
+    // which the mail live tests exercise against dovecot, but no request in
+    // this file is an HTTPS one.
+    //
+    // Not interoperability.  One server, one version, one configuration.  What
+    // it establishes is that the client's request line, its Host, and its
+    // reading of a response head are acceptable to something that was not
+    // written to accept them.
+    //
+    // Not the awkward shapes.  A chunked body whose data looks like its own
+    // framing, both framing fields at once, a header section with no end --
+    // nginx will not send any of those, which is why net_http_test exists.
+    std::cout << "\n" << (failures ? "FAILED" : "PASSED") << ": " << failures
+              << " failure(s)\n";
+
+    return failures ? 1 : 0;
+}

--- a/tests/net_http_live_test.cc
+++ b/tests/net_http_live_test.cc
@@ -33,6 +33,8 @@
 // SKIP (77) where there is no nginx, which is every machine that is not the
 // build container.
 
+#include "certificate.hh"
+
 #include <jlib/net/http.hh>
 #include <jlib/net/net.hh>
 
@@ -66,8 +68,10 @@ static void ok(const std::string& what, bool good, const std::string& detail = "
 struct site {
     fs::path dir;
     unsigned int port = 0;
+    unsigned int tls_port = 0;
     unsigned int proxy_port = 0;
     bool running = false;
+    bool tls = false;
     bool proxied = false;
 
     ~site() { stop(); }
@@ -84,6 +88,7 @@ struct site {
 
         // Derived from the pid, so two builds on one machine do not collide.
         port = 16000 + static_cast<unsigned int>(::getpid() % 900);
+        tls_port = port + 2000;
         proxy_port = port + 1000;
 
         dir = fs::temp_directory_path() / ("jlib-http-" + std::to_string(::getpid()));
@@ -97,6 +102,18 @@ struct site {
             std::ofstream f(dir / "www" / "hello.txt");
             f << "hello from nginx\n";
         }
+
+        // A certificate for localhost, and the client's trust store pointed at
+        // it.  Not a way around verification -- jlib still checks the name
+        // with SSL_set1_host -- but a way to make it succeed without a real
+        // CA.  The SAN says DNS:localhost, which is why the TLS requests below
+        // go to "localhost" and the plaintext ones to 127.0.0.1.
+        const std::string cert = (dir / "cert.pem").string();
+        const std::string key = (dir / "key.pem").string();
+
+        tls = make_cert(cert, key);
+
+        if(tls) ::setenv("SSL_CERT_FILE", cert.c_str(), 1);
 
         {
             std::ofstream f(dir / "nginx.conf");
@@ -126,8 +143,19 @@ struct site {
               << "    location = /teapot {\n"
               << "      return 418 \"short and stout\";\n"
               << "    }\n"
-              << "  }\n"
-              << "}\n";
+              << "  }\n";
+
+            if(tls) {
+                f << "  server {\n"
+                  << "    listen 127.0.0.1:" << tls_port << " ssl;\n"
+                  << "    server_name localhost;\n"
+                  << "    ssl_certificate " << cert << ";\n"
+                  << "    ssl_certificate_key " << key << ";\n"
+                  << "    root " << (dir / "www").string() << ";\n"
+                  << "  }\n";
+            }
+
+            f << "}\n";
         }
 
         if(jlib::sys::run({ "nginx", "-c", (dir / "nginx.conf").string(),
@@ -229,6 +257,10 @@ struct site {
 
     std::string url(const std::string& path) const {
         return "http://127.0.0.1:" + std::to_string(port) + path;
+    }
+
+    std::string secure_url(const std::string& path) const {
+        return "https://localhost:" + std::to_string(tls_port) + path;
     }
 
     std::string through_proxy(const std::string& path) const {
@@ -338,6 +370,42 @@ int main() {
         ok("a POST with a form body reaches it", false, e.what());
     }
 
+    if(s.tls) {
+        std::cout << "\nover TLS, to a real server on " << s.tls_port << ":\n";
+
+        try {
+            const http::Response r = http::get(URL(s.secure_url("/hello.txt")));
+
+            ok("an https:// request to nginx", r.status() == 200 &&
+               r.body() == "hello from nginx\n", r.body());
+        }
+        catch(std::exception& e) {
+            ok("an https:// request to nginx", false, e.what());
+        }
+
+        try {
+            // The certificate says DNS:localhost and nothing else.  Encrypted
+            // and unauthenticated is the failure that looked fine for years in
+            // sslproxystream, and here the thing being handed over would be an
+            // OAuth2 token.
+            bool threw = false;
+
+            try {
+                http::get(URL("https://127.0.0.1:" + std::to_string(s.tls_port) +
+                              "/hello.txt"));
+            }
+            catch(std::exception&) { threw = true; }
+
+            ok("and a name the certificate does not cover is refused", threw);
+        }
+        catch(std::exception& e) {
+            ok("and a name the certificate does not cover is refused", false, e.what());
+        }
+    }
+    else {
+        std::cout << "\n  skip  no certificate; the TLS path is untested here\n";
+    }
+
     if(s.start_proxy()) {
         std::cout << "\nthrough a real proxy on " << s.proxy_port << ":\n";
 
@@ -379,9 +447,17 @@ int main() {
 
     // What a green run does not establish.
     //
-    // Not TLS.  nginx here is plaintext; https:// goes through sys::tlsstream,
-    // which the mail live tests exercise against dovecot, but no request in
-    // this file is an HTTPS one.
+    // Not TLS to a stranger.  The https:// requests above handshake against a
+    // certificate this test generated, with the trust store pointed at it, so
+    // they prove the client's transport selection and its hostname checking
+    // and say nothing about a public CA chain or a server that picks something
+    // unexpected.  The first request to a real token endpoint will be the
+    // first one made to a peer nobody here configured.
+    //
+    // Not TLS through the proxy.  The CONNECT path carries plaintext HTTP here
+    // and tlsproxystream is exercised by sys_proxy_live_test against dovecot,
+    // but no request in this file is both proxied and encrypted -- which is
+    // the combination a corporate network would actually present.
     //
     // Not interoperability.  One server, one version, one configuration.  What
     // it establishes is that the client's request line, its Host, and its

--- a/tests/net_http_test.cc
+++ b/tests/net_http_test.cc
@@ -1,0 +1,527 @@
+/* -*- mode: C++ c-basic-offset: 4 -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// The HTTP client, against a server in this process.
+//
+// Two kinds of assertion here.  What the client *reads* -- a chunked body, a
+// 400 with a body worth having -- and what the client *sends*, which the
+// server records and which is the half that cannot be checked any other way:
+// that the query string reached the request-target, that Authorization came
+// off across an origin change, that a POST body was not re-sent to a redirect.
+//
+// net_http_live_test is the other half, against a real nginx, including
+// through a real proxy.
+
+#include "httpserver.hh"
+
+#include <jlib/net/http.hh>
+#include <jlib/net/net.hh>
+
+#include <jlib/util/URL.hh>
+
+#include <iostream>
+#include <map>
+#include <string>
+
+namespace http = jlib::net::http;
+
+using jlib::util::URL;
+
+static int failures = 0;
+
+static void ok(const std::string& what, bool good, const std::string& detail = "") {
+    if(!good) ++failures;
+    std::cout << (good ? "  ok   " : "  FAIL ") << what;
+    if(!detail.empty()) std::cout << ": " << detail;
+    std::cout << "\n";
+}
+
+static bool has_line(const std::string& head, const std::string& line) {
+    return head.find(line + "\r\n") != std::string::npos;
+}
+
+static void a_request_and_a_response() {
+    std::cout << "\na request and a response:\n";
+
+    httpserver::server s([](const httpserver::request&) {
+        return httpserver::reply(200, "OK", "hello",
+                                 "Content-Type: text/plain\r\n");
+    });
+
+    const http::Response r = http::get(URL(s.url("/thing?a=1&b=two")));
+
+    ok("the status is a number", r.status() == 200, std::to_string(r.status()));
+    ok("the body arrives", r.body() == "hello", r.body());
+    ok("and the fields", r.fields().get("Content-Type") == "text/plain");
+
+    const std::vector<httpserver::request> sent = s.requests();
+
+    ok("one request was made", sent.size() == 1, std::to_string(sent.size()));
+
+    if(sent.empty()) return;
+
+    // The request-target is path *and* query.  get_path() alone drops the
+    // query string, which for half the requests this client makes is the whole
+    // message -- and URL keeps the two apart, so it is easy to send only one.
+    ok("the query string is in the request target",
+       has_line(sent[0].head, "GET /thing?a=1&b=two HTTP/1.1"),
+       sent[0].head.substr(0, sent[0].head.find("\r\n")));
+
+    ok("Host names the authority",
+       has_line(sent[0].head, "Host: 127.0.0.1:" + std::to_string(s.port())));
+
+    // Not politeness: it ends the message at the end of the connection and
+    // takes every keep-alive framing question off the table.
+    ok("Connection: close is sent", has_line(sent[0].head, "Connection: close"));
+
+    // RFC 9110 12.5.3 lets a server send any coding to a client that sends no
+    // Accept-Encoding.  Nothing here can inflate a gzip body.
+    ok("and Accept-Encoding: identity, so nothing arrives compressed",
+       has_line(sent[0].head, "Accept-Encoding: identity"));
+
+    // An empty path is "/" (RFC 9112 3.2.1).  "GET  HTTP/1.1" is not a
+    // request line at all.
+    httpserver::server bare([](const httpserver::request&) {
+        return httpserver::reply(200, "OK");
+    });
+
+    http::get(URL("http://127.0.0.1:" + std::to_string(bare.port())));
+
+    const std::vector<httpserver::request> b = bare.requests();
+
+    ok("an empty path goes out as \"/\"",
+       !b.empty() && has_line(b[0].head, "GET / HTTP/1.1"),
+       b.empty() ? "" : b[0].head.substr(0, b[0].head.find("\r\n")));
+}
+
+static void a_non_2xx_is_not_an_exception() {
+    std::cout << "\na non-2xx is not an exception:\n";
+
+    // The whole reason this client exists.  A token endpoint answers 400 with
+    // a JSON body saying whether the refresh token was revoked -- go and get
+    // the user to authorize again -- or whether the server hiccuped and the
+    // right move is to retry.  http::get() compared the status against the
+    // string "200" and threw away everything else, so it could not tell those
+    // apart and neither could its caller.
+    const std::string error = "{\"error\":\"invalid_grant\"}";
+
+    httpserver::server s([&error](const httpserver::request&) {
+        return httpserver::reply(400, "Bad Request", error,
+                                 "Content-Type: application/json\r\n");
+    });
+
+    bool threw = false;
+    http::Response r;
+
+    try {
+        r = http::get(URL(s.url("/token")));
+    }
+    catch(std::exception&) {
+        threw = true;
+    }
+
+    ok("it does not throw", !threw);
+    ok("the status is there", r.status() == 400, std::to_string(r.status()));
+    ok("ok() is false", !r.ok());
+    ok("and the body is readable", r.body() == error, r.body());
+
+    // 204 and 304 have no body whatever the fields say (RFC 9112 6.3).
+    httpserver::server empty([](const httpserver::request&) {
+        return std::string("HTTP/1.1 204 No Content\r\n\r\n");
+    });
+
+    const http::Response n = http::get(URL(empty.url()));
+
+    ok("a 204 has no body and does not hang",
+       n.status() == 204 && n.body().empty());
+}
+
+static void bodies_of_every_shape() {
+    std::cout << "\nbodies of every shape:\n";
+
+    {
+        // The case that catches a chunked reader written with find(): the
+        // chunk data contains a line that looks exactly like a chunk header.
+        const std::string trap = "5\r\nnope\r\n";
+
+        httpserver::server s([&trap](const httpserver::request&) {
+            std::ostringstream o;
+
+            o << "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n"
+              << std::hex << trap.size() << "\r\n" << trap << "\r\n"
+              << "3\r\nend\r\n"
+              << "0\r\n\r\n";
+
+            return o.str();
+        });
+
+        const http::Response r = http::get(URL(s.url()));
+
+        ok("a chunked body reassembles, even one that looks like its own framing",
+           r.body() == trap + "end");
+    }
+
+    {
+        // No Content-Length and no Transfer-Encoding: the body is whatever
+        // arrives before the connection closes.
+        httpserver::server s([](const httpserver::request&) {
+            return std::string("HTTP/1.1 200 OK\r\n\r\nto the very end");
+        });
+
+        const http::Response r = http::get(URL(s.url()));
+
+        ok("a body with no framing runs to the close",
+           r.body() == "to the very end", r.body());
+    }
+
+    {
+        // RFC 9112 6.1, and this is the request-smuggling primitive: two
+        // recipients disagreeing about where a message ends is how one request
+        // becomes two.
+        httpserver::server s([](const httpserver::request&) {
+            return std::string("HTTP/1.1 200 OK\r\n"
+                               "Content-Length: 5\r\n"
+                               "Transfer-Encoding: chunked\r\n\r\n"
+                               "0\r\n\r\n");
+        });
+
+        bool refused = false;
+
+        try { http::get(URL(s.url())); }
+        catch(http::error&) { refused = true; }
+
+        ok("a response with both framing fields is refused", refused);
+    }
+
+    {
+        // A Content-Length from a stranger decides an allocation.
+        httpserver::server s([](const httpserver::request&) {
+            return std::string("HTTP/1.1 200 OK\r\nContent-Length: 999999999\r\n\r\nx");
+        });
+
+        bool capped = false;
+        http::options o;
+        o.max_body = 1024;
+
+        try { http::get(URL(s.url()), http::fields(), o); }
+        catch(http::error&) { capped = true; }
+
+        ok("and a body larger than the cap is refused rather than allocated", capped);
+    }
+}
+
+static void posting_a_form() {
+    std::cout << "\nposting a form:\n";
+
+    // Every OAuth2 token request is one of these (RFC 6749 4.1.3).
+    httpserver::server s([](const httpserver::request&) {
+        return httpserver::reply(200, "OK", "{}");
+    });
+
+    std::map<std::string, std::string> form;
+
+    form["grant_type"] = "refresh_token";
+    form["refresh_token"] = "a+b/c=";
+    form["scope"] = "mail read";
+
+    http::post_form(URL(s.url("/token")), form);
+
+    const std::vector<httpserver::request> sent = s.requests();
+
+    ok("a POST was made", !sent.empty() && has_line(sent[0].head, "POST /token HTTP/1.1"));
+
+    if(sent.empty()) return;
+
+    ok("with a form content type",
+       has_line(sent[0].head, "Content-Type: application/x-www-form-urlencoded"));
+
+    ok("and a Content-Length",
+       has_line(sent[0].head, "Content-Length: " + std::to_string(sent[0].body.size())));
+
+    // The encoding is HTML's, not RFC 3986's: a space is "+", so a "+" in the
+    // data has to be escaped.  That is the case that bites -- base64 produces
+    // "+" constantly, and a refresh token sent through uri::encode arrives
+    // with spaces in it and does not match.
+    ok("a space is \"+\" and a \"+\" is escaped",
+       sent[0].body.find("refresh_token=a%2Bb%2Fc%3D") != std::string::npos &&
+       sent[0].body.find("scope=mail+read") != std::string::npos,
+       sent[0].body);
+
+    ok("form_encode agrees on its own",
+       http::form_encode({ { "a", "x y" } }) == "a=x+y",
+       http::form_encode({ { "a", "x y" } }));
+}
+
+static void what_it_refuses_to_send() {
+    std::cout << "\nwhat it refuses to send:\n";
+
+    httpserver::server s([](const httpserver::request&) {
+        return httpserver::reply(200, "OK");
+    });
+
+    // A CR or LF in a field value is how one request becomes two.  Checked
+    // against the grammar rather than against a list of bad characters:
+    // field-name is a token and field-value is field-content, and those rules
+    // are both stricter and easier to defend than a blocklist.
+    http::fields bad;
+    bad.add("X-Thing", "one\r\nX-Injected: two");
+
+    bool refused = false;
+
+    try { http::get(URL(s.url()), bad); }
+    catch(http::error&) { refused = true; }
+
+    ok("a header value containing CRLF", refused);
+
+    http::fields worse;
+    worse.add("X Thing", "one");
+
+    refused = false;
+
+    try { http::get(URL(s.url()), worse); }
+    catch(http::error&) { refused = true; }
+
+    ok("a header name that is not a token", refused);
+
+    refused = false;
+
+    try { http::request("GET IT", URL(s.url())); }
+    catch(http::error&) { refused = true; }
+
+    ok("a method that is not a token", refused);
+
+    refused = false;
+
+    try { http::get(URL("ftp://example.com/x")); }
+    catch(http::error&) { refused = true; }
+
+    ok("and a URL that is not http or https", refused);
+
+    ok("nothing reached the server", s.requests().empty(),
+       std::to_string(s.requests().size()) + " request(s)");
+}
+
+static void redirects_are_off_and_stay_off() {
+    std::cout << "\nredirects are off, and what happens when they are on:\n";
+
+    {
+        // The one that matters.  Following a redirect on a POST means sending
+        // the body -- a client_secret and a refresh_token -- to a host named
+        // by the response.  A Location: is attacker-controlled the moment
+        // anything upstream is.
+        httpserver::server s([](const httpserver::request& r) {
+            if(r.head.find("POST /token") == 0)
+                return httpserver::reply(302, "Found", "",
+                                         "Location: http://127.0.0.1:1/steal\r\n");
+
+            return httpserver::reply(200, "OK", "should not get here");
+        });
+
+        const http::Response r = http::post_form(URL(s.url("/token")),
+                                                 { { "secret", "hunter2" } });
+
+        ok("a 302 on a POST is handed back, not followed", r.status() == 302);
+        ok("and only the one request was made", s.requests().size() == 1,
+           std::to_string(s.requests().size()));
+    }
+
+    {
+        // With redirects on, a POST is still not followed, because re-sending
+        // a body elsewhere is not a redirect.
+        httpserver::server s([](const httpserver::request& r) {
+            if(r.head.find("POST ") == 0)
+                return httpserver::reply(307, "Temporary Redirect", "",
+                                         "Location: /elsewhere\r\n");
+
+            return httpserver::reply(200, "OK", "arrived");
+        });
+
+        http::options o;
+        o.redirects = 3;
+
+        const http::Response r = http::post_form(URL(s.url("/token")),
+                                                 { { "secret", "hunter2" } }, http::fields(), o);
+
+        ok("even with redirects on, a 307 on a POST is not followed",
+           r.status() == 307 && s.requests().size() == 1);
+    }
+
+    {
+        // A GET is, when asked, and an absolute path resolves against the same
+        // origin without needing RFC 3986 5.3.
+        httpserver::server s([](const httpserver::request& r) {
+            if(r.head.find("GET /old") == 0)
+                return httpserver::reply(302, "Found", "", "Location: /new?q=1\r\n");
+
+            return httpserver::reply(200, "OK", "arrived");
+        });
+
+        http::options o;
+        o.redirects = 3;
+
+        const http::Response r = http::get(URL(s.url("/old")), http::fields(), o);
+
+        ok("a GET follows a relative redirect when told to",
+           r.status() == 200 && r.body() == "arrived", r.body());
+
+        const std::vector<httpserver::request> sent = s.requests();
+
+        ok("and the second request carries the new query string",
+           sent.size() == 2 && has_line(sent[1].head, "GET /new?q=1 HTTP/1.1"),
+           sent.size() >= 2 ? sent[1].head.substr(0, sent[1].head.find("\r\n")) : "");
+    }
+
+    {
+        // 303 says "go and GET this instead" and drops the body.  RFC 9110
+        // 15.4.4 -- this is the one redirect that legitimately changes a POST
+        // into a GET.
+        httpserver::server s([](const httpserver::request& r) {
+            if(r.head.find("POST ") == 0)
+                return httpserver::reply(303, "See Other", "", "Location: /result\r\n");
+
+            return httpserver::reply(200, "OK", "result");
+        });
+
+        http::options o;
+        o.redirects = 3;
+
+        const http::Response r = http::post_form(URL(s.url("/submit")),
+                                                 { { "a", "b" } }, http::fields(), o);
+
+        const std::vector<httpserver::request> sent = s.requests();
+
+        ok("a 303 turns a POST into a GET", r.status() == 200 && sent.size() == 2 &&
+           has_line(sent[1].head, "GET /result HTTP/1.1"));
+
+        ok("and does not carry the body", sent.size() == 2 && sent[1].body.empty());
+    }
+}
+
+static void a_credential_does_not_cross_an_origin() {
+    std::cout << "\na credential does not cross an origin:\n";
+
+    // Two servers, so the redirect really does change origin.  Authorization
+    // is scoped to one origin and to no other; a redirect that carried it
+    // would be a way to read somebody's bearer token by sending them a 302.
+    httpserver::server other([](const httpserver::request&) {
+        return httpserver::reply(200, "OK", "arrived");
+    });
+
+    const std::string away = other.url("/elsewhere");
+
+    httpserver::server first([&away](const httpserver::request&) {
+        return httpserver::reply(302, "Found", "", "Location: " + away + "\r\n");
+    });
+
+    http::options o;
+    o.redirects = 3;
+
+    http::fields send;
+    send.add("Authorization", "Bearer ya29.SECRET");
+    send.add("X-Harmless", "kept");
+
+    const http::Response r = http::get(URL(first.url("/start")), send, o);
+
+    ok("the redirect was followed", r.status() == 200 && r.body() == "arrived");
+
+    const std::vector<httpserver::request> at_first = first.requests();
+    const std::vector<httpserver::request> at_other = other.requests();
+
+    ok("the first origin got the Authorization",
+       !at_first.empty() &&
+       at_first[0].head.find("Authorization: Bearer ya29.SECRET") != std::string::npos);
+
+    ok("and the second origin did not",
+       !at_other.empty() &&
+       at_other[0].head.find("Authorization") == std::string::npos);
+
+    ok("but an ordinary field still travelled",
+       !at_other.empty() && at_other[0].head.find("X-Harmless: kept") != std::string::npos);
+}
+
+static void the_proxy_parameter_is_read_one_way() {
+    std::cout << "\nthe proxy parameter is read in one place:\n";
+
+    std::string host;
+    unsigned int port = 0;
+
+    ok("no parameter is not an error",
+       !jlib::net::proxy_of(URL("http://example.com/"), host, port));
+
+    ok("host:port reads",
+       jlib::net::proxy_of(URL("http://example.com/?proxy=p.example:3128"), host, port) &&
+       host == "p.example" && port == 3128, host + ":" + std::to_string(port));
+
+    // An IPv6 literal proxy has colons of its own, so the rightmost one is the
+    // separator.  tokenize on ":" -- which is what Imap4 did -- would have
+    // handed back "[" as the host.
+    ok("an IPv6 literal reads",
+       jlib::net::proxy_of(URL("http://example.com/?proxy=%5B::1%5D:3128"), host, port) &&
+       host == "::1" && port == 3128, host + ":" + std::to_string(port));
+
+    // Imap4 indexed pvec[1] with no size check, so this read off the end of a
+    // vector.  Pop3 did not read the parameter at all and connected direct,
+    // which is worse: a caller who asked for a proxy, perhaps because it is
+    // the only route out, silently did not get one.
+    for(const char* bad : { "host", "host:", ":3128", "host:nope", "host:0",
+                            "host:99999" }) {
+        bool threw = false;
+
+        try {
+            jlib::net::proxy_of(URL(std::string("http://example.com/?proxy=") + bad),
+                                host, port);
+        }
+        catch(std::exception&) { threw = true; }
+
+        ok(std::string("\"") + bad + "\" is refused rather than guessed at", threw);
+    }
+}
+
+int main() {
+    std::cout << std::unitbuf;
+
+    a_request_and_a_response();
+    a_non_2xx_is_not_an_exception();
+    bodies_of_every_shape();
+    posting_a_form();
+    what_it_refuses_to_send();
+    redirects_are_off_and_stay_off();
+    a_credential_does_not_cross_an_origin();
+    the_proxy_parameter_is_read_one_way();
+
+    // What a green run does not establish.
+    //
+    // Not TLS.  Every server here is plaintext on loopback; https:// goes
+    // through sys::tlsstream, which sys_tls_sigpipe_test and the mail live
+    // tests exercise, but no test in this file makes an HTTPS request.
+    //
+    // Not a real server.  This one sends exactly what it was told to, which is
+    // the point of it for the awkward cases and its whole limitation for the
+    // ordinary ones -- net_http_live_test runs the same client against nginx,
+    // and through tinyproxy, in the container.
+    //
+    // Not the redirect resolution jlib does not have.  RFC 3986 5.3 is not
+    // implemented; a relative Location that is not an absolute path throws
+    // rather than being guessed at, and that is asserted nowhere because
+    // nothing has needed it.
+    std::cout << "\n" << (failures ? "FAILED" : "PASSED") << ": " << failures
+              << " failure(s)\n";
+
+    return failures ? 1 : 0;
+}

--- a/tests/net_http_test.cc
+++ b/tests/net_http_test.cc
@@ -28,6 +28,7 @@
 // net_http_live_test is the other half, against a real nginx, including
 // through a real proxy.
 
+#include "certificate.hh"
 #include "httpserver.hh"
 
 #include <jlib/net/http.hh>
@@ -35,6 +36,7 @@
 
 #include <jlib/util/URL.hh>
 
+#include <cstdio>
 #include <iostream>
 #include <map>
 #include <string>
@@ -455,6 +457,113 @@ static void a_credential_does_not_cross_an_origin() {
        !at_other.empty() && at_other[0].head.find("X-Harmless: kept") != std::string::npos);
 }
 
+static void over_tls() {
+    std::cout << "\nover TLS:\n";
+
+    // The one thing net_http_test could not do until the test server learned
+    // to speak TLS, and the gap that mattered most: every request this client
+    // exists to make is an https:// one, and none of them had ever been made.
+    //
+    // The verification is real.  A certificate for localhost is generated
+    // here, SSL_CERT_FILE points the client's trust store at it -- which
+    // basic_tlsbuf reaches through SSL_CTX_set_default_verify_paths -- and the
+    // handshake succeeds because the certificate is genuinely trusted for this
+    // run, not because anything was turned off.  The same arrangement
+    // mailserver.hh and sys_tls_sigpipe_test use.
+    const std::string cert = "http_test_cert.pem";
+    const std::string key = "http_test_key.pem";
+
+    if(!make_cert(cert, key)) {
+        std::cout << "  skip  could not generate a test certificate\n";
+
+        return;
+    }
+
+    const char* const had = std::getenv("SSL_CERT_FILE");
+    const std::string keep = had ? had : "";
+
+    ::setenv("SSL_CERT_FILE", cert.c_str(), 1);
+
+    try {
+        httpserver::server s([](const httpserver::request&) {
+            return httpserver::reply(200, "OK", "over TLS",
+                                     "Content-Type: text/plain\r\n");
+        }, cert, key);
+
+        const http::Response r = http::get(URL(s.url("/secure?a=1")));
+
+        ok("an https:// request completes", r.status() == 200 &&
+           r.body() == "over TLS", r.body());
+
+        const std::vector<httpserver::request> sent = s.requests();
+
+        ok("and it is a real request, not a tunnel",
+           !sent.empty() && has_line(sent[0].head, "GET /secure?a=1 HTTP/1.1"),
+           sent.empty() ? "" : sent[0].head.substr(0, sent[0].head.find("\r\n")));
+
+        // The Host field names the port when it is not the scheme's default,
+        // and 443 is the default for https -- so this is also the assertion
+        // that the client knows which default goes with which scheme.
+        ok("Host carries the name that was verified, and the port",
+           !sent.empty() &&
+           has_line(sent[0].head, "Host: localhost:" + std::to_string(s.port())));
+    }
+    catch(std::exception& e) {
+        ok("an https:// request completes", false, e.what());
+    }
+
+    // A name the certificate does not cover.  The client must refuse it: TLS
+    // that is encrypted and unauthenticated is the failure that looked fine
+    // for years in sslproxystream, and an OAuth2 token handed to whoever
+    // answered is the whole game.
+    try {
+        httpserver::server s([](const httpserver::request&) {
+            return httpserver::reply(200, "OK", "should not get here");
+        }, cert, key);
+
+        bool threw = false;
+
+        try {
+            // 127.0.0.1 rather than localhost: the certificate says
+            // DNS:localhost and nothing else.
+            http::get(URL("https://127.0.0.1:" + std::to_string(s.port()) + "/"));
+        }
+        catch(std::exception&) { threw = true; }
+
+        ok("a certificate that does not cover the name is refused", threw);
+        ok("and nothing was sent to it", s.requests().empty(),
+           std::to_string(s.requests().size()) + " request(s)");
+    }
+    catch(std::exception& e) {
+        ok("a certificate that does not cover the name is refused", false, e.what());
+    }
+
+    // And an untrusted one, which is the same question asked the other way.
+    ::unsetenv("SSL_CERT_FILE");
+
+    try {
+        httpserver::server s([](const httpserver::request&) {
+            return httpserver::reply(200, "OK", "should not get here");
+        }, cert, key);
+
+        bool threw = false;
+
+        try { http::get(URL(s.url("/"))); }
+        catch(std::exception&) { threw = true; }
+
+        ok("and so is one nothing trusts", threw);
+    }
+    catch(std::exception& e) {
+        ok("and so is one nothing trusts", false, e.what());
+    }
+
+    if(keep.empty()) ::unsetenv("SSL_CERT_FILE");
+    else             ::setenv("SSL_CERT_FILE", keep.c_str(), 1);
+
+    std::remove(cert.c_str());
+    std::remove(key.c_str());
+}
+
 static void the_proxy_parameter_is_read_one_way() {
     std::cout << "\nthe proxy parameter is read in one place:\n";
 
@@ -503,13 +612,19 @@ int main() {
     what_it_refuses_to_send();
     redirects_are_off_and_stay_off();
     a_credential_does_not_cross_an_origin();
+    over_tls();
     the_proxy_parameter_is_read_one_way();
 
     // What a green run does not establish.
     //
-    // Not TLS.  Every server here is plaintext on loopback; https:// goes
-    // through sys::tlsstream, which sys_tls_sigpipe_test and the mail live
-    // tests exercise, but no test in this file makes an HTTPS request.
+    // Not a real TLS peer.  The HTTPS section here handshakes against
+    // OpenSSL configured by this test, with a certificate this test generated,
+    // so it proves the client's transport selection and its verification and
+    // says nothing about what a public certificate authority chain, a session
+    // ticket, or a server picking TLS 1.3 would do.  net_http_live_test does
+    // the same against nginx, which is one more real peer and still not a
+    // survey; the first request to a real token endpoint will be the first one
+    // made to a stranger.
     //
     // Not a real server.  This one sends exactly what it was told to, which is
     // the point of it for the awkward cases and its whole limitation for the

--- a/tests/sys_proxy_live_test.cc
+++ b/tests/sys_proxy_live_test.cc
@@ -30,13 +30,20 @@
 
 #include "mailserver.hh"
 
+#include <jlib/net/Pop3.hh>
+
 #include <jlib/sys/proxystream.hh>
 #include <jlib/sys/sslproxystream.hh>
 #include <jlib/sys/sslstream.hh>
 #include <jlib/sys/sys.hh>
 
+#include <jlib/util/URL.hh>
+
 #include <functional>
 #include <iostream>
+#include <list>
+#include <memory>
+#include <sstream>
 #include <string>
 
 static int failures = 0;
@@ -179,6 +186,42 @@ int main() {
         if(!keep.empty()) ::setenv("SSL_CERT_FILE", keep.c_str(), 1);
     }
 
+    // POP3 through the proxy, which is #103: Pop3::connect had no proxy
+    // branch at all, so the URL's parameter was parsed, stored and ignored and
+    // a caller who asked for a proxy got a direct connection instead.  Silence
+    // is the worst of the three possible behaviours -- they may have asked
+    // because it is the only route out.
+    {
+        std::ostringstream u;
+
+        u << "pop3://joe@127.0.0.1:" << s.pop_port << "/?proxy=127.0.0.1:"
+          << s.proxy_port;
+
+        jlib::util::URL url(u.str());
+
+        url.set_pass(mailserver::PASSWORD);
+
+        try {
+            // retrieve() is the public way in: it connects, reads the whole
+            // maildrop and disconnects.  Captured once -- calling it again for
+            // the detail argument would fetch the mail twice, which is the
+            // shape that broke the IMAP tests when the second call could not
+            // be made on an exhausted stream.
+            //
+            // false, so the messages are left where they are for whichever
+            // test runs next.
+            jlib::net::Pop3 pop(url, false);
+
+            const std::list<std::string> mail = pop.retrieve();
+
+            ok("POP3 reaches the server through the proxy", mail.size() == 2,
+               std::to_string(mail.size()) + " messages");
+        }
+        catch(std::exception& e) {
+            ok("POP3 reaches the server through the proxy", false, e.what());
+        }
+    }
+
     // What a green run does NOT establish.
     //
     // Not proxy authentication.  jlib sends no Proxy-Authorization header and
@@ -187,10 +230,6 @@ int main() {
     // reports as an error rather than tunnelling into.
     //
     // Not SOCKS.  basic_proxybuf speaks HTTP CONNECT and only that.
-    //
-    // Not POP3 through a proxy.  Pop3::connect has no proxy branch at all --
-    // only Imap4 does -- so the URL's proxy parameter is silently ignored
-    // there.  That is a gap, not a fix: worth its own issue.
     //
     // Not interoperability.  One proxy, one version.  tinyproxy answers
     // "HTTP/1.0 200 Connection established" and sends one header; a proxy that


### PR DESCRIPTION
# An HTTP/1.1 client, and one place that reads a proxy parameter

Fifth branch of the HTTP/OAuth2 work. The message layer landed last branch;
this makes the request.

## Narrow, and written down as narrow

GET, POST, a form body, Content-Length and chunked responses, TLS, and a
CONNECT proxy. No cookies, no keep-alive, no compression, no content
negotiation, no HTTP/2, no connection pool. That list is in the header so it
stays true: the way a narrow thing becomes a broad one is by nobody writing
down that it was meant to be narrow.

The old `jlib::net::http` is gone. It declared a `Request` and a `Response`
that were never defined in any file in the tree, and a `get()` that was
HTTP/1.0, plaintext-only, and compared the status against the string `"200"`.
Nothing had ever called it.

`net::http::Response` is `util::http::Response` pulled through, so a caller says
one name and gets the same class whichever half it came from.

## What the client gets right, and why each one is a decision

**A non-2xx is a Response, not an exception.** This is the whole reason the
client exists. A token endpoint answers **400 with a JSON body** saying whether
the refresh token was revoked -- go and make the user authorize again -- or
whether the server hiccuped and the right move is to retry. A client that
throws away the body of anything it does not like cannot tell those apart, and
neither can its caller. What throws is a failure to complete an exchange at all.

**Redirects are off, and that is not timidity.** Following one means sending the
request again to a host named by the response, and for the request this client
exists to make that request carries a `client_secret` and a `refresh_token`. A
`Location:` is attacker-controlled the moment anything upstream is. Switching
them on is a per-call decision, and even then:

- only GET and HEAD are followed -- re-sending a POST body somewhere else is not
  a redirect, it is handing the request to whoever wrote the Location;
- a 303 becomes a GET and drops the body, per RFC 9110 15.4.4;
- **`Authorization` comes off whenever the origin changes.** Scheme, host and
  port together: a credential is scoped to one origin and to no other, and a
  redirect that carried it would be a way to read somebody's bearer token by
  sending them a 302. There is a test with two servers proving the second one
  never sees it.

**No RFC 3986 5.3.** An absolute path resolves against the same origin without
an algorithm and is what servers actually send; anything else throws rather than
being guessed at. Implementing half of reference resolution would be worse than
not having it.

**The request-target is path *and* query.** `URL` keeps the two apart, so a
target built from `get_path()` alone silently drops `?code=...` -- which for
half the requests this client makes is the whole message. An empty path goes out
as `/`, per RFC 9112 3.2.1; `GET  HTTP/1.1` is not a request line. The fragment
is never sent (RFC 9110 7.1): it is the client's, not the server's.

**Fields from a caller are checked against the grammar**, not against a list of
bad characters. What it is really stopping is a CR or LF in a value, because
that is how one request becomes two -- but `field-name` being a token and
`field-value` being `field-content` are the rules that say so, and checking them
is both stricter and easier to defend than a blocklist.

**`Accept-Encoding: identity`.** RFC 9110 12.5.3 lets a server send any coding to
a client that sends no `Accept-Encoding` at all. Nothing here can inflate a gzip
body, so asking for one and handing the caller compressed bytes to parse as JSON
is a failure worth ruling out rather than diagnosing later.

**`Connection: close`** ends the message at the end of the connection and takes
every keep-alive framing question off the table. Those questions are where
request smuggling lives.

**`form_encode` is not `uri::encode`.** This encoding is HTML's, not RFC 3986's:
a space is `+` here and `%20` there, so `+` itself has to be escaped. That is
the case that bites -- base64 produces `+` constantly, and a refresh token sent
through the wrong encoder arrives with spaces in it and does not match.

## #103, closed: one place that reads a proxy parameter

`net::proxy_of()`. There were nearly two of these and the difference between
them was a bug each.

`Imap4::connect` had `util::tokenize(m_url["proxy"], ":")` and then `pvec[1]`
with no size check, so `?proxy=host` with no port read off the end of a vector.
It also cannot read an IPv6 literal proxy: `[::1]:3128` tokenizes to `[` as the
host. The rightmost colon is the separator now.

`Pop3::connect` did not read the parameter **at all**. It was accepted by the
URL parser, stored, and silently ignored, so `pop3s://host/?proxy=p:3128`
connected direct. That is the worst of the three things that could happen: a
caller who asked for a proxy, possibly because it is the only route out, got a
direct connection and no word about it. Pop3 has the three transport branches
now, and `sys_proxy_live_test` asserts a POP3 maildrop arrives through a real
tinyproxy.

Anything unreadable throws rather than falling back to direct.

## Tests

**`tests/httpserver.hh`** -- a scripted HTTP server on `sys::listener`, which
records every request. Reusable, and branch 6's fake token endpoint will want
it. Two kinds of assertion come out of it: what the client *reads*, and what
the client *sends* -- that the query string reached the request-target, that
`Authorization` came off across an origin change, that a POST body was not
re-sent to a redirect. The second kind cannot be checked any other way.

**`tests/net_http_test.cc`** -- eight sections against that server, including
the shapes no real server will produce on request: a chunked body whose data
contains a line that looks exactly like a chunk header, a response carrying both
framing fields, a `Content-Length` of a gigabyte.

**`tests/net_http_live_test.cc`** -- the same client against **nginx**, added to
the container, and through the tinyproxy that was already there. A server
somebody else wrote sends a Date and a Server and an ETag and a 404 body in an
order nobody here chose: 8 fields read on a plain GET, a 404 with 162 octets of
body, a 418 nobody has a branch for, a real 302 followed on request, and a real
proxy refusal arriving as *"the proxy refused CONNECT: 403 Access violation"*
rather than a mysterious connection failure. Skips where there is no nginx,
which is every machine that is not the build container.

## Second commit: TLS, which was the gap worth closing here

The first commit's closing note said no request in either test file was an
HTTPS one -- and every request this client exists to make is. That is now
covered in both places, and closing it turned up two real faults.

`httpserver::server` takes a certificate and speaks TLS. Server-side TLS is raw
OpenSSL in the test rather than jlib's own, because `basic_tlsbuf` calls
`SSL_connect` and there is no server-side counterpart in the library -- a gap
this works around rather than fixes. It matters that it is in-process: the live
test needs an nginx and there is not one outside the build container, so
without this the HTTPS path would be untested on the machine the library is
developed on.

The verification is real in both. A certificate for localhost is generated at
runtime, `SSL_CERT_FILE` points the client's trust store at it, and the
handshake succeeds because the certificate is genuinely trusted for the run --
the arrangement `mailserver.hh` and `sys_tls_sigpipe_test` already use. Nothing
is turned off, which is why the negative cases work: connecting to
`https://127.0.0.1:...` when the certificate says `DNS:localhost` is refused,
and so is a certificate nothing trusts. Encrypted and unauthenticated is the
failure that looked fine for years in `sslproxystream`, and the thing being
handed over here would be an OAuth2 token.

nginx gets a TLS server block for the same two assertions against a real peer.

**Two faults found by adding it.**

`make check` failed where the test had passed standalone: *"nothing reached the
server: 2 request(s)"*. When the test server's head reader was rewritten for
TLS it stopped using `util::http::read_head()`, which throws at end of stream,
for a byte loop that just stops -- and then recorded what it had. So a client
that connected and thought better of it looked exactly like one that asked for
something. It skips an incomplete head now.

It was right to look, because the client really was connecting. `once()` opened
the socket and only then validated the caller's fields, so a request that could
never be sent still cost a connection the server had to notice, time out and
clean up. The checks happen first now.

**What a green run still does not establish.** Not TLS to a stranger: both
peers handshake against a certificate these tests generated, with the trust
store pointed at it, so they prove transport selection and hostname checking
and say nothing about a public CA chain or a server picking something
unexpected. Not TLS *through* the proxy -- the CONNECT path here carries
plaintext, and proxied-and-encrypted is the combination a corporate network
would actually present. Not interoperability: one nginx, one configuration.
Not reference resolution, which is not implemented.

macOS: 50 pass, 4 skip, 0 fail. Linux container: 54 pass, 1 skip, 0 fail.
