### PR TITLE
Refresh an OAuth2 token and read mail with it, proven end to end against a real Dovecot

### DIFF
--- a/jlib/net/Imap4.cc
+++ b/jlib/net/Imap4.cc
@@ -20,6 +20,7 @@
 
 #include <jlib/net/net.hh>
 #include <jlib/net/Imap4.hh>
+#include <jlib/net/oauth.hh>
 
 #include <jlib/net/imap_response.hh>
 
@@ -853,6 +854,35 @@ namespace jlib {
 
                 return;
             }
+        }
+
+        void Imap4::authenticate_xoauth2(sys::socketstream& sock,
+                                         const std::string& user,
+                                         const std::string& access)
+        {
+            // A list that has been fetched and does not offer it is an
+            // objection; one that has never been fetched is not.  login()
+            // makes the same distinction the other way round, refusing only
+            // when LOGINDISABLED is positively present.
+            if(!m_capabilities.empty() && !has_capability("AUTH=XOAUTH2")) {
+                throw exception("the server does not offer AUTH=XOAUTH2");
+            }
+
+            if(access.empty()) throw exception("AUTHENTICATE XOAUTH2: no access token");
+
+            int round = 0;
+
+            authenticate(sock, "XOAUTH2",
+                         [&round, &user, &access](const std::string&) -> std::string {
+                             if(++round == 1) return oauth::xoauth2(user, access);
+
+                             // The second challenge is the failure report --
+                             // base64 JSON, "status" and "schemes" -- and the
+                             // server is waiting for an empty line before it
+                             // will send the tagged NO that says the same thing
+                             // in a form this code can throw.
+                             return std::string();
+                         });
         }
 
         void Imap4::cancel_authenticate(sys::socketstream& sock) {

--- a/jlib/net/Imap4.hh
+++ b/jlib/net/Imap4.hh
@@ -254,6 +254,31 @@ namespace jlib {
                                     const std::string& pass = "");
 
             /**
+             * AUTHENTICATE XOAUTH2, which is how OAuth2 reaches IMAP.
+             *
+             * Google's and Microsoft's mechanism, not an RFC -- RFC 7628's
+             * OAUTHBEARER is the standardised one and neither provider
+             * requires it.  See net::oauth::xoauth2() for the message.
+             *
+             * Two rounds, and the second is the reason this is not three lines
+             * on top of authenticate().  A rejected token is not reported as a
+             * tagged NO: the server sends a *continuation* carrying a base64
+             * JSON error and will not send the NO until the client answers it
+             * with an empty line.  A driver that answers only the first
+             * challenge waits forever on a socket that looks alive.
+             *
+             * Refuses when the capability list has been fetched and does not
+             * offer AUTH=XOAUTH2.  An unfetched list is not an objection --
+             * capability() is the caller's to call.
+             *
+             * @param user   the account's address, which is part of the message
+             * @param access the access token, not the refresh token
+             */
+            void authenticate_xoauth2(jlib::sys::socketstream& sock,
+                                      const std::string& user,
+                                      const std::string& access);
+
+            /**
              * Cancel an AUTHENTICATE in progress and leave the socket usable.
              *
              * RFC 3501 6.2.2's "*", followed by a read to the tagged

--- a/jlib/net/Makefile.am
+++ b/jlib/net/Makefile.am
@@ -4,7 +4,7 @@ lib_LTLIBRARIES = libjnet.la
 libjnet_la_SOURCES = Email.cc MailBox.cc Imap4Box.cc Pop3.cc MBox.cc \
                      Imap4.cc Imap4Fetch.cc net.cc MFolder.cc Imap4Folder.cc \
                      MailFolder.cc ASMailBox.cc ASImapBox.cc ASMBox.cc \
-                     address.cc imap_response.cc http.cc
+                     address.cc imap_response.cc http.cc oauth.cc
 libjnet_la_LDFLAGS = -version-info $(LIBJ_SO_VERSION) -release $(JLIB_RELEASE) -no-undefined
 libjnet_la_LIBADD = $(top_builddir)/jlib/sys/libjsys.la \
                     $(top_builddir)/jlib/util/libjutil.la \
@@ -16,4 +16,4 @@ libjnetinclude_HEADERS = Imap4Box.hh Pop3.hh MBox.hh Email.hh \
                          Imap4.hh Imap4Fetch.hh net.hh MFolder.hh \
                          Imap4Folder.hh MailBox.hh MailFetch.hh MailFolder.hh \
                          ASMailBox.hh ASImapBox.hh ASMBox.hh address.hh rfc5322.hh \
-                         imap_response.hh rfc3501.hh http.hh
+                         imap_response.hh rfc3501.hh http.hh oauth.hh

--- a/jlib/net/oauth.cc
+++ b/jlib/net/oauth.cc
@@ -1,0 +1,206 @@
+/* -*- mode: C++ c-basic-offset: 4 -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <jlib/net/oauth.hh>
+
+#include <jlib/util/URL.hh>
+#include <jlib/util/json.hh>
+
+#include <map>
+
+namespace jlib {
+namespace net {
+namespace oauth {
+
+namespace {
+
+    /** A minute, because the clock here and the clock there are not the same. */
+    const std::time_t SKEW = 60;
+
+    std::time_t clock_now(std::time_t now) {
+        return now ? now : std::time(0);
+    }
+
+}
+
+bool token::expired(std::time_t now) const {
+    if(m_access.empty()) return true;
+
+    // No expires_in in the reply is not "never": it is "the endpoint did not
+    // say", and the honest reading is that the token is good until something
+    // rejects it.  session::rejected() is how that gets noticed.
+    if(m_expires_at == 0) return false;
+
+    return clock_now(now) + SKEW >= m_expires_at;
+}
+
+token parse_token_response(const std::string& body,
+                           const std::string& sent_refresh,
+                           std::time_t now)
+{
+    util::json::object::ptr o;
+
+    try {
+        o = util::json::object::create(body);
+    }
+    catch(std::exception& e) {
+        // Deliberately without the body.  It is a bearer token when the
+        // request worked and often still one when it did not, and an exception
+        // message goes to a log.
+        throw error(std::string("the token endpoint did not answer with JSON: ") +
+                    e.what());
+    }
+
+    // RFC 6749 5.2.  An error body may arrive with a 400, and some providers
+    // send one with a 200, so the body decides rather than the status.
+    if(o->has("error")) {
+        throw denied(o->get("error").str_or("unknown"),
+                     o->get("error_description").str_or(""));
+    }
+
+    if(!o->has("access_token"))
+        throw error("the token endpoint's reply has no access_token in it");
+
+    token t;
+
+    t.m_access = std::string(o->get("access_token"));
+    t.m_type = o->get("token_type").str_or("Bearer");
+    t.m_scope = o->get("scope").str_or("");
+
+    // Rotation.  RFC 6749 6: the reply MAY carry a new refresh token, and when
+    // it does the old one stops working -- Microsoft rotates on every refresh.
+    // Absent, the one that was sent stays good.
+    if(o->has("refresh_token")) {
+        const std::string fresh = std::string(o->get("refresh_token"));
+
+        t.m_refresh = fresh;
+        t.m_rotated = fresh != sent_refresh;
+    }
+    else {
+        t.m_refresh = sent_refresh;
+        t.m_rotated = false;
+    }
+
+    if(o->has("expires_in")) {
+        // int_or, not int: Microsoft's v1 endpoint returns this as the string
+        // "3599" and Google as the number 3599.  util::json coerces both now;
+        // the default is for the third provider that sends something else,
+        // where "no expiry stated" beats a token that expired in 1970.
+        const int64_t in = o->get("expires_in").int_or(0);
+
+        if(in > 0) t.m_expires_at = clock_now(now) + static_cast<std::time_t>(in);
+    }
+
+    return t;
+}
+
+token refresh(const client& c, const std::string& refresh_token,
+              const http::options& o)
+{
+    if(c.token_endpoint.empty()) throw error("no token endpoint");
+    if(refresh_token.empty()) throw error("no refresh token to exchange");
+
+    const util::URL endpoint(c.token_endpoint);
+
+    if(endpoint.get_protocol() != "https" && !c.allow_http) {
+        // The request about to go out carries the refresh token and, if there
+        // is one, the client secret; the access token comes back the same way.
+        throw error("refusing to send a credential to a plaintext endpoint: " +
+                    c.token_endpoint);
+    }
+
+    std::map<std::string, std::string> form;
+
+    form["grant_type"] = "refresh_token";
+    form["refresh_token"] = refresh_token;
+
+    if(!c.id.empty()) form["client_id"] = c.id;
+    if(!c.secret.empty()) form["client_secret"] = c.secret;
+    if(!c.scope.empty()) form["scope"] = c.scope;
+
+    http::fields send;
+
+    send.add("Accept", "application/json");
+
+    // Redirects stay off, whatever the caller's options say.  Following one
+    // means POSTing this form -- a refresh token and a client secret -- to a
+    // host named by the response, and a Location: is attacker-controlled the
+    // moment anything upstream is.
+    http::options opts = o;
+
+    opts.redirects = 0;
+
+    const http::Response r = http::post_form(endpoint, form, send, opts);
+
+    // The body is read whatever the status was.  A 400 with a JSON body is the
+    // *normal* failure here and it is the only thing that says whether the
+    // refresh token is dead or the server merely hiccuped -- which is the whole
+    // reason the HTTP client hands a non-2xx back rather than throwing.
+    try {
+        return parse_token_response(r.body(), refresh_token, 0);
+    }
+    catch(denied&) {
+        throw;
+    }
+    catch(error&) {
+        if(!r.ok()) {
+            throw error("the token endpoint answered " +
+                        std::to_string(r.status()) + " " + r.reason() +
+                        " with nothing a program can act on");
+        }
+
+        throw;
+    }
+}
+
+session::session(client c, std::string refresh, store_fn store)
+    : m_client(std::move(c)),
+      m_refresh(std::move(refresh)),
+      m_store(std::move(store))
+{}
+
+const std::string& session::access() {
+    if(!m_token.expired()) return m_token.access();
+
+    const token fresh = oauth::refresh(m_client, m_refresh);
+
+    // The refresh token first, and the callback before anything uses the
+    // access token beside it.  If the endpoint rotated, the one this object
+    // was constructed with is already dead; a crash between here and the next
+    // save is a user who has to authorize again.
+    m_refresh = fresh.refresh();
+
+    if(m_store && fresh.rotated()) m_store(fresh);
+
+    m_token = fresh;
+
+    return m_token.access();
+}
+
+std::string xoauth2(const std::string& user, const std::string& access_token) {
+    // "\001", never "\x01".  A hexadecimal escape in C++ has no length limit --
+    // it consumes every hex digit that follows -- so "\x01auth=" is the one
+    // character 0x1A followed by "uth=", and it compiles without a warning.
+    // The octal form takes three digits at most and stops.
+    return "user=" + user + "\001auth=Bearer " + access_token + "\001\001";
+}
+
+}
+}
+}

