### PR TITLE
Job queue

### DIFF
--- a/jlib/sys/sync.hh
+++ b/jlib/sys/sync.hh
@@ -23,6 +23,7 @@
 
 #include <thread>
 #include <mutex>
+#include <concepts>
 #include <condition_variable>
 #include <fstream>
 #include <exception>
@@ -113,6 +114,37 @@ public:
     
     void wait(std::unique_lock<std::mutex>& lock, std::chrono::nanoseconds timeout) {
         m_cond.wait_for(lock, timeout);
+    }
+
+    /**
+     * Wait until the predicate holds.
+     *
+     * The form to reach for, and the one this wrapper was missing.  A bare
+     * wait() has to be written inside a loop -- against a spurious wakeup, and
+     * against a notification that arrived before the wait began -- and a caller
+     * who forgets gets a hang that reproduces once a week.  This cannot be got
+     * wrong: the condition is stated once, positively, and re-checked under the
+     * lock every time.
+     *
+     * Its absence was load-bearing.  media::Player wanted a predicate wait and
+     * used a raw std::condition_variable with its own std::mutex to get one,
+     * rather than a sync<T> (Player.hh:144, Player.cc:270); sys::job_queue
+     * wrote the loop out by hand.
+     *
+     * ## Why the constraint
+     *
+     * Without `requires std::predicate`, this overload swallows the timed one
+     * above.  wait(lock, milliseconds(5)) needs a converting constructor to
+     * reach std::chrono::nanoseconds -- a user-defined conversion -- while this
+     * template matches milliseconds exactly, and an exact template match beats
+     * a converting non-template.  So the duration would bind here and fail to
+     * compile inside, trying to call a duration.  The constraint excludes
+     * anything that is not callable, which puts the timed overload back.
+     */
+    template<typename Predicate>
+        requires std::predicate<Predicate>
+    void wait(std::unique_lock<std::mutex>& lock, Predicate pred) {
+        m_cond.wait(lock, std::move(pred));
     }
     
     void notify() {
@@ -253,14 +285,14 @@ protected:
             {
                 std::unique_lock<std::mutex> lock(m_queue);
 
-                // The predicate, written out, because sync<T>::wait has no
-                // overload that takes one.  It has to be a loop and it has to
-                // re-check under the lock: a worker that tested m_exit, was
-                // descheduled, and resumed after stop() had set the flag and
-                // notified would otherwise wait for a notification that has
-                // been and gone, and join() would never return.
-                while(!m_exit && m_queue().empty())
-                    m_queue.wait(lock);
+                // Re-checked under the lock, every time, which is what the
+                // predicate form guarantees: a worker that tested m_exit
+                // outside the lock and then waited would miss a stop() that
+                // landed in between -- a notification that has been and gone --
+                // and join() would never return.
+                m_queue.wait(lock, [this] {
+                    return m_exit || !m_queue().empty();
+                });
 
                 if(m_queue().empty()) return;        // stopped, nothing left
                 if(m_exit && !m_drain) return;       // stopped, abandoning
@@ -280,8 +312,6 @@ protected:
     void run(const std::function<void()>& job) {
         try {
             job();
-
-            return;
         }
         catch(std::exception& e) {
             // The handler is read under the lock, and only here: no data race
@@ -296,8 +326,6 @@ protected:
             }
 
             if(h) h(e);
-
-            return;
         }
         catch(...) {
             // Nothing to hand a handler that takes a std::exception&.

--- a/jlib/sys/sync.hh
+++ b/jlib/sys/sync.hh
@@ -169,11 +169,34 @@ protected:
  * What it is is a *job* queue: post a functor, and some thread in the pool
  * runs it.
  *
+ * ## A pool of none runs inline
+ *
+ * pool_size 0 is not a degenerate case, it is a mode: post() runs the job on
+ * the calling thread, then and there.  Everything else behaves the same --
+ * post() still swallows what a job throws and hands it to on_error(), stop()
+ * and join() still work, a job posted after stop() is still dropped -- so a
+ * caller can be written once and made synchronous or concurrent by one number.
+ *
+ * That is what it is for.  A server that would otherwise carry two code paths,
+ * one calling the handler inline and one dispatching it, carries neither: it
+ * always posts, and the size decides.
+ *
+ * Two consequences worth knowing.  A job that posts to its own inline queue
+ * *recurses* rather than queueing, so a job that posts itself will not stop.
+ * And with no pool nothing is ever queued, so stop(true) has nothing to drain.
+ *
+ * There is no default size, deliberately.  It was hardware_concurrency(), which
+ * is permitted to return 0 -- which used to mean a queue that accepted jobs and
+ * ran none, and would now mean a silently synchronous one.  Neither is a thing
+ * to arrive at by not choosing; a caller deriving the size from
+ * hardware_concurrency() should decide for itself what 0 means.
+ *
  * ## What it does not do
  *
- * No size(), no wait for idle, no priorities, no futures, no work stealing.  It
- * is twenty lines and its appeal is that it is twenty lines; anything that
- * wants one of those can ask for it then.
+ * No size(), no wait for idle, no priorities, no futures, no work stealing, no
+ * bound on how deep the queue may get.  It is twenty lines and its appeal is
+ * that it is twenty lines; anything that wants one of those can ask for it
+ * then.
  */
 class job_queue {
 public:
@@ -181,15 +204,12 @@ public:
     typedef std::function<void(const std::exception&)> error_handler;
 
     /**
-     * @param pool_size how many threads.  Clamped to at least one:
-     *                  hardware_concurrency() is permitted to return zero, and
-     *                  a pool with no threads accepts jobs and runs none.
+     * @param pool_size how many threads, or 0 to run each job on the thread
+     *                  that posts it.  No default: see the note above.
      */
-    job_queue(int pool_size = std::thread::hardware_concurrency()) {
+    explicit job_queue(int pool_size) {
         m_exit = false;
         m_drain = true;
-
-        if(pool_size < 1) pool_size = 1;
 
         for(int i = 0; i < pool_size; i++) {
             m_pool.push_back(std::thread([this](){ start(); }));
@@ -204,7 +224,15 @@ public:
     job_queue(const job_queue&) = delete;
     job_queue& operator=(const job_queue&) = delete;
 
-    /** Hand a job to the pool.  Ignored once the queue has been stopped. */
+    /**
+     * Hand a job to the pool, or run it here if there is no pool.
+     *
+     * Ignored once the queue has been stopped, either way.  And either way it
+     * does not throw what the job threw: an exception has nowhere to go from a
+     * worker thread, so run() catches it and on_error() gets it, and a caller
+     * whose behaviour changed with the pool size would defeat the point of
+     * being able to set that size to zero.
+     */
     void post(std::function<void()> job) {
         // Before the lock, deliberately: m_exit is atomic, so a stopped queue
         // is not worth contending a mutex to be told about.  It is an
@@ -212,6 +240,14 @@ public:
         // after this reads -- and under drain semantics that window is
         // harmless, because a job queued in it still runs.
         if(m_exit) return;
+
+        // m_pool is written once, in the constructor, and never touched again,
+        // so reading it here needs no lock.
+        if(m_pool.empty()) {
+            run(job);
+
+            return;
+        }
 
         std::unique_lock<std::mutex> lock(m_queue);
 

--- a/jlib/sys/sync.hh
+++ b/jlib/sys/sync.hh
@@ -30,6 +30,8 @@
 #include <queue>
 #include <atomic>
 #include <functional>
+#include <iostream>
+#include <vector>
 
 namespace jlib {
 namespace sys {
@@ -126,47 +128,194 @@ protected:
     mutable T m_val;
 };
 
-class queue {
+/**
+ * A pool of threads, and functors for them to run.
+ *
+ * Not a queue.  A queue that passes arbitrary objects between threads is
+ * sync<std::queue<T>>, which is right above this and which this is built out
+ * of -- so calling the wrapper "queue" as well named the wrong half of it.
+ * What it is is a *job* queue: post a functor, and some thread in the pool
+ * runs it.
+ *
+ * ## What it does not do
+ *
+ * No size(), no wait for idle, no priorities, no futures, no work stealing.  It
+ * is twenty lines and its appeal is that it is twenty lines; anything that
+ * wants one of those can ask for it then.
+ */
+class job_queue {
 public:
-    queue(int pool_size = std::thread::hardware_concurrency()) {
+    /** What to do with an exception a job let escape.  See on_error(). */
+    typedef std::function<void(const std::exception&)> error_handler;
+
+    /**
+     * @param pool_size how many threads.  Clamped to at least one:
+     *                  hardware_concurrency() is permitted to return zero, and
+     *                  a pool with no threads accepts jobs and runs none.
+     */
+    job_queue(int pool_size = std::thread::hardware_concurrency()) {
         m_exit = false;
-        
+        m_drain = true;
+
+        if(pool_size < 1) pool_size = 1;
+
         for(int i = 0; i < pool_size; i++) {
             m_pool.push_back(std::thread([this](){ start(); }));
         }
     }
 
-    ~queue() {
-        m_exit = true;
-        m_queue.notify_all();
-
-        for(auto& thread : m_pool) {
-            thread.join();
-        }
+    ~job_queue() {
+        stop();
+        join();
     }
-    
+
+    job_queue(const job_queue&) = delete;
+    job_queue& operator=(const job_queue&) = delete;
+
+    /** Hand a job to the pool.  Ignored once the queue has been stopped. */
     void post(std::function<void()> job) {
+        // Before the lock, deliberately: m_exit is atomic, so a stopped queue
+        // is not worth contending a mutex to be told about.  It is an
+        // optimisation and not a guarantee -- a stop() may land immediately
+        // after this reads -- and under drain semantics that window is
+        // harmless, because a job queued in it still runs.
+        if(m_exit) return;
+
         std::unique_lock<std::mutex> lock(m_queue);
-        m_queue().push(job);
+
+        m_queue().push(std::move(job));
         m_queue.notify();
     }
-    
-protected:
-    void start() {
-        while(!m_exit) {
+
+    /**
+     * What to do with an exception a job let escape.
+     *
+     * Runs on the worker's thread.  The default writes one line to std::cerr,
+     * built whole before it is written -- several workers reporting at once
+     * otherwise interleave in the middle of a message.
+     *
+     * There has to be one.  An exception escaping a thread function calls
+     * std::terminate, and it cannot be caught from outside: exceptions do not
+     * cross thread boundaries, so the catch has to be in the code that calls
+     * the job.  A pool that runs arbitrary functors will be handed one that
+     * throws eventually.
+     */
+    void on_error(error_handler h) {
+        std::unique_lock<std::mutex> lock(m_queue);
+
+        m_on_error = h;
+    }
+
+    /**
+     * Stop taking jobs and let the workers leave.
+     *
+     * @param drain run what is already queued first.  join() then means "every
+     *              job I posted has run", which is the useful guarantee -- and
+     *              the destructor calls this, so a queue going out of scope
+     *              does not silently discard work.  false leaves as soon as
+     *              the job in hand finishes.
+     *
+     * Idempotent, and safe from any thread including a job's own.  **Not a
+     * barrier**: jobs already running keep running, and join() is what waits
+     * for them.
+     *
+     * With drain set, a caller that goes on posting keeps the drain going.
+     * That is a caller's mistake and not something this defends against.
+     */
+    void stop(bool drain = true) {
+        {
+            // Both under the lock, so a worker that observes m_exit also
+            // observes the matching m_drain: they are read together in the
+            // predicate below, and two independent atomics give no such
+            // guarantee.  m_exit stays atomic all the same, because post()
+            // reads it without the lock.
             std::unique_lock<std::mutex> lock(m_queue);
-            if(!m_queue().empty()) {
-                m_queue().front()();
-                m_queue().pop();
-            } else {
-                m_queue.wait(lock);
-            }
+
+            m_drain = drain;
+            m_exit = true;
+        }
+
+        m_queue.notify_all();
+    }
+
+    /** Wait for every worker to leave.  Idempotent. */
+    void join() {
+        for(auto& thread : m_pool) {
+            if(thread.joinable()) thread.join();
         }
     }
-    
+
+protected:
+    void start() {
+        for(;;) {
+            std::function<void()> job;
+
+            {
+                std::unique_lock<std::mutex> lock(m_queue);
+
+                // The predicate, written out, because sync<T>::wait has no
+                // overload that takes one.  It has to be a loop and it has to
+                // re-check under the lock: a worker that tested m_exit, was
+                // descheduled, and resumed after stop() had set the flag and
+                // notified would otherwise wait for a notification that has
+                // been and gone, and join() would never return.
+                while(!m_exit && m_queue().empty())
+                    m_queue.wait(lock);
+
+                if(m_queue().empty()) return;        // stopped, nothing left
+                if(m_exit && !m_drain) return;       // stopped, abandoning
+
+                // Moved out under the lock so it can be called without one,
+                // which is the whole point.  Running it in here -- which is
+                // what this did -- made a pool of threads that took turns at
+                // one mutex, so exactly one job ran at a time.
+                job = std::move(m_queue().front());
+                m_queue().pop();
+            }
+
+            run(job);
+        }
+    }
+
+    void run(const std::function<void()>& job) {
+        try {
+            job();
+
+            return;
+        }
+        catch(std::exception& e) {
+            // The handler is read under the lock, and only here: no data race
+            // with on_error(), and no cost at all on the path where nothing
+            // throws.
+            error_handler h;
+
+            {
+                std::unique_lock<std::mutex> lock(m_queue);
+
+                h = m_on_error;
+            }
+
+            if(h) h(e);
+
+            return;
+        }
+        catch(...) {
+            // Nothing to hand a handler that takes a std::exception&.
+        }
+    }
+
     sync<std::queue<std::function<void()>>> m_queue;
     std::vector<std::thread> m_pool;
     std::atomic<bool> m_exit;
+    bool m_drain = true;                  // guarded by m_queue's mutex
+    error_handler m_on_error = default_error_handler;
+
+    static void default_error_handler(const std::exception& e) {
+        // One write of one whole string; several workers reporting at once
+        // otherwise interleave.
+        std::cerr << (std::string("jlib::sys::job_queue: a job threw: ") +
+                      e.what() + "\n") << std::flush;
+    }
 };
     
 }

--- a/jlib/sys/sync.hh
+++ b/jlib/sys/sync.hh
@@ -93,8 +93,15 @@ public:
     }
 
     void set(const_reference val) {
-        safe_set(m_val, val, m_lock);
-        notify_all();
+        // One critical section, covering the assignment *and* the notify.  See
+        // the note on notify() below: releasing first leaves a window in which
+        // a waiter can observe the new value, act on it, and destroy this
+        // object before the notify lands on it.
+        std::unique_lock<std::mutex> lock(m_lock);
+
+        m_val = val;
+
+        m_cond.notify_all();
     }
 
     reference ref() { return m_val; }
@@ -147,6 +154,38 @@ public:
         m_cond.wait(lock, std::move(pred));
     }
     
+    /**
+     * Wake one waiter, or all of them.
+     *
+     * ## Everything inside this class notifies with the lock held
+     *
+     * set() above does, and so does job_queue.  The reason is lifetime, not
+     * speed.  Notify after releasing the lock and there is a window in which a
+     * waiter can take the lock, see the condition it was waiting for, act on
+     * it, and destroy this object -- and then the notifier touches a dead
+     * condition variable.  It is the classic shape:
+     *
+     *     { lock; done = true; }
+     *     cv.notify_one();          // the waiter may already have deleted us
+     *
+     * Holding the lock across the notify makes that impossible, and a
+     * general-purpose primitive should be safe by construction rather than
+     * safe because its current callers happen to be arranged well.  Nothing in
+     * jlib can reach that window today; the point is that nothing using this
+     * later has to check.
+     *
+     * The cost is that a woken waiter may only get as far as blocking on the
+     * mutex the notifier still holds -- though an implementation is allowed to
+     * move it straight from this condition variable's queue onto the mutex's
+     * instead of scheduling it, so how much that costs is implementation
+     * dependent and nobody here has measured it.  For one waiter it is at most
+     * one thread either way.
+     *
+     * A caller that invokes this directly makes its own choice; jlib has one
+     * such place, media::Player, which notifies outside the lock and takes the
+     * lock and drops it first as a barrier -- aimed at a lost wakeup rather
+     * than at lifetime, and commented where it happens.
+     */
     void notify() {
         m_cond.notify_one();
     }
@@ -249,6 +288,8 @@ public:
             return;
         }
 
+        // Push and signal in one critical section; see the note on
+        // sync<T>::notify.
         std::unique_lock<std::mutex> lock(m_queue);
 
         m_queue().push(std::move(job));
@@ -301,9 +342,9 @@ public:
 
             m_drain = drain;
             m_exit = true;
-        }
 
-        m_queue.notify_all();
+            m_queue.notify_all();
+        }
     }
 
     /** Wait for every worker to leave.  Idempotent. */

--- a/tests/sys_sync_test.cc
+++ b/tests/sys_sync_test.cc
@@ -112,6 +112,50 @@ static void a_value_behind_a_mutex() {
     writer.join();
 
     ok("a waiter is woken by a set()", flag.get());
+
+    // The predicate form, which is the one to reach for: the condition is
+    // stated once, positively, and re-checked under the lock every time, so
+    // there is no loop to forget.
+    sys::sync<int> counter(0);
+
+    std::thread counting([&counter] {
+        for(int n = 1; n <= 3; n++) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+
+            counter.set(n);
+        }
+    });
+
+    {
+        std::unique_lock<std::mutex> lock(counter.mutex());
+
+        counter.wait(lock, [&counter] { return counter() == 3; });
+
+        ok("wait() with a predicate returns when it holds", counter() == 3,
+           std::to_string(counter()));
+    }
+
+    counting.join();
+
+    // And the timed overload still resolves, which is not a formality.  An
+    // unconstrained predicate template would swallow it: milliseconds needs a
+    // converting constructor to reach nanoseconds -- a user-defined conversion
+    // -- while the template matches it exactly, and an exact template match
+    // beats a converting non-template.  The call would bind to the predicate
+    // overload and fail to compile inside, trying to call a duration.  This
+    // line is what keeps the requires-clause from being tidied away.
+    {
+        sys::sync<int> quiet(0);
+
+        std::unique_lock<std::mutex> lock(quiet.mutex());
+
+        const auto start = std::chrono::steady_clock::now();
+
+        quiet.wait(lock, std::chrono::milliseconds(20));
+
+        ok("and a duration still picks the timed overload, not this one",
+           seconds_since(start) >= 0.01, std::to_string(seconds_since(start)) + "s");
+    }
 }
 
 static void jobs_run_on_more_than_one_thread() {
@@ -321,8 +365,8 @@ int main() {
     // still a wall-clock claim on a machine that may be busy.  A failure there
     // means look at the machine before looking at the code.
     //
-    // Not sync<T> in anger.  Two threads and one condition variable is the
-    // whole of what is exercised above; the ringbuffer test is where the
+    // Not sync<T> in anger.  A handful of threads and one condition variable
+    // is the whole of what is exercised above; the ringbuffer test is where the
     // memory-ordering questions in this library actually live, and it says the
     // same thing about itself.
     std::cout << "\n" << (failures ? "FAILED" : "PASSED") << ": " << failures

--- a/tests/sys_sync_test.cc
+++ b/tests/sys_sync_test.cc
@@ -1,6 +1,6 @@
 /* -*- mode: C++ c-basic-offset: 4 -*-
  *
- * Copyright (c) 2011 Joey Yandle <xoloki@gmail.com>
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,42 +17,316 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// sync<T>, and the job queue built out of one.
+//
+// This file used to construct a sync<int>, assign 1 to it, and exit -- which is
+// why the pool in the same header went years with a bug that made it a pool of
+// threads running one job at a time.  The assertion that matters below is the
+// one that counts how many jobs are in flight at once: it is the only one that
+// cannot pass merely because the code compiles.
+
 #include <jlib/sys/sync.hh>
 
+#include <atomic>
+#include <chrono>
 #include <iostream>
+#include <string>
+#include <thread>
+#include <vector>
 
-#include <cstdlib>
+// Qualified, never hoisted with a using-declaration.  "using jlib::sys::sync;"
+// at namespace scope collides with POSIX sync(2), which glibc drags in through
+// <thread>, and the error gcc gives for it -- "expected '(' after
+// template-argument-list" on the line below -- names neither <unistd.h> nor the
+// collision.  sys/signal.hh has the same note about ::signal, one name over.
+namespace sys = jlib::sys;
 
-int global_foo = 0;
+static int failures = 0;
 
-class Foo {
+static void ok(const std::string& what, bool good, const std::string& detail = "") {
+    if(!good) ++failures;
+    std::cout << (good ? "  ok   " : "  FAIL ") << what;
+    if(!detail.empty()) std::cout << ": " << detail;
+    std::cout << "\n";
+}
+
+static double seconds_since(std::chrono::steady_clock::time_point t) {
+    return std::chrono::duration<double>(std::chrono::steady_clock::now() - t).count();
+}
+
+/** Records the greatest number of jobs that were ever running at once. */
+class watcher {
 public:
-    virtual std::string foo() { return "foo"; }
-    std::string echo(std::string s) { return s; }
-    void set_global_foo(int s) { global_foo = s; }
-};
+    void enter() {
+        const int now = ++m_live;
 
-class Bar : public Foo {
-public:
-    virtual std::string foo() { return "bar"; }
-};
+        int seen = m_peak.load();
 
-int main(int argc, char** argv) {
-    using jlib::sys::sync;
-
-    sync<int> i(0);
-
-    if(i != 0) {
-        std::cerr << "error: incorrect value for sync: expected 0 got " << (int)i << std::endl;
-        exit(1);
+        while(now > seen && !m_peak.compare_exchange_weak(seen, now))
+            ;
     }
+
+    void leave() { m_live--; m_done++; }
+
+    int peak() const { return m_peak.load(); }
+    int done() const { return m_done.load(); }
+
+private:
+    std::atomic<int> m_live{0};
+    std::atomic<int> m_peak{0};
+    std::atomic<int> m_done{0};
+};
+
+static void a_value_behind_a_mutex() {
+    std::cout << "a value behind a mutex:\n";
+
+    sys::sync<int> i(0);
+
+    ok("it starts where it was put", i == 0, std::to_string(static_cast<int>(i)));
 
     i = 1;
 
-    if(i != 1) {
-        std::cerr << "error: incorrect value for sync: expected 1 got " << (int)i << std::endl;
-        exit(1);
+    ok("and holds what it is given", i == 1, std::to_string(static_cast<int>(i)));
+
+    i.set(2);
+
+    ok("set() and get() agree with the operators", i.get() == 2 && i == 2,
+       std::to_string(i.get()));
+
+    // A reader on another thread, woken by the writer.  wait() is what the job
+    // queue in the same header is built on.
+    sys::sync<bool> flag(false);
+
+    std::thread writer([&flag] {
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+        flag.set(true);
+    });
+
+    {
+        std::unique_lock<std::mutex> lock(flag.mutex());
+
+        while(!flag()) flag.wait(lock);
     }
 
-    exit(0);
+    writer.join();
+
+    ok("a waiter is woken by a set()", flag.get());
+}
+
+static void jobs_run_on_more_than_one_thread() {
+    std::cout << "\njobs run on more than one thread:\n";
+
+    // The headline.  Four workers, eight jobs of 100ms each.  Holding the lock
+    // while the job ran -- which is what this did -- makes the peak 1 and the
+    // whole thing take eight tenths of a second; releasing it first makes the
+    // peak up to four and the whole thing take about two.
+    watcher w;
+
+    const auto start = std::chrono::steady_clock::now();
+
+    {
+        sys::job_queue q(4);
+
+        for(int i = 0; i < 8; i++) {
+            q.post([&w] {
+                w.enter();
+                std::this_thread::sleep_for(std::chrono::milliseconds(100));
+                w.leave();
+            });
+        }
+
+        // The destructor drains and joins.
+    }
+
+    const double took = seconds_since(start);
+
+    ok("more than one job ran at once", w.peak() > 1,
+       "peak " + std::to_string(w.peak()));
+
+    ok("and never more than the pool", w.peak() <= 4,
+       "peak " + std::to_string(w.peak()));
+
+    // Written as a comparison rather than a number: a busy machine makes any
+    // absolute figure a lie, and this is the shape of the claim anyway.
+    ok("so it finished in less time than running them one at a time would take",
+       took < 0.8, std::to_string(took) + "s");
+
+    ok("every job ran", w.done() == 8, std::to_string(w.done()) + "/8");
+}
+
+static void the_destructor_drains() {
+    std::cout << "\nthe destructor drains:\n";
+
+    std::atomic<int> ran{0};
+
+    {
+        sys::job_queue q(2);
+
+        for(int i = 0; i < 20; i++) q.post([&ran] { ran++; });
+    }
+
+    // A queue going out of scope with work outstanding must not silently
+    // discard it -- ~job_queue() is stop() with drain, then join().
+    ok("everything posted before the queue went away had run", ran.load() == 20,
+       std::to_string(ran.load()) + "/20");
+}
+
+static void stopping_with_and_without_a_drain() {
+    std::cout << "\nstopping, with and without a drain:\n";
+
+    {
+        std::atomic<int> ran{0};
+
+        sys::job_queue q(2);
+
+        for(int i = 0; i < 20; i++) q.post([&ran] { ran++; });
+
+        q.stop();
+        q.join();
+
+        ok("stop() runs what was already queued", ran.load() == 20,
+           std::to_string(ran.load()) + "/20");
+    }
+
+    {
+        std::atomic<int> ran{0};
+
+        // One worker and slow jobs, so there is plenty still queued when the
+        // stop lands.
+        sys::job_queue q(1);
+
+        for(int i = 0; i < 20; i++) {
+            q.post([&ran] {
+                std::this_thread::sleep_for(std::chrono::milliseconds(20));
+                ran++;
+            });
+        }
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+        const auto start = std::chrono::steady_clock::now();
+
+        q.stop(false);
+        q.join();
+
+        const double took = seconds_since(start);
+
+        ok("stop(false) abandons what is left", ran.load() < 20,
+           std::to_string(ran.load()) + "/20");
+
+        // Bounded by the job in hand, not by everything queued: twenty of
+        // these would be four tenths of a second.
+        ok("and returns within one job", took < 0.2,
+           std::to_string(took) + "s");
+    }
+
+    {
+        sys::job_queue q(2);
+
+        std::atomic<int> ran{0};
+
+        q.stop();
+
+        // Ignored rather than queued: it would never run, and returning
+        // quietly having queued it would make that indistinguishable from
+        // having run it.
+        q.post([&ran] { ran++; });
+
+        q.join();
+
+        ok("a job posted after stop() is dropped", ran.load() == 0,
+           std::to_string(ran.load()));
+
+        // Both are idempotent, which the destructor relies on: it calls them
+        // again after this.
+        q.stop();
+        q.stop(false);
+        q.join();
+        q.join();
+
+        ok("and stop() and join() can be called twice", true);
+    }
+}
+
+static void a_job_that_throws() {
+    std::cout << "\na job that throws:\n";
+
+    // An exception escaping a thread function is std::terminate, and it cannot
+    // be caught from outside -- exceptions do not cross thread boundaries.  So
+    // the catch has to be where the job is called, and a pool that runs
+    // arbitrary functors will be handed a throwing one eventually.
+    std::atomic<int> reported{0};
+    std::atomic<int> after{0};
+
+    {
+        sys::job_queue q(2);
+
+        q.on_error([&reported](const std::exception&) { reported++; });
+
+        q.post([] { throw std::runtime_error("no"); });
+
+        // Give the throw a moment to land before the next job, so "the worker
+        // survived" is about the worker and not about the other one.
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+        for(int i = 0; i < 4; i++) q.post([&after] { after++; });
+    }
+
+    ok("the process is still here", true);
+    ok("the handler was told", reported.load() == 1,
+       std::to_string(reported.load()));
+    ok("and the pool went on taking jobs", after.load() == 4,
+       std::to_string(after.load()) + "/4");
+}
+
+static void a_pool_of_none_is_a_pool_of_one() {
+    std::cout << "\na pool of none is a pool of one:\n";
+
+    // std::thread::hardware_concurrency() is permitted to return 0, and it is
+    // the default argument -- so a queue that accepted jobs and ran none was
+    // one unlucky platform away.
+    std::atomic<int> ran{0};
+
+    {
+        sys::job_queue q(0);
+
+        for(int i = 0; i < 5; i++) q.post([&ran] { ran++; });
+    }
+
+    ok("jobs still run", ran.load() == 5, std::to_string(ran.load()) + "/5");
+}
+
+int main() {
+    std::cout << std::unitbuf;
+
+    a_value_behind_a_mutex();
+    jobs_run_on_more_than_one_thread();
+    the_destructor_drains();
+    stopping_with_and_without_a_drain();
+    a_job_that_throws();
+    a_pool_of_none_is_a_pool_of_one();
+
+    // What a green run does not establish.
+    //
+    // Not the absence of the lost wakeup this fixed.  A worker used to test
+    // m_exit outside the lock and then wait, so a stop() landing in between
+    // was a notification it never saw and a join() that never returned -- a
+    // window a few instructions wide.  What the predicate loop buys is that
+    // the race cannot happen; no timing test can show it gone, and one that
+    // claimed to would be worse than this paragraph.
+    //
+    // Not the timings.  "Peak greater than one" is robust and is the real
+    // assertion; "finished faster than serial would" has a wide margin and is
+    // still a wall-clock claim on a machine that may be busy.  A failure there
+    // means look at the machine before looking at the code.
+    //
+    // Not sync<T> in anger.  Two threads and one condition variable is the
+    // whole of what is exercised above; the ringbuffer test is where the
+    // memory-ordering questions in this library actually live, and it says the
+    // same thing about itself.
+    std::cout << "\n" << (failures ? "FAILED" : "PASSED") << ": " << failures
+              << " failure(s)\n";
+
+    return failures ? 1 : 0;
 }

--- a/tests/sys_sync_test.cc
+++ b/tests/sys_sync_test.cc
@@ -324,21 +324,77 @@ static void a_job_that_throws() {
        std::to_string(after.load()) + "/4");
 }
 
-static void a_pool_of_none_is_a_pool_of_one() {
-    std::cout << "\na pool of none is a pool of one:\n";
+static void a_pool_of_none_runs_inline() {
+    std::cout << "\na pool of none runs inline:\n";
 
-    // std::thread::hardware_concurrency() is permitted to return 0, and it is
-    // the default argument -- so a queue that accepted jobs and ran none was
-    // one unlucky platform away.
+    // Not a degenerate case but a mode: with no pool, post() runs the job on
+    // the calling thread.  Which is the point -- a caller that always posts can
+    // be made synchronous or concurrent by one number, and does not carry two
+    // code paths to choose between.
     std::atomic<int> ran{0};
+    std::thread::id where;
 
     {
         sys::job_queue q(0);
 
-        for(int i = 0; i < 5; i++) q.post([&ran] { ran++; });
+        for(int i = 0; i < 5; i++) {
+            q.post([&ran, &where] {
+                where = std::this_thread::get_id();
+                ran++;
+            });
+        }
+
+        // Already, before anything is stopped or joined: post() ran it.
+        ok("the job has run by the time post() returns", ran.load() == 5,
+           std::to_string(ran.load()) + "/5");
+
+        ok("and it ran on the thread that posted it",
+           where == std::this_thread::get_id());
     }
 
-    ok("jobs still run", ran.load() == 5, std::to_string(ran.load()) + "/5");
+    // The same job on a pool runs somewhere else, which is the contrast that
+    // makes the assertion above mean something.
+    std::thread::id elsewhere;
+
+    {
+        sys::job_queue q(1);
+
+        q.post([&elsewhere] { elsewhere = std::this_thread::get_id(); });
+    }
+
+    ok("where a pool of one does not", elsewhere != std::this_thread::get_id());
+
+    // Everything else is the same, which is what lets a caller ignore the
+    // difference: a job that throws is still caught and handed to on_error,
+    // and post() does not throw it at whoever called.
+    std::atomic<int> reported{0};
+    bool post_threw = false;
+
+    {
+        sys::job_queue q(0);
+
+        q.on_error([&reported](const std::exception&) { reported++; });
+
+        try { q.post([] { throw std::runtime_error("no"); }); }
+        catch(...) { post_threw = true; }
+    }
+
+    ok("a throwing job is caught inline too", reported.load() == 1,
+       std::to_string(reported.load()));
+    ok("and post() does not throw it at the caller", !post_threw);
+
+    // And a stopped queue drops the job rather than running it here.
+    std::atomic<int> after{0};
+
+    {
+        sys::job_queue q(0);
+
+        q.stop();
+        q.post([&after] { after++; });
+    }
+
+    ok("a job posted after stop() is dropped, pool or no pool",
+       after.load() == 0, std::to_string(after.load()));
 }
 
 int main() {
@@ -349,7 +405,7 @@ int main() {
     the_destructor_drains();
     stopping_with_and_without_a_drain();
     a_job_that_throws();
-    a_pool_of_none_is_a_pool_of_one();
+    a_pool_of_none_runs_inline();
 
     // What a green run does not establish.
     //


### PR DESCRIPTION
# `sys::queue` becomes `sys::job_queue`, and works

Closes #115.

## The name was wrong, and the name is why the bug survived

It is not a queue. A queue that passes arbitrary objects between threads is
`sync<std::queue<T>>`, which is directly above it in the same header — and
which this class *contains*. Calling the wrapper `queue` as well named the
wrong half of it. What it is is a **job queue**: post a functor, and some
thread in the pool runs it.

Nothing in the tree called it, and `tests/sys_sync_test.cc` was 58 lines that
constructed a `sync<int>`, assigned 1 to it and exited — so the pool had never
been exercised by anything at all. The rename is free: no call sites to migrate,
no compatibility alias worth keeping.

## The bug

`start()` ran the job while still holding the queue's mutex:

```cpp
std::unique_lock<std::mutex> lock(m_queue);
if(!m_queue().empty()) {
    m_queue().front()();     // <-- runs holding the lock
    m_queue().pop();
}
```

So `pool_size` threads took turns at one mutex and exactly one job ran at a
time. A pool of threads with no parallelism.

**Measured, by putting it back.** Four workers, eight jobs of 100 ms:

```
under the lock:   peak 1, 0.85s
released first:   peak 4, 0.21s
```

Popping before running rather than after falls out of the fix — the job has to
be moved out under the lock so it can be called without one.

## `stop(bool drain = true)` and `join()`

```cpp
void stop(bool drain = true);   // stop taking jobs, let the workers leave
void join();                    // wait for them
~job_queue() { stop(); join(); }
```

`drain` runs what is already queued first, so `join()` means "every job I posted
has run" — and since the destructor calls it, a queue going out of scope does
not silently discard work. `stop(false)` leaves as soon as the job in hand
finishes, bounded by one job rather than by everything queued: 0.02 s against
the 0.4 s that draining twenty would have taken.

`stop()` sets **both flags under the lock**. A worker that observes `m_exit`
must observe the matching `m_drain` — they are read together in the predicate —
and two independent atomics give no such guarantee. `m_exit` stays
`std::atomic<bool>` anyway, because `post()` reads it *without* the lock: a
stopped queue is not worth contending a mutex to be told about.

**The wait had to become a predicate, and that is part of `stop()` rather than a
separate fix.** A worker used to test `m_exit` outside the lock and then wait, so
a `stop()` landing in between was a notification it never saw and a `join()` that
never returned. Without it, `stop()` does not do what it says.

## `pool_size == 0` is a mode, not a mistake

With no pool, `post()` runs the job on the calling thread. Everything else is
unchanged — a job that throws is still caught and handed to `on_error()`,
`post()` still does not throw it at the caller, a job posted after `stop()` is
still dropped — so a caller can be written once and made synchronous or
concurrent by one number. That is what it is for: something like `sys::server`,
which would otherwise carry one path calling its handler inline and another
dispatching it, carries neither.

Which is why there is no clamp and **no default size**. It used to be
`hardware_concurrency()`, which is permitted to return 0 — that meant a queue
accepting jobs and running none, and would now mean a silently synchronous one.
Neither is a thing to arrive at by not choosing.

Two consequences in the header: a job that posts to its own inline queue
*recurses* rather than queueing, and with no pool nothing is ever queued, so
`stop(true)` has nothing to drain.

## The predicate wait `sync<T>` was missing

`job_queue` first wrote its wait out as a loop, because `sync<T>` exposed only
`wait(lock)` and `wait(lock, timeout)` — the two forms that are easy to misuse —
and not `wait(lock, predicate)`, the one that cannot be got wrong.

**Its absence was load-bearing.** `media::Player` wanted a predicate wait and
used a raw `std::condition_variable` with its own `std::mutex` to get one
(`Player.hh:144`, `Player.cc:270`) rather than the house wrapper.

So the loop becomes what it always meant:

```cpp
m_queue.wait(lock, [this] { return m_exit || !m_queue().empty(); });
```

### The wrinkle, which is why this is more than three lines

Added naively, the predicate overload **swallows the timed one**.
`wait(lock, milliseconds(5))` needs a converting constructor to reach
`std::chrono::nanoseconds` — a user-defined conversion — while an unconstrained
template matches `milliseconds` exactly, and an exact template match beats a
converting non-template. The duration binds to the predicate overload and fails
inside. Verified by removing the constraint:

```
error: type 'std::chrono::duration<long long, std::ratio<1, 1000>>'
       does not provide a call operator
```

So it carries `requires std::predicate<Predicate>`, which excludes anything not
callable and puts the timed overload back. Nothing calls that overload today,
which is exactly why the trap was worth not laying.

## Notifying with the lock held, throughout

`sync<T>::set()` notified after releasing the lock; `job_queue` did it both ways
in the same class. All three hold the lock across the notify now.

The reason is lifetime, not speed. Notify after releasing and there is a window
in which a waiter can take the lock, see the condition it was waiting for, act
on it, and destroy the object — and then the notifier touches a dead condition
variable:

```cpp
{ lock; done = true; }
cv.notify_one();          // the waiter may already have deleted us
```

`sync<T>::set()` is exactly that shape, and it is a general-purpose signal in a
library that does not get to audit its future callers. **Nothing in jlib can
reach that window today** — a `job_queue`'s workers cannot destroy the queue,
and every notifier here outlives its waiters by construction. The point is that
nothing written later has to check.

The cost is that a woken waiter may only get as far as blocking on the mutex the
notifier still holds, though an implementation is allowed to move it straight
onto the mutex's queue rather than scheduling it — implementation-dependent, and
unmeasured here. For one waiter it is at most one thread either way.

A survey while doing this: the only other `std::condition_variable` in the tree
is `media::Player`'s, which notifies outside the lock and takes-and-drops the
lock first as a barrier — aimed at a lost wakeup rather than at lifetime, and
already commented where it happens. It keeps its shape. The two notifies in
`PortAudioSink` are `std::atomic::notify_one/all`, a different mechanism with no
mutex involved at all.

## A job that throws no longer takes the process with it

An exception escaping a thread function is `std::terminate`, and it cannot be
caught from outside — exceptions do not cross thread boundaries, so the `catch`
has to be where the job is called. There is an `on_error` handler, read under
the lock *only in the catch*, so there is no data race with `on_error()` and no
cost at all on the path where nothing throws.

`post()` also moves the `std::function` where it used to copy it.

## Tests

`tests/sys_sync_test.cc` rewritten in the house style. The assertion that
matters is **peak concurrency greater than one** — the only one here that cannot
pass merely because the code compiles, and the one the numbers above come from.
Also: the destructor drains, `stop()` drains, `stop(false)` abandons and returns
within one job, a job posted after `stop()` is dropped, `stop()` and `join()` are
idempotent, and a throwing job is reported while the pool goes on taking jobs.

Inline mode is tested by asserting *where* the job ran, not merely that it did:
`std::this_thread::get_id()` inside the job equals the poster's with
`job_queue(0)` and differs with `job_queue(1)`. The second half is what makes
the first mean anything.

Both halves of the predicate overload are pinned: a wait that returns when its
condition holds, and a `wait(lock, milliseconds(20))` that still picks the timed
overload. The second is a **compile-time** guard — it is what stops the
requires-clause being tidied away as noise.

**One thing found by the container.** Hoisting the name with
`using jlib::sys::sync;` at namespace scope collides with POSIX `sync(2)`, which
glibc drags in through `<thread>` — and gcc reports it as *"expected '(' after
template-argument-list"*, naming neither `<unistd.h>` nor the collision. The old
test only escaped it by putting the `using` inside `main()`. It is qualified now,
with a comment; `sys/signal.hh` has the same note about `::signal`, one name over.

**What a green run does not establish**, and it is written into the test: the
absence of the lost wakeup. That window is a few instructions wide, and no
timing test can show it gone. What the predicate form buys is that the race
cannot happen; a test claiming to prove it absent would be worse than the
paragraph saying so.

## Not changed

`media::Player` keeps its raw condition variable. Converting it to a `sync<T>`
is a real refactor with its own history (#36) and does not belong here — but it
is now possible, which it was not before.

macOS: 52 pass, 4 skip, 0 fail. Linux container: 56 pass, 1 skip, 0 fail — peak
4 and 0.21 s on both.
