### PR TITLE
Obtain the first refresh token: the authorization-code flow with PKCE, on a loopback receiver

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,10 +17,10 @@ Each subdirectory of `jlib/` is one automake-built libtool library named
 
 | Dir | Library | What it is |
 | --- | --- | --- |
-| `jlib/sys` | `libjsys` | The foundation. iostream-based wrappers over OS facilities: `socketstream`, `sslstream`/`tlsstream`, `proxystream`, `sslproxystream`, `serialstream`, `pstream` (subprocess), `tfstream` (temp file). `run(argv, out, err)` executes a program with no shell involved — reach for it rather than `shell()`, which hands its argument to `/bin/sh`. Plus `Servent`/`ASServent` (threaded worker + command queue), `sync<T>` (mutex-wrapped value, C++11), `ringbuffer<T>` (lock-free, one producer and one consumer, written for the audio callback), `pipe`, `Directory`, `joystick`, `Object` (a polymorphic base), `signal<R(Args...)>`. |
-| `jlib/util` | `libjutil` | Two halves. The **parsing** half is the 2026 work: `abnf.hh` is a parser-combinator core with an RFC 5234 text front end on top (`compile()` reads an RFC's grammar as it stands), and the grammars themselves are pasted into headers — `rfc5322.hh` (3.2 lexical tokens, 3.3 date-time), `rfc2045.hh`, `rfc2047.hh`, `rfc3986.hh` — with `content_type`, `encoded_word`, `URL`, `Date` and `xml` reading them. The **grab bag** is the rest: `util.hh` (tokenize, trim, chop, base64/qp/URI codecs, byte `get`/`set`), `Regex` (POSIX `regex.h`, one live caller left), `Headers` (MIME header folding), `MimeType`, `Timer`, `json.hh` (a facade over json-c). |
+| `jlib/sys` | `libjsys` | The foundation. iostream-based wrappers over OS facilities: `socketstream`, `sslstream`/`tlsstream`, `proxystream`, `sslproxystream`, `serialstream`, `pstream` (subprocess), `tfstream` (temp file), and `listener` — bind/listen/accept, the accepting end jlib did without for twenty-six years. Sockets resolve with `getaddrinfo` (so IPv6 works and two threads no longer share `gethostbyname`'s static buffer), take a connect deadline, and can bound a read; `basic_socketbuf` adopts an accepted descriptor with the `sys::adopt` tag. `run(argv, out, err)` executes a program with no shell involved — reach for it rather than `shell()`, which hands its argument to `/bin/sh`. Plus `Servent`/`ASServent` (threaded worker + command queue), `sync<T>` (mutex-wrapped value, C++11), `ringbuffer<T>` (lock-free, one producer and one consumer, written for the audio callback), `pipe`, `Directory`, `joystick`, `Object` (a polymorphic base), `signal<R(Args...)>`. |
+| `jlib/util` | `libjutil` | Two halves. The **parsing** half is the 2026 work: `abnf.hh` is a parser-combinator core with an RFC 5234 text front end on top (`compile()` reads an RFC's grammar as it stands), and the grammars themselves are pasted into headers — `rfc5322.hh` (3.2 lexical tokens, 3.3 date-time), `rfc2045.hh`, `rfc2047.hh`, `rfc3986.hh`, and `rfc9110.hh`/`rfc9112.hh` (HTTP, pasted whole) — with `content_type`, `encoded_word`, `URL`, `Date`, `xml` and `http` reading them. `http.hh` is the HTTP *message* layer — a status line, a field section, and how the body after them is framed — and it lives here rather than in `net` because `sys/proxystream.hh` reads the answer to CONNECT with it and `sys` may not include `net`. The **grab bag** is the rest: `util.hh` (tokenize, trim, chop, base64/qp/URI codecs, byte `get`/`set`), `Regex` (POSIX `regex.h`, one live caller left), `Headers` (MIME header folding), `MimeType`, `Timer`, `json.hh` (a facade over json-c). |
 | `jlib/crypt` | `libjcrypt` | `crypt.hh` wraps GPGME (OpenPGP encrypt/sign/verify). The `curve`/`schnorr`/`groth` trio is the recent work: ristretto255 `Scalar`/`Point`/`Commitment` over libsodium, Schnorr proofs (single, double, `GeneralProof<N>`), and Groth binary/zero-argument proofs. Built only when libsodium *with* ristretto headers is present. |
-| `jlib/net` | `libjnet` | Email client stack: `Email` (MIME), `MailBox`/`MBox`/`Imap4Box`, `Pop3`, `Imap4`, `MailFolder`, plus `AS*` async variants layered on `sys::ASServent`. The protocol grammars live here — `rfc5322.hh` (addresses, appended to util's lexical block) read by `address.{hh,cc}`, and `rfc3501.hh` (IMAP responses) read by `imap_response.{hh,cc}`. `imap::read()` follows literals, which is why a response is not a line; `imap::quote()` writes command arguments. |
+| `jlib/net` | `libjnet` | Email client stack: `Email` (MIME), `MailBox`/`MBox`/`Imap4Box`, `Pop3`, `Imap4`, `MailFolder`, plus `AS*` async variants layered on `sys::ASServent`. The protocol grammars live here — `rfc5322.hh` (addresses, appended to util's lexical block) read by `address.{hh,cc}`, and `rfc3501.hh` (IMAP responses) read by `imap_response.{hh,cc}`. `imap::read()` follows literals, which is why a response is not a line; `imap::quote()` writes command arguments. `http.{hh,cc}` is the client — deliberately narrow, and the header says so — and `oauth.{hh,cc}` is OAuth2: the refresh grant, the authorization-code grant with PKCE, a loopback `redirect_receiver`, and the XOAUTH2 message that carries a token to IMAP. |
 | `jlib/media` | `libjmedia` | Audio via PortAudio, driven from its **callback**: `write()` fills a `sys::ringbuffer` and the device's callback drains it, so nothing in the path sleeps or polls. `AudioSink` is the device interface and `PortAudioSink` the implementation; `Player` (a `Servent`) runs a feeder thread so transport commands never wait on the device. Plus `AudioFile`/`WavFile`, `PlayList`, and streambuf-based `datastream`/`wavstream`/`notestream`/`audiofilestream`. `Type.hh` is a template-specialization table over PCM sample formats. `Dsp` is the retired OSS backend, kept but not built. |
 | `jlib/math` | `libjmath` | Header-only despite being a `lib_LTLIBRARIES` (its `_SOURCES` are all `.hh`). `matrix`, `vertex`, `tensor`, `buffer`, `polynomial` (templated on a Power type so it can hold curve `Scalar`s), and `Plot<T>` — the abstract plotting base, with `projection_mode` for perspective, orthographic or mixed. `object<T>` holds index-based topology — vertices, edges, and 2-faces built lazily — with `cuboid`, `pyramoid`, `spheroid`, `staroid` and `torus` (a flat k-torus in n dimensions; equal radii and k=2 is the Clifford torus). |
 | `jlib/x` | `libjx` | Raw Xlib: `Display`, `Window`, and an X11 `Plot`. |
@@ -130,21 +130,45 @@ done. `jhardhyper` draws translucent depth-sorted faces with per-frame normals,
 for hypercubes and for the flat torus, and under stereographic projection shows
 the Hopf foliation as nested tori.
 
+**jlib speaks OAuth2, which is what it needed to reach a real mailbox.** Gmail
+has wanted it since 2022 and Outlook.com has required it for personal accounts
+since September 2024, so a client with only LOGIN and AUTH PLAIN could not
+connect to either. Closing that took an HTTP client (RFC 9110 and 9112 pasted
+whole, `check()`-clean), a `jlib::sys` that can accept a connection, a real
+`AUTHENTICATE` driver, and a `util::json` that survives a stranger's reply.
+`net_imap_live_test` runs the whole chain against a real Dovecot: jlib fetches a
+token over HTTP, presents it over IMAP with XOAUTH2, and Dovecot goes back over
+HTTP to check it — using an in-process server that is the token endpoint and the
+tokeninfo endpoint at once, because Google's has the same shape.
+
+What that cannot establish, and no test here can: **neither Google nor Microsoft
+will issue a client id without the user registering an application first.** The
+library can be complete and the feature still not work for a given user.
+
 **The parsing arc is done too, and it is what most of the library now rests
 on.** An ABNF parser was built (`util::abnf`), an RFC's grammar can be pasted
 into a header and read as it stands, and everything that used to guess now does
 not: addresses (RFC 5322), MIME headers (2045/2047/2231), URLs (3986), dates
-(5322 §3.3), IMAP responses (3501), and XML. The XML parser was replaced
+(5322 §3.3), IMAP responses (3501), HTTP messages (9110/9112), and XML. The XML parser was replaced
 clean-room along the way, which removed the last copyright the author did not
 hold and **let the whole library relicense from GPL v2+ to Apache 2.0**.
 
-`tests/net_imap_live_test` starts a real Dovecot with a generated certificate
-and drives `Imap4` against it, in plaintext and over TLS. It is the only test
-that talks to a server rather than a `std::istringstream`, and the only way to
-exercise an IMAP literal, because only a server decides when to send one.
+The `*_live_test` programs start a real server — Dovecot, tinyproxy, nginx — and
+drive jlib against it. They exist because a `std::istringstream` produces only
+the responses somebody thought of, and so does an in-process server you wrote
+yourself: an IMAP literal, a Date and an ETag in an order nobody chose, a
+proxy's 403, are all things only a server decides to send. The in-process
+servers (`tests/httpserver.hh`, and the scripted one in `net_imap_sasl_test`)
+are for the opposite case — a chunked body whose data looks like its own
+framing, a challenge that never ends — which no real server will produce on
+request. Both kinds are needed and neither substitutes for the other.
 
 Remaining work is tracked in GitHub issues; the phase labels are historical now.
-What is left is the graphics chain that would let one `HyperPlot` serve both
+The HTTP arc left three of its own: #112 (`jlib::sys` can be the client end of a
+TLS connection and not the server end, so two tests hand-roll `SSL_accept`),
+#104 (proxy authentication — and `rfc9110.hh` already records that
+`credentials`/`challenge` need reordering under ordered choice before it can
+work) and #105 (SOCKS5). Otherwise what is left is the graphics chain that would let one `HyperPlot` serve both
 apps (#20 → #24 → #28), tessellation and face enumeration for the remaining
 shapes (#31, #35), two `math` bugs (#53, and #76 — `vertex` and `matrix` share
 storage when copied but deep-copy when assigned, which is why `jhypermusic`

--- a/jlib/net/oauth.cc
+++ b/jlib/net/oauth.cc
@@ -19,14 +19,26 @@
 
 #include <jlib/net/oauth.hh>
 
+#include <jlib/sys/listener.hh>
+#include <jlib/sys/socketstream.hh>
+
 #include <jlib/util/URL.hh>
+#include <jlib/util/http.hh>
 #include <jlib/util/json.hh>
+#include <jlib/util/util.hh>
+
+#include <openssl/evp.h>
+#include <openssl/rand.h>
 
 #include <map>
+#include <memory>
+#include <sstream>
 
 namespace jlib {
 namespace net {
 namespace oauth {
+
+namespace abnf = util::abnf;
 
 namespace {
 
@@ -191,6 +203,306 @@ const std::string& session::access() {
     m_token = fresh;
 
     return m_token.access();
+}
+
+// ------------------------------------------------------------ PKCE and state
+
+std::string random_token(std::size_t bytes) {
+    std::string raw(bytes, '\0');
+
+    // RAND_bytes, not std::random_device or rand().  This is the value that
+    // makes a stolen authorization code useless, so a predictable one is the
+    // same as none -- and OpenSSL is already a hard dependency here, where
+    // libsodium is optional and gated.
+    if(RAND_bytes(reinterpret_cast<unsigned char*>(&raw[0]),
+                  static_cast<int>(bytes)) != 1) {
+        throw error("the system random number generator failed");
+    }
+
+    return util::base64url::encode(raw);
+}
+
+pkce::pkce(std::string verifier)
+    : m_verifier(std::move(verifier))
+{
+    // RFC 7636 4.1: 43 to 128 characters of unreserved.  Checked rather than
+    // assumed, because a caller supplying its own is the case where it can be
+    // wrong, and a provider's complaint about it says "invalid_request".
+    if(m_verifier.length() < 43 || m_verifier.length() > 128)
+        throw error("a PKCE verifier is 43 to 128 characters; this one is " +
+                    std::to_string(m_verifier.length()));
+
+    for(char c : m_verifier) {
+        const bool unreserved = (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') ||
+                                (c >= '0' && c <= '9') ||
+                                c == '-' || c == '.' || c == '_' || c == '~';
+
+        if(!unreserved)
+            throw error("a PKCE verifier is unreserved characters only");
+    }
+
+    unsigned char hash[EVP_MAX_MD_SIZE];
+    unsigned int len = 0;
+
+    if(EVP_Digest(m_verifier.data(), m_verifier.length(), hash, &len,
+                  EVP_sha256(), 0) != 1) {
+        throw error("SHA-256 failed");
+    }
+
+    // RFC 7636 4.2: base64url of the hash of the *ASCII* verifier, unpadded.
+    // The padding matters -- a provider compares the whole string.
+    m_challenge = util::base64url::encode(
+        std::string(reinterpret_cast<const char*>(hash), len));
+}
+
+pkce pkce::generate() {
+    // 32 random octets is 43 base64url characters, which is the minimum length
+    // RFC 7636 4.1 allows and 256 bits of entropy.
+    return pkce(random_token(32));
+}
+
+// -------------------------------------------------------- redirect_receiver
+
+class redirect_receiver::impl {
+public:
+    explicit impl(unsigned short port)
+        : listener(port, "127.0.0.1", 1)
+    {}
+
+    sys::listener listener;
+};
+
+redirect_receiver::redirect_receiver(unsigned short port)
+    : m_impl(new impl(port))
+{}
+
+redirect_receiver::~redirect_receiver() = default;
+
+unsigned short redirect_receiver::port() const {
+    return m_impl->listener.port();
+}
+
+std::string redirect_receiver::redirect_uri() const {
+    // The address literal, not "localhost".  RFC 8252 7.3: "localhost" is
+    // whatever the resolver says it is, and the resolver is not always ours.
+    return "http://127.0.0.1:" + std::to_string(port()) + "/";
+}
+
+callback redirect_receiver::wait(const std::string& expect_state, double timeout) {
+    std::unique_ptr<sys::socketstream> browser;
+
+    try {
+        browser = m_impl->listener.accept_stream(timeout);
+    }
+    catch(std::exception& e) {
+        throw error(std::string("waiting for the browser: ") + e.what());
+    }
+
+    if(!browser)
+        throw error("no redirect arrived within " + std::to_string(timeout) +
+                    " seconds");
+
+    // Reading is bounded twice over: a deadline, and a cap on the request line.
+    // Whatever connected is not necessarily a browser.
+    browser->set_timeout(10);
+
+    std::string line;
+
+    std::getline(*browser, line);
+
+    while(!line.empty() && line.back() == '\r') line.pop_back();
+
+    if(line.length() > 8192) throw error("the redirect's request line is absurd");
+
+    // "GET /?code=...&state=... HTTP/1.1".  Read with the grammar rather than
+    // with find(): request-line is RFC 9112 3, and the pieces come out of the
+    // match instead of out of offsets counted by hand.
+    const abnf::parse_result p =
+        util::http::grammar().at("request-line").try_parse(line);
+
+    if(!p) throw error("what connected to the redirect port did not send a "
+                       "request line");
+
+    const abnf::match m = p.root();
+
+    if(m["method"].str() != "GET")
+        throw error("the redirect was not a GET");
+
+    // The target is origin-form: an absolute path and a query.  URL learned to
+    // parse a relative reference two branches ago, which is exactly this.
+    util::URL target;
+
+    try {
+        target.parse_reference(m["request-target"].str());
+    }
+    catch(std::exception&) {
+        throw error("the redirect's request target is not a URI reference");
+    }
+
+    callback back;
+
+    back.code = target["code"];
+    back.state = target["state"];
+    back.error = target["error"];
+    back.error_description = target["error_description"];
+
+    // The state first, and before anything else is believed.  RFC 6749 10.12:
+    // this is the client's only defence against someone else's authorization
+    // code being planted on it, and the check is worthless if it happens after
+    // the code has been used.
+    const bool state_ok = !expect_state.empty() && back.state == expect_state;
+
+    // One fixed page, whatever happened, because the person is looking at a
+    // browser and an empty response is indistinguishable from a crash.  It
+    // never contains the code: a URL bar is shoulder-surfable and a page is
+    // saveable.
+    const std::string body =
+        state_ok && back.ok()
+        ? "<html><body><h1>Signed in</h1><p>You can close this window and "
+          "return to the application.</p></body></html>"
+        : "<html><body><h1>Sign-in failed</h1><p>Return to the application; "
+          "it has the details.</p></body></html>";
+
+    std::ostringstream reply;
+
+    reply << "HTTP/1.1 200 OK\r\n"
+          << "Content-Type: text/html; charset=utf-8\r\n"
+          << "Content-Length: " << body.length() << "\r\n"
+          << "Connection: close\r\n"
+          << "\r\n"
+          << body;
+
+    *browser << reply.str() << std::flush;
+    browser->close();
+
+    if(!state_ok) {
+        throw error("the redirect's state does not match the one that was sent; "
+                    "refusing it");
+    }
+
+    if(!back.error.empty()) {
+        throw denied(back.error, back.error_description);
+    }
+
+    if(back.code.empty()) throw error("the redirect carried neither a code nor an error");
+
+    return back;
+}
+
+// ----------------------------------------------------- the code grant itself
+
+std::string authorize_url(const client& c,
+                          const std::string& redirect_uri,
+                          const std::string& state,
+                          const pkce& p)
+{
+    if(c.authorize_endpoint.empty()) throw error("no authorization endpoint");
+    if(c.id.empty()) throw error("no client id");
+    if(state.empty()) throw error("no state; see RFC 6749 10.12");
+
+    const util::URL endpoint(c.authorize_endpoint);
+
+    if(endpoint.get_protocol() != "https" && !c.allow_http) {
+        // Not because a secret goes out on it -- nothing here does -- but
+        // because whoever can rewrite this URL chooses where the user types
+        // their password.
+        throw error("refusing to send a user to a plaintext authorization "
+                    "endpoint: " + c.authorize_endpoint);
+    }
+
+    std::map<std::string, std::string> query;
+
+    query["response_type"] = "code";
+    query["client_id"] = c.id;
+    query["redirect_uri"] = redirect_uri;
+    query["state"] = state;
+    query["code_challenge"] = p.challenge();
+    query["code_challenge_method"] = pkce::method();
+
+    if(!c.scope.empty()) query["scope"] = c.scope;
+
+    // form_encode, which is the encoding a query string uses: space is "+".
+    // The separator is whatever the endpoint already has -- a provider is
+    // entitled to put its own parameters in the URL it publishes.
+    const std::string sep = endpoint.get_qs().empty() ? "?" : "&";
+
+    return c.authorize_endpoint + sep + http::form_encode(query);
+}
+
+token exchange(const client& c,
+               const std::string& code,
+               const pkce& p,
+               const std::string& redirect_uri,
+               const http::options& o)
+{
+    if(c.token_endpoint.empty()) throw error("no token endpoint");
+    if(code.empty()) throw error("no authorization code to exchange");
+
+    const util::URL endpoint(c.token_endpoint);
+
+    if(endpoint.get_protocol() != "https" && !c.allow_http) {
+        throw error("refusing to send a credential to a plaintext endpoint: " +
+                    c.token_endpoint);
+    }
+
+    std::map<std::string, std::string> form;
+
+    form["grant_type"] = "authorization_code";
+    form["code"] = code;
+    form["redirect_uri"] = redirect_uri;
+    form["code_verifier"] = p.verifier();
+
+    if(!c.id.empty()) form["client_id"] = c.id;
+    if(!c.secret.empty()) form["client_secret"] = c.secret;
+
+    http::fields send;
+
+    send.add("Accept", "application/json");
+
+    http::options opts = o;
+
+    opts.redirects = 0;
+
+    const http::Response r = http::post_form(endpoint, form, send, opts);
+
+    // An authorization code is single-use, so there is no refresh token to
+    // fall back on here: whatever the reply says about one is all there is.
+    try {
+        return parse_token_response(r.body(), std::string(), 0);
+    }
+    catch(denied&) {
+        throw;
+    }
+    catch(error&) {
+        if(!r.ok()) {
+            throw error("the token endpoint answered " +
+                        std::to_string(r.status()) + " " + r.reason() +
+                        " with nothing a program can act on");
+        }
+
+        throw;
+    }
+}
+
+token authorize(const client& c,
+                const std::function<void(const std::string&)>& open,
+                unsigned short port,
+                double timeout)
+{
+    if(!open) throw error("no way to open a browser was given");
+
+    // Bound before the URL is built, because the URL has to name the port.
+    redirect_receiver receiver(port);
+
+    const pkce p = pkce::generate();
+    const std::string state = random_token(32);
+    const std::string uri = receiver.redirect_uri();
+
+    open(authorize_url(c, uri, state, p));
+
+    const callback back = receiver.wait(state, timeout);
+
+    return exchange(c, back.code, p, uri);
 }
 
 std::string xoauth2(const std::string& user, const std::string& access_token) {

--- a/jlib/net/oauth.hh
+++ b/jlib/net/oauth.hh
@@ -22,8 +22,10 @@
 
 #include <jlib/net/http.hh>
 
+#include <cstddef>
 #include <ctime>
 #include <functional>
+#include <memory>
 #include <string>
 
 namespace jlib {
@@ -42,11 +44,14 @@ namespace net {
  * already hold into an access token, and XOAUTH2, which is how that access
  * token reaches an IMAP server.
  *
- * Not here: the authorization-code flow that *obtains* the first refresh token.
- * That needs a browser, a loopback listener and PKCE, and it is a branch of its
- * own.  Until then a refresh token has to come from somewhere else -- a
- * provider's playground, another client, a script -- and this reads mail with
- * it, which is the smallest useful thing.
+ * Here too, since the branch that added it: the authorization-code flow with
+ * PKCE, which obtains that first refresh token -- authorize_url(),
+ * redirect_receiver, exchange(), and authorize() tying the three together.
+ *
+ * A caveat that is not a bug and cannot be fixed here: neither Google nor
+ * Microsoft will issue a client id without the user registering an
+ * application with them first.  jlib can be complete and this can still not
+ * work for somebody who has not done that.
  *
  * Not here: the device-code flow, OAUTHBEARER (RFC 7628), token introspection,
  * or anything that stores a credential on disk.  Where the refresh token lives
@@ -112,6 +117,9 @@ private:
 struct client {
     /** The provider's token endpoint.  Must be https unless allow_http. */
     std::string token_endpoint;
+
+    /** Where a browser is sent to authorize.  Only the code grant needs it. */
+    std::string authorize_endpoint;
 
     std::string id;
 
@@ -252,6 +260,163 @@ private:
     store_fn m_store;
     token m_token;
 };
+
+/**
+ * PKCE, RFC 7636: a secret and the hash a request carries in its place.
+ *
+ * The authorization code comes back over a loopback HTTP redirect, which any
+ * other application on the machine can race for -- it is a plain TCP port on
+ * localhost.  PKCE is what makes stealing the code useless: the exchange that
+ * turns it into a token also demands the verifier, which never left this
+ * process.
+ *
+ * **S256 only.**  RFC 7636 4.2 also defines "plain", where the challenge *is*
+ * the verifier, and RFC 8252 8.1 says a native application must use S256.
+ * Offering plain would only be useful to a server that cannot do SHA-256, and
+ * a client that can be talked down to plain by a server's say-so has no
+ * protection at all.
+ */
+class pkce {
+public:
+    /** A fresh verifier from the system's CSPRNG. */
+    static pkce generate();
+
+    /** Build from a verifier you already have; validates its shape. */
+    explicit pkce(std::string verifier);
+
+    /** RFC 7636 4.1: 43-128 characters of unreserved.  Never sent anywhere but
+     *  the token request. */
+    const std::string& verifier() const { return m_verifier; }
+
+    /** base64url(SHA-256(verifier)), unpadded.  This is what goes in the URL. */
+    const std::string& challenge() const { return m_challenge; }
+
+    /** "S256". */
+    static const char* method() { return "S256"; }
+
+private:
+    std::string m_verifier;
+    std::string m_challenge;
+};
+
+/** Unguessable text from the system CSPRNG, base64url, for state and nonces. */
+std::string random_token(std::size_t bytes = 32);
+
+/**
+ * What came back to the redirect URI.
+ *
+ * Either a code or an error -- RFC 6749 4.1.2 and 4.1.2.1 -- and in both cases
+ * the state that was sent, which the caller must check.
+ */
+struct callback {
+    std::string code;
+    std::string state;
+    std::string error;
+    std::string error_description;
+
+    bool ok() const { return error.empty() && !code.empty(); }
+};
+
+/**
+ * Receive one OAuth2 redirect on loopback.
+ *
+ * Not a server, and the name is load-bearing.  It binds one loopback port,
+ * accepts one connection, reads one request line, writes one fixed page and
+ * stops.  Calling it a server is what turns eighty lines into eight hundred:
+ * there is no routing, no second request, no keep-alive, and no configuration.
+ *
+ * 127.0.0.1 explicitly, never INADDR_ANY -- what arrives here is an
+ * authorization code, and a receiver reachable from the network receives it
+ * from the network.  RFC 8252 7.3 also says to use the address literal rather
+ * than "localhost", because "localhost" is whatever the resolver says it is.
+ *
+ * Plaintext, which is correct: 8.3 says a loopback redirect does not need TLS,
+ * and a self-signed certificate would only teach the user to click through a
+ * browser warning.
+ */
+class redirect_receiver {
+public:
+    /** Bind a loopback port.  0 lets the kernel choose; see redirect_uri(). */
+    explicit redirect_receiver(unsigned short port = 0);
+
+    ~redirect_receiver();
+
+    redirect_receiver(const redirect_receiver&) = delete;
+    redirect_receiver& operator=(const redirect_receiver&) = delete;
+
+    unsigned short port() const;
+
+    /** "http://127.0.0.1:<port>/" -- register this with the provider. */
+    std::string redirect_uri() const;
+
+    /**
+     * Wait for the browser, and answer it.
+     *
+     * @param expect_state  the state that was sent.  A callback carrying
+     *                      anything else is refused without being parsed
+     *                      further: RFC 6749 10.12 makes this the client's
+     *                      only defence against having someone else's
+     *                      authorization code planted on it.
+     * @param timeout       seconds to wait.  The user may be typing a password
+     *                      or approving on a phone, so this is generous by
+     *                      default.
+     *
+     * @throw error on a timeout, a request that is not a GET of the redirect
+     *        URI, or a state mismatch.
+     *
+     * Never logs or prints the code.
+     */
+    callback wait(const std::string& expect_state, double timeout = 300);
+
+private:
+    class impl;
+    std::unique_ptr<impl> m_impl;
+};
+
+/**
+ * The URL to send a browser to.  RFC 6749 4.1.1, with RFC 7636 4.3's fields.
+ *
+ * @param redirect_uri  where the provider sends the browser back; must be the
+ *                      one registered with them, which for a native
+ *                      application is a loopback URI
+ */
+std::string authorize_url(const client& c,
+                          const std::string& redirect_uri,
+                          const std::string& state,
+                          const pkce& p);
+
+/**
+ * Turn an authorization code into tokens.  RFC 6749 4.1.3.
+ *
+ * The redirect URI goes with it and must be the same one: it is not where
+ * anything is sent, it is a value the provider compares.
+ *
+ * @throw denied when the endpoint refuses in the documented way
+ */
+token exchange(const client& c,
+               const std::string& code,
+               const pkce& p,
+               const std::string& redirect_uri,
+               const http::options& o = http::options());
+
+/**
+ * The whole flow: open a browser, wait, exchange.
+ *
+ * Blocking, on purpose.  The application runs it on a thread; sys::ASServent is
+ * the house pattern and ASMailBox and ASImapBox are the precedent.  It cannot
+ * be anything else without inventing an event loop jlib does not have.
+ *
+ * @param open  called with the authorization URL.  Opening a browser is the
+ *              application's business -- it may be a desktop, a terminal
+ *              printing the URL, or a test -- and jlib guessing at xdg-open
+ *              would be wrong more often than right.
+ *
+ * The refresh token is in the result, and storing it is the caller's job.
+ */
+token authorize(const client& c,
+                const std::function<void(const std::string& url)>& open,
+                unsigned short port = 0,
+                double timeout = 300);
 
 /**
  * The SASL XOAUTH2 message, before base64.

--- a/jlib/util/util.cc
+++ b/jlib/util/util.cc
@@ -518,6 +518,58 @@ namespace jlib {
 
         }
 
+        // --------------------------------------------------------- base64url
+
+        namespace base64url {
+
+            std::string encode(const std::string& s)
+            {
+                std::string out = base64::encode(s);
+
+                // The three characters that differ, and the padding.  RFC 4648
+                // 5 is the same alphabet with two substitutions; RFC 7636 4.2
+                // is what requires the "=" to come off.
+                for(char& c : out) {
+                    if(c == '+')      c = '-';
+                    else if(c == '/') c = '_';
+                }
+
+                while(!out.empty() && out.back() == '=') out.pop_back();
+
+                return out;
+            }
+
+            std::string decode(const std::string& s, bool& clean)
+            {
+                std::string in;
+
+                in.reserve(s.size() + 3);
+
+                for(char c : s) {
+                    if(c == '-')      in += '+';
+                    else if(c == '_') in += '/';
+                    else if(c == '=') continue;   // tolerated, not required
+                    else              in += c;
+                }
+
+                // base64::decode drops a final group of one symbol and clears
+                // clean, which is the right answer -- six bits is not a byte.
+                // Padding it back is only so the length is a multiple of four,
+                // which is what that decoder expects to see.
+                while(in.size() % 4) in += '=';
+
+                return base64::decode(in, clean);
+            }
+
+            std::string decode(const std::string& s)
+            {
+                bool clean = true;
+
+                return decode(s, clean);
+            }
+
+        }
+
         // -------------------------------------------------- quoted-printable
 
         namespace qp {

--- a/jlib/util/util.hh
+++ b/jlib/util/util.hh
@@ -333,6 +333,41 @@ namespace jlib {
         }
 
         /**
+         * base64url, RFC 4648 section 5, without padding.
+         *
+         * The same six-bit alphabet with "-" and "_" in place of "+" and "/",
+         * so that a value can go in a URL or a filename without being
+         * percent-encoded first.
+         *
+         * **Separate from base64 rather than a flag on it, and the padding is
+         * the reason.**  RFC 7636 4.2 requires the PKCE code challenge to be
+         * base64url with the "=" stripped, and OAuth2 tokens are compared as
+         * whole strings by the server that issued them -- so a challenge with
+         * padding on the end simply does not match, and the error a provider
+         * returns for it says nothing about padding.  Meanwhile the XOAUTH2
+         * blob two files away is standard base64 *with* padding.  Two
+         * encodings that differ in three characters, used within a few lines
+         * of each other, is exactly the sort of thing a bool argument gets
+         * wrong silently.
+         *
+         * decode() accepts padding if it finds any, because other people's
+         * encoders emit it and refusing would be pedantry; encode() never
+         * writes it.
+         */
+        namespace base64url {
+
+            /** Encoded, no padding, no line breaks. */
+            std::string encode(const std::string& s);
+
+            /** Decoded.  Padding is tolerated on input and is not required. */
+            std::string decode(const std::string& s);
+
+            /** As decode(s), and clears clean if anything was not as declared. */
+            std::string decode(const std::string& s, bool& clean);
+
+        }
+
+        /**
          * Quoted-printable, RFC 2045 section 6.7.
          *
          * Not RFC 2047's "Q" encoding, which is a different rule set on the

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -58,6 +58,7 @@ TESTS = \
 	net_imap_sasl_test \
 	net_http_test \
 	net_oauth_test \
+	net_oauth_authorize_test \
 	net_http_live_test \
 	net_imap_live_test \
 	sys_proxy_live_test \
@@ -159,6 +160,9 @@ net_imap_test_LDADD             = $(JNET_LA) $(JUTIL_LA)
 
 net_http_live_test_SOURCES      = net_http_live_test.cc
 net_http_live_test_LDADD        = $(JNET_LA) $(JUTIL_LA) $(JSYS_LA) $(OPENSSL_LIBS)
+
+net_oauth_authorize_test_SOURCES = net_oauth_authorize_test.cc
+net_oauth_authorize_test_LDADD   = $(JNET_LA) $(JUTIL_LA) $(JSYS_LA) $(OPENSSL_LIBS)
 
 net_oauth_test_SOURCES          = net_oauth_test.cc
 net_oauth_test_LDADD            = $(JNET_LA) $(JUTIL_LA) $(JSYS_LA) $(OPENSSL_LIBS)

--- a/tests/net_oauth_authorize_test.cc
+++ b/tests/net_oauth_authorize_test.cc
@@ -1,0 +1,457 @@
+/* -*- mode: C++ c-basic-offset: 4 -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// The authorization-code flow with PKCE: obtaining the first refresh token.
+//
+// Three things here are worth more than the rest.  RFC 7636 Appendix B
+// publishes a verifier and the challenge it must produce, so the PKCE
+// arithmetic is checked against the RFC rather than against itself.  The state
+// check is the client's only defence against someone else's authorization code
+// being planted on it, so it is tested by planting one.  And the whole flow
+// runs -- a thread standing in for the browser, jlib's own HTTP client fetching
+// the redirect, and a token endpoint that verifies the PKCE binding by hashing
+// the verifier it was sent and comparing it to the challenge it saw earlier.
+
+#include "httpserver.hh"
+
+#include <jlib/net/http.hh>
+#include <jlib/net/oauth.hh>
+
+#include <jlib/sys/socketstream.hh>
+
+#include <jlib/util/URL.hh>
+#include <jlib/util/util.hh>
+
+#include <iostream>
+#include <string>
+#include <thread>
+
+namespace oauth = jlib::net::oauth;
+namespace http = jlib::net::http;
+
+using jlib::util::URL;
+
+static int failures = 0;
+
+static void ok(const std::string& what, bool good, const std::string& detail = "") {
+    if(!good) ++failures;
+    std::cout << (good ? "  ok   " : "  FAIL ") << what;
+    if(!detail.empty()) std::cout << ": " << detail;
+    std::cout << "\n";
+}
+
+static void base64url_is_not_base64() {
+    std::cout << "\nbase64url is not base64:\n";
+
+    // The three characters that differ, chosen so all of them appear.
+    const std::string raw("\xfb\xff\xbe", 3);
+
+    ok("\"+\" becomes \"-\" and \"/\" becomes \"_\"",
+       jlib::util::base64::encode(raw) == "+/++" &&
+       jlib::util::base64url::encode(raw) == "-_--",
+       jlib::util::base64url::encode(raw));
+
+    // RFC 7636 4.2 requires the padding off.  A provider compares the whole
+    // string, so a challenge with "=" on the end does not match -- and the
+    // error it returns says "invalid_request", which explains nothing.
+    ok("and the padding comes off",
+       jlib::util::base64url::encode("a") == "YQ" &&
+       jlib::util::base64::encode("a") == "YQ==",
+       jlib::util::base64url::encode("a"));
+
+    // Lengths, so every remainder mod 3 is covered, and one with a NUL and a
+    // high byte in it.  Written with explicit lengths: as a const char* the
+    // binary case stops at the NUL and silently becomes the empty string,
+    // which is a test that passes without testing anything.
+    const std::string cases[] = {
+        std::string(""), std::string("a"), std::string("ab"),
+        std::string("abc"), std::string("abcd"),
+        std::string("\x00\x01\xfe\xff", 4),
+        std::string("any old bytes at all")
+    };
+
+    for(const std::string& in : cases) {
+        ok("round trip: " + std::to_string(in.length()) + " octets",
+           jlib::util::base64url::decode(jlib::util::base64url::encode(in)) == in);
+    }
+
+    // Other people's encoders emit padding.  Refusing it would be pedantry.
+    ok("padding on input is tolerated",
+       jlib::util::base64url::decode("YQ==") == "a" &&
+       jlib::util::base64url::decode("YQ") == "a");
+}
+
+static void pkce_against_the_rfc() {
+    std::cout << "\nPKCE, against RFC 7636's own vector:\n";
+
+    // Appendix B.  The one place in this branch where the arithmetic can be
+    // checked against the document instead of against itself.
+    const std::string verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
+    const std::string expected = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM";
+
+    const oauth::pkce p(verifier);
+
+    ok("the challenge is base64url(SHA-256(verifier)), unpadded",
+       p.challenge() == expected, p.challenge());
+
+    ok("and the verifier is kept as it was", p.verifier() == verifier);
+
+    // RFC 7636 4.2 also defines "plain", where the challenge is the verifier.
+    // RFC 8252 8.1 says a native application must use S256; a client that can
+    // be talked down to plain has no protection at all.
+    ok("the method is S256 and nothing else",
+       std::string(oauth::pkce::method()) == "S256");
+
+    const oauth::pkce fresh = oauth::pkce::generate();
+
+    // 32 random octets is 43 base64url characters, which is the minimum RFC
+    // 7636 4.1 allows.
+    ok("a generated verifier is the length the RFC requires",
+       fresh.verifier().length() == 43, std::to_string(fresh.verifier().length()));
+
+    ok("and two of them differ", oauth::pkce::generate().verifier() !=
+       oauth::pkce::generate().verifier());
+
+    // Checked rather than assumed, because a caller supplying its own is where
+    // it can be wrong -- and a provider's complaint about it is
+    // "invalid_request", which says nothing.
+    for(const char* bad : { "short", "has spaces in it and is quite long enough otherwise",
+                            "has+plus+signs+which+are+not+unreserved+and+is+long+enough" }) {
+        bool threw = false;
+
+        try { oauth::pkce p2(bad); }
+        catch(oauth::error&) { threw = true; }
+
+        ok(std::string("a verifier that is not RFC 7636 4.1's shape is refused: \"") +
+           std::string(bad).substr(0, 12) + "...\"", threw);
+    }
+}
+
+static void the_url_the_browser_gets() {
+    std::cout << "\nthe URL the browser is sent to:\n";
+
+    oauth::client c;
+
+    c.authorize_endpoint = "https://accounts.example.com/o/oauth2/v2/auth";
+    c.token_endpoint = "https://oauth2.example.com/token";
+    c.id = "jlib.apps.example.com";
+    c.scope = "https://mail.example.com/ offline_access";
+
+    const oauth::pkce p("dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk");
+
+    const std::string url = oauth::authorize_url(c, "http://127.0.0.1:9999/",
+                                                 "st-at-e", p);
+
+    URL parsed(url);
+
+    ok("it is the endpoint that was configured",
+       parsed.get_host() == "accounts.example.com" &&
+       parsed.get_path() == "/o/oauth2/v2/auth", url);
+
+    ok("response_type is code", parsed["response_type"] == "code");
+    ok("the client id is there", parsed["client_id"] == c.id);
+    ok("the redirect URI is there", parsed["redirect_uri"] == "http://127.0.0.1:9999/",
+       parsed["redirect_uri"]);
+    ok("the state is there", parsed["state"] == "st-at-e");
+    ok("the challenge is there, and not the verifier",
+       parsed["code_challenge"] == p.challenge() &&
+       url.find(p.verifier()) == std::string::npos);
+    ok("and the method is named", parsed["code_challenge_method"] == "S256");
+
+    // A space in a scope is a separator between scopes, and this encoding
+    // spells it "+".  Sent as "%20" some providers accept it and some do not.
+    ok("the scope's spaces are encoded",
+       url.find("scope=https%3A%2F%2Fmail.example.com%2F+offline_access") !=
+       std::string::npos, url);
+
+    // Not because a secret goes on this URL -- nothing here does -- but
+    // because whoever can rewrite it chooses where the user types a password.
+    c.authorize_endpoint = "http://accounts.example.com/auth";
+
+    bool threw = false;
+
+    try { oauth::authorize_url(c, "http://127.0.0.1:9999/", "s", p); }
+    catch(oauth::error&) { threw = true; }
+
+    ok("a plaintext authorization endpoint is refused", threw);
+
+    // RFC 6749 10.12 makes state the client's only defence here.
+    c.authorize_endpoint = "https://accounts.example.com/auth";
+    threw = false;
+
+    try { oauth::authorize_url(c, "http://127.0.0.1:9999/", "", p); }
+    catch(oauth::error&) { threw = true; }
+
+    ok("and so is a request with no state", threw);
+}
+
+/** Pretend to be a browser: GET the redirect URI with these parameters. */
+static void visit(const std::string& uri, const std::string& query) {
+    try {
+        jlib::util::URL u(uri);
+
+        u.set_qs(query);
+
+        http::get(u);
+    }
+    catch(std::exception&) {
+        // The receiver answers and closes; a client-side error here is not
+        // what any of these sections is asserting.
+    }
+}
+
+static void the_receiver() {
+    std::cout << "\nthe redirect receiver:\n";
+
+    {
+        oauth::redirect_receiver r;
+
+        ok("it binds loopback and says where",
+           r.redirect_uri() == "http://127.0.0.1:" + std::to_string(r.port()) + "/",
+           r.redirect_uri());
+
+        // The address literal, not "localhost".  RFC 8252 7.3: "localhost" is
+        // whatever the resolver says it is.
+        ok("by its address, not by a name",
+           r.redirect_uri().find("127.0.0.1") != std::string::npos);
+
+        std::thread browser([&r] {
+            visit(r.redirect_uri(), "code=THE-CODE&state=the-state");
+        });
+
+        const oauth::callback back = r.wait("the-state", 10);
+
+        browser.join();
+
+        ok("a code arrives", back.code == "THE-CODE", back.code);
+        ok("with its state", back.state == "the-state");
+        ok("and it is ok()", back.ok());
+    }
+
+    {
+        // The attack the state exists for.  Somebody else's authorization code
+        // planted on this client, which would then exchange it and attach the
+        // attacker's account to the user's session.  RFC 6749 10.12.
+        oauth::redirect_receiver r;
+
+        std::thread browser([&r] {
+            visit(r.redirect_uri(), "code=SOMEONE-ELSES&state=wrong");
+        });
+
+        bool threw = false;
+
+        try { r.wait("the-state", 10); }
+        catch(oauth::error&) { threw = true; }
+
+        browser.join();
+
+        ok("a callback whose state does not match is refused", threw);
+    }
+
+    {
+        // A user who clicked "no".  RFC 6749 4.1.2.1 -- an error rather than a
+        // code, and it arrives at the same URI.
+        oauth::redirect_receiver r;
+
+        std::thread browser([&r] {
+            visit(r.redirect_uri(),
+                  "error=access_denied&error_description=The+user+said+no&state=s");
+        });
+
+        bool denied_thrown = false;
+        std::string code;
+
+        try { r.wait("s", 10); }
+        catch(oauth::denied& d) { denied_thrown = true; code = d.code(); }
+        catch(oauth::error&) {}
+
+        browser.join();
+
+        ok("a refusal comes back as denied, with its reason", denied_thrown &&
+           code == "access_denied", code);
+    }
+
+    {
+        // Whatever connects to a loopback port is not necessarily a browser.
+        oauth::redirect_receiver r;
+
+        std::thread other([&r] {
+            try {
+                jlib::sys::socketstream s("127.0.0.1", r.port());
+
+                s << "PING\r\n\r\n" << std::flush;
+            }
+            catch(std::exception&) {}
+        });
+
+        bool threw = false;
+
+        try { r.wait("s", 10); }
+        catch(oauth::error&) { threw = true; }
+
+        other.join();
+
+        ok("something that is not a request line is refused", threw);
+    }
+
+    {
+        oauth::redirect_receiver r;
+
+        bool threw = false;
+
+        // Nothing connects.  The user closed the browser, or never saw it.
+        try { r.wait("s", 0.5); }
+        catch(oauth::error&) { threw = true; }
+
+        ok("and waiting for a browser that never comes gives up", threw);
+    }
+}
+
+static void the_whole_flow() {
+    std::cout << "\nthe whole flow, end to end:\n";
+
+    std::string seen_challenge;
+    std::string seen_verifier;
+    std::string seen_redirect;
+
+    // A token endpoint that checks the PKCE binding for real: it hashes the
+    // verifier it was sent and compares it to the challenge it saw in the
+    // authorization request.  That is what makes a stolen authorization code
+    // useless, so a test that did not check it would be testing the shape of
+    // the flow and not the point of it.
+    httpserver::server endpoint([&](const httpserver::request& r) {
+        const std::map<std::string, std::string> form =
+            URL::parse_qs(r.body);
+
+        std::map<std::string, std::string>::const_iterator v = form.find("code_verifier");
+
+        if(form.find("grant_type")->second != "authorization_code")
+            return httpserver::reply(400, "Bad Request",
+                                     "{\"error\":\"unsupported_grant_type\"}");
+
+        if(v == form.end())
+            return httpserver::reply(400, "Bad Request",
+                                     "{\"error\":\"invalid_request\"}");
+
+        seen_verifier = v->second;
+
+        std::string derived;
+
+        try { derived = oauth::pkce(v->second).challenge(); }
+        catch(std::exception&) {}
+
+        if(derived != seen_challenge)
+            return httpserver::reply(400, "Bad Request",
+                                     "{\"error\":\"invalid_grant\"}");
+
+        if(form.find("redirect_uri")->second != seen_redirect)
+            return httpserver::reply(400, "Bad Request",
+                                     "{\"error\":\"invalid_grant\"}");
+
+        return httpserver::reply(200, "OK",
+                                 "{\"access_token\":\"AT\",\"refresh_token\":\"RT\","
+                                 "\"expires_in\":3600}",
+                                 "Content-Type: application/json\r\n");
+    });
+
+    oauth::client c;
+
+    c.authorize_endpoint = "http://127.0.0.1:1/authorize";
+    c.token_endpoint = endpoint.url("/token");
+    c.id = "jlib-test";
+    c.allow_http = true;
+
+    std::thread browser;
+
+    try {
+        const oauth::token t = oauth::authorize(
+            c,
+            [&](const std::string& url) {
+                // Standing in for a browser.  It reads the authorization URL
+                // the way a provider would, and redirects back with a code.
+                URL u(url);
+
+                seen_challenge = u["code_challenge"];
+                seen_redirect = u["redirect_uri"];
+
+                const std::string state = u["state"];
+
+                browser = std::thread([u, state] {
+                    visit(u["redirect_uri"], "code=AUTH-CODE&state=" + state);
+                });
+            },
+            0, 10);
+
+        if(browser.joinable()) browser.join();
+
+        ok("a refresh token comes out the far end", t.refresh() == "RT", t.refresh());
+        ok("and an access token with it", t.access() == "AT", t.access());
+
+        // The two halves of PKCE really were connected: the challenge that went
+        // in the URL is the hash of the verifier that went to the token
+        // endpoint, and the endpoint above rejected anything else.
+        ok("the verifier hashes to the challenge that was sent",
+           !seen_verifier.empty() && !seen_challenge.empty() &&
+           oauth::pkce(seen_verifier).challenge() == seen_challenge);
+
+        ok("the challenge was sent, and the verifier was not, in the URL",
+           !seen_challenge.empty() && seen_challenge != seen_verifier);
+
+        // The redirect URI is not a place anything was sent -- it is a value
+        // the provider compares, and it has to be the same in both requests.
+        ok("the same redirect URI was used in both halves",
+           seen_redirect.find("http://127.0.0.1:") == 0, seen_redirect);
+    }
+    catch(std::exception& e) {
+        if(browser.joinable()) browser.join();
+
+        ok("a refresh token comes out the far end", false, e.what());
+    }
+}
+
+int main() {
+    std::cout << std::unitbuf;
+
+    base64url_is_not_base64();
+    pkce_against_the_rfc();
+    the_url_the_browser_gets();
+    the_receiver();
+    the_whole_flow();
+
+    // What a green run does not establish.
+    //
+    // That Google or Microsoft accepts any of it, and this is the branch where
+    // that gap is widest: the flow's other half is a provider's consent screen
+    // and a human, and neither is reachable from make check.  Worse, **neither
+    // provider will issue a client id at all without the user registering an
+    // application first** -- so this can be complete and correct and still not
+    // work for somebody who has not done that.  The "browser" here is a thread
+    // that reads the URL and redirects back, which is the happy path and
+    // nothing else.
+    //
+    // Nor TLS on either endpoint.  Both are plaintext loopback with allow_http
+    // set, which is what the code refuses by default.
+    //
+    // Nor what a real browser does with the page the receiver writes.  It is
+    // served, and no test looks at it rendered.
+    std::cout << "\n" << (failures ? "FAILED" : "PASSED") << ": " << failures
+              << " failure(s)\n";
+
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
# The authorization-code flow, with PKCE

The last branch of the HTTP/OAuth2 plan. The previous one could refresh a token
you already had; this obtains the first one, so jlib no longer needs a refresh
token to come from somewhere else.

Everything it needed already existed by the time it started: `sys::listener`
from the foundations branch, a `util::http` that reads any head rather than only
responses, a `URL` that parses a relative reference, and a token exchange that
is the same POST with different form fields. What is new is base64url, PKCE, and
eighty lines that receive one redirect.

## PKCE, checked against the RFC rather than against itself

The authorization code comes back over a **loopback HTTP redirect**, which is a
plain TCP port on localhost that any other program on the machine can race for.
PKCE is what makes stealing the code useless: the exchange that turns it into a
token also demands a verifier that never left this process.

RFC 7636 Appendix B publishes a verifier and the challenge it must produce, so
that is the assertion -- the one place in this branch where the arithmetic is
checked against the document instead of against itself.

**S256 only.** RFC 7636 4.2 also defines "plain", where the challenge *is* the
verifier, and RFC 8252 8.1 says a native application must use S256. A client
that can be talked down to plain by a server's say-so has no protection at all.

`RAND_bytes`, not `std::random_device` or `rand()`. This is the value that makes
a stolen code useless, so a predictable one is the same as none -- and OpenSSL is
already a hard dependency, where libsodium is optional and gated.

## base64url is its own namespace, and the padding is why

RFC 4648 5 is the same six-bit alphabet with `-` and `_` for `+` and `/`. RFC
7636 4.2 requires the challenge to have its `=` stripped, and a provider compares
the whole string -- so a padded challenge simply does not match, and the error
returned for it is `invalid_request`, which explains nothing.

Meanwhile the XOAUTH2 blob two files away is standard base64 **with** padding.
Two encodings differing in three characters, used within a few lines of each
other, is exactly what a bool argument gets wrong silently. Decoding tolerates
padding on input, because other people's encoders emit it and refusing would be
pedantry.

## A receiver, not a server, and the name is load-bearing

It binds one loopback port, accepts one connection, reads one request line,
writes one fixed page and stops. No routing, no second request, no keep-alive,
no configuration. Calling it a server is what turns eighty lines into eight
hundred.

- **127.0.0.1 explicitly, never INADDR_ANY.** What arrives is an authorization
  code, and a receiver reachable from the network receives it from the network.
- **The address literal, not "localhost"** -- RFC 8252 7.3, because "localhost"
  is whatever the resolver says it is and the resolver is not always ours.
- **Plaintext, which is correct.** 8.3 says a loopback redirect does not need
  TLS, and a self-signed certificate would only teach the user to click through
  a browser warning.
- **The state is checked before anything else is believed.** RFC 6749 10.12
  makes it the client's only defence against someone else's authorization code
  being planted on it, and the check is worthless after the code has been used.
  There is a test that plants one.
- **The page never contains the code.** A URL bar is shoulder-surfable and a
  page is saveable. Nothing logs or prints it either.
- The request line is read with the **grammar** -- `request-line` from RFC 9112,
  and the target through `URL::parse_reference`, which is exactly the relative
  reference that branch added. Not `find()` and offsets counted by hand.
- Bounded twice: a deadline on the read and a cap on the line. Whatever connects
  to a loopback port is not necessarily a browser.

`authorize()` ties it together and is **blocking on purpose**: the application
runs it on a thread, which is the house pattern -- `ASMailBox` and `ASImapBox`
are the precedent -- and anything else would need an event loop jlib does not
have. Opening the browser is a callback, because that is the application's
business: a desktop, a terminal printing the URL, or a test.

## Tests

`tests/net_oauth_authorize_test.cc`, five sections. The flow runs end to end
with a thread standing in for the browser and jlib's own HTTP client fetching
the redirect -- and the fake token endpoint **verifies the PKCE binding for
real**: it hashes the verifier it was sent and compares it to the challenge it
saw in the authorization request, rejecting anything else. A test that skipped
that would be testing the shape of the flow and not the point of it.

Also: a callback with the wrong state, a user who clicked "no" (RFC 6749
4.1.2.1, which arrives at the same URI), something that connects and is not a
browser, and a browser that never comes.

**One weakness found in my own test.** The base64url round trip listed its cases
as `const char*`, so `"\x00\x01\xfe\xff"` stopped at the NUL and silently became
the empty string -- the binary case, which is the only one that could have
failed, was not being tested. The cases carry explicit lengths now.

**What a green run does not establish**, and here the gap is widest of any
branch: the flow's other half is a provider's consent screen and a human, and
neither is reachable from `make check`. Worse, **neither Google nor Microsoft
will issue a client id without the user registering an application first** -- so
this can be complete and correct and still not work for somebody who has not
done that. The "browser" here is a thread that reads the URL and redirects back,
which is the happy path and nothing else. And no endpoint in any test is
`https://`; both are plaintext loopback with `allow_http` set, which is what the
code refuses by default.

## CLAUDE.md

Updated, since this finishes the arc: `sys` has an accepting end and resolves
with `getaddrinfo`, `util` has the HTTP message layer and two more pasted RFCs,
`net` has the client and OAuth2. The note on live tests now says why there are
two kinds of test server and why neither substitutes for the other. The three
issues the arc left open -- #112, #104, #105 -- are named.

macOS: 52 pass, 4 skip, 0 fail. Linux container: 56 pass, 1 skip, 0 fail.