--- a/jlib/net/oauth.hh
+++ b/jlib/net/oauth.hh
@@ -1,0 +1,276 @@
+/* -*- mode: C++ c-basic-offset: 4 -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef JLIB_NET_OAUTH_HH
+#define JLIB_NET_OAUTH_HH
+
+#include <jlib/net/http.hh>
+
+#include <ctime>
+#include <functional>
+#include <string>
+
+namespace jlib {
+namespace net {
+
+/**
+ * OAuth2, as much of it as reading mail needs.
+ *
+ * Gmail has wanted this since 2022 and Outlook.com has required it for personal
+ * accounts since September 2024; a mail client that speaks only LOGIN and
+ * AUTH PLAIN cannot reach either.
+ *
+ * ## What is here, and what is not
+ *
+ * Here: the refresh-token grant (RFC 6749 6), which turns a refresh token you
+ * already hold into an access token, and XOAUTH2, which is how that access
+ * token reaches an IMAP server.
+ *
+ * Not here: the authorization-code flow that *obtains* the first refresh token.
+ * That needs a browser, a loopback listener and PKCE, and it is a branch of its
+ * own.  Until then a refresh token has to come from somewhere else -- a
+ * provider's playground, another client, a script -- and this reads mail with
+ * it, which is the smallest useful thing.
+ *
+ * Not here: the device-code flow, OAUTHBEARER (RFC 7628), token introspection,
+ * or anything that stores a credential on disk.  Where the refresh token lives
+ * is the application's decision and jlib should not make it.
+ *
+ * ## Two things the interface has to get right, not the implementation
+ *
+ * **Rotation.**  RFC 6749 6 lets the token endpoint issue a *new* refresh token
+ * with every refresh, and Microsoft always does, invalidating the old one at the
+ * same moment.  An API that takes a refresh token and cannot hand a new one back
+ * logs the user out after the first refresh and cannot be fixed without changing
+ * every caller.  So token::refresh() is always the one to keep, whether or not
+ * it changed, and session has a store callback that fires the instant a new one
+ * arrives -- before the access token beside it is used for anything, because a
+ * crash in between is the same lockout.
+ *
+ * **A client secret in a native application is not secret.**  RFC 8252 8.5 says
+ * so plainly: it ships inside the binary and anyone who has the binary has it.
+ * client::secret exists because Microsoft's older endpoints reject a request
+ * without one, not because it protects anything, and nothing here is compiled
+ * in.  A caller supplies their own registration.
+ */
+namespace oauth {
+
+class error : public std::exception {
+public:
+    error(const std::string& msg = "") { m_msg = "oauth error: " + msg; }
+    virtual ~error() {}
+    virtual const char* what() const noexcept { return m_msg.c_str(); }
+protected:
+    std::string m_msg;
+};
+
+/**
+ * The endpoint refused, and said why in a way a program can act on.
+ *
+ * RFC 6749 5.2.  The one that matters is "invalid_grant": the refresh token is
+ * dead -- revoked, expired, or rotated out from under you -- and no amount of
+ * retrying will help.  The user has to authorize again.  Anything else is worth
+ * retrying.
+ */
+class denied : public error {
+public:
+    denied(const std::string& code, const std::string& description)
+        : error("the token endpoint refused: " + code +
+                (description.empty() ? "" : " (" + description + ")")),
+          m_code(code),
+          m_description(description)
+    {}
+
+    const std::string& code() const { return m_code; }
+    const std::string& description() const { return m_description; }
+
+    /** Nothing will fix this but authorizing again. */
+    bool fatal() const { return m_code == "invalid_grant" || m_code == "invalid_client"; }
+
+private:
+    std::string m_code;
+    std::string m_description;
+};
+
+/** Who we say we are, and where to say it. */
+struct client {
+    /** The provider's token endpoint.  Must be https unless allow_http. */
+    std::string token_endpoint;
+
+    std::string id;
+
+    /** Often empty; see the note above about what it is not. */
+    std::string secret;
+
+    /** Space-separated, and optional on a refresh (RFC 6749 6). */
+    std::string scope;
+
+    /**
+     * Send a client credential to a plaintext endpoint.
+     *
+     * Off, and only a test should turn it on.  A token request over http://
+     * puts the refresh token and the client secret on the wire in the clear,
+     * and the access token comes back the same way.
+     */
+    bool allow_http = false;
+};
+
+/** What came back from the token endpoint. */
+class token {
+public:
+    token() = default;
+
+    const std::string& access() const { return m_access; }
+
+    /**
+     * The refresh token to keep.
+     *
+     * The new one when the endpoint issued one, and the one that was sent when
+     * it did not.  Either way this is what to store: see the note on rotation.
+     */
+    const std::string& refresh() const { return m_refresh; }
+
+    /** Whether the endpoint issued a new refresh token this time. */
+    bool rotated() const { return m_rotated; }
+
+    /** "Bearer", almost always. */
+    const std::string& type() const { return m_type; }
+
+    const std::string& scope() const { return m_scope; }
+
+    /** When it stops being accepted, as a time_t.  0 if unknown. */
+    std::time_t expires_at() const { return m_expires_at; }
+
+    /**
+     * Whether it is worth using.
+     *
+     * With a minute of slack, because the clock here and the clock there are
+     * not the same clock and a token that expires between the check and the
+     * command is a failure that looks like a wrong password.
+     */
+    bool expired(std::time_t now = 0) const;
+
+    bool empty() const { return m_access.empty(); }
+
+    friend token parse_token_response(const std::string& body,
+                                      const std::string& sent_refresh,
+                                      std::time_t now);
+
+private:
+    std::string m_access;
+    std::string m_refresh;
+    std::string m_type;
+    std::string m_scope;
+    std::time_t m_expires_at = 0;
+    bool m_rotated = false;
+};
+
+/**
+ * Read a token endpoint's reply.
+ *
+ * Exposed because it is the half worth testing without a server: every
+ * provider's oddity -- expires_in as a string, a missing refresh_token, an
+ * error body with a 200 status -- is a string this can be handed.
+ *
+ * @param sent_refresh what was sent, so refresh() has something to fall back on
+ * @param now          for a test that needs a fixed clock; 0 means std::time
+ *
+ * @throw denied on an RFC 6749 5.2 error body, error on anything unreadable
+ */
+token parse_token_response(const std::string& body,
+                           const std::string& sent_refresh,
+                           std::time_t now = 0);
+
+/**
+ * Exchange a refresh token for an access token.  RFC 6749 6.
+ *
+ * @throw denied when the endpoint says no in the documented way, error
+ *        otherwise.  A 400 with a JSON body is the *normal* failure and comes
+ *        back as denied with its code; that is the whole reason the HTTP client
+ *        hands back a non-2xx rather than throwing.
+ */
+token refresh(const client& c, const std::string& refresh_token,
+              const http::options& o = http::options());
+
+/**
+ * An access token, kept fresh.
+ *
+ * Holds a refresh token, fetches an access token when there is none or the one
+ * it has is stale, and hands the same one out until it goes stale.  The cache
+ * is an optimisation and never the truth: if the server rejects a token, say so
+ * with rejected() and the next access() fetches another, whatever the expiry
+ * said.  Clocks disagree and tokens get revoked mid-session.
+ *
+ * Not thread-safe.  Run it on the thread that owns the connection, which is the
+ * house pattern -- ASMailBox and ASImapBox do their work on a sys::ASServent.
+ */
+class session {
+public:
+    /** Called the instant a new refresh token arrives.  Persist it here. */
+    typedef std::function<void(const token&)> store_fn;
+
+    session(client c, std::string refresh_token, store_fn store = store_fn());
+
+    /** A usable access token, fetching or refreshing as needed. */
+    const std::string& access();
+
+    /** The refresh token as it stands, which access() may have changed. */
+    const std::string& refresh_token() const { return m_refresh; }
+
+    /** The whole of the last reply. */
+    const token& current() const { return m_token; }
+
+    /**
+     * The server did not accept the last access token.
+     *
+     * Drops it, so the next access() fetches another.  A NO from IMAP is
+     * authoritative and the expiry this holds is only a guess.
+     */
+    void rejected() { m_token = token(); }
+
+    const client& who() const { return m_client; }
+
+private:
+    client m_client;
+    std::string m_refresh;
+    store_fn m_store;
+    token m_token;
+};
+
+/**
+ * The SASL XOAUTH2 message, before base64.
+ *
+ * Google's and Microsoft's spelling, which is not an RFC:
+ *
+ *     user=<email>^Aauth=Bearer <token>^A^A
+ *
+ * where ^A is one octet, 0x01.
+ *
+ * Written "\001" and not "\x01".  A hexadecimal escape in C++ has no length
+ * limit -- it eats every hex digit that follows -- so "\x01auth=" is the single
+ * character 0x1A followed by "uth=", and compiles without a word.  The octal
+ * form takes at most three digits and stops.
+ */
+std::string xoauth2(const std::string& user, const std::string& access_token);
+
+}
+}
+}
+
+#endif // JLIB_NET_OAUTH_HH

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -57,6 +57,7 @@ TESTS = \
 	net_imap_test \
 	net_imap_sasl_test \
 	net_http_test \
+	net_oauth_test \
 	net_http_live_test \
 	net_imap_live_test \
 	sys_proxy_live_test \
@@ -158,6 +159,9 @@ net_imap_test_LDADD             = $(JNET_LA) $(JUTIL_LA)
 
 net_http_live_test_SOURCES      = net_http_live_test.cc
 net_http_live_test_LDADD        = $(JNET_LA) $(JUTIL_LA) $(JSYS_LA) $(OPENSSL_LIBS)
+
+net_oauth_test_SOURCES          = net_oauth_test.cc
+net_oauth_test_LDADD            = $(JNET_LA) $(JUTIL_LA) $(JSYS_LA) $(OPENSSL_LIBS)
 
 net_http_test_SOURCES           = net_http_test.cc
 net_http_test_LDADD             = $(JNET_LA) $(JUTIL_LA) $(JSYS_LA) $(OPENSSL_LIBS)

--- a/tests/mailserver.hh
+++ b/tests/mailserver.hh
@@ -98,6 +98,22 @@ struct server {
     unsigned int pop_port = 0;
     unsigned int pop_tls_port = 0;
     unsigned int proxy_port = 0;
+
+    /**
+     * Where dovecot should go to find out whether an access token is good.
+     *
+     * Set this before start() and the server offers AUTH=XOAUTH2, validating
+     * every token by GETting <tokeninfo_port>/tokeninfo?access_token=<token>
+     * and reading an "email" out of the JSON that comes back.  That is
+     * dovecot's oauth2 passdb doing exactly what Google's and Microsoft's do
+     * -- which is what makes an end-to-end XOAUTH2 test possible without
+     * either of them.
+     *
+     * Zero leaves the configuration as it was, so net_pop3_live_test is
+     * unaffected.
+     */
+    unsigned int tokeninfo_port = 0;
+
     bool running = false;
     bool proxied = false;
 
@@ -178,6 +194,29 @@ struct server {
               << (dir / "users").string() << "\n}\n"
               << "userdb {\n  driver = passwd-file\n  args = "
               << (dir / "users").string() << "\n}\n";
+
+            // The oauth2 passdb, when a tokeninfo endpoint was named.  It goes
+            // after the passwd-file one and is restricted to the xoauth2
+            // mechanism, so PLAIN and LOGIN keep working exactly as they did.
+            if(tokeninfo_port != 0) {
+                f << "auth_mechanisms = plain xoauth2\n"
+                  << "passdb {\n"
+                  << "  driver = oauth2\n"
+                  << "  mechanisms = xoauth2\n"
+                  << "  args = " << (dir / "oauth2").string() << "\n"
+                  << "}\n";
+            }
+        }
+
+        if(tokeninfo_port != 0) {
+            std::ofstream f(dir / "oauth2");
+
+            // dovecot appends the token to this URL and expects JSON with the
+            // account's address in it.  Google's endpoint has the same shape,
+            // which is the point: the client cannot tell the difference.
+            f << "tokeninfo_url = http://127.0.0.1:" << tokeninfo_port
+              << "/tokeninfo?access_token=\n"
+              << "username_attribute = email\n";
         }
 
         {

--- a/tests/net_imap_live_test.cc
+++ b/tests/net_imap_live_test.cc
@@ -28,6 +28,7 @@
 // Exit 77 (SKIP) when there is no dovecot to start, which is every machine
 // that is not the build container.
 
+#include "httpserver.hh"
 #include "mailserver.hh"
 
 #include <jlib/net/Imap4.hh>
@@ -35,6 +36,8 @@
 
 #include <jlib/sys/socketstream.hh>
 #include <jlib/sys/sys.hh>
+
+#include <jlib/net/oauth.hh>
 
 #include <jlib/util/URL.hh>
 #include <jlib/util/util.hh>
@@ -85,6 +88,41 @@ int main() {
     }
 
     mailserver::server s;
+
+    // An HTTP server in this process, wearing two hats at once.  To jlib it is
+    // an OAuth2 token endpoint -- POST a refresh token, get an access token.
+    // To dovecot it is the tokeninfo endpoint its oauth2 passdb consults to
+    // find out whether that access token is any good and whose it is.
+    //
+    // Which is what makes an end-to-end XOAUTH2 test possible without Google
+    // or Microsoft.  Both of them are exactly this shape and neither can be
+    // reached from make check.
+    httpserver::server tokens([](const httpserver::request& r) {
+        if(r.head.find("POST /token") == 0) {
+            // A refresh token this test wrote, exchanged for an access token
+            // this test will recognise.
+            if(r.body.find("refresh_token=good-refresh") == std::string::npos)
+                return httpserver::reply(400, "Bad Request",
+                                         "{\"error\":\"invalid_grant\"}");
+
+            return httpserver::reply(200, "OK",
+                                     "{\"access_token\":\"live-access-token\","
+                                     "\"refresh_token\":\"rotated-refresh\","
+                                     "\"expires_in\":3600}",
+                                     "Content-Type: application/json\r\n");
+        }
+
+        // dovecot's half.  Any token but the good one is not joe's.
+        if(r.head.find("GET /tokeninfo?access_token=live-access-token ") == 0)
+            return httpserver::reply(200, "OK", "{\"email\":\"joe\"}",
+                                     "Content-Type: application/json\r\n");
+
+        return httpserver::reply(401, "Unauthorized",
+                                 "{\"error\":\"invalid_token\"}",
+                                 "Content-Type: application/json\r\n");
+    });
+
+    s.tokeninfo_port = tokens.port();
 
     if(!s.start()) {
         std::cerr << s.log();
@@ -502,6 +540,103 @@ int main() {
         }
     }
 
+    // OAuth2 end to end: jlib fetches an access token over HTTP, presents it
+    // to dovecot over IMAP, and dovecot goes back over HTTP to check it.  Four
+    // pieces of this branch's work in one line of a user's day.
+    {
+        jlib::net::oauth::client provider;
+
+        provider.token_endpoint = "http://127.0.0.1:" +
+                                  std::to_string(tokens.port()) + "/token";
+        provider.id = "jlib-live-test";
+
+        // Plaintext, which refresh() refuses by default and a real provider
+        // would never offer.  It is loopback to a server in this process.
+        provider.allow_http = true;
+
+        std::string persisted;
+
+        jlib::net::oauth::session account(provider, "good-refresh",
+                                          [&persisted](const jlib::net::oauth::token& t) {
+                                              persisted = t.refresh();
+                                          });
+
+        try {
+            const std::string access = account.access();
+
+            ok("an access token comes back from the token endpoint",
+               access == "live-access-token", access);
+
+            // Microsoft rotates on every refresh and kills the old one at the
+            // same moment, so a client that cannot store the new one is logged
+            // out after the first refresh.
+            ok("and the rotated refresh token was handed over to be stored",
+               persisted == "rotated-refresh", persisted);
+
+            jlib::util::URL u("imap://joe@127.0.0.1:" + std::to_string(s.port) +
+                              "/INBOX");
+
+            jlib::net::Imap4 imap(u);
+
+            std::unique_ptr<jlib::sys::socketstream> sock(imap.connect());
+
+            imap.capability(*sock);
+
+            ok("dovecot offers AUTH=XOAUTH2", imap.has_capability("AUTH=XOAUTH2"));
+
+            imap.authenticate_xoauth2(*sock, "joe", access);
+
+            ok("XOAUTH2 authenticates against a real server",
+               imap.state() == jlib::net::Imap4::Authenticated);
+
+            imap.select(*sock, "INBOX");
+
+            ok("and the mailbox is there afterwards", imap.exists() == 2,
+               std::to_string(imap.exists()));
+
+            imap.logout(*sock);
+        }
+        catch(std::exception& e) {
+            ok("XOAUTH2 authenticates against a real server", false, e.what());
+            std::cerr << s.log();
+        }
+    }
+
+    // A token the endpoint will not vouch for.  dovecot answers with a
+    // continuation carrying base64 JSON and withholds the tagged NO until the
+    // client replies -- which is the shape net_imap_sasl_test asserts against a
+    // scripted server, here confirmed against a real one.
+    {
+        jlib::util::URL u("imap://joe@127.0.0.1:" + std::to_string(s.port) + "/INBOX");
+
+        jlib::net::Imap4 imap(u);
+
+        try {
+            std::unique_ptr<jlib::sys::socketstream> sock(imap.connect());
+
+            bool threw = false;
+
+            try { imap.authenticate_xoauth2(*sock, "joe", "not-a-real-token"); }
+            catch(std::exception&) { threw = true; }
+
+            ok("a token the endpoint rejects is refused", threw);
+
+            // The assertion that matters: the exchange finished, so the socket
+            // is at a response boundary and can still be used.
+            imap.authenticate_plain(*sock, "joe", mailserver::PASSWORD);
+
+            ok("and the connection survives to try another mechanism",
+               imap.state() == jlib::net::Imap4::Authenticated);
+
+            imap.logout(*sock);
+        }
+        catch(std::exception& e) {
+            ok("and the connection survives to try another mechanism", false,
+               e.what());
+            std::cerr << s.log();
+        }
+    }
+
     // The port it picks when it is not told one.
     ok("imaps:// with no port is still secure",
        jlib::net::Imap4(jlib::util::URL("imaps://joe@localhost/INBOX")).is_secure());
@@ -519,9 +654,15 @@ int main() {
     // Not the commands #85 is about.  SEARCH, UID and a ranged FETCH are still
     // unimplemented; this exercises what was already there.
     //
-    // Not the mechanisms that matter for a real account.  AUTH=PLAIN is what
-    // dovecot offers out of the box; XOAUTH2 is what Gmail and Outlook.com
-    // require, and nothing here has ever spoken to either.  The exchange is
-    // the same shape and the credential is not.
+    // Not a real provider.  The XOAUTH2 section above is end to end -- jlib
+    // fetches a token over HTTP, dovecot validates it over HTTP, and the
+    // mechanism in the middle is the one Gmail and Outlook.com require -- but
+    // both endpoints are servers in this process, answering what this test told
+    // them to.  Neither Google nor Microsoft can be reached from make check:
+    // both need a registered application and a human at a browser.
+    //
+    // Nor TLS on the OAuth2 half.  The token endpoint here is plaintext
+    // loopback with allow_http set, which is exactly what oauth::refresh
+    // refuses by default.
     return failures ? 1 : 0;
 }

--- a/tests/net_imap_sasl_test.cc
+++ b/tests/net_imap_sasl_test.cc
@@ -68,11 +68,16 @@ static void ok(const std::string& what, bool good, const std::string& detail = "
 static std::string show(const std::string& s) {
     std::string out;
 
-    for(char c : s) {
-        if(c == '\r')      out += "\\r";
-        else if(c == '\n') out += "\\n";
-        else if(c == '\0') out += "\\0";
-        else               out += c;
+    for(unsigned char c : s) {
+        if(c == '\r')       out += "\\r";
+        else if(c == '\n')  out += "\\n";
+        else if(c == '\0')  out += "\\0";
+        // The XOAUTH2 separator, which is the whole point of one assertion
+        // here: printed raw it is invisible, and an invisible octet is exactly
+        // how "\x01auth=" being 0x1A goes unnoticed.
+        else if(c == '\001') out += "^A";
+        else if(c < 0x20)    out += "\\" + std::to_string(static_cast<int>(c));
+        else                 out += static_cast<char>(c);
     }
 
     return out;
@@ -459,6 +464,144 @@ static void an_endless_challenge_is_not_endless() {
     ok("and cancels rather than falling silent", cancelled);
 }
 
+static void xoauth2_end_to_end() {
+    std::cout << "\nAUTHENTICATE XOAUTH2, both ways it can end:\n";
+
+    {
+        scripted_server server({ "* CAPABILITY IMAP4rev1 AUTH=XOAUTH2\r\n"
+                                 "A00001 OK capability completed\r\n",
+                                 "+ \r\n",
+                                 "A00002 OK [CAPABILITY IMAP4rev1] logged in\r\n" });
+
+        jlib::net::Imap4 imap(url_for(server.port()));
+
+        try {
+            std::unique_ptr<jlib::sys::socketstream> sock = connect_to(imap);
+
+            imap.capability(*sock);
+
+            imap.authenticate_xoauth2(*sock, "joe@example.com", "ya29.TOKEN");
+
+            ok("it completes", imap.state() == jlib::net::Imap4::Authenticated);
+
+            sock->close();
+        }
+        catch(std::exception& e) {
+            ok("it completes", false, e.what());
+        }
+
+        const std::vector<std::string>& sent = server.sent();
+
+        ok("the mechanism is named XOAUTH2",
+           sent.size() >= 2 && sent[1] == "A00002 AUTHENTICATE XOAUTH2",
+           sent.size() >= 2 ? show(sent[1]) : "");
+
+        if(sent.size() >= 3) {
+            const std::string message = util::base64::decode(sent[2]);
+
+            // What the two providers expect, byte for byte.  The separator is
+            // one octet: "\x01auth=" would have been 0x1A followed by "uth=",
+            // because a hexadecimal escape in C++ eats every hex digit after it.
+            ok("and the message is what Google and Microsoft expect",
+               message == std::string("user=joe@example.com\001auth=Bearer "
+                                      "ya29.TOKEN\001\001"),
+               show(message));
+        }
+        else {
+            ok("and the message is what Google and Microsoft expect", false,
+               "nothing was sent");
+        }
+    }
+
+    {
+        // How a bad token is actually reported, and the reason this mechanism
+        // needs two rounds.  Not a tagged NO: a *continuation* carrying base64
+        // JSON, with the NO withheld until the client answers it -- so a driver
+        // that answers only the first challenge waits forever on a socket that
+        // looks perfectly alive.
+        const std::string blob =
+            "{\"status\":\"401\",\"schemes\":\"Bearer\",\"scope\":\"https://mail.google.com/\"}";
+
+        scripted_server server({ "* CAPABILITY IMAP4rev1 AUTH=XOAUTH2\r\n"
+                                 "A00001 OK capability completed\r\n",
+                                 "+ \r\n",
+                                 "+ " + util::base64::encode(blob) + "\r\n",
+                                 "A00002 NO Invalid credentials (Failure)\r\n" });
+
+        jlib::net::Imap4 imap(url_for(server.port()));
+
+        try {
+            std::unique_ptr<jlib::sys::socketstream> sock = connect_to(imap);
+
+            imap.capability(*sock);
+
+            bool threw = false;
+
+            try {
+                imap.authenticate_xoauth2(*sock, "joe@example.com", "expired");
+            }
+            catch(std::exception&) { threw = true; }
+
+            ok("a rejected token throws rather than hanging", threw);
+            ok("and the client is not authenticated",
+               imap.state() != jlib::net::Imap4::Authenticated);
+
+            imap.noop(*sock);
+
+            ok("and the connection is still usable afterwards", true);
+
+            sock->close();
+        }
+        catch(std::exception& e) {
+            ok("and the connection is still usable afterwards", false, e.what());
+        }
+
+        const std::vector<std::string>& sent = server.sent();
+
+        // The empty line is what unblocks the tagged NO.  Without it the
+        // server never sends one and the client never returns.
+        ok("the error challenge is answered with an empty line",
+           sent.size() >= 4 && sent[3].empty(),
+           sent.size() >= 4 ? show(sent[3]) : "");
+
+        ok("and the next command went out under the next tag",
+           sent.size() >= 5 && sent[4] == "A00003 NOOP",
+           sent.size() >= 5 ? show(sent[4]) : "");
+    }
+
+    {
+        // A capability list that has been fetched and does not offer it is an
+        // objection; sending a bearer token to a server that will not take it
+        // is putting a credential on the wire for nothing.
+        scripted_server server({ "* CAPABILITY IMAP4rev1 AUTH=PLAIN\r\n"
+                                 "A00001 OK capability completed\r\n" });
+
+        jlib::net::Imap4 imap(url_for(server.port()));
+
+        try {
+            std::unique_ptr<jlib::sys::socketstream> sock = connect_to(imap);
+
+            imap.capability(*sock);
+
+            bool threw = false;
+
+            try { imap.authenticate_xoauth2(*sock, "joe@example.com", "t"); }
+            catch(std::exception&) { threw = true; }
+
+            ok("a server that does not offer XOAUTH2 is not sent a token", threw);
+
+            sock->close();
+        }
+        catch(std::exception& e) {
+            ok("a server that does not offer XOAUTH2 is not sent a token", false,
+               e.what());
+        }
+
+        ok("and the token never reached the wire", server.sent().size() == 1,
+           std::to_string(server.sent().size()) + " line(s)");
+    }
+}
+
 static void a_nul_in_a_credential_is_refused() {
     std::cout << "\na NUL in a credential is refused before it is sent:\n";
 
@@ -501,6 +644,7 @@ int main() {
     a_responder_that_gives_up_cancels();
     a_second_challenge_is_answered();
     an_endless_challenge_is_not_endless();
+    xoauth2_end_to_end();
     a_nul_in_a_credential_is_refused();
 
     // What a green run does not establish: that a real server accepts what

--- a/tests/net_oauth_test.cc
+++ b/tests/net_oauth_test.cc
@@ -1,0 +1,422 @@
+/* -*- mode: C++ c-basic-offset: 4 -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// The refresh-token grant, against a token endpoint written here.
+//
+// Neither Google nor Microsoft can be reached from make check -- both need a
+// registered application and a human at a browser -- so what is testable is
+// everything up to the moment a real provider is involved: the form that goes
+// out, the reply that comes back in every shape a provider actually sends it,
+// and what the session does with the answer.
+//
+// The parts that carry a real risk of being wrong are the ones a test can
+// reach: rotation, which locks a user out if the interface cannot hand a new
+// refresh token back; the XOAUTH2 message, whose separator is an octet that C++
+// will silently mis-escape; and the second challenge, which is how a bad token
+// is reported and which hangs a client that answers only the first.
+
+#include "httpserver.hh"
+
+#include <jlib/net/oauth.hh>
+
+#include <jlib/util/URL.hh>
+#include <jlib/util/util.hh>
+
+#include <iostream>
+#include <string>
+
+namespace oauth = jlib::net::oauth;
+
+using jlib::util::URL;
+
+static int failures = 0;
+
+static void ok(const std::string& what, bool good, const std::string& detail = "") {
+    if(!good) ++failures;
+    std::cout << (good ? "  ok   " : "  FAIL ") << what;
+    if(!detail.empty()) std::cout << ": " << detail;
+    std::cout << "\n";
+}
+
+static std::string show(const std::string& s) {
+    std::string out;
+
+    for(unsigned char c : s) {
+        if(c == '\001')    out += "^A";
+        else if(c == '\r') out += "\\r";
+        else if(c == '\n') out += "\\n";
+        else if(c < 0x20)  out += "\\" + std::to_string(static_cast<int>(c));
+        else               out += static_cast<char>(c);
+    }
+
+    return out;
+}
+
+/** A client pointed at a test server, with the plaintext guard lifted. */
+static oauth::client client_for(const httpserver::server& s) {
+    oauth::client c;
+
+    c.token_endpoint = s.url("/token");
+    c.id = "jlib-test";
+    c.allow_http = true;
+
+    return c;
+}
+
+static void a_reply_in_every_shape_a_provider_sends_it() {
+    std::cout << "\na reply, in every shape a provider sends it:\n";
+
+    {
+        // Google: expires_in as a number, no refresh_token in the reply.
+        const oauth::token t = oauth::parse_token_response(
+            "{\"access_token\":\"ya29.A\",\"expires_in\":3599,"
+            "\"scope\":\"https://mail.google.com/\",\"token_type\":\"Bearer\"}",
+            "1//old", 1000);
+
+        ok("an access token reads", t.access() == "ya29.A", t.access());
+        ok("the type and scope read", t.type() == "Bearer" &&
+           t.scope() == "https://mail.google.com/");
+        ok("expires_in becomes a moment", t.expires_at() == 1000 + 3599,
+           std::to_string(t.expires_at()));
+
+        // No refresh_token in the reply means the one that was sent is still
+        // good -- and it is what the caller must go on storing.
+        ok("with no refresh_token, the one that was sent stays",
+           t.refresh() == "1//old" && !t.rotated(), t.refresh());
+    }
+
+    {
+        // Microsoft v1: expires_in as the *string* "3599".  util::json coerces
+        // it; before this arc it threw, because it demanded json_type_int.
+        const oauth::token t = oauth::parse_token_response(
+            "{\"access_token\":\"EwB.A\",\"expires_in\":\"3599\","
+            "\"token_type\":\"Bearer\"}", "M.old", 1000);
+
+        ok("expires_in as a string reads too", t.expires_at() == 1000 + 3599,
+           std::to_string(t.expires_at()));
+    }
+
+    {
+        // Microsoft rotates on every refresh and kills the old one at the same
+        // moment.  An interface that could not hand this back would log the
+        // user out after one refresh and could not be fixed without changing
+        // every caller.
+        const oauth::token t = oauth::parse_token_response(
+            "{\"access_token\":\"EwB.B\",\"refresh_token\":\"M.new\","
+            "\"expires_in\":3599}", "M.old", 1000);
+
+        ok("a rotated refresh token comes back", t.refresh() == "M.new", t.refresh());
+        ok("and says that it rotated", t.rotated());
+    }
+
+    {
+        // Sent back unchanged is not rotation, and a caller watching for a
+        // save should not be woken for it.
+        const oauth::token t = oauth::parse_token_response(
+            "{\"access_token\":\"a\",\"refresh_token\":\"same\"}", "same", 1000);
+
+        ok("the same refresh token echoed back is not a rotation", !t.rotated());
+    }
+
+    {
+        // No expires_in at all is "the endpoint did not say", not "never".
+        const oauth::token t = oauth::parse_token_response(
+            "{\"access_token\":\"a\"}", "r", 1000);
+
+        ok("no expires_in means no stated expiry", t.expires_at() == 0);
+        ok("and such a token is not treated as already dead", !t.expired(1000));
+    }
+
+    {
+        const oauth::token t = oauth::parse_token_response(
+            "{\"access_token\":\"a\",\"expires_in\":3599}", "r", 1000);
+
+        ok("a token is expired before it expires, by a minute of slack",
+           !t.expired(1000 + 3538) && t.expired(1000 + 3540),
+           "clocks disagree; a token that dies mid-command looks like a wrong "
+           "password");
+    }
+}
+
+static void what_the_endpoint_says_when_it_says_no() {
+    std::cout << "\nwhat the endpoint says when it says no:\n";
+
+    // RFC 6749 5.2.  This is the reason the HTTP client hands back a non-2xx
+    // instead of throwing: the body is the only thing that says whether to
+    // retry or to send the user back to a browser.
+    bool caught = false;
+
+    try {
+        oauth::parse_token_response(
+            "{\"error\":\"invalid_grant\",\"error_description\":\"Token has been "
+            "expired or revoked.\"}", "r", 1000);
+    }
+    catch(oauth::denied& d) {
+        caught = true;
+
+        ok("the error code is readable", d.code() == "invalid_grant", d.code());
+        ok("and the description", !d.description().empty(), d.description());
+
+        // The one distinction that matters: nothing will fix this but
+        // authorizing again, so a client that retries is wasting its time and
+        // a client that gives up on a transient error is wrong the other way.
+        ok("invalid_grant is fatal", d.fatal());
+    }
+
+    ok("an error body throws denied", caught);
+
+    caught = false;
+
+    try {
+        oauth::parse_token_response("{\"error\":\"temporarily_unavailable\"}", "r", 1000);
+    }
+    catch(oauth::denied& d) {
+        caught = true;
+        ok("and a transient one is not fatal", !d.fatal());
+    }
+
+    ok("which is still a refusal", caught);
+
+    // A reply with neither an error nor an access token is not something to
+    // guess about.
+    caught = false;
+
+    try { oauth::parse_token_response("{\"token_type\":\"Bearer\"}", "r", 1000); }
+    catch(oauth::error&) { caught = true; }
+
+    ok("a reply with no access_token is an error", caught);
+
+    caught = false;
+    std::string message;
+
+    try { oauth::parse_token_response("<html>go away</html>", "r", 1000); }
+    catch(oauth::error& e) { caught = true; message = e.what(); }
+
+    ok("and so is one that is not JSON at all", caught);
+
+    // The body is a bearer token when the request worked and often still one
+    // when it did not.  An exception message goes to a log.
+    ok("whose message does not quote the body",
+       message.find("go away") == std::string::npos, message);
+}
+
+static void the_request_that_goes_out() {
+    std::cout << "\nthe request that goes out:\n";
+
+    httpserver::server s([](const httpserver::request&) {
+        return httpserver::reply(200, "OK",
+                                 "{\"access_token\":\"A\",\"expires_in\":3599}",
+                                 "Content-Type: application/json\r\n");
+    });
+
+    oauth::client c = client_for(s);
+
+    c.secret = "not-a-secret";
+    c.scope = "https://mail.google.com/";
+
+    const oauth::token t = oauth::refresh(c, "1//r+e/f=");
+
+    ok("the exchange completes", t.access() == "A", t.access());
+
+    const std::vector<httpserver::request> sent = s.requests();
+
+    ok("one POST was made", sent.size() == 1 &&
+       sent[0].head.find("POST /token HTTP/1.1\r\n") == 0,
+       std::to_string(sent.size()));
+
+    if(sent.empty()) return;
+
+    ok("with grant_type=refresh_token, per RFC 6749 6",
+       sent[0].body.find("grant_type=refresh_token") != std::string::npos,
+       sent[0].body);
+
+    // The one that would fail silently: base64 produces "+" and "/" and "=",
+    // and this encoding is HTML's, where "+" means a space.  A refresh token
+    // sent through uri::encode arrives with spaces in it and is rejected as
+    // invalid_grant, which reads exactly like a revoked token.
+    ok("and a refresh token whose characters need escaping survives",
+       sent[0].body.find("refresh_token=1%2F%2Fr%2Be%2Ff%3D") != std::string::npos,
+       sent[0].body);
+
+    ok("the client id and scope go too",
+       sent[0].body.find("client_id=jlib-test") != std::string::npos &&
+       sent[0].body.find("scope=https%3A%2F%2Fmail.google.com%2F") != std::string::npos);
+}
+
+static void a_plaintext_endpoint_is_refused() {
+    std::cout << "\na plaintext endpoint is refused:\n";
+
+    // The request carries the refresh token and the client secret, and the
+    // access token comes back the same way.
+    //
+    // Against a server here, not a name on the internet.  The first draft of
+    // this pointed at http://example.com/token expecting the connection to
+    // fail, and it did not: the request went out and came back 405.  A test
+    // that reaches the network is a test that depends on the network, and this
+    // one was about to assert something about a stranger's web server.
+    httpserver::server s([](const httpserver::request&) {
+        return httpserver::reply(200, "OK", "{\"access_token\":\"A\"}");
+    });
+
+    oauth::client c = client_for(s);
+
+    c.allow_http = false;
+    c.secret = "not-a-secret";
+
+    bool threw = false;
+    std::string why;
+
+    try { oauth::refresh(c, "r"); }
+    catch(oauth::error& e) { threw = true; why = e.what(); }
+
+    ok("http:// is refused by default", threw);
+    ok("and the refusal says what was wrong with it",
+       why.find("plaintext") != std::string::npos, why);
+
+    // Refused before anything was sent, which is the assertion that matters:
+    // the credential never reached the socket.
+    ok("nothing was sent to it", s.requests().empty(),
+       std::to_string(s.requests().size()) + " request(s)");
+
+    c.allow_http = true;
+
+    ok("and allowed only when a caller says so",
+       oauth::refresh(c, "r").access() == "A");
+}
+
+static void a_session_keeps_one_token() {
+    std::cout << "\na session keeps one token, and knows when not to:\n";
+
+    int fetches = 0;
+
+    httpserver::server s([&fetches](const httpserver::request&) {
+        const std::string n = std::to_string(++fetches);
+
+        return httpserver::reply(200, "OK",
+                                 "{\"access_token\":\"A" + n + "\","
+                                 "\"refresh_token\":\"R" + n + "\","
+                                 "\"expires_in\":3599}");
+    });
+
+    std::string stored;
+    int stores = 0;
+
+    oauth::session session(client_for(s), "R0",
+                           [&stored, &stores](const oauth::token& t) {
+                               stored = t.refresh();
+                               stores++;
+                           });
+
+    ok("the first access fetches one", session.access() == "A1" && fetches == 1);
+
+    // The point of a cache: an IMAP client asks for the token on every
+    // connection and a token endpoint has a rate limit.
+    ok("the second does not", session.access() == "A1" && fetches == 1,
+       std::to_string(fetches) + " fetches");
+
+    // The rotated token is handed to the store callback the instant it
+    // arrives, before anything uses the access token beside it -- because a
+    // crash in between means the refresh token on disk is the dead one.
+    ok("the rotated refresh token reached the store callback",
+       stored == "R1" && stores == 1, stored);
+
+    ok("and the session is holding it", session.refresh_token() == "R1",
+       session.refresh_token());
+
+    // The cache is an optimisation and never the truth.  Tokens get revoked
+    // mid-session and clocks disagree; a NO from IMAP is authoritative whatever
+    // the expiry said.
+    session.rejected();
+
+    ok("after a rejection it fetches again", session.access() == "A2" && fetches == 2);
+    ok("and the second rotation was stored too", stored == "R2" && stores == 2);
+
+    // The second exchange must have sent the rotated token, not the one the
+    // session was constructed with -- Microsoft kills the old one on rotation,
+    // so sending it again is a lockout.
+    const std::vector<httpserver::request> sent = s.requests();
+
+    ok("and the second request sent the rotated token, not the original",
+       sent.size() == 2 && sent[1].body.find("refresh_token=R1") != std::string::npos,
+       sent.size() >= 2 ? sent[1].body : "");
+}
+
+static void the_xoauth2_message() {
+    std::cout << "\nthe XOAUTH2 message:\n";
+
+    const std::string m = oauth::xoauth2("joe@example.com", "ya29.TOKEN");
+
+    // Google's and Microsoft's spelling:
+    //     user=<email>^Aauth=Bearer <token>^A^A
+    ok("it is user, then auth, separated by 0x01",
+       m == std::string("user=joe@example.com\001auth=Bearer ya29.TOKEN\001\001"),
+       show(m));
+
+    // The trap this exists to avoid.  A hexadecimal escape in C++ has no
+    // length limit: "\x01auth=" is not 0x01 followed by "auth=", it is the
+    // single character 0x1A followed by "uth=" -- and it compiles silently.
+    // The octal form takes three digits at most.
+    ok("the separator really is one octet, 0x01",
+       m.find('\001') != std::string::npos &&
+       m.find('\032') == std::string::npos,
+       "\\x01a would have been 0x1A");
+
+    ok("and it ends with two of them",
+       m.size() >= 2 && m[m.size() - 1] == '\001' && m[m.size() - 2] == '\001');
+
+    // What actually goes on the wire is this, base64-encoded, which is what
+    // Imap4::authenticate_xoauth2 hands to the SASL driver.
+    const std::string wire = jlib::util::base64::encode(m);
+
+    ok("and it survives the base64 the SASL driver applies",
+       jlib::util::base64::decode(wire) == m);
+}
+
+int main() {
+    std::cout << std::unitbuf;
+
+    a_reply_in_every_shape_a_provider_sends_it();
+    what_the_endpoint_says_when_it_says_no();
+    the_request_that_goes_out();
+    a_plaintext_endpoint_is_refused();
+    a_session_keeps_one_token();
+    the_xoauth2_message();
+
+    // What a green run does not establish.
+    //
+    // That Google or Microsoft accepts any of it.  Neither can be reached from
+    // make check: both need a registered application and a human at a browser,
+    // so the library can be complete and the feature still not work for a given
+    // user until they have registered one.  Every reply parsed here is one this
+    // test wrote, in a shape taken from the providers' documentation rather
+    // than from a provider.
+    //
+    // Nor TLS to a token endpoint.  The server here is plaintext with
+    // allow_http set, which is exactly what refresh() refuses by default -- and
+    // the real thing is an https:// POST to a host with a public certificate
+    // chain, which nothing here has made.
+    //
+    // Nor the authorization-code flow.  There is no way to obtain a first
+    // refresh token in jlib yet; this reads mail with one that came from
+    // somewhere else.
+    std::cout << "\n" << (failures ? "FAILED" : "PASSED") << ": " << failures
+              << " failure(s)\n";
+
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
# OAuth2: a refresh token in, mail out

Sixth branch of the HTTP/OAuth2 work, and the one that makes the rest useful.
Gmail has wanted OAuth2 since 2022 and Outlook.com has *required* it for
personal accounts since September 2024; a client that speaks only LOGIN and
AUTH PLAIN cannot reach either. This closes that.

The smallest useful product: **hold a refresh token, get mail.** Obtaining the
first refresh token needs a browser, a loopback listener and PKCE, and that is a
branch of its own -- deliberately last, and deliberately after this has been
used in anger.

## Two things the interface had to get right

**Rotation.** RFC 6749 6 lets the token endpoint issue a *new* refresh token
with every refresh, and Microsoft always does, killing the old one at the same
moment. An API that takes a refresh token and cannot hand a new one back logs
the user out after the first refresh and cannot be fixed without changing every
caller. So `token::refresh()` is always the one to keep -- the new one when
there was one, the one that was sent when there was not -- and `session` takes a
store callback that fires the instant a new token arrives, **before** the access
token beside it is used for anything, because a crash in between is the same
lockout.

**A client secret in a native application is not secret.** RFC 8252 8.5 says so
plainly: it ships inside the binary. `client::secret` exists because Microsoft's
older endpoints reject a request without one, not because it protects anything,
and nothing is compiled in.

## What else it gets right, each because it would fail quietly otherwise

- **A 400 with a JSON body is the normal failure**, and the only thing that says
  whether the refresh token is dead (`invalid_grant` -- send the user back to a
  browser) or the server hiccuped (retry). `denied::fatal()` is that
  distinction. This is what the HTTP client handing back a non-2xx was for.
- **The body decides, not the status.** Some providers send an RFC 6749 5.2
  error body with a 200.
- **`expires_in` arrives as a number from Google and as the string `"3599"`
  from Microsoft.** Both read, because `util::json` was widened to coerce them
  two branches ago. Absent, it means "the endpoint did not say", not "never".
- **A minute of slack on expiry.** The clock here and the clock there are not
  the same clock, and a token that dies between the check and the command looks
  exactly like a wrong password.
- **The cache is never the truth.** `session::rejected()` drops the token
  whatever the expiry said, because a NO from IMAP is authoritative and tokens
  get revoked mid-session.
- **Redirects are forced off** for the token request whatever the caller's
  options say, and a **plaintext endpoint is refused** before anything is sent:
  the form carries the refresh token and the client secret, and the access token
  comes back the same way.
- **`"\001"`, never `"\x01"`.** A hexadecimal escape in C++ has no length limit
  -- it eats every hex digit after it -- so `"\x01auth="` is the single
  character 0x1A followed by `"uth="`, and it compiles without a word. The test
  output renders the octet as `^A` for the same reason: an invisible character
  is exactly how this goes unnoticed.

`Imap4::authenticate_xoauth2` sits on the SASL driver from the AUTHENTICATE
branch. It needs the driver's two-round handling, because a rejected token is
**not** reported as a tagged NO: the server sends a continuation carrying base64
JSON and withholds the NO until the client answers with an empty line. A driver
that answers only the first challenge waits forever on a socket that looks
alive. It also refuses to send a token to a server whose capability list has
been fetched and does not offer AUTH=XOAUTH2 -- putting a bearer token on the
wire for nothing.

## The test that surprised me: XOAUTH2 end to end, against dovecot

dovecot's oauth2 passdb validates a token by GETting a **tokeninfo URL** and
reading an address out of the JSON -- which is the same shape as Google's
endpoint. So `net_imap_live_test` now runs one in-process HTTP server wearing
two hats:

- to jlib it is the **token endpoint**: POST a refresh token, get an access
  token and a rotated refresh token back;
- to dovecot it is the **tokeninfo endpoint** it consults to find out whether
  that access token is good and whose it is.

The whole chain runs: jlib's HTTP client fetches a token, jlib's JSON reads it,
jlib's SASL driver presents it over IMAP, real dovecot goes back over HTTP to
check it, and the mailbox opens. And the failing half: a token the endpoint will
not vouch for is refused *and the connection survives*, so
`authenticate_plain()` then works on the same socket -- the two-round exchange
confirmed against a real server rather than a scripted one.

`tests/mailserver.hh` gained one optional field for this; zero leaves the
configuration exactly as it was, so `net_pop3_live_test` is untouched.

## Tests

`tests/net_oauth_test.cc`, new -- replies in every shape a provider sends them,
the RFC 6749 5.2 error bodies, the form that goes out, the session's caching and
rotation and rejection, and the XOAUTH2 message byte for byte.

The form assertion is the one that would have failed silently: base64 produces
`+`, `/` and `=`, and form encoding spells a space `+`. A refresh token sent
through `uri::encode` arrives with spaces in it and is rejected as
`invalid_grant`, which reads exactly like a revoked token.

`net_imap_sasl_test` gains three XOAUTH2 sections against the scripted server.

**One thing found by running it.** The plaintext-endpoint section first pointed
at `http://example.com/token`, expecting the connection to fail. It did not --
the request went out and came back **405**. A test that reaches the network is a
test that depends on the network, and that one was about to assert something
about a stranger's web server. It runs against a server in this process now, and
asserts the stronger thing: the refusal happens before anything is sent.

**What a green run does not establish.** That Google or Microsoft accepts any of
it. Neither can be reached from `make check` -- both need a registered
application and a human at a browser -- so **the library can be complete and the
feature still not work for a given user** until they have registered one. Every
reply parsed here is one these tests wrote, in shapes taken from the providers'
documentation rather than from a provider. And no token request in any test is
an `https://` one: the endpoints are plaintext loopback with `allow_http` set,
which is exactly what `refresh()` refuses by default.

macOS: 51 pass, 4 skip, 0 fail. Linux container: 55 pass, 1 skip, 0 fail.
