### PR TITLE
Basic server implementation using job_queue with optional TLS support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,10 +17,10 @@ Each subdirectory of `jlib/` is one automake-built libtool library named
 
 | Dir | Library | What it is |
 | --- | --- | --- |
-| `jlib/sys` | `libjsys` | The foundation. iostream-based wrappers over OS facilities: `socketstream`, `sslstream`/`tlsstream`, `proxystream`, `sslproxystream`, `serialstream`, `pstream` (subprocess), `tfstream` (temp file), and `listener` — bind/listen/accept, the accepting end jlib did without for twenty-six years. Sockets resolve with `getaddrinfo` (so IPv6 works and two threads no longer share `gethostbyname`'s static buffer), take a connect deadline, and can bound a read; `basic_socketbuf` adopts an accepted descriptor with the `sys::adopt` tag. `run(argv, out, err)` executes a program with no shell involved — reach for it rather than `shell()`, which hands its argument to `/bin/sh`. Plus `Servent`/`ASServent` (threaded worker + command queue), `sync<T>` (mutex-wrapped value, C++11), `ringbuffer<T>` (lock-free, one producer and one consumer, written for the audio callback), `pipe`, `Directory`, `joystick`, `Object` (a polymorphic base), `signal<R(Args...)>`. |
-| `jlib/util` | `libjutil` | Two halves. The **parsing** half is the 2026 work: `abnf.hh` is a parser-combinator core with an RFC 5234 text front end on top (`compile()` reads an RFC's grammar as it stands), and the grammars themselves are pasted into headers — `rfc5322.hh` (3.2 lexical tokens, 3.3 date-time), `rfc2045.hh`, `rfc2047.hh`, `rfc3986.hh`, and `rfc9110.hh`/`rfc9112.hh` (HTTP, pasted whole) — with `content_type`, `encoded_word`, `URL`, `Date`, `xml` and `http` reading them. `http.hh` is the HTTP *message* layer — a status line, a field section, and how the body after them is framed — and it lives here rather than in `net` because `sys/proxystream.hh` reads the answer to CONNECT with it and `sys` may not include `net`. The **grab bag** is the rest: `util.hh` (tokenize, trim, chop, base64/qp/URI codecs, byte `get`/`set`), `Regex` (POSIX `regex.h`, one live caller left), `Headers` (MIME header folding), `MimeType`, `Timer`, `json.hh` (a facade over json-c). |
+| `jlib/sys` | `libjsys` | The foundation. iostream-based wrappers over OS facilities: `socketstream`, `sslstream`/`tlsstream`, `proxystream`, `sslproxystream`, `serialstream`, `pstream` (subprocess), `tfstream` (temp file), and the accepting end jlib did without for twenty-six years: `listener` (bind/listen/accept, and who connected), `tls_context` (a refcounted `SSL_CTX`, so a server reads its certificate once rather than per connection), and `server` — accept, optionally secure, hand each connection to a handler as a `socketstream&`, dispatching through a `job_queue` so that serial and threaded are one code path and a number. `basic_tlsbuf` answers a handshake as well as starting one, so `sslstream` works in both directions. Sockets resolve with `getaddrinfo` (so IPv6 works and two threads no longer share `gethostbyname`'s static buffer), take a connect deadline, and can bound a read; `basic_socketbuf` adopts an accepted descriptor with the `sys::adopt` tag. `run(argv, out, err)` executes a program with no shell involved — reach for it rather than `shell()`, which hands its argument to `/bin/sh`. Plus `Servent`/`ASServent` (threaded worker + command queue), `sync<T>` (mutex-wrapped value) and the `job_queue` built on one — post a functor, and either a pool thread runs it or, with no pool, the thread that posted it does, `ringbuffer<T>` (lock-free, one producer and one consumer, written for the audio callback), `pipe`, `Directory`, `joystick`, `Object` (a polymorphic base), `signal<R(Args...)>`. |
+| `jlib/util` | `libjutil` | Two halves. The **parsing** half is the 2026 work: `abnf.hh` is a parser-combinator core with an RFC 5234 text front end on top (`compile()` reads an RFC's grammar as it stands), and the grammars themselves are pasted into headers — `rfc5322.hh` (3.2 lexical tokens, 3.3 date-time), `rfc2045.hh`, `rfc2047.hh`, `rfc3986.hh`, and `rfc9110.hh`/`rfc9112.hh` (HTTP, pasted whole) — with `content_type`, `encoded_word`, `URL`, `Date`, `xml` and `http` reading them. `http.hh` is the HTTP *message* layer — a request or a status line, a field section, and how the body after them is framed — and it lives here rather than in `net` because `sys/proxystream.hh` reads the answer to CONNECT with it and `sys` may not include `net`. The **grab bag** is the rest: `util.hh` (tokenize, trim, chop, base64/qp/URI codecs, byte `get`/`set`), `Regex` (POSIX `regex.h`, one live caller left), `Headers` (MIME header folding), `MimeType`, `Timer`, `json.hh` (a facade over json-c). |
 | `jlib/crypt` | `libjcrypt` | `crypt.hh` wraps GPGME (OpenPGP encrypt/sign/verify). The `curve`/`schnorr`/`groth` trio is the recent work: ristretto255 `Scalar`/`Point`/`Commitment` over libsodium, Schnorr proofs (single, double, `GeneralProof<N>`), and Groth binary/zero-argument proofs. Built only when libsodium *with* ristretto headers is present. |
-| `jlib/net` | `libjnet` | Email client stack: `Email` (MIME), `MailBox`/`MBox`/`Imap4Box`, `Pop3`, `Imap4`, `MailFolder`, plus `AS*` async variants layered on `sys::ASServent`. The protocol grammars live here — `rfc5322.hh` (addresses, appended to util's lexical block) read by `address.{hh,cc}`, and `rfc3501.hh` (IMAP responses) read by `imap_response.{hh,cc}`. `imap::read()` follows literals, which is why a response is not a line; `imap::quote()` writes command arguments. `http.{hh,cc}` is the client — deliberately narrow, and the header says so — and `oauth.{hh,cc}` is OAuth2: the refresh grant, the authorization-code grant with PKCE, a loopback `redirect_receiver`, and the XOAUTH2 message that carries a token to IMAP. |
+| `jlib/net` | `libjnet` | Email client stack: `Email` (MIME), `MailBox`/`MBox`/`Imap4Box`, `Pop3`, `Imap4`, `MailFolder`, plus `AS*` async variants layered on `sys::ASServent`. The protocol grammars live here — `rfc5322.hh` (addresses, appended to util's lexical block) read by `address.{hh,cc}`, and `rfc3501.hh` (IMAP responses) read by `imap_response.{hh,cc}`. `imap::read()` follows literals, which is why a response is not a line; `imap::quote()` writes command arguments. `http.{hh,cc}` is the client and `http_server.{hh,cc}` the server, both deliberately narrow and both saying so; `oauth.{hh,cc}` is OAuth2: the refresh grant, the authorization-code grant with PKCE, a loopback `redirect_receiver`, and the XOAUTH2 message that carries a token to IMAP. |
 | `jlib/media` | `libjmedia` | Audio via PortAudio, driven from its **callback**: `write()` fills a `sys::ringbuffer` and the device's callback drains it, so nothing in the path sleeps or polls. `AudioSink` is the device interface and `PortAudioSink` the implementation; `Player` (a `Servent`) runs a feeder thread so transport commands never wait on the device. Plus `AudioFile`/`WavFile`, `PlayList`, and streambuf-based `datastream`/`wavstream`/`notestream`/`audiofilestream`. `Type.hh` is a template-specialization table over PCM sample formats. `Dsp` is the retired OSS backend, kept but not built. |
 | `jlib/math` | `libjmath` | Header-only despite being a `lib_LTLIBRARIES` (its `_SOURCES` are all `.hh`). `matrix`, `vertex`, `tensor`, `buffer`, `polynomial` (templated on a Power type so it can hold curve `Scalar`s), and `Plot<T>` — the abstract plotting base, with `projection_mode` for perspective, orthographic or mixed. `object<T>` holds index-based topology — vertices, edges, and 2-faces built lazily — with `cuboid`, `pyramoid`, `spheroid`, `staroid` and `torus` (a flat k-torus in n dimensions; equal radii and k=2 is the Clifford torus). |
 | `jlib/x` | `libjx` | Raw Xlib: `Display`, `Window`, and an X11 `Plot`. |
@@ -153,6 +153,32 @@ not: addresses (RFC 5322), MIME headers (2045/2047/2231), URLs (3986), dates
 clean-room along the way, which removed the last copyright the author did not
 hold and **let the whole library relicense from GPL v2+ to Apache 2.0**.
 
+jlib serves as well as connects now. `sys::server` accepts a connection and
+hands it to a handler as a stream, plain or TLS; `net::http::server` reads a
+request against the same RFC 9112 grammar the client's responses go through. It
+is a server for a loopback OAuth2 redirect and a test harness, **not for a
+public port**, and both headers say so — the way a narrow thing becomes a broad
+one is by nobody writing down that it was meant to be narrow. An event-driven
+design belongs with #4; what had to survive that change is the handler contract,
+which is why `run()` is a thin loop over `serve_one()` rather than the reverse.
+
+`sys::server` owns no threads of its own. `job_queue(0)` runs a job on the
+thread that posts it and `job_queue(N)` runs it on a pool, with the same
+semantics either way, so the server posts and the number decides — where an
+earlier draft carried one branch calling the handler inline and another
+dispatching it, with a live count, a mutex and a condition variable to go with
+them. What it does still own is admission control: the queue is a place
+connections can pile up as held descriptors, so the accept loop waits on the
+queue's depth *before* it polls, and the overflow stays in the kernel's listen
+backlog where a connection is supposed to wait.
+
+That work paid for itself immediately in deletions: `tests/httpserver.hh` lost
+its hand-rolled `SSL_accept`, its own descriptor ownership and its byte-at-a-time
+head reader, `sys_tls_sigpipe_test` lost twenty lines of raw OpenSSL, and
+`oauth::redirect_receiver` stopped parsing a request line by hand. All three
+kept passing unchanged, which is what makes it a de-duplication rather than a
+rewrite.
+
 The `*_live_test` programs start a real server — Dovecot, tinyproxy, nginx — and
 drive jlib against it. They exist because a `std::istringstream` produces only
 the responses somebody thought of, and so does an in-process server you wrote
@@ -164,11 +190,10 @@ framing, a challenge that never ends — which no real server will produce on
 request. Both kinds are needed and neither substitutes for the other.
 
 Remaining work is tracked in GitHub issues; the phase labels are historical now.
-The HTTP arc left three of its own: #112 (`jlib::sys` can be the client end of a
-TLS connection and not the server end, so two tests hand-roll `SSL_accept`),
-#104 (proxy authentication — and `rfc9110.hh` already records that
-`credentials`/`challenge` need reordering under ordered choice before it can
-work) and #105 (SOCKS5). Otherwise what is left is the graphics chain that would let one `HyperPlot` serve both
+The HTTP arc left #104 (proxy authentication — and `rfc9110.hh` already records
+that `credentials`/`challenge` need reordering under ordered choice before it
+can work) and #105 (SOCKS5); the server work added #116 (`ASServent::reset()` leaks its worker
+thread). Otherwise what is left is the graphics chain that would let one `HyperPlot` serve both
 apps (#20 → #24 → #28), tessellation and face enumeration for the remaining
 shapes (#31, #35), two `math` bugs (#53, and #76 — `vertex` and `matrix` share
 storage when copied but deep-copy when assigned, which is why `jhypermusic`

--- a/jlib/net/Makefile.am
+++ b/jlib/net/Makefile.am
@@ -4,7 +4,7 @@ lib_LTLIBRARIES = libjnet.la
 libjnet_la_SOURCES = Email.cc MailBox.cc Imap4Box.cc Pop3.cc MBox.cc \
                      Imap4.cc Imap4Fetch.cc net.cc MFolder.cc Imap4Folder.cc \
                      MailFolder.cc ASMailBox.cc ASImapBox.cc ASMBox.cc \
-                     address.cc imap_response.cc http.cc oauth.cc
+                     address.cc imap_response.cc http.cc http_server.cc oauth.cc
 libjnet_la_LDFLAGS = -version-info $(LIBJ_SO_VERSION) -release $(JLIB_RELEASE) -no-undefined
 libjnet_la_LIBADD = $(top_builddir)/jlib/sys/libjsys.la \
                     $(top_builddir)/jlib/util/libjutil.la \
@@ -16,4 +16,4 @@ libjnetinclude_HEADERS = Imap4Box.hh Pop3.hh MBox.hh Email.hh \
                          Imap4.hh Imap4Fetch.hh net.hh MFolder.hh \
                          Imap4Folder.hh MailBox.hh MailFetch.hh MailFolder.hh \
                          ASMailBox.hh ASImapBox.hh ASMBox.hh address.hh rfc5322.hh \
-                         imap_response.hh rfc3501.hh http.hh oauth.hh
+                         imap_response.hh rfc3501.hh http.hh http_server.hh oauth.hh

--- a/jlib/net/http.hh
+++ b/jlib/net/http.hh
@@ -58,6 +58,7 @@ namespace http {
 using jlib::util::http::error;
 using jlib::util::http::fields;
 using jlib::util::http::framing;
+using jlib::util::http::Request;
 using jlib::util::http::Response;
 
 /** How to make a request. */

--- a/jlib/net/http_server.cc
+++ b/jlib/net/http_server.cc
@@ -1,0 +1,320 @@
+/* -*- mode: C++ c-basic-offset: 4 -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <jlib/net/http_server.hh>
+
+#include <jlib/util/URL.hh>
+#include <jlib/util/util.hh>
+
+#include <ctime>
+#include <sstream>
+
+namespace jlib {
+namespace net {
+namespace http {
+
+namespace {
+
+    /** RFC 9110 5.6.7's IMF-fixdate, which is fixed-format and never localised. */
+    std::string http_date() {
+        static const char* const DAY[] = { "Sun", "Mon", "Tue", "Wed", "Thu",
+                                           "Fri", "Sat" };
+        static const char* const MONTH[] = { "Jan", "Feb", "Mar", "Apr", "May",
+                                             "Jun", "Jul", "Aug", "Sep", "Oct",
+                                             "Nov", "Dec" };
+
+        const std::time_t now = std::time(0);
+
+        std::tm tm;
+
+        // Spelled out rather than strftime, because strftime's %a and %b are
+        // whatever the locale says and RFC 9110 requires these exact names.
+        if(::gmtime_r(&now, &tm) == 0) return std::string();
+
+        char buf[64];
+
+        std::snprintf(buf, sizeof buf, "%s, %02d %s %04d %02d:%02d:%02d GMT",
+                      DAY[tm.tm_wday % 7], tm.tm_mday, MONTH[tm.tm_mon % 12],
+                      tm.tm_year + 1900, tm.tm_hour, tm.tm_min, tm.tm_sec);
+
+        return buf;
+    }
+
+    const char* reason_for(int status) {
+        switch(status) {
+        case 100: return "Continue";
+        case 200: return "OK";
+        case 201: return "Created";
+        case 204: return "No Content";
+        case 301: return "Moved Permanently";
+        case 302: return "Found";
+        case 303: return "See Other";
+        case 304: return "Not Modified";
+        case 400: return "Bad Request";
+        case 401: return "Unauthorized";
+        case 403: return "Forbidden";
+        case 404: return "Not Found";
+        case 405: return "Method Not Allowed";
+        case 413: return "Content Too Large";
+        case 414: return "URI Too Long";
+        case 431: return "Request Header Fields Too Large";
+        case 500: return "Internal Server Error";
+        case 501: return "Not Implemented";
+        case 505: return "HTTP Version Not Supported";
+        default:  return "";
+        }
+    }
+
+}
+
+// ------------------------------------------------------------------ response
+
+server::response& server::response::status(int code, const std::string& reason) {
+    m_status = code;
+    m_reason = reason.empty() ? reason_for(code) : reason;
+
+    return *this;
+}
+
+server::response& server::response::field(std::string name, std::string value) {
+    m_fields.add(std::move(name), std::move(value));
+
+    return *this;
+}
+
+server::response& server::response::type(const std::string& content_type) {
+    return field("Content-Type", content_type);
+}
+
+server::response& server::response::body(std::string body) {
+    m_body = std::move(body);
+
+    return *this;
+}
+
+std::string server::response::str(const std::string& server_name) const {
+    std::ostringstream o;
+
+    const std::string reason = m_reason.empty() ? reason_for(m_status) : m_reason;
+
+    o << "HTTP/1.1 " << m_status << " " << reason << "\r\n";
+
+    // Supplied unless the handler said otherwise, so a handler that wants to
+    // lie about Content-Length -- which no correct one does -- has to say so.
+    if(!m_fields.has("Date")) {
+        const std::string when = http_date();
+
+        if(!when.empty()) o << "Date: " << when << "\r\n";
+    }
+
+    if(!m_fields.has("Server") && !server_name.empty())
+        o << "Server: " << server_name << "\r\n";
+
+    if(!m_fields.has("Content-Length"))
+        o << "Content-Length: " << m_body.size() << "\r\n";
+
+    // Always.  One request per connection takes every keep-alive framing
+    // question off the table, and those questions are where smuggling lives.
+    if(!m_fields.has("Connection")) o << "Connection: close\r\n";
+
+    for(const fields::value_type& f : m_fields) {
+        // Checked on the way out, against the grammar rather than a blocklist.
+        // A CR or an LF in a value is how one response becomes two, and a
+        // handler builds these from whatever it was given.
+        const std::string line = f.first + ": " + f.second;
+
+        if(!util::http::grammar().at("field-line").try_parse(line))
+            throw error("a handler produced a header field that cannot be sent: "
+                        "\"" + line + "\"");
+
+        o << f.first << ": " << f.second << "\r\n";
+    }
+
+    o << "\r\n" << m_body;
+
+    return o.str();
+}
+
+// -------------------------------------------------------------------- server
+
+server::server(unsigned short port, const std::string& host,
+               const sys::tls_context& tls, const sys::server::policy& p,
+               const options& o)
+    : m_options(o),
+      m_tls(!tls.empty())
+{
+    m_otherwise = [](const Request&, response& r) {
+        r.status(404).type("text/plain").body("not found\n");
+    };
+
+    m_transport.reset(new sys::server(
+        sys::listener(port, host),
+        [this](sys::socketstream& s, const sys::peer& from) { serve(s, from); },
+        tls, p));
+}
+
+server::~server() = default;
+
+unsigned short server::port() const { return m_transport->port(); }
+
+bool server::tls() const { return m_tls; }
+
+std::string server::url(const std::string& path) const {
+    std::ostringstream o;
+
+    // localhost rather than 127.0.0.1 for the TLS form, because a certificate
+    // covers a name and the test ones cover that one.
+    o << (m_tls ? "https://localhost:" : "http://127.0.0.1:") << port() << path;
+
+    return o.str();
+}
+
+void server::route(const std::string& method, const std::string& path, handler h) {
+    entry e;
+
+    e.method = method;
+    e.path = path;
+    e.run = std::move(h);
+
+    m_routes.push_back(std::move(e));
+}
+
+void server::otherwise(handler h) {
+    if(h) m_otherwise = std::move(h);
+}
+
+bool server::serve_one(double timeout) { return m_transport->serve_one(timeout); }
+
+void server::run() { m_transport->run(); }
+
+void server::stop() { m_transport->stop(); }
+
+void server::join() { m_transport->join(); }
+
+sys::server& server::transport() { return *m_transport; }
+
+void server::serve(sys::socketstream& s, const sys::peer&) {
+    response r;
+
+    Request q;
+
+    try {
+        q = util::http::read_request_head(s, m_options.max_head);
+
+        // RFC 9110 10.1.1.  curl sends this for any POST over about a kilobyte
+        // and then waits for it; a server that ignores it makes every such
+        // client wait out its own timeout before sending the body.
+        if(util::http::fold(q.fields().get("Expect")) == "100-continue") {
+            s << "HTTP/1.1 100 Continue\r\n\r\n" << std::flush;
+        }
+
+        q.set_body(util::http::read_body(s, q.body_framing(), q.content_length(),
+                                         m_options.max_body));
+    }
+    catch(util::http::error& e) {
+        // A message this cannot read at all.  Answer, so a client learns
+        // something rather than seeing a bare close, and stop.
+        r.status(400).type("text/plain").body(std::string(e.what()) + "\n");
+
+        s << r.str(m_options.server_name) << std::flush;
+
+        return;
+    }
+
+    // The path, without the query.  parse_reference is what learned to read one
+    // of these two branches ago.
+    std::string path;
+
+    {
+        const std::string& target = q.target();
+
+        // An encoded separator is refused rather than decoded: decoding one
+        // would change how many segments the path has, which is the shape of a
+        // traversal bug.  Everything else is decoded, because RFC 3986 2.1
+        // makes "%65" and "e" the same character.
+        const std::string lowered = util::http::fold(target);
+
+        if(lowered.find("%2f") != std::string::npos ||
+           lowered.find("%5c") != std::string::npos) {
+            r.status(400).type("text/plain")
+             .body("an encoded path separator in the request target\n");
+
+            s << r.str(m_options.server_name) << std::flush;
+
+            return;
+        }
+
+        try {
+            util::URL u;
+
+            u.parse_reference(target);
+
+            path = util::uri::decode(u.get_path());
+        }
+        catch(std::exception&) {
+            r.status(400).type("text/plain").body("not a request target\n");
+
+            s << r.str(m_options.server_name) << std::flush;
+
+            return;
+        }
+    }
+
+    const handler* chosen = 0;
+
+    for(const entry& e : m_routes) {
+        if(e.method == q.method() && e.path == path) {
+            chosen = &e.run;
+            break;
+        }
+    }
+
+    // Nothing has reached the socket yet, so a handler that throws can still be
+    // answered -- which is the whole reason a response is accumulated rather
+    // than streamed.
+    //
+    // Serialising it is inside the try as well, and that is not fussiness:
+    // str() refuses a field a handler built that cannot be sent, and without
+    // this the client would get a bare close, which is indistinguishable from
+    // a crash.  A refused field is the server's fault and 500 is what says so.
+    std::string answer;
+
+    try {
+        (chosen ? *chosen : m_otherwise)(q, r);
+
+        answer = r.str(m_options.server_name);
+    }
+    catch(...) {
+        response oops;
+
+        oops.status(500).type("text/plain").body("internal error\n");
+
+        s << oops.str(m_options.server_name) << std::flush;
+
+        // Rethrown, so sys::server::on_error sees it: answering the client is
+        // not the same as the failure having been dealt with.
+        throw;
+    }
+
+    s << answer << std::flush;
+}
+
+}
+}
+}

--- a/jlib/net/http_server.cc
+++ b/jlib/net/http_server.cc
@@ -203,7 +203,7 @@ bool server::serve_one(double timeout) { return m_transport->serve_one(timeout);
 
 void server::run() { m_transport->run(); }
 
-void server::stop() { m_transport->stop(); }
+void server::stop(bool drain) { m_transport->stop(drain); }
 
 void server::join() { m_transport->join(); }
 

--- a/jlib/net/http_server.hh
+++ b/jlib/net/http_server.hh
@@ -155,7 +155,30 @@ public:
     bool serve_one(double timeout = 0);
     /** serve_one() until stop().  One-shot; see sys::server::run(). */
     void run();
-    void stop();
+
+    /**
+     * Ask run(), and any serve_one() that is waiting, to return.
+     *
+     * @param drain  answer the requests already accepted but not yet started,
+     *               or drop them unanswered.  Queued work only: a handler
+     *               already running finishes either way.
+     *
+     * Passed straight to sys::server::stop(), which is where the whole story
+     * is.  The part worth repeating here is that dropping a request answers it
+     * with nothing -- not a 503, not a close-after-status, just a close -- so
+     * false is for shutting down under duress and true is for shutting down.
+     */
+    void stop(bool drain = true);
+
+    /**
+     * Wait for the handler threads to retire.  **stop() first.**
+     *
+     * sys::server::join() does not stop on its own behalf and neither does
+     * this, so a join() without a preceding stop() hangs -- with a pool.  With
+     * the default policy there is no pool, nothing to retire, and this returns
+     * at once, which is why every serial section of a test can get the order
+     * wrong and never find out.  The destructor does both, in order.
+     */
     void join();
 
     /** The transport underneath: its policy, its peers, its on_error. */

--- a/jlib/net/http_server.hh
+++ b/jlib/net/http_server.hh
@@ -1,0 +1,184 @@
+/* -*- mode: C++ c-basic-offset: 4 -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef JLIB_NET_HTTP_SERVER_HH
+#define JLIB_NET_HTTP_SERVER_HH
+
+#include <jlib/net/http.hh>
+
+#include <jlib/sys/server.hh>
+#include <jlib/sys/tls.hh>
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace jlib {
+namespace net {
+namespace http {
+
+/**
+ * Caps and the Server field.
+ *
+ * At namespace scope beside sys::server_policy, and for the same reason: a
+ * default argument is a complete-class context, so `const options& o =
+ * options()` on a member of the class that nests options does not compile.  An
+ * earlier version routed around it with a second constructor.  Defining the
+ * struct first removes the problem, and server::options still spells.
+ */
+struct server_options {
+    std::size_t max_head = 8192;
+    std::size_t max_body = 1 << 20;
+    std::string server_name = "jlib/1.2";
+};
+
+/**
+ * An HTTP/1.1 server.
+ *
+ * Separate from http.hh, which is a client and says at length that it is a
+ * deliberately narrow one.  Two ends of a protocol in one header would muddy
+ * that claim, and every existing client caller would start including
+ * <jlib/sys/server.hh>, <thread> and OpenSSL to get it.
+ *
+ * ## As narrow as the client, and for the same reasons
+ *
+ * One request per connection and `Connection: close`, always.  No keep-alive:
+ * the branch that built the message layer refused it because keep-alive framing
+ * is where request smuggling lives, and a server has strictly more to lose there
+ * than a client.  No streaming: a response is accumulated whole and written in
+ * one go, which is what lets a handler that throws still be answered with a 500,
+ * and which means a body has to fit in memory.
+ *
+ * It exists to receive an OAuth2 redirect on loopback and to be a test harness.
+ * **It is not hardened for a public port** -- see the note on sys::server.
+ */
+class server {
+public:
+    using error = jlib::util::http::error;
+    using fields = jlib::util::http::fields;
+    using Request = jlib::util::http::Request;
+
+    /**
+     * A response under construction.
+     *
+     * Accumulated rather than streamed, so nothing has reached the socket until
+     * the handler has returned -- which is why a handler that throws can still
+     * be answered.
+     */
+    class response {
+    public:
+        response& status(int code, const std::string& reason = "");
+        response& field(std::string name, std::string value);
+        response& type(const std::string& content_type);
+        response& body(std::string body);
+
+        int status() const { return m_status; }
+        const http::fields& fields() const { return m_fields; }
+        const std::string& body() const { return m_body; }
+
+        /** The octets, head and body, as they go on the wire. */
+        std::string str(const std::string& server_name) const;
+
+    private:
+        int m_status = 200;
+        std::string m_reason;
+        http::fields m_fields;
+        std::string m_body;
+    };
+
+    typedef std::function<void(const Request&, response&)> handler;
+
+    using options = server_options;
+
+    /**
+     * Bind and serve.  Loopback by default.
+     *
+     * @param tls  a server context makes it https://; an empty one leaves it
+     *             plaintext
+     * @param p    threads, timeouts and the queue depth, all fixed here
+     */
+    server(unsigned short port = 0,
+           const std::string& host = "127.0.0.1",
+           const sys::tls_context& tls = sys::tls_context(),
+           const sys::server::policy& p = sys::server::policy(),
+           const options& o = options());
+
+    ~server();
+
+    server(const server&) = delete;
+    server& operator=(const server&) = delete;
+
+    unsigned short port() const;
+    bool tls() const;
+
+    /** http:// or https://, with the port, and that path. */
+    std::string url(const std::string& path = "/") const;
+
+    /**
+     * Route an exact method and an exact path.
+     *
+     * The path is the target's path component with the query removed.  Matching
+     * is exact: no prefixes, no wildcards, no trailing-slash equivalence, and
+     * routes are tried in the order they were added so a later one can never
+     * shadow an earlier one.
+     *
+     * Percent-encoding *is* decoded first, because RFC 3986 2.1 makes "%65" and
+     * "e" the same character -- but a target whose path contains an encoded
+     * separator ("%2F") is refused rather than decoded, since decoding one
+     * would change how many segments the path has and that is the shape of a
+     * traversal bug.
+     *
+     * A GET route does not answer HEAD.  Register both, or use otherwise().
+     */
+    void route(const std::string& method, const std::string& path, handler h);
+
+    /** What runs when no route matched.  The default answers 404. */
+    void otherwise(handler h);
+
+    bool serve_one(double timeout = 0);
+    /** serve_one() until stop().  One-shot; see sys::server::run(). */
+    void run();
+    void stop();
+    void join();
+
+    /** The transport underneath: its policy, its peers, its on_error. */
+    sys::server& transport();
+
+private:
+    void serve(sys::socketstream& s, const sys::peer& from);
+
+    struct entry {
+        std::string method;
+        std::string path;
+        handler run;
+    };
+
+    options m_options;
+    std::vector<entry> m_routes;
+    handler m_otherwise;
+    std::unique_ptr<sys::server> m_transport;
+    bool m_tls = false;
+};
+
+}
+}
+}
+
+#endif // JLIB_NET_HTTP_SERVER_HH

--- a/jlib/net/oauth.cc
+++ b/jlib/net/oauth.cc
@@ -19,6 +19,8 @@
 
 #include <jlib/net/oauth.hh>
 
+#include <jlib/net/http_server.hh>
+
 #include <jlib/sys/listener.hh>
 #include <jlib/sys/socketstream.hh>
 
@@ -266,10 +268,75 @@ pkce pkce::generate() {
 class redirect_receiver::impl {
 public:
     explicit impl(unsigned short port)
-        : listener(port, "127.0.0.1", 1)
-    {}
+        : server(port, "127.0.0.1")
+    {
+        // One handler, no routes: whatever path the provider redirects to is
+        // the redirect, and refusing an unexpected one would only mean a user
+        // staring at a 404 with their authorization already spent.
+        server.otherwise([this](const http::server::Request& q,
+                                http::server::response& r) {
+            record(q, r);
+        });
 
-    sys::listener listener;
+        // A failure on this connection is the caller's to hear about, through
+        // wait(), not something to print behind their back.
+        server.transport().on_error([](const std::exception&, const sys::peer&) {});
+    }
+
+    /**
+     * Read the callback, answer the browser, and remember what happened.
+     *
+     * The checking is deliberately *not* here.  This runs inside a handler, and
+     * an exception from a handler is caught by the server -- so throwing here
+     * would answer the browser and then lose the reason.  wait() does the
+     * deciding once the exchange is over, which also puts the state check
+     * before anything else is believed rather than merely near it.
+     */
+    void record(const http::server::Request& q, http::server::response& r) {
+        // The target is origin-form: an absolute path and a query.  URL learned
+        // to parse a relative reference two branches ago, which is exactly
+        // this shape.
+        util::URL target;
+
+        try {
+            target.parse_reference(q.target());
+        }
+        catch(std::exception&) {
+            arrived = true;
+            bad_target = true;
+
+            r.status(400).type("text/plain").body("not a redirect\n");
+
+            return;
+        }
+
+        got.code = target["code"];
+        got.state = target["state"];
+        got.error = target["error"];
+        got.error_description = target["error_description"];
+
+        arrived = true;
+
+        // One fixed page whatever happened, because the person is looking at a
+        // browser and an empty response is indistinguishable from a crash.  It
+        // never contains the code: a URL bar is shoulder-surfable and a page is
+        // saveable.
+        const bool good = got.error.empty() && !got.code.empty() &&
+                          !expect.empty() && got.state == expect;
+
+        r.status(200).type("text/html; charset=utf-8").body(
+            good
+            ? "<html><body><h1>Signed in</h1><p>You can close this window and "
+              "return to the application.</p></body></html>"
+            : "<html><body><h1>Sign-in failed</h1><p>Return to the application; "
+              "it has the details.</p></body></html>");
+    }
+
+    http::server server;
+    callback got;
+    std::string expect;
+    bool arrived = false;
+    bool bad_target = false;
 };
 
 redirect_receiver::redirect_receiver(unsigned short port)
@@ -279,7 +346,7 @@ redirect_receiver::redirect_receiver(unsigned short port)
 redirect_receiver::~redirect_receiver() = default;
 
 unsigned short redirect_receiver::port() const {
-    return m_impl->listener.port();
+    return m_impl->server.port();
 }
 
 std::string redirect_receiver::redirect_uri() const {
@@ -289,93 +356,39 @@ std::string redirect_receiver::redirect_uri() const {
 }
 
 callback redirect_receiver::wait(const std::string& expect_state, double timeout) {
-    std::unique_ptr<sys::socketstream> browser;
+    m_impl->expect = expect_state;
+    m_impl->arrived = false;
+    m_impl->bad_target = false;
+    m_impl->got = callback();
+
+    // One connection, and one request on it.  net::http::server reads the whole
+    // head against the grammar -- request-line, field-line -- where this used
+    // to read a single line and parse it by hand.
+    bool served = false;
 
     try {
-        browser = m_impl->listener.accept_stream(timeout);
+        served = m_impl->server.serve_one(timeout);
     }
     catch(std::exception& e) {
         throw error(std::string("waiting for the browser: ") + e.what());
     }
 
-    if(!browser)
+    if(!served || !m_impl->arrived) {
         throw error("no redirect arrived within " + std::to_string(timeout) +
                     " seconds");
-
-    // Reading is bounded twice over: a deadline, and a cap on the request line.
-    // Whatever connected is not necessarily a browser.
-    browser->set_timeout(10);
-
-    std::string line;
-
-    std::getline(*browser, line);
-
-    while(!line.empty() && line.back() == '\r') line.pop_back();
-
-    if(line.length() > 8192) throw error("the redirect's request line is absurd");
-
-    // "GET /?code=...&state=... HTTP/1.1".  Read with the grammar rather than
-    // with find(): request-line is RFC 9112 3, and the pieces come out of the
-    // match instead of out of offsets counted by hand.
-    const abnf::parse_result p =
-        util::http::grammar().at("request-line").try_parse(line);
-
-    if(!p) throw error("what connected to the redirect port did not send a "
-                       "request line");
-
-    const abnf::match m = p.root();
-
-    if(m["method"].str() != "GET")
-        throw error("the redirect was not a GET");
-
-    // The target is origin-form: an absolute path and a query.  URL learned to
-    // parse a relative reference two branches ago, which is exactly this.
-    util::URL target;
-
-    try {
-        target.parse_reference(m["request-target"].str());
-    }
-    catch(std::exception&) {
-        throw error("the redirect's request target is not a URI reference");
     }
 
-    callback back;
+    if(m_impl->bad_target)
+        throw error("what connected to the redirect port did not ask for a "
+                    "URI reference");
 
-    back.code = target["code"];
-    back.state = target["state"];
-    back.error = target["error"];
-    back.error_description = target["error_description"];
+    const callback back = m_impl->got;
 
     // The state first, and before anything else is believed.  RFC 6749 10.12:
     // this is the client's only defence against someone else's authorization
     // code being planted on it, and the check is worthless if it happens after
     // the code has been used.
-    const bool state_ok = !expect_state.empty() && back.state == expect_state;
-
-    // One fixed page, whatever happened, because the person is looking at a
-    // browser and an empty response is indistinguishable from a crash.  It
-    // never contains the code: a URL bar is shoulder-surfable and a page is
-    // saveable.
-    const std::string body =
-        state_ok && back.ok()
-        ? "<html><body><h1>Signed in</h1><p>You can close this window and "
-          "return to the application.</p></body></html>"
-        : "<html><body><h1>Sign-in failed</h1><p>Return to the application; "
-          "it has the details.</p></body></html>";
-
-    std::ostringstream reply;
-
-    reply << "HTTP/1.1 200 OK\r\n"
-          << "Content-Type: text/html; charset=utf-8\r\n"
-          << "Content-Length: " << body.length() << "\r\n"
-          << "Connection: close\r\n"
-          << "\r\n"
-          << body;
-
-    *browser << reply.str() << std::flush;
-    browser->close();
-
-    if(!state_ok) {
+    if(expect_state.empty() || back.state != expect_state) {
         throw error("the redirect's state does not match the one that was sent; "
                     "refusing it");
     }

--- a/jlib/sys/Makefile.am
+++ b/jlib/sys/Makefile.am
@@ -1,13 +1,16 @@
 AM_CPPFLAGS = -I$(top_srcdir) $(OPENSSL_CFLAGS)
 
 lib_LTLIBRARIES = libjsys.la
-libjsys_la_SOURCES = tfstream.cc sys.cc Directory.cc Servent.cc pipe.cc listener.cc
+libjsys_la_SOURCES = tfstream.cc sys.cc Directory.cc Servent.cc pipe.cc listener.cc \
+                     tls.cc server.cc
 libjsys_la_LDFLAGS = -version-info $(LIBJ_SO_VERSION) -release $(JLIB_RELEASE) -no-undefined
-libjsys_la_LIBADD = $(PTHREAD_LIBS)
+# tls.cc is the first OpenSSL .cc in libjsys -- sslstream.hh is header-only,
+# so until now the flags were enough and the libraries were not needed.
+libjsys_la_LIBADD = $(PTHREAD_LIBS) $(OPENSSL_LIBS)
 
 libjsysincludedir = $(includedir)/jlib-1.2/jlib/sys
 libjsysinclude_HEADERS = tfstream.hh socketstream.hh sslstream.hh proxystream.hh \
-                         listener.hh \
+                         listener.hh tls.hh server.hh \
                          sslproxystream.hh serialstream.hh pstream.hh \
                          sys.hh Directory.hh auto.hh sync.hh ringbuffer.hh Servent.hh \
                          ASServent.hh pipe.hh object.hh joystick.hh

--- a/jlib/sys/listener.cc
+++ b/jlib/sys/listener.cc
@@ -46,6 +46,30 @@ namespace {
         return ntohs(reinterpret_cast<const struct sockaddr_in*>(&ss)->sin_port);
     }
 
+    std::string address_of(const struct sockaddr_storage& ss, socklen_t len) {
+        char host[NI_MAXHOST];
+
+        // NI_NUMERICHOST: no reverse lookup.  See the note on peer::address.
+        if(::getnameinfo(reinterpret_cast<const struct sockaddr*>(&ss), len,
+                         host, sizeof host, 0, 0,
+                         NI_NUMERICHOST | NI_NUMERICSERV) != 0) {
+            return std::string();
+        }
+
+        return host;
+    }
+
+}
+
+bool peer::loopback() const {
+    if(address == "::1") return true;
+
+    // The IPv4-mapped form, which is what arrives on a v6 socket accepting a v4
+    // connection -- not hypothetical the moment anything binds dual-stack.
+    const std::string v4 = address.compare(0, 7, "::ffff:") == 0
+                           ? address.substr(7) : address;
+
+    return v4.compare(0, 4, "127.") == 0;
 }
 
 listener::listener(unsigned short port, const std::string& host, int backlog) {
@@ -140,6 +164,28 @@ listener& listener::operator=(listener&& other) noexcept {
 }
 
 int listener::accept(double timeout) {
+    return accept_into(0, timeout);
+}
+
+int listener::accept(peer& from, double timeout) {
+    return accept_into(&from, timeout);
+}
+
+void listener::set_blocking(bool blocking) {
+    if(m_sock == -1) return;
+
+    const int flags = ::fcntl(m_sock, F_GETFL, 0);
+
+    if(flags == -1)
+        throw exception(std::string("error in fcntl(F_GETFL): ") + std::strerror(errno));
+
+    const int want = blocking ? (flags & ~O_NONBLOCK) : (flags | O_NONBLOCK);
+
+    if(::fcntl(m_sock, F_SETFL, want) == -1)
+        throw exception(std::string("error in fcntl(F_SETFL): ") + std::strerror(errno));
+}
+
+int listener::accept_into(peer* from, double timeout) {
     if(m_sock == -1)
         throw exception("accept() on a closed listener");
 
@@ -164,25 +210,60 @@ int listener::accept(double timeout) {
             throw exception(std::string("error in poll(): ") + std::strerror(errno));
     }
 
+    struct sockaddr_storage ss;
+    socklen_t len = sizeof(ss);
+
+    std::memset(&ss, 0, sizeof(ss));
+
     int fd;
 
-    while((fd = ::accept(m_sock, 0, 0)) < 0 && errno == EINTR)
-        ;
+    while((fd = ::accept(m_sock, reinterpret_cast<struct sockaddr*>(&ss), &len)) < 0 &&
+          errno == EINTR) {
+        len = sizeof(ss);
+    }
 
-    if(fd < 0)
+    if(fd < 0) {
+        // Nothing waiting, on a listener a caller has set non-blocking -- which
+        // is the same answer as "the timeout ran out", so it is the same
+        // return.  One meaning, one value.
+        if(errno == EAGAIN || errno == EWOULDBLOCK) return -1;
+
         throw exception(std::string("error in accept(): ") + std::strerror(errno));
+    }
+
+    // On BSD and macOS an accepted descriptor *inherits* O_NONBLOCK from the
+    // listening socket; on Linux it does not.  So the moment a caller sets the
+    // listener non-blocking, every connection on macOS would arrive
+    // non-blocking and every read a handler made would return EAGAIN -- while
+    // working perfectly in a Linux container, which is the worst way for a
+    // difference like this to be found.  Put it back, always.
+    const int flags = ::fcntl(fd, F_GETFL, 0);
+
+    if(flags != -1 && (flags & O_NONBLOCK))
+        ::fcntl(fd, F_SETFL, flags & ~O_NONBLOCK);
+
+    if(from != 0) {
+        from->address = address_of(ss, len);
+        from->port = port_of(ss);
+    }
 
     return fd;
 }
 
 std::unique_ptr<socketstream> listener::accept_stream(double timeout) {
-    const int fd = accept(timeout);
+    peer from;
+
+    return accept_stream(from, timeout);
+}
+
+std::unique_ptr<socketstream> listener::accept_stream(peer& from, double timeout) {
+    const int fd = accept(from, timeout);
 
     if(fd < 0)
         return std::unique_ptr<socketstream>();
 
     try {
-        return std::make_unique<socketstream>(adopt, fd);
+        return std::make_unique<socketstream>(adopt, fd, from.address, from.port);
     }
     catch(...) {
         ::close(fd);

--- a/jlib/sys/listener.hh
+++ b/jlib/sys/listener.hh
@@ -48,6 +48,30 @@ namespace sys {
  * redirect that binds every interface is reachable from the network, and what
  * arrives on it is an authorization code.
  */
+/**
+ * Who connected.
+ *
+ * ::accept(m_sock, 0, 0) discarded this for the whole of the listener's first
+ * life, because nothing wanted it.  A server does: a handler that cannot tell a
+ * loopback client from a stranger cannot make the one decision a loopback
+ * receiver exists to make.
+ */
+struct peer {
+    /**
+     * Numeric, from getnameinfo(NI_NUMERICHOST).
+     *
+     * Never a name.  A reverse lookup is a stranger's DNS deciding what a log
+     * line says, it costs a round trip on the accept path, and the answer is
+     * not authenticated by anything.
+     */
+    std::string address;
+
+    unsigned short port = 0;
+
+    /** 127.0.0.0/8, ::1, or an IPv4-mapped loopback address. */
+    bool loopback() const;
+};
+
 class listener {
 public:
     class exception : public std::exception {
@@ -107,12 +131,33 @@ public:
      */
     int accept(double timeout = 0);
 
+    /** As accept(), and says who it was. */
+    int accept(peer& from, double timeout = 0);
+
     /** accept(), wrapped in a stream.  Null if the timeout ran out. */
     std::unique_ptr<socketstream> accept_stream(double timeout = 0);
 
+    std::unique_ptr<socketstream> accept_stream(peer& from, double timeout = 0);
+
     void close();
 
+    /**
+     * Take the listening socket out of blocking mode.
+     *
+     * For a caller that polls several descriptors at once and cannot let
+     * accept() block on one of them -- sys::server does.  With it set, accept()
+     * returns -1 rather than waiting when the poll and the accept disagree,
+     * which happens when a client sends an RST between the two.
+     *
+     * It does not follow the connection: an accepted descriptor is always put
+     * back into blocking mode, because on BSD and macOS it would otherwise
+     * inherit this and every read a handler made would fail with EAGAIN.
+     */
+    void set_blocking(bool blocking);
+
 private:
+    int accept_into(peer* from, double timeout);
+
     int m_sock = -1;
     unsigned short m_port = 0;
 };

--- a/jlib/sys/pipe.cc
+++ b/jlib/sys/pipe.cc
@@ -34,7 +34,6 @@ namespace jlib {
             : m_block_read(block_read),
               m_block_write(block_write)
         {
-            m_pipe = new int[2];
             if(::pipe(m_pipe) == -1) {
                 exception::throw_errno("unable to create pipe");
             }
@@ -61,7 +60,14 @@ namespace jlib {
         }
 
         pipe::~pipe() {
-            delete [] m_pipe;
+            // Both descriptors, which is new.  What was here deleted the array
+            // and left the files open, so a process that made pipes in a loop
+            // ran out of descriptors rather than memory -- and the two the
+            // command queue holds were leaked once per Servent.
+            if(m_pipe[0] != -1) ::close(m_pipe[0]);
+            if(m_pipe[1] != -1) ::close(m_pipe[1]);
+
+            m_pipe[0] = m_pipe[1] = -1;
         }
         
         int pipe::read_int() {

--- a/jlib/sys/pipe.hh
+++ b/jlib/sys/pipe.hh
@@ -91,8 +91,20 @@ namespace jlib {
             int get_reader() const;
             int get_writer() const;
 
+            // Deleted, and the leak below is why it matters: with a raw int*
+            // member and no copy control, copying one gave two objects owning
+            // the same array -- a double delete[], and once the destructor
+            // learned to close, a double close of two live descriptors.  A
+            // pipe is a pair of open files; it is not a value.
+            pipe(const pipe&) = delete;
+            pipe& operator=(const pipe&) = delete;
+
         private:
-            int* m_pipe;
+            // An array of two, not a new int[2].  Nothing was ever gained by
+            // the allocation and the destructor deleted it without closing
+            // either descriptor -- so every Servent and every ASServent, both
+            // of which hold one for their lifetime, leaked two.
+            int m_pipe[2] = { -1, -1 };
             bool m_block_read;
             bool m_block_write;
         };

--- a/jlib/sys/proxystream.hh
+++ b/jlib/sys/proxystream.hh
@@ -153,6 +153,8 @@ public:
     void open(const std::string& host, unsigned int port,
               const std::string& phost, u_int pport) 
     {
+        if(this->m_buf != 0)
+            delete this->m_buf;
         this->m_buf=new basic_proxybuf<charT,traitT>(host,port,phost,pport);
         this->init(this->m_buf);
     }

--- a/jlib/sys/server.cc
+++ b/jlib/sys/server.cc
@@ -119,16 +119,22 @@ std::size_t server::cap() const {
     return m_policy.max_queued != 0 ? m_policy.max_queued : m_policy.threads;
 }
 
-void server::stop() {
+void server::stop(bool drain) {
     m_stop.store(true);
+
+    // What drain decides is the fate of jobs still queued -- connections
+    // accepted but not yet started.  Abandoning one destroys the
+    // shared_ptr<held_fd> it carries, so the descriptor closes rather than
+    // leaks (see serve_one, which names this as one of the three drop paths
+    // that indirection buys).  A handler already running is not affected.
+    //
+    // Kept out of the enumeration below because it is a separate question: the
+    // call wakes a parked thread whichever way drain goes.
 
     // Three ways a thread can be blocked in here, and shutdown hangs if any one
     // is missed.  This is the second: a thread parked in the queue's depth
     // wait, whose predicate ORs in the queue's own exit flag.
-    //
-    // Drained, so a connection already accepted is still served: it is not the
-    // client's fault that we are going away.
-    m_jobs.stop(true);
+    m_jobs.stop(drain);
 
     // And the third: a thread in poll(2).  A byte down the pipe rather than
     // closing the listening descriptor, which is undefined while another thread
@@ -138,11 +144,10 @@ void server::stop() {
 }
 
 void server::join() {
-    // The stop is what makes this terminate.  job_queue's workers wait for work
-    // indefinitely, so joining them without telling them to leave waits for
-    // something that never happens.  Draining, so nothing accepted is
-    // discarded; idempotent, so ~server calling stop() first costs nothing.
-    m_jobs.stop(true);
+    // No stop() here, deliberately -- see the header.  The workers wait for
+    // work forever, so a caller who has not stopped will hang; a stop() added
+    // here to prevent that would have to pick a drain argument, and picking one
+    // overwrites what a caller who did stop already asked for.
     m_jobs.join();
 }
 

--- a/jlib/sys/server.cc
+++ b/jlib/sys/server.cc
@@ -1,0 +1,328 @@
+/* -*- mode: C++ c-basic-offset: 4  -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+#include <jlib/sys/server.hh>
+
+#include <jlib/sys/sslstream.hh>
+
+#include <openssl/err.h>
+
+#include <cerrno>
+#include <chrono>
+#include <cstring>
+#include <iostream>
+#include <memory>
+#include <sstream>
+#include <thread>
+
+#include <poll.h>
+#include <unistd.h>
+
+namespace jlib {
+namespace sys {
+
+namespace {
+
+    void complain(const std::exception& e, const peer& from) {
+        std::ostringstream o;
+
+        o << "jlib::sys::server: " << (from.address.empty() ? "a client"
+                                                            : from.address)
+          << ": " << e.what() << "\n";
+
+        // One write of one whole string.  Several threads reporting at once
+        // otherwise interleave in the middle of a message.
+        std::cerr << o.str() << std::flush;
+    }
+
+    /** A descriptor that closes itself unless somebody takes it. */
+    class held_fd {
+    public:
+        explicit held_fd(int fd) : m_fd(fd) {}
+
+        ~held_fd() { if(m_fd >= 0) ::close(m_fd); }
+
+        held_fd(const held_fd&) = delete;
+        held_fd& operator=(const held_fd&) = delete;
+
+        /** Hand it over; this no longer closes it. */
+        int release() { const int fd = m_fd; m_fd = -1; return fd; }
+
+    private:
+        int m_fd;
+    };
+
+}
+
+server::server(listener l, handler h, tls_context tls, const policy& p)
+    : m_listener(std::move(l)),
+      m_handler(std::move(h)),
+      m_on_error(complain),
+      m_tls(std::move(tls)),
+      m_policy(p),
+      m_jobs(static_cast<int>(p.threads))
+{
+    if(!m_handler) throw exception("a server with no handler");
+
+    // So the accept never blocks: serve_one polls the listening descriptor and
+    // the wake pipe together, and a client that sends an RST between the poll
+    // and the accept would otherwise leave it waiting for the next one.
+    m_listener.set_blocking(false);
+}
+
+server::server(unsigned short port, handler h, const std::string& host,
+               tls_context tls, const policy& p)
+    : server(listener(port, host), std::move(h), std::move(tls), p)
+{}
+
+server::~server() {
+    stop();
+    join();
+}
+
+unsigned short server::port() const { return m_listener.port(); }
+
+bool server::tls() const { return !m_tls.empty(); }
+
+std::size_t server::pending() const { return m_jobs.size(); }
+
+void server::on_error(error_handler h) {
+    m_on_error = h ? h : error_handler(complain);
+}
+
+bool server::stopped() const { return m_stop.load(); }
+
+std::size_t server::cap() const {
+    // With no pool the cap is one -- the connection being handled -- so the
+    // admission predicate below reads the same in both modes and serve_one
+    // needs no branch.  Nothing is ever queued there, so the wait answers
+    // pred(0), which is 0 < 1.
+    if(m_policy.threads == 0) return 1;
+
+    return m_policy.max_queued != 0 ? m_policy.max_queued : m_policy.threads;
+}
+
+void server::stop() {
+    m_stop.store(true);
+
+    // Three ways a thread can be blocked in here, and shutdown hangs if any one
+    // is missed.  This is the second: a thread parked in the queue's depth
+    // wait, whose predicate ORs in the queue's own exit flag.
+    //
+    // Drained, so a connection already accepted is still served: it is not the
+    // client's fault that we are going away.
+    m_jobs.stop(true);
+
+    // And the third: a thread in poll(2).  A byte down the pipe rather than
+    // closing the listening descriptor, which is undefined while another thread
+    // polls it and on macOS does not wake it.
+    try { m_wake.write_int(1); }
+    catch(std::exception&) { /* full is fine; one byte is all it takes */ }
+}
+
+void server::join() {
+    // The stop is what makes this terminate.  job_queue's workers wait for work
+    // indefinitely, so joining them without telling them to leave waits for
+    // something that never happens.  Draining, so nothing accepted is
+    // discarded; idempotent, so ~server calling stop() first costs nothing.
+    m_jobs.stop(true);
+    m_jobs.join();
+}
+
+void server::serve(int fd, const peer& from) {
+    held_fd held(fd);
+
+    // A pooled thread keeps OpenSSL's per-thread error queue between
+    // connections, where a thread per connection got a fresh one.  open_ssl()
+    // clears before the handshake, so that path is safe; this is for a
+    // mid-connection SSL_read or SSL_write failure, which drains the queue to
+    // build its message and would otherwise report residue left by whatever
+    // this worker did last.
+    ERR_clear_error();
+
+    try {
+        std::unique_ptr<socketstream> s;
+
+        // Constructed here, on the worker, not before the dispatch: building a
+        // tlsstream performs SSL_accept, and doing that on the accept thread
+        // would let one slow or hostile client stall every other connection
+        // through a full handshake -- which is exactly what a pool is for.
+        if(!m_tls.empty()) {
+            s.reset(new tlsstream(tls_server, m_tls, adopt, held.release(),
+                                  from.address, from.port, m_policy.io_timeout));
+        }
+        else {
+            s.reset(new socketstream(adopt, held.release(), from.address,
+                                     from.port, m_policy.io_timeout));
+        }
+
+        try {
+            m_handler(*s, from);
+        }
+        catch(std::exception& e) {
+            m_on_error(e, from);
+        }
+        catch(...) {
+            const exception unknown("a handler threw something that is not an "
+                                    "exception");
+
+            m_on_error(unknown, from);
+        }
+
+        s->flush();
+        s->close();
+    }
+    catch(std::exception& e) {
+        // The outer one: constructing the stream, which for a TLS server is the
+        // handshake.  A connection that fails here must not take the loop with
+        // it.
+        m_on_error(e, from);
+    }
+    catch(...) {
+        const exception unknown("a connection failed with something that is "
+                                "not an exception");
+
+        m_on_error(unknown, from);
+    }
+}
+
+bool server::serve_one(double timeout) {
+    if(m_stop.load()) return false;
+
+    // Admission control before the poll, so an overflow connection waits in the
+    // kernel's listen backlog rather than here, accepted and holding a
+    // descriptor.  The queue holds the depth and the lock; what counts as full
+    // is this caller's opinion, and this is the one line that has one.
+    const std::size_t room = cap();
+    const auto full = [room](std::size_t depth) { return depth < room; };
+
+    // One budget across both waits, not one each.  The header says the timeout
+    // covers admission control as well as the accept, and without a deadline
+    // serve_one(10) could spend ten seconds waiting for room and ten more in
+    // poll(2) -- twenty, for a caller who asked for ten.
+    const auto deadline = std::chrono::steady_clock::now() +
+        std::chrono::duration_cast<std::chrono::steady_clock::duration>(
+            std::chrono::duration<double>(timeout));
+
+    const bool have_room = timeout > 0
+        ? m_jobs.wait(full, std::chrono::duration_cast<std::chrono::nanoseconds>(
+                                std::chrono::duration<double>(timeout)))
+        : m_jobs.wait(full);
+
+    if(!have_room) return false;
+
+    struct pollfd fds[2];
+
+    fds[0].fd = m_listener.get_socket();
+    fds[0].events = POLLIN;
+    fds[0].revents = 0;
+
+    fds[1].fd = m_wake.get_reader();
+    fds[1].events = POLLIN;
+    fds[1].revents = 0;
+
+    int ms = -1;
+
+    if(timeout > 0) {
+        const auto left = deadline - std::chrono::steady_clock::now();
+
+        if(left <= std::chrono::steady_clock::duration::zero()) return false;
+
+        ms = static_cast<int>(
+            std::chrono::duration_cast<std::chrono::milliseconds>(left).count());
+    }
+
+    int r;
+
+    while((r = ::poll(fds, 2, ms)) < 0 && errno == EINTR)
+        ;
+
+    if(r < 0)
+        throw exception(std::string("error in poll(): ") + std::strerror(errno));
+
+    if(r == 0) return false;
+
+    if(fds[1].revents & POLLIN) {
+        // Drain it; the pipe's read end is non-blocking.
+        try {
+            for(;;) m_wake.read_int();
+        }
+        catch(std::exception&) {}
+
+        return false;
+    }
+
+    if(!(fds[0].revents & POLLIN)) return false;
+
+    peer from;
+    int fd;
+
+    try {
+        fd = m_listener.accept(from, 0);
+    }
+    catch(std::exception& e) {
+        // Out of descriptors is not a reason to stop serving, and it is a
+        // condition that clears.  Without the pause this spins at full tilt,
+        // because the connection stays queued and the poll stays readable.
+        if(errno == EMFILE || errno == ENFILE) {
+            m_on_error(e, from);
+
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+            return false;
+        }
+
+        throw;
+    }
+
+    if(fd < 0) return false;
+
+    // A shared_ptr, and it is not shared: refcount one for its whole life,
+    // except while job_queue copies the std::function around.  The indirection
+    // is doing two jobs.  post() takes a std::function, which requires a
+    // *copyable* callable, so a move-only holder captured by value will not
+    // compile -- and std::move_only_function is C++23 and absent from both
+    // toolchains here.  And a held_fd captured by value into a non-mutable
+    // lambda would be const, so release() would not compile either.
+    //
+    // What it buys: every path that drops the job closes the descriptor by
+    // RAII.  post() returning early because the queue stopped, a worker
+    // abandoning queued jobs on stop(false), post() itself throwing -- a bare
+    // int leaks in all three, and a stop() landing between the accept and the
+    // post is exactly that race.
+    std::shared_ptr<held_fd> held = std::make_shared<held_fd>(fd);
+
+    m_jobs.post([this, held, from] { serve(held->release(), from); });
+
+    return true;
+}
+
+void server::run() {
+    // No m_stop.store(false) here.  job_queue::stop() retires the pool and
+    // nothing respawns it, so a "restarted" server would accept connections and
+    // drop every one in silence -- post() returns early once the queue has
+    // stopped.  One-shot, and said so in the header.
+    while(!m_stop.load()) {
+        serve_one(0);
+    }
+}
+
+}
+}

--- a/jlib/sys/server.hh
+++ b/jlib/sys/server.hh
@@ -227,7 +227,8 @@ public:
     /**
      * Ask run(), and any serve_one() that is waiting, to return.
      *
-     * Safe from any thread, including from inside a handler.  Idempotent.
+     * Safe from any thread, including from inside a handler.  Calling it twice
+     * is harmless, but it is *not* first-wins: see @p drain.
      *
      * **This is not a barrier**, and everywhere else in this library "stop"
      * means stopped.  Handlers already running keep running, and whatever they
@@ -239,23 +240,48 @@ public:
      * rather than closing the listening descriptor, because closing one that
      * another thread is blocked in poll(2) on is undefined and on macOS does
      * not wake it.
+     *
+     * @param drain  serve what has been accepted but not yet started, or throw
+     *               it away.
+     *
+     * Queued work only.  A handler already running is unaffected either way, so
+     * this draws the same line between waiting and running that max_queued
+     * draws against threads -- and for the same reason, since a job that has
+     * been popped is no longer the queue's to abandon.
+     *
+     * False drops those connections with no answer at all.  Their descriptors
+     * are closed rather than leaked, because each rides in the job's
+     * shared_ptr<held_fd> and dropping the job destroys it, so the client sees
+     * an immediate close rather than waiting out its own timeout -- but it is
+     * still a close in place of a response, which is why true is the default.
+     *
+     * job_queue::stop() assigns its drain flag every time, so a later
+     * stop(true) silently upgrades an earlier stop(false) back to draining.
+     * That is why join() does not stop on your behalf: it would have to guess
+     * at this, and guessing overwrites what the caller asked for.
      */
-    void stop();
+    void stop(bool drain = true);
 
     bool stopped() const;
 
     /**
-     * Stop taking work, and wait for what has been accepted to be served.
+     * Wait for the handler threads to retire.  **stop() first.**
      *
-     * **This stops the queue**, and that is not an implementation detail to be
-     * tidied away: a job_queue's workers wait for work forever, so "wait for
-     * them to finish" is only a terminating question once they have been told
-     * to leave.  A join() that did not stop would hang, which is exactly what
-     * an earlier version of this did.
+     * A job_queue's workers wait for work forever, so "wait for them to finish"
+     * is only a terminating question once they have been told to leave.  This
+     * does not tell them.  An earlier version called stop() here to make the
+     * ordering impossible to get wrong; it no longer does, because stop() is
+     * not first-wins and joining would have to guess at its drain argument.
      *
-     * So: serving is over when this returns.  It is the second half of the
-     * destructor, callable on its own -- not a barrier you can take in the
-     * middle of a run and carry on from.
+     * So the sequence is stop() then join(), which is what the destructor does.
+     * Serving is over when this returns.  It is not a barrier you can take in
+     * the middle of a run and carry on from.
+     *
+     * **A join() without a stop() hangs** -- and hangs only with a pool.  With
+     * threads == 0 there is nothing to retire and this returns at once, so a
+     * serial server survives the wrong order and a pooled one deadlocks on it.
+     * That is a bad failure mode to discover by adding a thread later, so the
+     * order is worth getting right even where it currently cannot bite.
      *
      * **Never from a handler**: with a pool that joins a worker to itself.  And
      * it does not wait for run() -- join the thread you started run() on

--- a/jlib/sys/server.hh
+++ b/jlib/sys/server.hh
@@ -1,0 +1,293 @@
+/* -*- mode: C++ c-basic-offset: 4  -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+#ifndef JLIB_SYS_SERVER_HH
+#define JLIB_SYS_SERVER_HH
+
+#include <jlib/sys/listener.hh>
+#include <jlib/sys/pipe.hh>
+#include <jlib/sys/socketstream.hh>
+#include <jlib/sys/sync.hh>
+#include <jlib/sys/tls.hh>
+
+#include <atomic>
+#include <cstddef>
+#include <exception>
+#include <functional>
+#include <string>
+
+namespace jlib {
+namespace sys {
+
+/**
+ * How a server is set up.  All of it is fixed at construction.
+ *
+ * At namespace scope rather than nested in server, and that is not style: a
+ * default argument is a complete-class context, so `const policy& p = policy()`
+ * on a member of the class that *nests* policy needs the nested aggregate's
+ * member initializers while the enclosing class is still incomplete, and does
+ * not compile.  An earlier version of this header routed around that by
+ * splitting run() into two overloads.  Defining the struct first removes the
+ * problem instead, and server::policy still spells.
+ */
+struct server_policy {
+    /**
+     * Handler threads.  Zero -- the default -- serves each connection on the
+     * accept thread, one at a time.
+     *
+     * A serial server's liveness rests entirely on io_timeout: one client that
+     * connects and says nothing blocks every other client for exactly as long
+     * as a read may block.  Which is why io_timeout is not zero, and why a
+     * caller who sets it to zero "to be safe" has built a denial of service out
+     * of a single connection.
+     */
+    unsigned int threads = 0;
+
+    /** Seconds a handler's reads and writes may block.  Zero is forever. */
+    double io_timeout = 30;
+
+    /**
+     * How deep the job queue may get before the accept loop stops accepting.
+     *
+     * Queue depth and nothing else: a job that has been taken by a worker is
+     * running, not queued, and does not count -- so a busy pool does not make
+     * the queue look full and stall the accept loop against work already under
+     * way.  Zero means "threads", resolved at construction.
+     *
+     * **This bounds descriptors, not concurrency.**  Concurrency is threads.
+     * Since up to threads jobs can be running, the process holds at most
+     * max_queued + threads connection descriptors.  Two numbers, two jobs, and
+     * blurring them is how somebody later removes the cap as redundant and
+     * finds the descriptor bound was load-bearing.
+     */
+    std::size_t max_queued = 0;
+};
+
+/**
+ * Accept connections and hand each one to a handler as a stream.
+ *
+ * jlib was a client for twenty-six years.  listener gave it an accepting
+ * socket; this gives it something to do with one.
+ *
+ * ## Deliberately small, and deliberately blocking
+ *
+ * It accepts, optionally secures, and dispatches.  There is no event loop, no
+ * connection reuse, no protocol.  An event-driven design belongs with the async
+ * I/O work, and the thing that has to survive that change is the *handler
+ * contract* -- given a connection, do something with it -- which is why run()
+ * is a thin loop over serve_one() and not the other way round.
+ *
+ * It is a server for a loopback OAuth2 redirect and a test harness.  **It is
+ * not hardened for a public port**: nothing here defends against a slow-loris,
+ * a flood, or a client that connects and never speaks, beyond a thread count, a
+ * queue depth, a listen backlog and a read timeout.  Saying so is the only
+ * thing that keeps a narrow thing narrow.
+ *
+ * ## One reference covers both transports
+ *
+ * A handler takes a socketstream&, and gets a TLS connection through the same
+ * reference, because basic_tlsstream derives from basic_socketstream.  A
+ * handler cannot tell which it was given, which is the point -- net/http.cc
+ * already holds a unique_ptr<socketstream> for both and this is that idiom
+ * pointed the other way.
+ *
+ * ## Where the connections wait
+ *
+ * A job_queue holds what has been accepted and not yet started, so this does
+ * accept a little ahead of its capacity -- which an earlier version did not,
+ * and which completes a TCP handshake for a client that cannot be served yet.
+ * policy::max_queued is what keeps that bounded: the accept loop waits for room
+ * *before* it polls, so the overflow stays in the kernel's listen backlog,
+ * where a connection is supposed to wait and where the backlog refuses it with
+ * behaviour every client understands.
+ */
+class server {
+public:
+    class exception : public std::exception {
+    public:
+        exception(const std::string& msg = "") {
+            m_msg = "server exception: " + msg;
+        }
+        virtual ~exception() {}
+        virtual const char* what() const noexcept { return m_msg.c_str(); }
+    protected:
+        std::string m_msg;
+    };
+
+    using policy = server_policy;
+
+    /**
+     * What runs for one accepted connection.
+     *
+     * **The reference is valid only for the duration of the call.**  The stream
+     * is destroyed, and its descriptor closed, the moment the handler returns;
+     * a handler that stores the reference has stored a dangling one.
+     */
+    typedef std::function<void(socketstream&, const peer&)> handler;
+
+    /**
+     * What to do with an exception a handler let escape, or a handshake that
+     * did not complete.  Runs on whichever thread the connection did.
+     *
+     * The default writes one line to std::cerr, assembled whole before it is
+     * written -- several threads reporting at once otherwise interleave in the
+     * middle of a message.
+     */
+    typedef std::function<void(const std::exception&, const peer&)> error_handler;
+
+    /** From a listener already bound: the caller chose the port and backlog. */
+    server(listener l, handler h, tls_context tls = tls_context(),
+           const policy& p = policy());
+
+    /** Bind and serve.  Loopback by default, for the reason listener gives. */
+    server(unsigned short port, handler h,
+           const std::string& host = "127.0.0.1",
+           tls_context tls = tls_context(),
+           const policy& p = policy());
+
+    /**
+     * stop(), then join().
+     *
+     * It has to be both.  A handler reaches this object through the handler it
+     * was given, so the wait is what keeps that reference valid.
+     *
+     * **This can block**, for as long as the queued connections take to serve:
+     * the drain is what stops something already accepted being silently
+     * discarded, and io_timeout is what keeps it finite.  A handler that blocks
+     * forever hangs this, which is why io_timeout does not default to never.
+     */
+    ~server();
+
+    server(const server&) = delete;
+    server& operator=(const server&) = delete;
+
+    unsigned short port() const;
+    bool tls() const;
+
+    /** Fixed at construction.  There is no setter; see server_policy. */
+    const policy& get_policy() const { return m_policy; }
+
+    /** Accepted connections waiting for a worker.  Always 0 when serial. */
+    std::size_t pending() const;
+
+    void on_error(error_handler h);
+
+    /**
+     * Accept at most one connection and serve it.
+     *
+     * @param timeout seconds to wait; zero waits until a connection arrives or
+     *                stop() is called.  The wait covers admission control as
+     *                well as the accept: with the queue full this spends the
+     *                timeout waiting for room and returns false without
+     *                accepting, leaving the connection in the listen backlog.
+     * @return true if a connection was accepted, false if the wait ran out or
+     *         stop() interrupted it.
+     *
+     * True means accepted, not served: with a pool the handler has been posted
+     * and may not have started.
+     *
+     * A failure inside one connection -- a handshake that did not complete, a
+     * handler that threw -- goes to on_error() and is not an error here.  A
+     * failure of the listener itself throws.
+     *
+     * **One accept thread.**  Nothing here calls this concurrently, and the
+     * depth cap is only exact if nothing does: two threads can each find room
+     * and then both post.
+     */
+    bool serve_one(double timeout = 0);
+
+    /**
+     * serve_one() until stop().  Blocking; run it on a thread if you want one.
+     *
+     * **One-shot.**  A stopped server cannot be restarted, because
+     * job_queue::stop() retires the pool and nothing respawns it -- a restarted
+     * server would accept connections and drop every one in silence.  So unlike
+     * an earlier version this does not clear the stop flag on entry, and
+     * calling it after stop() returns immediately.
+     */
+    void run();
+
+    /**
+     * Ask run(), and any serve_one() that is waiting, to return.
+     *
+     * Safe from any thread, including from inside a handler.  Idempotent.
+     *
+     * **This is not a barrier**, and everywhere else in this library "stop"
+     * means stopped.  Handlers already running keep running, and whatever they
+     * captured is still in use when this returns.  join() waits for them; the
+     * destructor calls both.
+     *
+     * It has to wake all three ways a thread can be blocked here -- the flag,
+     * the queue's depth wait, and poll(2) -- and the last is a byte down a pipe
+     * rather than closing the listening descriptor, because closing one that
+     * another thread is blocked in poll(2) on is undefined and on macOS does
+     * not wake it.
+     */
+    void stop();
+
+    bool stopped() const;
+
+    /**
+     * Stop taking work, and wait for what has been accepted to be served.
+     *
+     * **This stops the queue**, and that is not an implementation detail to be
+     * tidied away: a job_queue's workers wait for work forever, so "wait for
+     * them to finish" is only a terminating question once they have been told
+     * to leave.  A join() that did not stop would hang, which is exactly what
+     * an earlier version of this did.
+     *
+     * So: serving is over when this returns.  It is the second half of the
+     * destructor, callable on its own -- not a barrier you can take in the
+     * middle of a run and carry on from.
+     *
+     * **Never from a handler**: with a pool that joins a worker to itself.  And
+     * it does not wait for run() -- join the thread you started run() on
+     * yourself, before this object goes out of scope.
+     */
+    void join();
+
+private:
+    void serve(int fd, const peer& from);
+    std::size_t cap() const;
+
+    listener      m_listener;
+    handler       m_handler;
+    error_handler m_on_error;
+    tls_context   m_tls;
+    policy        m_policy;
+
+    // Non-blocking at both ends, so a stop() called a thousand times cannot
+    // block once the pipe fills.
+    pipe m_wake{false, false};
+
+    std::atomic<bool> m_stop{false};
+
+    // Declared last, so it is destroyed first: ~job_queue is stop() then
+    // join(), and every worker has to have left before m_handler, m_tls and
+    // m_listener are destroyed -- a running handler reaches all three.  The
+    // destructor below makes that redundant in the ordinary case and not
+    // redundant when a constructor throws after the pool is built.
+    job_queue m_jobs;
+};
+
+}
+}
+
+#endif // JLIB_SYS_SERVER_HH

--- a/jlib/sys/socketstream.hh
+++ b/jlib/sys/socketstream.hh
@@ -116,11 +116,22 @@ namespace jlib {
              * and by basic_tlsbuf for the name it verifies against -- not for
              * anything to connect to.
              */
-            basic_socketbuf(adopt_t, int fd, const std::string& host = "", unsigned int port = 0) {
+            basic_socketbuf(adopt_t, int fd, const std::string& host = "",
+                            unsigned int port = 0, double timeout = -1) {
                 init_buffers();
                 m_host = host;
                 m_port = port;
                 m_sock = fd;
+
+                // Before configure(), which is the only place it can be got in
+                // front of: configure() calls apply_timeout() unconditionally,
+                // so a SO_RCVTIMEO set on the descriptor before adopting it is
+                // overwritten with the library default -- which is forever.
+                // That is why this parameter exists rather than the caller
+                // setting the option itself: a server has to bound the TLS
+                // handshake, and the handshake happens inside the constructor
+                // that adopts the descriptor.
+                m_io_timeout = timeout;
 
                 try {
                     configure(m_sock);
@@ -483,11 +494,12 @@ namespace jlib {
             }
 
             /** Take over an already-connected descriptor; see basic_socketbuf. */
-            basic_socketstream(adopt_t, int fd, const std::string& host = "", unsigned int port = 0)
+            basic_socketstream(adopt_t, int fd, const std::string& host = "",
+                               unsigned int port = 0, double timeout = -1)
                 : std::basic_iostream<charT,traitT>(NULL)
             {
                 m_buf = 0;
-                m_buf=new basic_socketbuf<charT,traitT>(adopt,fd,host,port);
+                m_buf=new basic_socketbuf<charT,traitT>(adopt,fd,host,port,timeout);
                 this->init(m_buf);
             }
 
@@ -503,21 +515,37 @@ namespace jlib {
                 this->init(m_buf);
             }
 
-            void close() {
-                m_buf->close();
+            /** As the adopting constructor.  There was no open() for one. */
+            void open(adopt_t, int fd, const std::string& host = "",
+                      unsigned int port = 0, double timeout = -1) {
+                if(m_buf != 0)
+                    delete m_buf;
+                m_buf=new basic_socketbuf<charT,traitT>(adopt,fd,host,port,timeout);
+                this->init(m_buf);
             }
 
-            bool interrupted() { return m_buf->interrupted(); }
+            // Every one of these dereferenced m_buf without checking it, so
+            // any of them on a default-constructed socketstream -- which is a
+            // perfectly ordinary thing to have, since open() exists -- was a
+            // null dereference rather than an error.
+            void close() {
+                if(m_buf != 0) m_buf->close();
+            }
+
+            bool interrupted() { return m_buf != 0 && m_buf->interrupted(); }
 
             /** Whether the last read or write gave up on a timeout. */
-            bool timed_out() const { return m_buf->timed_out(); }
+            bool timed_out() const { return m_buf != 0 && m_buf->timed_out(); }
 
             /** Seconds a read or write may block; zero is forever. */
-            void set_timeout(double seconds) { m_buf->set_timeout(seconds); }
+            void set_timeout(double seconds) {
+                if(m_buf != 0) m_buf->set_timeout(seconds);
+            }
 
-            double get_timeout() const { return m_buf->get_timeout(); }
+            double get_timeout() const { return m_buf != 0 ? m_buf->get_timeout() : 0; }
 
-            int get_socket() { return m_buf->get_socket(); }
+            /** -1 when there is no connection, as an unopened descriptor is. */
+            int get_socket() { return m_buf != 0 ? m_buf->get_socket() : -1; }
             
         protected:
             basic_socketbuf<charT,traitT>* m_buf;

--- a/jlib/sys/sslproxystream.hh
+++ b/jlib/sys/sslproxystream.hh
@@ -72,6 +72,8 @@ public:
     void open(const std::string& host, unsigned int port,
               const std::string& phost, u_int pport, bool delay = false)
     {
+        if(this->m_buf != 0)
+            delete this->m_buf;
         this->m_buf = new basic_sslproxybuf<charT,traitT>(host, delay,
                                                           host, port, phost, pport);
         this->init(this->m_buf);

--- a/jlib/sys/sslstream.hh
+++ b/jlib/sys/sslstream.hh
@@ -22,6 +22,7 @@
 #define JLIB_SYS_SSLSTREAM_HH
 
 #include <jlib/sys/socketstream.hh>
+#include <jlib/sys/tls.hh>
 
 #include <openssl/ssl.h>
 #include <openssl/err.h>
@@ -46,6 +47,14 @@ namespace jlib {
          * base, because for a proxy connection the base's m_host is the
          * *proxy's* name.  The certificate has to belong to the server that
          * was asked for.
+         *
+         * ## Both directions
+         *
+         * The same mixin answers a handshake as well as starting one.  Which it
+         * does is fixed by the constructor -- there are three, and the first
+         * argument says which: a name to verify is a client, a tls_server_t tag
+         * is a server.  Everything below the handshake is identical, which is
+         * why this is a second open_ssl() branch and not a second class.
          */
         template< typename Base, typename charT, typename traitT = std::char_traits<charT> >
         class basic_tlsbuf : public Base {
@@ -59,6 +68,8 @@ namespace jlib {
             static const unsigned int BUF_SIZE = 1024;
 
             /**
+             * A client, with a context built for this connection.
+             *
              * @param verify_host the name the certificate must be good for
              * @param delay       connect without handshaking; see start()
              * @param args        whatever Base's constructor takes
@@ -66,13 +77,57 @@ namespace jlib {
             template<typename... Args>
             basic_tlsbuf(const std::string& verify_host, bool delay, Args&&... args)
                 : Base(std::forward<Args>(args)...),
-                  m_ctx(0),
                   m_ssl(0),
                   m_verify_host(verify_host),
-                  m_delay(delay)
+                  m_delay(delay),
+                  m_accept(false)
             {
                 if(getenv("JLIB_SYS_SOCKET_DEBUG"))
                     std::cerr << "basic_tlsbuf::basic_tlsbuf(" << verify_host << ", "
+                              << std::boolalpha << delay << ")"<<std::endl;
+                if(!m_delay)
+                    open_ssl();
+            }
+
+            /** A client, against a context the caller keeps and shares. */
+            template<typename... Args>
+            basic_tlsbuf(tls_context ctx, const std::string& verify_host, bool delay,
+                         Args&&... args)
+                : Base(std::forward<Args>(args)...),
+                  m_ctx(std::move(ctx)),
+                  m_ssl(0),
+                  m_verify_host(verify_host),
+                  m_delay(delay),
+                  m_accept(false)
+            {
+                if(!m_delay)
+                    open_ssl();
+            }
+
+            /**
+             * A server: answer the handshake rather than start it.
+             *
+             * There is no verify_host, and that is not an omission.  A server
+             * verifies the name of a client only if the client offered a
+             * certificate, and by the note on tls_context it is never asked
+             * for one -- so there is no name here to check against anything.
+             *
+             * @param ctx    the certificate and key, shared across connections
+             * @param delay  take the connection without handshaking; start()
+             *               does it later, which is STARTTLS on this side
+             * @param args   whatever Base's constructor takes -- for a server
+             *               that is sys::adopt and an accepted descriptor
+             */
+            template<typename... Args>
+            basic_tlsbuf(tls_server_t, tls_context ctx, bool delay, Args&&... args)
+                : Base(std::forward<Args>(args)...),
+                  m_ctx(std::move(ctx)),
+                  m_ssl(0),
+                  m_delay(delay),
+                  m_accept(true)
+            {
+                if(getenv("JLIB_SYS_SOCKET_DEBUG"))
+                    std::cerr << "basic_tlsbuf::basic_tlsbuf(server, "
                               << std::boolalpha << delay << ")"<<std::endl;
                 if(!m_delay)
                     open_ssl();
@@ -159,16 +214,40 @@ namespace jlib {
                 if(m_ssl != 0) {
                     SSL_shutdown(m_ssl);
                     SSL_free(m_ssl);
-                    SSL_CTX_free(m_ctx);
                     m_ssl = 0;
-                    m_ctx = 0;
                 }
+
+                // No SSL_CTX_free: the context is refcounted now, so dropping
+                // this reference frees it only if it was the last -- which is
+                // what lets a server share one across every connection.
+                m_ctx = tls_context();
                 Base::close();
             }
 
             void start() {
                 m_delay = false;
                 open_ssl();
+            }
+
+            /**
+             * Drop the connection without a close_notify.
+             *
+             * Which is what a server that has gone down leaves behind, and what
+             * a test simulating one has to be able to produce.  close() is the
+             * polite form and is what everything else should use; this exists
+             * because sys_tls_sigpipe_test needs a peer that vanishes, and it
+             * had been calling SSL_free with no SSL_shutdown in front of it by
+             * hand to get one.
+             */
+            virtual void reset() {
+                if(m_ssl != 0) {
+                    SSL_free(m_ssl);
+                    m_ssl = 0;
+                }
+
+                m_ctx = tls_context();
+
+                Base::close();
             }
 
         protected:
@@ -230,38 +309,50 @@ namespace jlib {
                 // and SSL_load_error_strings became no-ops there and are gone
                 // in 3.0, along with the hand-rolled once-guard they needed.
 
-                // TLS_client_method, always.  It was a constructor parameter,
-                // and TLS_client_method was the only thing any caller ever
-                // passed -- the older spellings it existed to allow are
-                // SSLv2 and SSLv3, both removed from OpenSSL.
-                m_ctx = SSL_CTX_new(TLS_client_method());
-                if(m_ctx == 0) {
-                    std::cerr <<"exception in jlib::sys::sslstream::open_ssl()"<<std::endl;
-                    throw typename Base::exception("error calling SSL_CTX_new()");
+                if(m_ctx.empty()) {
+                    if(m_accept) {
+                        throw typename Base::exception("a server handshake with "
+                                                       "no certificate");
+                    }
+
+                    // What was written out here: TLS_client_method, a TLS 1.2
+                    // floor, SSL_VERIFY_PEER and the default verify paths.  A
+                    // client with no context of its own still gets one per
+                    // connection, deliberately -- see the note in tls.hh about
+                    // SSL_CERT_FILE being read when the context is built.
+                    m_ctx = tls_context::client();
                 }
 
-                // SSL_OP_NO_SSLv2 has been a no-op since 1.1 and SSLv3 is long
-                // dead; state the floor directly instead.
-                SSL_CTX_set_min_proto_version(m_ctx, TLS1_2_VERSION);
+                // So print() reports this operation rather than whatever last
+                // failed on this thread.
+                ERR_clear_error();
 
-                SSL_CTX_set_verify(m_ctx, SSL_VERIFY_PEER, nullptr);
-
-                // This used to hardcode /etc/ssl/certs, which does not exist on
-                // macOS -- so with SSL_VERIFY_PEER set, every connection there
-                // failed to validate.  Use the locations OpenSSL was built
-                // with, still overridable via SSL_CERT_FILE and SSL_CERT_DIR.
-                // NB: not print() here -- that reports via SSL_get_error(m_ssl),
-                // and m_ssl does not exist until SSL_new below.
-                if(!SSL_CTX_set_default_verify_paths(m_ctx)) {
-                    throw typename Base::exception("error calling SSL_CTX_set_default_verify_paths()");
+                try {
+                    m_ssl = m_ctx.new_ssl();
+                }
+                catch(tls_context::exception& e) {
+                    throw typename Base::exception(e.what());
                 }
 
-                m_ssl = SSL_new(m_ctx);
-                if(m_ssl == 0) {
-                    std::cerr <<"exception in jlib::sys::sslstream::open_ssl()"<<std::endl;
-                    throw typename Base::exception("error calling SSL_new()");
-                }
+                try {
+                    throw_if("SSL_set_fd", SSL_set_fd(m_ssl, this->m_sock));
 
+                    if(m_accept) accept_tls();
+                    else         connect_tls();
+                }
+                catch(...) {
+                    // A constructor that throws gets no destructor, so without
+                    // this the SSL leaks -- once per failed handshake.  On a
+                    // client that is a rare accident; on a server it is once
+                    // per connection an attacker chooses to fail.
+                    SSL_free(m_ssl);
+                    m_ssl = 0;
+                    throw;
+                }
+            }
+
+            /** Start a handshake, and insist the certificate is the right one. */
+            void connect_tls() {
                 // Check that the certificate actually belongs to the host we
                 // asked for.  Verifying the chain without this accepts any
                 // valid certificate from any server the trust store covers,
@@ -278,14 +369,27 @@ namespace jlib {
                     SSL_set_tlsext_host_name(m_ssl, m_verify_host.c_str());
                 }
 
-                throw_if("SSL_set_fd", SSL_set_fd(m_ssl, this->m_sock));
                 throw_if("SSL_connect", SSL_connect(m_ssl));
             }
-            
-            SSL_CTX* m_ctx;
+
+            /**
+             * Answer one, and nothing else.
+             *
+             * No SSL_set1_host and no SNI: there is no name to check, because
+             * the client has not offered a certificate and by the note on
+             * tls_context is not asked to.  SNI is something a client sends and
+             * a server may read; reading it would mean choosing a certificate
+             * per name, which is a virtual-hosting feature this does not have.
+             */
+            void accept_tls() {
+                throw_if("SSL_accept", SSL_accept(m_ssl));
+            }
+
+            tls_context m_ctx;
             SSL* m_ssl;
             std::string m_verify_host;
             bool m_delay;
+            bool m_accept;
         };
 
         /** TLS straight over a socket. */
@@ -322,13 +426,72 @@ namespace jlib {
             }
             
             void open(const std::string& host, unsigned int port, bool delay = false) {
+                // delete first: this replaced m_buf without freeing the old one,
+                // where basic_socketstream::open has always got it right.
+                if(this->m_buf != 0)
+                    delete this->m_buf;
                 this->m_buf = new basic_sslbuf<charT,traitT>(host, delay, host, port);
+                this->init(this->m_buf);
+            }
+
+            /**
+             * Server side: take over an accepted descriptor and answer the
+             * handshake on it.
+             *
+             * Both tags, because both facts carry weight.  tls_server_t says
+             * which direction the handshake goes; adopt_t says the int is a
+             * descriptor and not a port, which is the whole reason adopt_t
+             * exists.
+             *
+             * @param ctx      the certificate and key, shared across connections
+             * @param fd       an accepted descriptor, which this takes over
+             * @param host     what to call the peer in a message; not connected to
+             * @param timeout  seconds a read or write may block, applied to the
+             *                 descriptor *before* the handshake, so it bounds
+             *                 the handshake too.  Negative takes the library
+             *                 default, which is forever.
+             * @param delay    take the connection without handshaking; start()
+             *                 does it later, which is STARTTLS on this side
+             */
+            basic_tlsstream(tls_server_t, const tls_context& ctx, adopt_t, int fd,
+                            const std::string& host = "", unsigned int port = 0,
+                            double timeout = -1, bool delay = false)
+                : basic_socketstream<charT,traitT>()
+            {
+                this->m_buf = new basic_sslbuf<charT,traitT>(tls_server, ctx, delay,
+                                                             adopt, fd, host, port,
+                                                             timeout);
+                this->init(this->m_buf);
+            }
+
+            void open(tls_server_t, const tls_context& ctx, adopt_t, int fd,
+                      const std::string& host = "", unsigned int port = 0,
+                      double timeout = -1, bool delay = false)
+            {
+                if(this->m_buf != 0)
+                    delete this->m_buf;
+
+                this->m_buf = new basic_sslbuf<charT,traitT>(tls_server, ctx, delay,
+                                                             adopt, fd, host, port,
+                                                             timeout);
                 this->init(this->m_buf);
             }
 
             /** Handshake now, on a stream opened with delay = true. */
             void start() {
                 dynamic_cast< basic_sslbuf<charT,traitT>* >(this->m_buf)->start();
+            }
+
+            /**
+             * Drop the connection without a close_notify; see basic_tlsbuf.
+             *
+             * For a peer that has to look like it vanished.  close() is the
+             * polite form and is what everything else wants.
+             */
+            void reset() {
+                if(basic_sslbuf<charT,traitT>* b =
+                       dynamic_cast< basic_sslbuf<charT,traitT>* >(this->m_buf))
+                    b->reset();
             }
 
         };

--- a/jlib/sys/sync.hh
+++ b/jlib/sys/sync.hh
@@ -84,7 +84,7 @@ public:
     void operator()(const_reference val) { set(val); }
 
     operator T() const { return get(); }
-    operator std::mutex&() { return m_lock; }
+    operator std::mutex&() const { return m_lock; }
 
     sync<T>& operator=(const_reference val) { set(val); return *this; }
 
@@ -110,7 +110,10 @@ public:
     pointer operator->() { return &m_val; }
     const_pointer operator->() const { return &m_val; }
 
-    std::mutex& mutex() { return m_lock; }
+    // const, because m_lock is mutable and get() above already hands it to
+    // safe_get from a const member.  Without this a const sync<T> cannot be
+    // locked, which is what job_queue::size() needs.
+    std::mutex& mutex() const { return m_lock; }
 
     void lock() { m_lock.lock(); }
     void unlock() { m_lock.unlock(); }
@@ -121,6 +124,24 @@ public:
     
     void wait(std::unique_lock<std::mutex>& lock, std::chrono::nanoseconds timeout) {
         m_cond.wait_for(lock, timeout);
+    }
+
+    /**
+     * Wait until the predicate holds or the time runs out.
+     *
+     * @return what the predicate said at the end, as std::condition_variable
+     *         does -- so false means the deadline won, not that anything failed.
+     *
+     * The requires clause is not load-bearing here the way it is on the
+     * two-argument form below, since arity already tells the overloads apart.
+     * It is here so that a third argument which is not callable fails as a
+     * constraint rather than somewhere inside condition_variable.
+     */
+    template<typename Predicate>
+        requires std::predicate<Predicate>
+    bool wait(std::unique_lock<std::mutex>& lock, std::chrono::nanoseconds timeout,
+              Predicate pred) {
+        return m_cond.wait_for(lock, timeout, std::move(pred));
     }
 
     /**
@@ -290,10 +311,87 @@ public:
 
         // Push and signal in one critical section; see the note on
         // sync<T>::notify.
+        //
+        // notify_all, not notify_one, and this changed when wait() arrived.
+        // One condition variable now serves two predicates -- a worker waiting
+        // for work, a caller waiting for room -- and they are anti-correlated:
+        // a push makes the worker's true and the waiter's no more true, and a
+        // pop does the reverse.  So notify_one can hand the wakeup to a thread
+        // whose predicate is false, which sleeps again and consumes it.  It was
+        // correct here for as long as there was only one predicate.
         std::unique_lock<std::mutex> lock(m_queue);
 
         m_queue().push(std::move(job));
-        m_queue.notify();
+        m_queue.notify_all();
+    }
+
+    /**
+     * How many jobs are queued and not yet started.
+     *
+     * Not how much work is outstanding: a job that has been popped is running,
+     * not queued, and is not counted here.  Always 0 when there is no pool,
+     * because post() runs the job instead of queueing it.
+     */
+    std::size_t size() const {
+        std::unique_lock<std::mutex> lock(m_queue);
+
+        return m_queue().size();
+    }
+
+    /**
+     * Block until the queue's depth satisfies a predicate.
+     *
+     * @param pred called with the current depth, under the lock, whenever the
+     *             depth changes
+     * @return true when the predicate held, false if the queue was stopped first
+     *
+     * The queue does not decide what "full" means; a caller does.  "Room for
+     * one more" is [cap](std::size_t d) { return d < cap; }, and "nothing
+     * waiting" is [](std::size_t d) { return d == 0; }.
+     *
+     * The wait's own predicate ORs in the exit flag, which is why the return
+     * value distinguishes "the predicate held" from "we were stopped": without
+     * that term stop() would wake a waiter, it would re-evaluate the caller's
+     * predicate, find it still false and sleep again -- and stop() would have
+     * stopped nothing for that thread.
+     *
+     * **With no pool this never blocks.**  Nothing is ever queued, so the depth
+     * is 0 and can never change; blocking would be a deadlock with no second
+     * party.  It answers pred(0) -- yes to "is there room", and a truthful no
+     * to a predicate that cannot hold, rather than a hang.
+     *
+     * **Never from a job.**  A worker waiting for the queue to drain is the
+     * thread that would drain it.  And no thread may be blocked here when the
+     * queue is destroyed: join() waits for pool threads, not for foreign
+     * callers parked in this.
+     */
+    template<typename Predicate>
+        requires std::predicate<Predicate, std::size_t>
+    bool wait(Predicate pred) {
+        if(m_pool.empty()) return !m_exit && pred(0);
+
+        std::unique_lock<std::mutex> lock(m_queue);
+
+        m_queue.wait(lock, [this, &pred] {
+            return m_exit || pred(m_queue().size());
+        });
+
+        return !m_exit;
+    }
+
+    /** As above, giving up after timeout.  False for either reason. */
+    template<typename Predicate>
+        requires std::predicate<Predicate, std::size_t>
+    bool wait(Predicate pred, std::chrono::nanoseconds timeout) {
+        if(m_pool.empty()) return !m_exit && pred(0);
+
+        std::unique_lock<std::mutex> lock(m_queue);
+
+        m_queue.wait(lock, timeout, [this, &pred] {
+            return m_exit || pred(m_queue().size());
+        });
+
+        return !m_exit && pred(m_queue().size());
     }
 
     /**
@@ -380,6 +478,13 @@ protected:
                 // one mutex, so exactly one job ran at a time.
                 job = std::move(m_queue().front());
                 m_queue().pop();
+
+                // A caller parked in wait() has no other way to learn the queue
+                // got shorter.  Here rather than after run(): the slot is free
+                // the instant the job is popped, and notifying after would make
+                // a depth cap bound work in flight instead, and make the waiter
+                // wait on how long a job takes.
+                m_queue.notify_all();
             }
 
             run(job);

--- a/jlib/sys/tls.cc
+++ b/jlib/sys/tls.cc
@@ -1,0 +1,134 @@
+/* -*- mode: C++ c-basic-offset: 4  -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+#include <jlib/sys/tls.hh>
+
+#include <openssl/err.h>
+#include <openssl/ssl.h>
+
+namespace jlib {
+namespace sys {
+
+namespace {
+
+    /** Whatever OpenSSL has to say about the last failure, drained. */
+    std::string why() {
+        std::string out;
+
+        for(unsigned long e = ERR_get_error(); e != 0; e = ERR_get_error()) {
+            char buf[256];
+
+            ERR_error_string_n(e, buf, sizeof buf);
+
+            if(!out.empty()) out += "; ";
+
+            out += buf;
+        }
+
+        return out.empty() ? std::string("no further detail") : out;
+    }
+
+}
+
+tls_context::tls_context(SSL_CTX* ctx)
+    : m_ctx(ctx, SSL_CTX_free)
+{}
+
+tls_context tls_context::client() {
+    // OpenSSL 1.1 initializes itself on first use, so there is no library init
+    // here and no once-guard; configure.ac requires >= 1.1.
+    ERR_clear_error();
+
+    SSL_CTX* ctx = SSL_CTX_new(TLS_client_method());
+
+    if(ctx == 0) throw exception("SSL_CTX_new: " + why());
+
+    tls_context held(ctx);
+
+    // TLS 1.0 and 1.1 are deprecated by RFC 8996 and no mail or token endpoint
+    // needs them.
+    if(!SSL_CTX_set_min_proto_version(ctx, TLS1_2_VERSION))
+        throw exception("SSL_CTX_set_min_proto_version: " + why());
+
+    SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER, 0);
+
+    // Read here, which is why there is no cached context: a caller that sets
+    // SSL_CERT_FILE for one run -- as three tests in this tree do -- needs the
+    // context built after they set it.
+    if(!SSL_CTX_set_default_verify_paths(ctx))
+        throw exception("SSL_CTX_set_default_verify_paths: " + why());
+
+    return held;
+}
+
+tls_context tls_context::server(const std::string& cert_file,
+                                const std::string& key_file)
+{
+    ERR_clear_error();
+
+    SSL_CTX* ctx = SSL_CTX_new(TLS_server_method());
+
+    if(ctx == 0) throw exception("SSL_CTX_new: " + why());
+
+    tls_context held(ctx);
+
+    if(!SSL_CTX_set_min_proto_version(ctx, TLS1_2_VERSION))
+        throw exception("SSL_CTX_set_min_proto_version: " + why());
+
+    // The chain form, not SSL_CTX_use_certificate_file: a certificate signed by
+    // an intermediate has to send the intermediate too, or every client that
+    // does not already hold it fails to build a path.  It reads a
+    // single-certificate file identically, so there is nothing to choose
+    // between them for the simple case.
+    if(SSL_CTX_use_certificate_chain_file(ctx, cert_file.c_str()) != 1)
+        throw exception("could not read the certificate \"" + cert_file +
+                        "\": " + why());
+
+    if(SSL_CTX_use_PrivateKey_file(ctx, key_file.c_str(), SSL_FILETYPE_PEM) != 1)
+        throw exception("could not read the private key \"" + key_file +
+                        "\": " + why());
+
+    // Now, rather than on the first client to connect.  A mismatched pair
+    // otherwise fails inside SSL_accept, where it reads as a handshake problem
+    // and the certificate is the last thing anyone looks at.
+    if(SSL_CTX_check_private_key(ctx) != 1)
+        throw exception("the private key \"" + key_file + "\" does not match "
+                        "the certificate \"" + cert_file + "\": " + why());
+
+    // No SSL_CTX_set_verify and no client CA list: see the note in the header
+    // about client certificates being out of scope.
+
+    return held;
+}
+
+SSL* tls_context::new_ssl() const {
+    if(!m_ctx) throw exception("new_ssl() on an empty context");
+
+    ERR_clear_error();
+
+    SSL* ssl = SSL_new(m_ctx.get());
+
+    if(ssl == 0) throw exception("SSL_new: " + why());
+
+    return ssl;
+}
+
+}
+}

--- a/jlib/sys/tls.hh
+++ b/jlib/sys/tls.hh
@@ -1,0 +1,126 @@
+/* -*- mode: C++ c-basic-offset: 4  -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+#ifndef JLIB_SYS_TLS_HH
+#define JLIB_SYS_TLS_HH
+
+#include <exception>
+#include <memory>
+#include <string>
+
+struct ssl_ctx_st;
+struct ssl_st;
+
+namespace jlib {
+namespace sys {
+
+/**
+ * Tag for the handshake that answers rather than starts.
+ *
+ * A tag rather than a flag because the two roles are not two settings of one
+ * thing: a client verifies a name it was given, a server presents a certificate
+ * it holds, and neither has the other's arguments.  Spelling them as separate
+ * constructors makes a call site say which it is.
+ */
+struct tls_server_t { explicit tls_server_t() = default; };
+inline constexpr tls_server_t tls_server{};
+
+/**
+ * A refcounted SSL_CTX.
+ *
+ * basic_tlsbuf built one of these per connection and freed it in close(), which
+ * is affordable for a client making one call and is not what a server does: a
+ * server's certificate and key are read once and every accepted connection
+ * SSL_new()s against the same context.  Copying one is a refcount, so a context
+ * outlives any connection using it and the last reference frees it.
+ *
+ * ## Client certificates are out of scope
+ *
+ * A server context here sets no SSL_VERIFY_PEER and installs no client CA list,
+ * so a client that offers a certificate is not asked for one and one offered
+ * anyway is not examined.  Mutual TLS is a different feature with a different
+ * API, and this is deliberately not half of it -- an unexercised verification
+ * path that looks like it works is worse than none.
+ *
+ * ## There is no cached default client context, on purpose
+ *
+ * client() builds a new one every time, and that is not an oversight to be
+ * optimised away later.  SSL_CTX_set_default_verify_paths reads SSL_CERT_FILE
+ * *when the context is built*, and three tests in this tree install trust for
+ * one run by setting that variable at runtime -- see tests/certificate.hh.  A
+ * context cached at first use would freeze the trust store at whatever the
+ * first connection in the process happened to see, and the failure would look
+ * like a certificate problem rather than a caching one.
+ */
+class tls_context {
+public:
+    class exception : public std::exception {
+    public:
+        exception(const std::string& msg = "") {
+            m_msg = "tls_context exception: " + msg;
+        }
+        virtual ~exception() {}
+        virtual const char* what() const noexcept { return m_msg.c_str(); }
+    protected:
+        std::string m_msg;
+    };
+
+    /** Absent.  For a client this means "make the usual one per connection". */
+    tls_context() = default;
+
+    /**
+     * What basic_tlsbuf::open_ssl() used to build inline: TLS_client_method,
+     * TLS 1.2 as the floor, SSL_VERIFY_PEER, and the default verify paths.
+     */
+    static tls_context client();
+
+    /**
+     * A server identity: that certificate chain, that private key, both PEM.
+     *
+     * Uses SSL_CTX_use_certificate_chain_file rather than the single-certificate
+     * form, because a real server has intermediates -- and the chain form reads
+     * a one-certificate file too, so nothing is given up.
+     *
+     * The key is checked against the certificate here, so a mismatched pair is
+     * a failure now rather than a handshake failure on the first client to
+     * arrive, which is a much harder thing to read.
+     */
+    static tls_context server(const std::string& cert_file,
+                              const std::string& key_file);
+
+    bool empty() const { return !m_ctx; }
+    explicit operator bool() const { return static_cast<bool>(m_ctx); }
+
+    /** Borrowed; null when empty(). */
+    ssl_ctx_st* get() const { return m_ctx.get(); }
+
+    /** SSL_new against it.  Throws rather than handing back a null. */
+    ssl_st* new_ssl() const;
+
+private:
+    explicit tls_context(ssl_ctx_st* ctx);      // takes ownership
+
+    std::shared_ptr<ssl_ctx_st> m_ctx;          // deleter is SSL_CTX_free
+};
+
+}
+}
+
+#endif // JLIB_SYS_TLS_HH

--- a/jlib/util/http.cc
+++ b/jlib/util/http.cc
@@ -121,14 +121,14 @@ std::string read_head(std::istream& is, std::size_t cap) {
         const int c = is.get();
 
         if(c == std::char_traits<char>::eof()) {
-            throw error("the connection closed before the response head ended, "
+            throw error("the connection closed before the message head ended, "
                         "after " + std::to_string(head.size()) + " octets");
         }
 
         head += static_cast<char>(c);
 
         if(head.size() > cap) {
-            throw error("no end to the response head within " +
+            throw error("no end to the message head within " +
                         std::to_string(cap) + " octets");
         }
     }
@@ -190,6 +190,160 @@ namespace {
 
 }
 
+namespace {
+
+    /**
+     * The field lines of a head, read against field-line.
+     *
+     * Shared by a request and a response because a field section is the same
+     * production in both -- RFC 9112 2.1 puts start-line above it and says
+     * nothing else differs.
+     */
+    void read_fields(const std::vector<std::string>& lines, std::size_t from,
+                     fields& into)
+    {
+        const abnf::rule field = grammar().at("field-line");
+
+        for(std::size_t i = from; i < lines.size(); i++) {
+            // obs-fold: a line beginning with SP or HTAB continues the one
+            // before it.  RFC 9112 5.2 says a recipient of a message that is
+            // not a message/http payload must either reject it or replace the
+            // fold with a space; rejecting is the safe half of that choice.
+            if(lines[i][0] == ' ' || lines[i][0] == '\t') {
+                throw error("obs-fold, an obsolete line continuation, in the "
+                            "message head: \"" + lines[i] + "\"");
+            }
+
+            const abnf::parse_result p = field.try_parse(lines[i]);
+
+            if(!p) throw error("not a header field: \"" + lines[i] + "\"");
+
+            const abnf::match m = p.root();
+
+            // The value comes from the match, not from find(':'), which is the
+            // point of having the grammar: field-line puts the OWS outside
+            // field-value, so what is captured is already trimmed at both ends.
+            into.add(m["field-name"].str(), m["field-value"].str());
+        }
+    }
+
+    /**
+     * RFC 9112 6.  Which of Content-Length and Transfer-Encoding governs, and
+     * what to refuse outright.
+     *
+     * @param no_body   this message cannot have one whatever the fields say
+     * @param bodyless  what to use when neither field is present: framing::none
+     *                  for a request, framing::until_close for a response
+     */
+    void decide_framing(const fields& f, bool no_body, framing bodyless,
+                        framing& how, std::size_t& length)
+    {
+        const bool has_te = f.has("Transfer-Encoding");
+        const bool has_cl = f.has("Content-Length");
+
+        how = bodyless;
+        length = 0;
+
+        if(has_te && has_cl) {
+            // The request-smuggling primitive.  RFC 9112 6.1: a message with
+            // both "ought to be handled as an error"; the reason it is an error
+            // rather than a preference is that a proxy in front of us may pick
+            // the other one, and then the tail of this message is the head of
+            // the next request as far as one of us is concerned.
+            throw error("both Content-Length and Transfer-Encoding are present; "
+                        "where this message ends depends on who is reading it");
+        }
+
+        if(has_cl) {
+            const std::vector<std::string> all = f.all("Content-Length");
+
+            for(const std::string& v : all) {
+                if(!all_digits(v))
+                    throw error("Content-Length is not a number: \"" + v + "\"");
+
+                if(v != all[0])
+                    throw error("two Content-Length fields that do not agree: \"" +
+                                all[0] + "\" and \"" + v + "\"");
+            }
+
+            try {
+                length = static_cast<std::size_t>(std::stoull(all[0]));
+            }
+            catch(std::exception&) {
+                throw error("Content-Length does not fit: \"" + all[0] + "\"");
+            }
+
+            how = framing::length;
+        }
+        else if(has_te) {
+            // 6.1: chunked must be the final coding.
+            const std::string te = fold(f.get("Transfer-Encoding"));
+            const std::size_t last = te.find_last_of(',');
+            const std::string final = last == std::string::npos
+                                      ? te : te.substr(last + 1);
+
+            std::string trimmed;
+
+            for(char c : final) {
+                if(c != ' ' && c != '\t') trimmed += c;
+            }
+
+            if(trimmed == "chunked") {
+                how = framing::chunked;
+            }
+            else if(bodyless == framing::none) {
+                // A request.  6.3: if the final coding is not chunked the
+                // server cannot tell where the body ends, and reading to close
+                // would mean waiting out a client that is waiting for us.
+                throw error("a request whose Transfer-Encoding does not end in "
+                            "chunked has no discernible end: \"" +
+                            f.get("Transfer-Encoding") + "\"");
+            }
+            else {
+                how = framing::until_close;
+            }
+        }
+
+        if(no_body) {
+            how = framing::none;
+            length = 0;
+        }
+    }
+
+}
+
+Request parse_request_head(std::string_view head) {
+    const std::vector<std::string> lines = split_lines(head);
+
+    if(lines.empty()) throw error("the request head is empty");
+
+    Request r;
+
+    {
+        const abnf::parse_result p = grammar().at("request-line").try_parse(lines[0]);
+
+        if(!p) throw error("not a request line: \"" + lines[0] + "\"");
+
+        const abnf::match m = p.root();
+
+        r.m_method = m["method"].str();
+        r.m_target = m["request-target"].str();
+        r.m_version = m["HTTP-version"].str();
+    }
+
+    read_fields(lines, 1, r.m_fields);
+
+    // framing::none when neither field is there, which is the whole difference
+    // from a response: RFC 9112 6.3, and see the note in the header.
+    decide_framing(r.m_fields, false, framing::none, r.m_framing, r.m_length);
+
+    return r;
+}
+
+Request read_request_head(std::istream& is, std::size_t cap) {
+    return parse_request_head(read_head(is, cap));
+}
+
 Response parse_head(std::string_view head, bool head_request) {
     const std::vector<std::string> lines = split_lines(head);
 
@@ -223,95 +377,17 @@ Response parse_head(std::string_view head, bool head_request) {
         if(reason) r.m_reason = reason.str();
     }
 
-    {
-        const abnf::rule field = grammar().at("field-line");
+    read_fields(lines, 1, r.m_fields);
 
-        for(std::size_t i = 1; i < lines.size(); i++) {
-            // obs-fold: a line beginning with SP or HTAB continues the one
-            // before it.  RFC 9112 5.2 says a recipient of a message that is
-            // not a message/http payload must either reject it or replace the
-            // fold with a space; rejecting is the safe half of that choice,
-            // and nothing has sent jlib one since HTTP/1.0.
-            if(lines[i][0] == ' ' || lines[i][0] == '\t') {
-                throw error("obs-fold, an obsolete line continuation, in the "
-                            "response head: \"" + lines[i] + "\"");
-            }
-
-            const abnf::parse_result p = field.try_parse(lines[i]);
-
-            if(!p) throw error("not a header field: \"" + lines[i] + "\"");
-
-            const abnf::match m = p.root();
-
-            // The value comes from the match, not from find(':'), which is the
-            // point of having the grammar: field-line puts the OWS outside
-            // field-value, so what is captured is already trimmed at both ends.
-            r.m_fields.add(m["field-name"].str(), m["field-value"].str());
-        }
-    }
-
-    // ------------------------------------------------------ RFC 9112 6.3
-
+    // RFC 9112 6.3.  A response with neither framing field runs until the
+    // connection closes, which is the difference from a request.
     const bool no_body = head_request ||
                          (r.m_status >= 100 && r.m_status < 200) ||
                          r.m_status == 204 ||
                          r.m_status == 304;
 
-    const bool has_te = r.m_fields.has("Transfer-Encoding");
-    const bool has_cl = r.m_fields.has("Content-Length");
-
-    if(has_te && has_cl) {
-        // The request-smuggling primitive.  RFC 9112 6.1: a message with both
-        // "ought to be handled as an error"; the reason it is an error rather
-        // than a preference is that a proxy in front of us may pick the other
-        // one, and then the tail of this message is the head of the next
-        // request as far as one of us is concerned.
-        throw error("both Content-Length and Transfer-Encoding are present; "
-                    "where this message ends depends on who is reading it");
-    }
-
-    if(has_cl) {
-        const std::vector<std::string> all = r.m_fields.all("Content-Length");
-
-        for(const std::string& v : all) {
-            if(!all_digits(v))
-                throw error("Content-Length is not a number: \"" + v + "\"");
-
-            if(v != all[0])
-                throw error("two Content-Length fields that do not agree: \"" +
-                            all[0] + "\" and \"" + v + "\"");
-        }
-
-        try {
-            r.m_length = static_cast<std::size_t>(std::stoull(all[0]));
-        }
-        catch(std::exception&) {
-            throw error("Content-Length does not fit: \"" + all[0] + "\"");
-        }
-
-        r.m_framing = framing::length;
-    }
-    else if(has_te) {
-        // 6.1: chunked must be the final coding, and if it is not there the
-        // message ends at the close of the connection.
-        const std::string te = fold(r.m_fields.get("Transfer-Encoding"));
-        const std::size_t last = te.find_last_of(',');
-        const std::string final = last == std::string::npos
-                                  ? te : te.substr(last + 1);
-
-        std::string trimmed;
-
-        for(char c : final) {
-            if(c != ' ' && c != '\t') trimmed += c;
-        }
-
-        r.m_framing = trimmed == "chunked" ? framing::chunked : framing::until_close;
-    }
-
-    if(no_body) {
-        r.m_framing = framing::none;
-        r.m_length = 0;
-    }
+    decide_framing(r.m_fields, no_body, framing::until_close,
+                   r.m_framing, r.m_length);
 
     return r;
 }
@@ -380,12 +456,18 @@ namespace {
 }
 
 std::string read_body(std::istream& is, const Response& head, std::size_t cap) {
-    switch(head.body_framing()) {
+    return read_body(is, head.body_framing(), head.content_length(), cap);
+}
+
+std::string read_body(std::istream& is, framing how, std::size_t length,
+                      std::size_t cap)
+{
+    switch(how) {
     case framing::none:
         return std::string();
 
     case framing::length:
-        return read_exactly(is, head.content_length(), cap);
+        return read_exactly(is, length, cap);
 
     case framing::chunked: {
         std::string body;

--- a/jlib/util/http.hh
+++ b/jlib/util/http.hh
@@ -173,6 +173,80 @@ private:
 };
 
 /**
+ * One request: its head, and its body once something has read one.
+ *
+ * The mirror of Response, and here rather than in net for the same reason: the
+ * grammar, the line splitting and the framing checks are all in this file and
+ * must not be written twice.  net::http re-exports the name, so a caller says
+ * net::http::Request either way.
+ */
+class Request {
+public:
+    Request() = default;
+
+    /** "GET".  A token, and compared with case -- RFC 9110 9.1. */
+    const std::string& method() const { return m_method; }
+
+    /** The request-target exactly as it arrived, query and all. */
+    const std::string& target() const { return m_target; }
+
+    const std::string& version() const { return m_version; }
+
+    const http::fields& fields() const { return m_fields; }
+
+    const std::string& body() const { return m_body; }
+    void set_body(std::string body) { m_body = std::move(body); }
+
+    http::framing body_framing() const { return m_framing; }
+
+    /** Meaningful only when body_framing() is framing::length. */
+    std::size_t content_length() const { return m_length; }
+
+    /** The Host field, which HTTP/1.1 requires -- RFC 9112 3.2. */
+    std::string host() const { return m_fields.get("Host"); }
+
+    friend Request parse_request_head(std::string_view head);
+
+private:
+    std::string m_method;
+    std::string m_target;
+    std::string m_version;
+    http::fields m_fields;
+    std::string m_body;
+    http::framing m_framing = framing::none;
+    std::size_t m_length = 0;
+};
+
+/**
+ * Parse a request head against the grammar.
+ *
+ * The same refusals parse_head() makes -- both Content-Length and
+ * Transfer-Encoding, two Content-Lengths that disagree, a Content-Length that
+ * is not digits, obs-fold, a bare CR or LF, whitespace before a colon.
+ *
+ * **One difference from a response, and it matters.**  A request with neither
+ * framing field has *no body* (RFC 9112 6.3), where a response with neither
+ * runs until the connection closes.  framing::until_close on a request would
+ * mean reading until a client that is waiting for an answer gives up -- a hang,
+ * not a body.  So the default here is framing::none, and a Transfer-Encoding
+ * that does not end in chunked is refused rather than quietly becoming a read
+ * to end of stream.
+ */
+Request parse_request_head(std::string_view head);
+
+/** read_head() then parse_request_head(). */
+Request read_request_head(std::istream& is, std::size_t cap = 8192);
+
+/**
+ * Read a body whose framing is already known.
+ *
+ * The Response overload below forwards to this; a Request needs it because its
+ * framing is decided by different rules.
+ */
+std::string read_body(std::istream& is, framing how, std::size_t length,
+                      std::size_t cap = 1 << 20);
+
+/**
  * The composed grammar: RFC 3986, then RFC 9110, then RFC 9112.
  *
  * Built once, on first use.  Exposed so a test can ask it what it knows --
@@ -182,7 +256,10 @@ private:
 const abnf::grammar& grammar();
 
 /**
- * Read a response head from a stream, to and including the blank line.
+ * Read a message head from a stream, to and including the blank line.
+ *
+ * A response head or a request head: the two are the same shape above the
+ * start line, and this reads the shape.
  *
  * Returns everything read, CRLFs and all.  Framing is procedural here for the
  * reason written down in rfc9112.hh: abnf::rule::parse takes a string_view, so

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -22,8 +22,6 @@ MEDIA_TESTS = media_datastream_test \
               media_wavstream_test \
               sys_ringbuffer_test \
               math_lookat_test \
-              sys_sigpipe_test \
-              sys_tls_sigpipe_test \
               media_voice_test \
               media_source_test \
               media_wavetable_test \
@@ -57,6 +55,7 @@ TESTS = \
 	net_imap_test \
 	net_imap_sasl_test \
 	net_http_test \
+	net_http_server_test \
 	net_oauth_test \
 	net_oauth_authorize_test \
 	net_http_live_test \
@@ -69,6 +68,10 @@ TESTS = \
 	sys_sync_test \
 	sys_run_test \
 	sys_socket_test \
+	sys_sigpipe_test \
+	sys_tls_sigpipe_test \
+	sys_tls_server_test \
+	sys_server_test \
  \
 	util_test \
 	util_codec_test \
@@ -167,6 +170,9 @@ net_oauth_authorize_test_LDADD   = $(JNET_LA) $(JUTIL_LA) $(JSYS_LA) $(OPENSSL_L
 net_oauth_test_SOURCES          = net_oauth_test.cc
 net_oauth_test_LDADD            = $(JNET_LA) $(JUTIL_LA) $(JSYS_LA) $(OPENSSL_LIBS)
 
+net_http_server_test_SOURCES    = net_http_server_test.cc
+net_http_server_test_LDADD      = $(JNET_LA) $(JUTIL_LA) $(JSYS_LA) $(OPENSSL_LIBS)
+
 net_http_test_SOURCES           = net_http_test.cc
 net_http_test_LDADD             = $(JNET_LA) $(JUTIL_LA) $(JSYS_LA) $(OPENSSL_LIBS)
 
@@ -193,6 +199,12 @@ sys_sync_test_LDADD   = $(JSYS_LA)
 
 sys_socket_test_SOURCES = sys_socket_test.cc
 sys_socket_test_LDADD   = $(JSYS_LA)
+
+sys_tls_server_test_SOURCES = sys_tls_server_test.cc
+sys_tls_server_test_LDADD   = $(JSYS_LA) $(OPENSSL_LIBS)
+
+sys_server_test_SOURCES = sys_server_test.cc
+sys_server_test_LDADD   = $(JSYS_LA) $(OPENSSL_LIBS)
 
 util_json_test_SOURCES = util_json_test.cc
 util_json_test_LDADD   = $(JUTIL_LA) $(JSYS_LA) $(JSONC_LIBS)

--- a/tests/certificate.hh
+++ b/tests/certificate.hh
@@ -23,8 +23,11 @@
 // A self-signed certificate, generated at runtime, for a test that needs a
 // real TLS handshake.
 //
-// Shared by sys_tls_sigpipe_test, which serves TLS in-process, and
-// net_imap_live_test, which hands it to a Dovecot.  Both point the client's
+// Shared by everything that needs a TLS server for one run:
+// sys_tls_server_test, sys_server_test, net_http_server_test and
+// sys_tls_sigpipe_test all serve in-process, net_http_test and
+// net_http_live_test hand it to a test HTTP server and to nginx, and
+// net_imap_live_test hands it to a Dovecot.  Both point the client's
 // trust store at it with SSL_CERT_FILE -- which sslstream reaches through
 // SSL_CTX_set_default_verify_paths -- so nothing about the verification is
 // weakened: the handshake is real, the hostname is checked, and it succeeds

--- a/tests/httpserver.hh
+++ b/tests/httpserver.hh
@@ -35,10 +35,21 @@
 //
 // It speaks TLS when handed a certificate, which is the only way jlib gets an
 // HTTPS test that runs on a developer's machine: net_http_live_test needs an
-// nginx and there is not one outside the build container.  Server-side TLS is
-// raw OpenSSL here rather than jlib's own -- basic_tlsbuf calls SSL_connect and
-// there is no server-side counterpart in the library, which is a gap this test
-// works around rather than one it fixes.
+// nginx and there is not one outside the build container.
+//
+// This used to be about two hundred and fifty lines, most of them raw OpenSSL:
+// its own SSL_CTX, its own SSL_accept, its own SSL_read and SSL_write, its own
+// descriptor ownership, and a byte-at-a-time head reader -- because
+// basic_tlsbuf could only call SSL_connect and there was no server-side
+// counterpart in the library to reach for.  Its own header said so, and called
+// it a gap this test worked around rather than one it fixed.  That gap is #112
+// and it is closed; what is left here is sys::server plus a handler.
+//
+// It stays on sys::server rather than net::http::server on purpose.  Its whole
+// job is to send responses a correct server would not -- both framing fields at
+// once, a chunk header inside chunk data, a Content-Length that lies -- and a
+// response class that computes its own Content-Length cannot produce those.
+// Those are the assertions that matter most in net_http_test.
 //
 // It is not a substitute for a real server and net_http_live_test is the other
 // half: a server nobody wrote sends responses nobody thought of.  This one
@@ -46,23 +57,15 @@
 // its whole limitation.
 
 #include <jlib/sys/listener.hh>
+#include <jlib/sys/server.hh>
 #include <jlib/sys/socketstream.hh>
+#include <jlib/sys/tls.hh>
 
 #include <jlib/util/http.hh>
 
-#include <openssl/err.h>
-#include <openssl/ssl.h>
-
-#include <unistd.h>
-
-#include <algorithm>
-#include <atomic>
-#include <cctype>
 #include <functional>
-#include <istream>
 #include <memory>
 #include <mutex>
-#include <stdexcept>
 #include <string>
 #include <thread>
 #include <vector>
@@ -84,49 +87,40 @@ public:
      * @param h     what to answer with
      * @param cert  a PEM certificate, or "" for a plaintext server
      * @param key   its private key
-     *
-     * With a certificate this speaks TLS, and the client is expected to
-     * verify it for real -- point SSL_CERT_FILE at the same file and connect
-     * to a name the certificate covers.  Nothing here weakens verification;
-     * the handshake succeeds because the certificate is genuinely trusted for
-     * the run, which is the pattern mailserver.hh and sys_tls_sigpipe_test
-     * both use.
      */
     explicit server(handler h,
                     const std::string& cert = std::string(),
                     const std::string& key = std::string())
-        : m_listener(),
-          m_handler(std::move(h))
+        : m_handler(std::move(h))
     {
-        if(!cert.empty()) {
-            m_ctx = SSL_CTX_new(TLS_server_method());
+        jlib::sys::tls_context ctx;
 
-            if(!m_ctx ||
-               SSL_CTX_use_certificate_file(m_ctx, cert.c_str(), SSL_FILETYPE_PEM) != 1 ||
-               SSL_CTX_use_PrivateKey_file(m_ctx, key.c_str(), SSL_FILETYPE_PEM) != 1) {
-                if(m_ctx) SSL_CTX_free(m_ctx);
+        if(!cert.empty()) ctx = jlib::sys::tls_context::server(cert, key);
 
-                m_ctx = 0;
+        m_tls = !ctx.empty();
 
-                throw std::runtime_error("could not set up a TLS test server");
-            }
-        }
+        m_server.reset(new jlib::sys::server(
+            jlib::sys::listener(0, "127.0.0.1"),
+            [this](jlib::sys::socketstream& s, const jlib::sys::peer&) {
+                serve(s);
+            },
+            ctx));
 
-        m_thread = std::thread([this] { run(); });
+        // Every connection is one a test made; a failure on one is not
+        // something a test wants on its standard error unless it asks.
+        m_server->on_error([](const std::exception&, const jlib::sys::peer&) {});
+
+        m_thread = std::thread([this] { m_server->run(); });
     }
 
-    ~server() {
-        stop();
-
-        if(m_ctx) SSL_CTX_free(m_ctx);
-    }
+    ~server() { stop(); }
 
     server(const server&) = delete;
     server& operator=(const server&) = delete;
 
-    unsigned short port() const { return m_listener.port(); }
+    unsigned short port() const { return m_server->port(); }
 
-    bool tls() const { return m_ctx != 0; }
+    bool tls() const { return m_tls; }
 
     /**
      * Where to reach it.
@@ -136,8 +130,8 @@ public:
      * SSL_set1_host.
      */
     std::string url(const std::string& path = "/") const {
-        return (m_ctx ? "https://localhost:" : "http://127.0.0.1:") +
-               std::to_string(m_listener.port()) + path;
+        return (m_tls ? "https://localhost:" : "http://127.0.0.1:") +
+               std::to_string(port()) + path;
     }
 
     /** Every request served so far. */
@@ -148,186 +142,44 @@ public:
     }
 
     void stop() {
-        m_stop = true;
+        if(m_server) m_server->stop();
 
         if(m_thread.joinable()) m_thread.join();
-
-        m_listener.close();
     }
 
 private:
-    /**
-     * One accepted connection, plain or TLS.
-     *
-     * A pair of read/write calls rather than a streambuf, because there is no
-     * server-side one in jlib to reach for and writing one to serve a test
-     * would be the tail wagging the dog.
-     */
-    class conn {
-    public:
-        conn(int fd, SSL_CTX* ctx) : m_fd(fd) {
-            if(!ctx) return;
+    void serve(jlib::sys::socketstream& s) {
+        request r;
 
-            m_ssl = SSL_new(ctx);
+        // read_head throws where the hand-rolled byte loop this replaced just
+        // stopped -- which is what used to record a connection carrying no
+        // complete head as though it were a request, and failed make check.
+        r.head = jlib::util::http::read_head(s, 65536);
 
-            if(!m_ssl || SSL_set_fd(m_ssl, fd) != 1 || SSL_accept(m_ssl) != 1) {
-                if(m_ssl) { SSL_free(m_ssl); m_ssl = 0; }
+        const jlib::util::http::Request q =
+            jlib::util::http::parse_request_head(r.head);
 
-                // Closed here, not left to the destructor: a constructor that
-                // throws does not get one, and the descriptor would leak once
-                // per failed handshake.
-                ::close(m_fd);
-                m_fd = -1;
+        r.body = jlib::util::http::read_body(s, q.body_framing(),
+                                             q.content_length(), 1 << 20);
 
-                throw std::runtime_error("the TLS handshake failed");
-            }
+        std::string reply;
+
+        {
+            std::lock_guard<std::mutex> lock(m_lock);
+
+            m_requests.push_back(r);
         }
 
-        ~conn() {
-            if(m_ssl) {
-                SSL_shutdown(m_ssl);
-                SSL_free(m_ssl);
-            }
+        reply = m_handler(r);
 
-            if(m_fd >= 0) ::close(m_fd);
-        }
-
-        conn(const conn&) = delete;
-        conn& operator=(const conn&) = delete;
-
-        /** Bytes read, 0 at end of stream. */
-        std::size_t read(char* buf, std::size_t n) {
-            const int got = m_ssl ? SSL_read(m_ssl, buf, static_cast<int>(n))
-                                  : static_cast<int>(::read(m_fd, buf, n));
-
-            return got > 0 ? static_cast<std::size_t>(got) : 0;
-        }
-
-        void write(const std::string& s) {
-            std::size_t sent = 0;
-
-            while(sent < s.size()) {
-                const int n = m_ssl
-                    ? SSL_write(m_ssl, s.data() + sent, static_cast<int>(s.size() - sent))
-                    : static_cast<int>(::write(m_fd, s.data() + sent, s.size() - sent));
-
-                if(n <= 0) return;
-
-                sent += static_cast<std::size_t>(n);
-            }
-        }
-
-    private:
-        int m_fd = -1;
-        SSL* m_ssl = 0;
-    };
-
-    /** Exactly n octets, or fewer if the peer stopped. */
-    static std::string take(conn& c, std::size_t n) {
-        std::string out;
-
-        while(out.size() < n) {
-            char buf[4096];
-            const std::size_t want = std::min(sizeof buf, n - out.size());
-            const std::size_t got = c.read(buf, want);
-
-            if(!got) break;
-
-            out.append(buf, got);
-        }
-
-        return out;
+        s << reply << std::flush;
     }
 
-    void run() {
-        while(!m_stop) {
-            int fd = -1;
-
-            try {
-                // A short deadline rather than a blocking accept, so that
-                // stopping does not depend on one more client turning up.
-                fd = m_listener.accept(0.2);
-            }
-            catch(std::exception&) {
-                return;
-            }
-
-            if(fd < 0) continue;
-
-            try {
-                conn c(fd, m_ctx);
-
-                request r;
-
-                // A byte at a time to the blank line.  util::http::read_head()
-                // does this over an istream and there is not one here; the
-                // duplication is four lines and the alternative is a
-                // server-side streambuf nothing else would use.
-                while(r.head.size() < 4 ||
-                      r.head.compare(r.head.size() - 4, 4, "\r\n\r\n") != 0) {
-                    char one;
-
-                    if(!c.read(&one, 1)) break;
-
-                    r.head += one;
-
-                    if(r.head.size() > 65536) break;
-                }
-
-                // A connection that carried no complete head is not a
-                // request and must not be recorded as one.  read_head(), which
-                // this replaced, threw on end of stream and so never got here;
-                // the loop above just stops, and recording what it had made a
-                // client that connected and thought better of it look exactly
-                // like one that asked for something.
-                if(r.head.size() < 4 ||
-                   r.head.compare(r.head.size() - 4, 4, "\r\n\r\n") != 0) {
-                    continue;
-                }
-
-                // Only what a test sends: a Content-Length body, or none.
-                const std::string::size_type at = find_ci(r.head, "\r\ncontent-length:");
-
-                if(at != std::string::npos) {
-                    const std::string::size_type eol = r.head.find("\r\n", at + 2);
-                    const std::string value = r.head.substr(at + 17, eol - at - 17);
-
-                    r.body = take(c, std::stoul(value));
-                }
-
-                {
-                    std::lock_guard<std::mutex> lock(m_lock);
-
-                    m_requests.push_back(r);
-                }
-
-                // The client sends Connection: close and so does this; conn's
-                // destructor closing is what ends a body with no framing
-                // fields on it.
-                c.write(m_handler(r));
-            }
-            catch(std::exception&) {
-                // A client that hung up mid-request, or a handshake that did
-                // not complete, are both cases some tests create on purpose.
-                // conn closes the descriptor either way.
-            }
-        }
-    }
-
-    static std::string::size_type find_ci(const std::string& hay, const std::string& needle) {
-        std::string lower;
-
-        for(char c : hay) lower += static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
-
-        return lower.find(needle);
-    }
-
-    jlib::sys::listener m_listener;
     handler m_handler;
-    SSL_CTX* m_ctx = 0;
+    bool m_tls = false;
     mutable std::mutex m_lock;
     std::vector<request> m_requests;
-    std::atomic<bool> m_stop{false};
+    std::unique_ptr<jlib::sys::server> m_server;
     std::thread m_thread;
 };
 

--- a/tests/net_http_server_test.cc
+++ b/tests/net_http_server_test.cc
@@ -35,16 +35,23 @@
 
 #include <jlib/util/URL.hh>
 
+#include <atomic>
+#include <chrono>
 #include <cstdio>
 #include <iostream>
 #include <string>
 #include <thread>
+#include <vector>
 
 namespace http = jlib::net::http;
 
 using jlib::util::URL;
 
 static int failures = 0;
+
+static double seconds_since(std::chrono::steady_clock::time_point t) {
+    return std::chrono::duration<double>(std::chrono::steady_clock::now() - t).count();
+}
 
 static void ok(const std::string& what, bool good, const std::string& detail = "") {
     if(!good) ++failures;
@@ -269,6 +276,155 @@ static void what_it_refuses() {
        std::to_string(reported));
 }
 
+/**
+ * Ask for a path on a thread, leaving the response where the caller can see it.
+ *
+ * exchange() drives serve_one() itself, which is what makes it serial.  These
+ * sections need the requests in flight *before* anything is served, so the
+ * accept loop is the thing under test rather than the pacing.
+ */
+static std::thread ask(http::server& s, const std::string& path,
+                       http::Response* into)
+{
+    return std::thread([&s, path, into] {
+        try { *into = http::get(URL(s.url(path))); }
+        catch(std::exception&) { /* status stays 0, which is the assertion */ }
+    });
+}
+
+static void a_pool_answers_them_at_once() {
+    std::cout << "\na pool answers them at once:\n";
+
+    std::atomic<int> live{0};
+    std::atomic<int> most{0};
+
+    jlib::sys::server::policy p;
+    p.threads = 4;
+
+    http::server s(0, "127.0.0.1", jlib::sys::tls_context(), p);
+
+    furnish(s);
+
+    s.route("GET", "/slow", [&live, &most](const http::server::Request&,
+                                           http::server::response& r) {
+        const int now = ++live;
+
+        int seen = most.load();
+        while(now > seen && !most.compare_exchange_weak(seen, now))
+            ;
+
+        // Long enough that serial handling would show up as one at a time.
+        std::this_thread::sleep_for(std::chrono::milliseconds(150));
+
+        live--;
+
+        r.status(200).type("text/plain").body("slow\n");
+    });
+
+    const int clients = 8;
+
+    std::vector<http::Response> got(clients);
+    std::vector<std::thread> them;
+
+    for(int i = 0; i < clients; i++) them.push_back(ask(s, "/slow", &got[i]));
+
+    const auto start = std::chrono::steady_clock::now();
+
+    for(int i = 0; i < clients; i++) s.serve_one(10);
+
+    // stop() then join(), in that order: join() waits for the pool to retire
+    // and does not tell it to leave.
+    s.stop();
+    s.join();
+
+    const double took = seconds_since(start);
+
+    for(std::thread& t : them) t.join();
+
+    int answered = 0;
+
+    for(const http::Response& r : got)
+        if(r.status() == 200 && r.body() == "slow\n") answered++;
+
+    ok("every client got its answer", answered == clients,
+       std::to_string(answered) + "/" + std::to_string(clients));
+
+    // The direct assertion that this is concurrent at all.  Serially, eight
+    // handlers of 150ms take at least 1.2 seconds and the maximum overlap is 1.
+    ok("more than one handler ran at once", most.load() > 1,
+       "peak " + std::to_string(most.load()));
+
+    ok("and never more than the pool", most.load() <= 4,
+       "peak " + std::to_string(most.load()));
+
+    ok("and it took less than answering them one by one would",
+       took < clients * 0.15, std::to_string(took) + "s");
+}
+
+static void stopping_a_pool_without_draining() {
+    std::cout << "\nstopping a pool without draining:\n";
+
+    std::atomic<int> ran{0};
+
+    // One worker and a queue with room, so all three requests are accepted at
+    // once and the two behind the first are still waiting when the stop lands.
+    jlib::sys::server::policy p;
+    p.threads = 1;
+    p.max_queued = 4;
+
+    const int clients = 3;
+
+    std::vector<http::Response> got(clients);
+    std::vector<std::thread> them;
+
+    double took = 0;
+
+    {
+        http::server s(0, "127.0.0.1", jlib::sys::tls_context(), p);
+
+        s.route("GET", "/slow", [&ran](const http::server::Request&,
+                                       http::server::response& r) {
+            ran++;
+
+            std::this_thread::sleep_for(std::chrono::milliseconds(400));
+
+            r.status(200).type("text/plain").body("slow\n");
+        });
+
+        for(int i = 0; i < clients; i++) them.push_back(ask(s, "/slow", &got[i]));
+
+        for(int i = 0; i < clients; i++) s.serve_one(10);
+
+        const auto start = std::chrono::steady_clock::now();
+
+        s.stop(false);
+        s.join();
+
+        took = seconds_since(start);
+    }
+
+    for(std::thread& t : them) t.join();
+
+    // The request already being handled is answered: drain is about what is
+    // queued, not about cancelling a handler mid-flight.  So this waits for
+    // that one and not for the two behind it.
+    ok("join() waits for the running handler and not for the queue",
+       took < clients * 0.4, std::to_string(took) + "s");
+
+    ok("the queued requests never reached a handler", ran.load() < clients,
+       std::to_string(ran.load()) + "/" + std::to_string(clients) + " ran");
+
+    int answered = 0;
+
+    for(const http::Response& r : got) if(r.status() != 0) answered++;
+
+    // Nothing, not even a 503.  Dropping the job destroys the descriptor it
+    // carries, so the client sees a close where a response should have been --
+    // which is why stop(false) is for shutting down under duress.
+    ok("and their clients got no response at all", answered < clients,
+       std::to_string(answered) + " of " + std::to_string(clients) + " answered");
+}
+
 static void over_tls() {
     std::cout << "\nover TLS:\n";
 
@@ -326,6 +482,8 @@ int main() {
     the_two_halves_meet();
     what_the_handler_sees();
     what_it_refuses();
+    a_pool_answers_them_at_once();
+    stopping_a_pool_without_draining();
     over_tls();
 
     // What a green run does not establish.
@@ -341,8 +499,17 @@ int main() {
     // in memory.  None of those is implemented and none is a gap -- see the
     // header.
     //
-    // Not concurrency.  Every section serves one connection at a time;
-    // sys_server_test is where the threaded policy is exercised.
+    // Not concurrency beyond the fact of it.  Two sections run a pool, and
+    // they establish that handlers overlap, that the overlap is bounded by
+    // threads, and that stop(false) drops what is queued -- not that a handler
+    // is safe to write.  Every handler here touches only its own arguments and
+    // atomics; a handler sharing anything else is on its own, and nothing in
+    // this file would notice.
+    //
+    // Not the timing assertions.  "More than one at once" and "less than one by
+    // one" are wall-clock claims on a machine that may be busy; they are
+    // written with wide margins, and a failure means look at the machine before
+    // looking at the code.
     std::cout << "\n" << (failures ? "FAILED" : "PASSED") << ": " << failures
               << " failure(s)\n";
 

--- a/tests/net_http_server_test.cc
+++ b/tests/net_http_server_test.cc
@@ -1,0 +1,350 @@
+/* -*- mode: C++ c-basic-offset: 4 -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// jlib's HTTP client against jlib's HTTP server.
+//
+// Both halves of a protocol this library has only ever spoken one end of, in
+// one process, over plaintext and over TLS.  Which is a strong test and a
+// dangerous one: two implementations by the same hand agree about things a
+// stranger would not, so net_http_live_test keeps driving the client at a real
+// nginx and no live test is converted to this shape.
+
+#include "certificate.hh"
+
+#include <jlib/net/http.hh>
+#include <jlib/net/http_server.hh>
+
+#include <jlib/sys/socketstream.hh>
+#include <jlib/sys/tls.hh>
+
+#include <jlib/util/URL.hh>
+
+#include <cstdio>
+#include <iostream>
+#include <string>
+#include <thread>
+
+namespace http = jlib::net::http;
+
+using jlib::util::URL;
+
+static int failures = 0;
+
+static void ok(const std::string& what, bool good, const std::string& detail = "") {
+    if(!good) ++failures;
+    std::cout << (good ? "  ok   " : "  FAIL ") << what;
+    if(!detail.empty()) std::cout << ": " << detail;
+    std::cout << "\n";
+}
+
+/** Wire up a server with the routes every section here uses. */
+static void furnish(http::server& s, std::string* saw_body = 0,
+                    std::string* saw_target = 0)
+{
+    s.route("GET", "/hello", [](const http::server::Request&,
+                                http::server::response& r) {
+        r.status(200).type("text/plain").body("hello from jlib\n");
+    });
+
+    s.route("GET", "/echo", [saw_target](const http::server::Request& q,
+                                         http::server::response& r) {
+        if(saw_target) *saw_target = q.target();
+
+        r.status(200).type("text/plain").body(q.target());
+    });
+
+    s.route("POST", "/form", [saw_body](const http::server::Request& q,
+                                        http::server::response& r) {
+        if(saw_body) *saw_body = q.body();
+
+        r.status(200).type("application/json").body("{\"got\":true}");
+    });
+
+    s.route("GET", "/boom", [](const http::server::Request&,
+                               http::server::response&) {
+        throw std::runtime_error("the handler gave up");
+    });
+
+    s.route("GET", "/bad-field", [](const http::server::Request&,
+                                    http::server::response& r) {
+        // A CR in a value is how one response becomes two.  Whatever a handler
+        // was given, this must not reach the wire.
+        r.status(200).field("X-Thing", "one\r\nX-Injected: two").body("x");
+    });
+}
+
+/** One request, on a thread, while the server serves one. */
+static http::Response exchange(http::server& s, const std::string& method,
+                               const std::string& path,
+                               const std::map<std::string, std::string>& form =
+                                   std::map<std::string, std::string>())
+{
+    http::Response got;
+    std::string trouble;
+
+    std::thread client([&] {
+        try {
+            if(method == "POST") got = http::post_form(URL(s.url(path)), form);
+            else                 got = http::get(URL(s.url(path)));
+        }
+        catch(std::exception& e) { trouble = e.what(); }
+    });
+
+    try { s.serve_one(10); }
+    catch(std::exception&) {}
+
+    client.join();
+
+    if(!trouble.empty() && got.status() == 0)
+        std::cout << "         (client: " << trouble << ")\n";
+
+    return got;
+}
+
+static void the_two_halves_meet() {
+    std::cout << "\nthe two halves meet:\n";
+
+    http::server s;
+
+    furnish(s);
+
+    ok("the server bound a port", s.port() != 0, std::to_string(s.port()));
+    ok("and it is plaintext", !s.tls());
+
+    const http::Response r = exchange(s, "GET", "/hello");
+
+    ok("a routed GET is answered", r.status() == 200 && r.body() == "hello from jlib\n",
+       r.body());
+
+    // Fields the server supplies unless a handler said otherwise.
+    ok("with a Date, a Server and a Content-Length",
+       r.fields().has("Date") && r.fields().has("Server") &&
+       r.content_length() == r.body().size());
+
+    // Always, so no keep-alive framing question ever arises.
+    ok("and Connection: close",
+       jlib::util::http::fold(r.fields().get("Connection")) == "close",
+       r.fields().get("Connection"));
+
+    const http::Response missing = exchange(s, "GET", "/nowhere");
+
+    ok("an unrouted path gets the fallback", missing.status() == 404,
+       std::to_string(missing.status()));
+
+    // Exact matching, in the order routes were added.  A GET route does not
+    // answer a POST.
+    const http::Response wrong = exchange(s, "POST", "/hello");
+
+    ok("and a method that was not routed does too", wrong.status() == 404,
+       std::to_string(wrong.status()));
+}
+
+static void what_the_handler_sees() {
+    std::cout << "\nwhat the handler sees:\n";
+
+    std::string body, target;
+
+    http::server s;
+
+    furnish(s, &body, &target);
+
+    const http::Response r = exchange(s, "GET", "/echo?a=1&b=two");
+
+    // The query reaches the handler whole, and does not affect routing --
+    // /echo?a=1 routes on /echo.
+    ok("the target arrives with its query", target == "/echo?a=1&b=two", target);
+    ok("and routing ignored the query", r.status() == 200);
+
+    const http::Response posted = exchange(s, "POST", "/form",
+                                           { { "grant_type", "refresh_token" } });
+
+    ok("a form body arrives whole",
+       body == "grant_type=refresh_token", body);
+    ok("and the handler's answer comes back",
+       posted.status() == 200 && posted.body() == "{\"got\":true}", posted.body());
+}
+
+static void what_it_refuses() {
+    std::cout << "\nwhat it refuses:\n";
+
+    http::server s;
+
+    furnish(s);
+
+    // Something that is not a request at all.  A bare close would be
+    // indistinguishable from a crash, so it answers and stops.
+    {
+        std::string reply;
+
+        std::thread client([&s, &reply] {
+            try {
+                jlib::sys::socketstream c("127.0.0.1", s.port(), 5);
+
+                c.set_timeout(5);
+                c << "GET\r\n\r\n" << std::flush;
+
+                std::getline(c, reply);
+            }
+            catch(std::exception&) {}
+        });
+
+        s.serve_one(10);
+        client.join();
+
+        ok("a malformed request line gets a 400",
+           reply.find("400") != std::string::npos, reply);
+    }
+
+    // And the server is still serving, which is the point of answering rather
+    // than dropping.
+    const http::Response after = exchange(s, "GET", "/hello");
+
+    ok("and the server carries on", after.status() == 200);
+
+    // An encoded separator is refused rather than decoded: decoding one would
+    // change how many segments the path has.
+    {
+        std::string reply;
+
+        std::thread client([&s, &reply] {
+            try {
+                jlib::sys::socketstream c("127.0.0.1", s.port(), 5);
+
+                c.set_timeout(5);
+                c << "GET /a%2F..%2Fb HTTP/1.1\r\nHost: x\r\n\r\n" << std::flush;
+
+                std::getline(c, reply);
+            }
+            catch(std::exception&) {}
+        });
+
+        s.serve_one(10);
+        client.join();
+
+        ok("an encoded path separator is refused",
+           reply.find("400") != std::string::npos, reply);
+    }
+
+    // A handler that throws is answered with a 500, because nothing has reached
+    // the socket until it returns -- which is why a response is accumulated.
+    int reported = 0;
+
+    s.transport().on_error([&reported](const std::exception&, const jlib::sys::peer&) {
+        reported++;
+    });
+
+    const http::Response boom = exchange(s, "GET", "/boom");
+
+    ok("a handler that throws still answers, with a 500", boom.status() == 500,
+       std::to_string(boom.status()));
+    ok("and the failure is reported rather than swallowed", reported == 1,
+       std::to_string(reported));
+
+    // A field a handler built from something it was given.  Checked against the
+    // grammar on the way out, so it cannot become two responses.
+    const http::Response bad = exchange(s, "GET", "/bad-field");
+
+    // 500, not a bare close: serialising the response happens inside the same
+    // try that answers, so a field the server refuses to send is reported to
+    // the client as the server's fault rather than as a dropped connection.
+    ok("a header value containing CRLF never reaches the wire, and says so",
+       bad.status() == 500, std::to_string(bad.status()));
+    ok("and that failure is reported too", reported == 2,
+       std::to_string(reported));
+}
+
+static void over_tls() {
+    std::cout << "\nover TLS:\n";
+
+    const std::string cert = "http_server_cert.pem";
+    const std::string key = "http_server_key.pem";
+
+    if(!make_cert(cert, key)) {
+        std::cout << "  skip  could not generate a test certificate\n";
+
+        return;
+    }
+
+    const char* const had = std::getenv("SSL_CERT_FILE");
+    const std::string keep = had ? had : "";
+
+    ::setenv("SSL_CERT_FILE", cert.c_str(), 1);
+
+    try {
+        http::server s(0, "127.0.0.1", jlib::sys::tls_context::server(cert, key));
+
+        furnish(s);
+
+        ok("it is an https:// server", s.tls() &&
+           s.url("/hello").compare(0, 8, "https://") == 0, s.url("/hello"));
+
+        const http::Response r = exchange(s, "GET", "/hello");
+
+        ok("and the client reaches it over TLS",
+           r.status() == 200 && r.body() == "hello from jlib\n", r.body());
+
+        const http::Response posted = exchange(s, "POST", "/form",
+                                               { { "a", "b" } });
+
+        ok("a POST works over TLS too", posted.status() == 200, posted.body());
+
+        const http::Response missing = exchange(s, "GET", "/nowhere");
+
+        ok("and so does the 404 fallback", missing.status() == 404,
+           std::to_string(missing.status()));
+    }
+    catch(std::exception& e) {
+        ok("an https:// server runs", false, e.what());
+    }
+
+    if(keep.empty()) ::unsetenv("SSL_CERT_FILE");
+    else             ::setenv("SSL_CERT_FILE", keep.c_str(), 1);
+
+    std::remove(cert.c_str());
+    std::remove(key.c_str());
+}
+
+int main() {
+    std::cout << std::unitbuf;
+
+    the_two_halves_meet();
+    what_the_handler_sees();
+    what_it_refuses();
+    over_tls();
+
+    // What a green run does not establish.
+    //
+    // Interoperability, and this is the section to read twice.  Both ends here
+    // were written by the same hand, from the same grammar, in the same week --
+    // so they agree about things a stranger would not, and a disagreement
+    // between jlib and the rest of the world would show up as two green ticks.
+    // net_http_live_test drives the client at a real nginx for exactly that
+    // reason, and nothing here replaces it.
+    //
+    // Not keep-alive, cookies, compression, ranges, or a body that does not fit
+    // in memory.  None of those is implemented and none is a gap -- see the
+    // header.
+    //
+    // Not concurrency.  Every section serves one connection at a time;
+    // sys_server_test is where the threaded policy is exercised.
+    std::cout << "\n" << (failures ? "FAILED" : "PASSED") << ": " << failures
+              << " failure(s)\n";
+
+    return failures ? 1 : 0;
+}

--- a/tests/sys_server_test.cc
+++ b/tests/sys_server_test.cc
@@ -1,0 +1,641 @@
+/* -*- mode: C++ c-basic-offset: 4 -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// sys::server -- accept a connection, maybe secure it, hand it to a handler.
+//
+// The assertions worth having are about the awkward parts, not the echo: that a
+// handler which throws does not take the loop with it, that the thread cap is a
+// cap and not a suggestion, that stop() returns promptly rather than after a
+// poll interval, and that the destructor does not return while a handler is
+// still using what it captured.  Those are the ways a server goes wrong quietly.
+//
+// Entirely in one process, including the TLS section: the certificate is
+// generated at runtime and the client's trust store points at it, so this runs
+// on a developer's machine and not only in the build container.
+
+#include "certificate.hh"
+
+#include <jlib/sys/listener.hh>
+#include <jlib/sys/server.hh>
+#include <jlib/sys/sync.hh>
+#include <jlib/sys/socketstream.hh>
+#include <jlib/sys/sslstream.hh>
+#include <jlib/sys/tls.hh>
+
+#include <atomic>
+#include <chrono>
+#include <cstdio>
+#include <iostream>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace sys = jlib::sys;
+
+static int failures = 0;
+
+static void ok(const std::string& what, bool good, const std::string& detail = "") {
+    if(!good) ++failures;
+    std::cout << (good ? "  ok   " : "  FAIL ") << what;
+    if(!detail.empty()) std::cout << ": " << detail;
+    std::cout << "\n";
+}
+
+static double seconds_since(std::chrono::steady_clock::time_point t) {
+    return std::chrono::duration<double>(std::chrono::steady_clock::now() - t).count();
+}
+
+/** Send one line and read one back.  "" if anything went wrong. */
+static std::string ask(unsigned short port, const std::string& what) {
+    try {
+        sys::socketstream s("127.0.0.1", port, 5);
+
+        s.set_timeout(5);
+        s << what << "\r\n" << std::flush;
+
+        std::string line;
+        std::getline(s, line);
+
+        while(!line.empty() && line.back() == '\r') line.pop_back();
+
+        return line;
+    }
+    catch(std::exception&) {
+        return std::string();
+    }
+}
+
+static void echo(sys::socketstream& s, const sys::peer&) {
+    std::string line;
+    std::getline(s, line);
+
+    while(!line.empty() && line.back() == '\r') line.pop_back();
+
+    s << "echo: " << line << "\r\n" << std::flush;
+}
+
+static void one_connection_at_a_time() {
+    std::cout << "\none connection at a time:\n";
+
+    sys::server srv(0, echo);
+
+    ok("it bound a port", srv.port() != 0, std::to_string(srv.port()));
+    ok("and it is not a TLS server", !srv.tls());
+
+    // Nothing is connecting, so this must come back rather than wait.
+    const auto start = std::chrono::steady_clock::now();
+
+    ok("serve_one with nothing waiting returns false", !srv.serve_one(0.3));
+    ok("and takes about as long as it was told to",
+       seconds_since(start) >= 0.2 && seconds_since(start) < 3.0,
+       std::to_string(seconds_since(start)) + "s");
+
+    std::string got;
+    std::thread client([&srv, &got] { got = ask(srv.port(), "hello"); });
+
+    ok("and true when one is", srv.serve_one(5));
+
+    client.join();
+
+    ok("the handler ran and the answer came back", got == "echo: hello", got);
+
+    // The peer really is filled in, on the path a server actually uses.
+    sys::peer seen;
+    sys::server watcher(0, [&seen](sys::socketstream& s, const sys::peer& from) {
+        seen = from;
+        s << "ok\r\n" << std::flush;
+    });
+
+    std::thread second([&watcher] { ask(watcher.port(), "x"); });
+    watcher.serve_one(5);
+    second.join();
+
+    ok("the handler is told who connected",
+       seen.address == "127.0.0.1" && seen.port != 0 && seen.loopback(),
+       seen.address + ":" + std::to_string(seen.port));
+}
+
+static void a_handler_that_throws_does_not_stop_the_server() {
+    std::cout << "\na handler that throws does not stop the server:\n";
+
+    std::atomic<int> served{0};
+    std::atomic<int> reported{0};
+
+    sys::server srv(0, [&served](sys::socketstream& s, const sys::peer&) {
+        std::string line;
+        std::getline(s, line);
+
+        served++;
+
+        if(line.find("boom") != std::string::npos)
+            throw std::runtime_error("the handler gave up");
+
+        s << "fine\r\n" << std::flush;
+    });
+
+    srv.on_error([&reported](const std::exception&, const sys::peer&) {
+        reported++;
+    });
+
+    std::thread first([&srv] { ask(srv.port(), "boom"); });
+    srv.serve_one(5);
+    first.join();
+
+    ok("the throw is reported", reported.load() == 1,
+       std::to_string(reported.load()));
+
+    // The one that matters: the loop is still alive.
+    std::string got;
+    std::thread second([&srv, &got] { got = ask(srv.port(), "again"); });
+
+    ok("and the server serves the next connection", srv.serve_one(5));
+
+    second.join();
+
+    ok("which gets its own answer", got == "fine", got);
+    ok("both connections reached the handler", served.load() == 2,
+       std::to_string(served.load()));
+}
+
+static void several_at_once_when_asked() {
+    std::cout << "\nseveral at once, when asked:\n";
+
+    std::atomic<int> live{0};
+    std::atomic<int> most{0};
+    std::atomic<int> done{0};
+
+    sys::server::policy p;
+    p.threads = 4;
+
+    sys::server srv(0, [&live, &most, &done](sys::socketstream& s, const sys::peer&) {
+        const int now = ++live;
+
+        int seen = most.load();
+        while(now > seen && !most.compare_exchange_weak(seen, now))
+            ;
+
+        std::string line;
+        std::getline(s, line);
+
+        // Long enough that serial handling would show up as one at a time.
+        std::this_thread::sleep_for(std::chrono::milliseconds(150));
+
+        s << "slow\r\n" << std::flush;
+
+        live--;
+        done++;
+    }, "127.0.0.1", sys::tls_context(), p);
+
+    const int clients = 12;
+    std::vector<std::thread> them;
+
+    for(int i = 0; i < clients; i++)
+        them.emplace_back([&srv] { ask(srv.port(), "go"); });
+
+    const auto start = std::chrono::steady_clock::now();
+
+    for(int i = 0; i < clients; i++) srv.serve_one(10);
+
+    srv.join();
+
+    const double took = seconds_since(start);
+
+    for(std::thread& t : them) t.join();
+
+    ok("every client is served", done.load() == clients,
+       std::to_string(done.load()) + "/" + std::to_string(clients));
+
+    // The direct assertion that this is concurrent at all.  Serially, twelve
+    // handlers of 150ms take at least 1.8 seconds and the maximum overlap is 1.
+    ok("more than one handler ran at once", most.load() > 1,
+       "peak " + std::to_string(most.load()));
+
+    ok("and it took less than serving them one by one would",
+       took < clients * 0.15, std::to_string(took) + "s");
+
+    // The cap is a cap.  Four threads means never five.
+    ok("and never more than the cap", most.load() <= 4,
+       "peak " + std::to_string(most.load()));
+}
+
+static void the_cap_holds_at_two() {
+    std::cout << "\nthe cap holds:\n";
+
+    std::atomic<int> live{0};
+    std::atomic<int> most{0};
+    std::atomic<int> done{0};
+
+    // Two, so a breach is unambiguous rather than a scheduling artefact.
+    sys::server::policy p;
+    p.threads = 2;
+
+    sys::server srv(0, [&live, &most, &done](sys::socketstream& s, const sys::peer&) {
+        const int now = ++live;
+
+        int seen = most.load();
+        while(now > seen && !most.compare_exchange_weak(seen, now))
+            ;
+
+        std::string line;
+        std::getline(s, line);
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+        s << "done\r\n" << std::flush;
+
+        live--;
+        done++;
+    }, "127.0.0.1", sys::tls_context(), p);
+
+    const int clients = 10;
+    std::vector<std::thread> them;
+
+    for(int i = 0; i < clients; i++)
+        them.emplace_back([&srv] { ask(srv.port(), "go"); });
+
+    for(int i = 0; i < clients; i++) srv.serve_one(10);
+
+    srv.join();
+
+    for(std::thread& t : them) t.join();
+
+    ok("never three handlers at once", most.load() <= 2,
+       "peak " + std::to_string(most.load()));
+
+    // Nothing is dropped: the ones that did not fit waited in the kernel's
+    // listen backlog, which is where a connection is supposed to wait.
+    ok("and none of the ten was dropped", done.load() == clients,
+       std::to_string(done.load()) + "/" + std::to_string(clients));
+}
+
+static void the_two_paths_became_one() {
+    std::cout << "\nserial and threaded are one path now:\n";
+
+    // The acceptance test for the whole rewrite.  The old server had an
+    // if(threads == 0) fork in serve_one -- one branch calling the handler
+    // inline, one dispatching it.  job_queue(0) runs a job on the thread that
+    // posts it, so there is one path and a number, and this is what proves the
+    // number still means what it did.
+    std::thread::id where;
+
+    {
+        // threads defaults to 0.
+        sys::server srv(0, [&where](sys::socketstream& s, const sys::peer&) {
+            where = std::this_thread::get_id();
+
+            std::string line;
+            std::getline(s, line);
+
+            s << "inline\r\n" << std::flush;
+        });
+
+        std::thread client([&srv] { ask(srv.port(), "go"); });
+
+        srv.serve_one(5);
+        client.join();
+
+        ok("with no pool the handler runs on the accept thread",
+           where == std::this_thread::get_id());
+    }
+
+    std::thread::id elsewhere;
+
+    {
+        sys::server::policy p;
+        p.threads = 1;
+
+        sys::server srv(0, [&elsewhere](sys::socketstream& s, const sys::peer&) {
+            elsewhere = std::this_thread::get_id();
+
+            std::string line;
+            std::getline(s, line);
+
+            s << "pooled\r\n" << std::flush;
+        }, "127.0.0.1", sys::tls_context(), p);
+
+        std::thread client([&srv] { ask(srv.port(), "go"); });
+
+        srv.serve_one(5);
+        client.join();
+        srv.join();
+
+        ok("and with a pool of one it does not",
+           elsewhere != std::this_thread::get_id());
+    }
+}
+
+static void a_busy_pool_is_not_a_full_queue() {
+    std::cout << "\na busy pool is not a full queue:\n";
+
+    // The cap counts what is *waiting*, not what is running.  If a job that had
+    // been taken still counted, one slow handler on a pool of one would make
+    // the queue look full and stall the accept loop against work already under
+    // way -- which is the whole reason size() is the queue's depth and nothing
+    // else.
+    sys::sync<bool> go(false);
+
+    sys::server::policy p;
+    p.threads = 1;
+    p.max_queued = 1;
+
+    sys::server srv(0, [&go](sys::socketstream& s, const sys::peer&) {
+        std::string line;
+        std::getline(s, line);
+
+        std::unique_lock<std::mutex> lock(go.mutex());
+
+        go.wait(lock, [&go] { return go(); });
+
+        s << "held\r\n" << std::flush;
+    }, "127.0.0.1", sys::tls_context(), p);
+
+    std::thread first([&srv] { ask(srv.port(), "one"); });
+
+    ok("the first connection is accepted", srv.serve_one(5));
+
+    // The worker has it, so nothing is queued -- and the loop must be willing
+    // to accept again even though the pool is entirely busy.
+    for(int i = 0; i < 200 && srv.pending() != 0; i++)
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+
+    ok("and with it running, nothing is queued", srv.pending() == 0,
+       std::to_string(srv.pending()));
+
+    std::thread second([&srv] { ask(srv.port(), "two"); });
+
+    const auto start = std::chrono::steady_clock::now();
+
+    ok("so a second is accepted with the pool busy", srv.serve_one(5));
+    ok("promptly, rather than waiting for the first to finish",
+       seconds_since(start) < 2.0, std::to_string(seconds_since(start)) + "s");
+
+    ok("and now one is queued", srv.pending() == 1,
+       std::to_string(srv.pending()));
+
+    // A third would have to wait: depth 1 is the cap.  stop() has to release
+    // that wait, which is what the exit term in job_queue's own predicate is
+    // for -- without it the accept thread sleeps through the shutdown.
+    std::atomic<bool> returned{false};
+    std::atomic<bool> accepted{true};
+
+    std::thread third([&srv, &returned, &accepted] {
+        accepted = srv.serve_one(0);
+        returned = true;
+    });
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    ok("a third accept waits for room", !returned.load());
+
+    srv.stop();
+
+    for(int i = 0; i < 200 && !returned.load(); i++)
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+
+    ok("and stop() releases it", returned.load());
+    ok("which reports that it accepted nothing", !accepted.load());
+
+    go.set(true);
+
+    third.join();
+    first.join();
+    second.join();
+}
+
+static void stopping() {
+    std::cout << "\nstopping:\n";
+
+    sys::server srv(0, echo);
+
+    std::thread loop([&srv] { srv.run(); });
+
+    // Let it get into the poll.
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    const auto start = std::chrono::steady_clock::now();
+
+    srv.stop();
+    loop.join();
+
+    const double took = seconds_since(start);
+
+    // Promptly, which is the whole reason for the wake pipe: a loop that
+    // polled with a short timeout instead would take up to that timeout, and a
+    // loop that closed its own listening descriptor would be racing.
+    ok("run() returns as soon as stop() is called", took < 1.0,
+       std::to_string(took) + "s");
+
+    ok("and the server says it is stopped", srv.stopped());
+
+    // From inside a handler, which a joining stop() could not allow.
+    sys::server inner(0, [&inner](sys::socketstream& s, const sys::peer&) {
+        std::string line;
+        std::getline(s, line);
+
+        s << "bye\r\n" << std::flush;
+
+        inner.stop();
+    });
+
+    std::thread inner_loop([&inner] { inner.run(); });
+    std::thread client([&inner] { ask(inner.port(), "quit"); });
+
+    inner_loop.join();
+    client.join();
+
+    ok("and stop() works from inside a handler", inner.stopped());
+}
+
+static void the_destructor_waits_for_a_handler() {
+    std::cout << "\nthe destructor waits for a handler:\n";
+
+    // A detached handler reaches the server through the handler it was given,
+    // so a destructor that returned while one was running would be pulling the
+    // ground out from under it.
+    std::atomic<bool> finished{false};
+    std::atomic<bool> destroyed_first{false};
+
+    {
+        sys::server::policy p;
+        p.threads = 2;
+
+        sys::server srv(0, [&finished](sys::socketstream& s, const sys::peer&) {
+            std::string line;
+            std::getline(s, line);
+
+            std::this_thread::sleep_for(std::chrono::milliseconds(250));
+
+            s << "slow\r\n" << std::flush;
+
+            finished = true;
+        }, "127.0.0.1", sys::tls_context(), p);
+
+        std::thread client([&srv] { ask(srv.port(), "go"); });
+
+        srv.serve_one(5);
+
+        // The handler is running on its own thread now.  Leaving this scope
+        // must not return until it has finished.
+        srv.stop();
+
+        if(!finished.load()) destroyed_first = true;
+
+        client.join();
+    }
+
+    ok("the handler was still running when the scope ended",
+       destroyed_first.load(), "otherwise this proves nothing");
+
+    ok("and the destructor did not return until it had finished",
+       finished.load());
+}
+
+static void over_tls() {
+    std::cout << "\nover TLS:\n";
+
+    const std::string cert = "server_test_cert.pem";
+    const std::string key = "server_test_key.pem";
+
+    if(!make_cert(cert, key)) {
+        std::cout << "  skip  could not generate a test certificate\n";
+
+        return;
+    }
+
+    const char* const had = std::getenv("SSL_CERT_FILE");
+    const std::string keep = had ? had : "";
+
+    ::setenv("SSL_CERT_FILE", cert.c_str(), 1);
+
+    try {
+        sys::server srv(0, echo, "127.0.0.1", sys::tls_context::server(cert, key));
+
+        ok("it says it is a TLS server", srv.tls());
+
+        std::string got;
+
+        std::thread client([&srv, &got] {
+            try {
+                // "localhost" is the name the certificate covers.
+                sys::tlsstream s("localhost", srv.port());
+
+                s.set_timeout(5);
+                s << "secure\r\n" << std::flush;
+
+                std::getline(s, got);
+
+                while(!got.empty() && got.back() == '\r') got.pop_back();
+            }
+            catch(std::exception&) {}
+        });
+
+        srv.serve_one(10);
+        client.join();
+
+        ok("a TLS client is served through the same handler", got == "echo: secure",
+           got);
+
+        // A handshake that fails must not take the loop with it -- the same
+        // assertion as the throwing handler, one layer down.
+        std::atomic<int> reported{0};
+
+        srv.on_error([&reported](const std::exception&, const sys::peer&) {
+            reported++;
+        });
+
+        std::thread plain([&srv] {
+            try {
+                sys::socketstream s("127.0.0.1", srv.port(), 5);
+
+                s << "GET / HTTP/1.1\r\n\r\n" << std::flush;
+                s.close();
+            }
+            catch(std::exception&) {}
+        });
+
+        srv.serve_one(10);
+        plain.join();
+
+        ok("a plaintext client is reported, not fatal", reported.load() == 1,
+           std::to_string(reported.load()));
+
+        std::string after;
+
+        std::thread again([&srv, &after] {
+            try {
+                sys::tlsstream s("localhost", srv.port());
+
+                s.set_timeout(5);
+                s << "still here\r\n" << std::flush;
+
+                std::getline(s, after);
+
+                while(!after.empty() && after.back() == '\r') after.pop_back();
+            }
+            catch(std::exception&) {}
+        });
+
+        srv.serve_one(10);
+        again.join();
+
+        ok("and the next TLS connection is served", after == "echo: still here",
+           after);
+    }
+    catch(std::exception& e) {
+        ok("a TLS server runs", false, e.what());
+    }
+
+    if(keep.empty()) ::unsetenv("SSL_CERT_FILE");
+    else             ::setenv("SSL_CERT_FILE", keep.c_str(), 1);
+
+    std::remove(cert.c_str());
+    std::remove(key.c_str());
+}
+
+int main() {
+    std::cout << std::unitbuf;
+
+    one_connection_at_a_time();
+    a_handler_that_throws_does_not_stop_the_server();
+    several_at_once_when_asked();
+    the_cap_holds_at_two();
+    the_two_paths_became_one();
+    a_busy_pool_is_not_a_full_queue();
+    stopping();
+    the_destructor_waits_for_a_handler();
+    over_tls();
+
+    // What a green run does not establish.
+    //
+    // That this is safe on a public port.  Nothing here is hardened against a
+    // slow-loris, a flood, or a client that connects and never speaks, beyond
+    // a thread cap, the listen backlog and a read timeout.  It is a server for
+    // a loopback redirect and a test harness and should stay one.
+    //
+    // Not the timing assertions under load.  "More than one handler ran at
+    // once" and "it took less than serving them one by one" are wall-clock
+    // claims on a machine that may be busy; they are written with wide margins,
+    // and a failure means look at the machine before looking at the code.
+    //
+    // Not client certificates, which the context deliberately neither asks for
+    // nor examines.
+    std::cout << "\n" << (failures ? "FAILED" : "PASSED") << ": " << failures
+              << " failure(s)\n";
+
+    return failures ? 1 : 0;
+}

--- a/tests/sys_server_test.cc
+++ b/tests/sys_server_test.cc
@@ -212,6 +212,10 @@ static void several_at_once_when_asked() {
 
     for(int i = 0; i < clients; i++) srv.serve_one(10);
 
+    // stop() then join(), in that order.  join() waits for the pool to retire
+    // and does not tell it to leave, so joining a pooled server without
+    // stopping it first waits for something that never happens.
+    srv.stop();
     srv.join();
 
     const double took = seconds_since(start);
@@ -270,6 +274,7 @@ static void the_cap_holds_at_two() {
 
     for(int i = 0; i < clients; i++) srv.serve_one(10);
 
+    srv.stop();
     srv.join();
 
     for(std::thread& t : them) t.join();
@@ -332,6 +337,7 @@ static void the_two_paths_became_one() {
 
         srv.serve_one(5);
         client.join();
+        srv.stop();
         srv.join();
 
         ok("and with a pool of one it does not",
@@ -459,6 +465,75 @@ static void stopping() {
     client.join();
 
     ok("and stop() works from inside a handler", inner.stopped());
+}
+
+static void stopping_without_draining() {
+    std::cout << "\nstopping without draining:\n";
+
+    std::atomic<int> ran{0};
+
+    // One worker and a queue with room, so all three connections are posted at
+    // once and the two behind the first are still waiting when the stop lands.
+    sys::server::policy p;
+    p.threads = 1;
+    p.max_queued = 4;
+
+    const int clients = 3;
+
+    std::vector<std::string> answers(clients);
+    std::vector<std::thread> them;
+
+    double took = 0;
+
+    {
+        sys::server srv(0, [&ran](sys::socketstream& s, const sys::peer&) {
+            ran++;
+
+            std::string line;
+            std::getline(s, line);
+
+            std::this_thread::sleep_for(std::chrono::milliseconds(400));
+
+            s << "served\r\n" << std::flush;
+        }, "127.0.0.1", sys::tls_context(), p);
+
+        for(int i = 0; i < clients; i++)
+            them.emplace_back([&srv, &answers, i] {
+                answers[i] = ask(srv.port(), "go");
+            });
+
+        for(int i = 0; i < clients; i++) srv.serve_one(10);
+
+        const auto start = std::chrono::steady_clock::now();
+
+        srv.stop(false);
+        srv.join();
+
+        took = seconds_since(start);
+    }
+
+    for(std::thread& t : them) t.join();
+
+    // The one already running still finishes: drain is about queued work, not
+    // about cancelling a handler mid-flight.  So this waits for that one and
+    // not for the two behind it.
+    ok("join() waits for the running handler and not for the queue",
+       took < clients * 0.4, std::to_string(took) + "s");
+
+    ok("the queued connections never reached the handler", ran.load() < clients,
+       std::to_string(ran.load()) + "/" + std::to_string(clients) + " ran");
+
+    int answered = 0;
+
+    for(const std::string& a : answers) if(!a.empty()) answered++;
+
+    // Closed rather than left hanging.  The descriptor rides in the job's
+    // shared_ptr<held_fd>, so dropping the job destroys it and the client gets
+    // an immediate EOF; ask() would otherwise sit on its own five-second
+    // timeout, and this section would take five seconds rather than one.
+    ok("and their clients were closed rather than left waiting",
+       answered < clients,
+       std::to_string(answered) + " of " + std::to_string(clients) + " answered");
 }
 
 static void the_destructor_waits_for_a_handler() {
@@ -617,6 +692,7 @@ int main() {
     the_two_paths_became_one();
     a_busy_pool_is_not_a_full_queue();
     stopping();
+    stopping_without_draining();
     the_destructor_waits_for_a_handler();
     over_tls();
 
@@ -634,6 +710,12 @@ int main() {
     //
     // Not client certificates, which the context deliberately neither asks for
     // nor examines.
+    //
+    // Not that an abandoned connection's descriptor is closed at the OS level.
+    // "Stopping without draining" infers it from the client seeing an
+    // immediate EOF, which is what a close looks like from the far end but is
+    // also what it would look like if the process had exited.  Only a
+    // descriptor count across the whole section would say it properly.
     std::cout << "\n" << (failures ? "FAILED" : "PASSED") << ": " << failures
               << " failure(s)\n";
 

--- a/tests/sys_socket_test.cc
+++ b/tests/sys_socket_test.cc
@@ -30,8 +30,12 @@
 // and takes RFC 5737's TEST-NET-1 for it.
 
 #include <jlib/sys/listener.hh>
+#include <jlib/sys/pipe.hh>
 #include <jlib/sys/socketstream.hh>
 #include <jlib/sys/sys.hh>
+
+#include <fcntl.h>
+#include <unistd.h>
 
 #include <chrono>
 #include <iostream>
@@ -184,6 +188,93 @@ static void an_ipv6_literal_resolves() {
     }
 }
 
+static void a_listener_says_who_connected() {
+    std::cout << "a listener says who connected\n";
+
+    try {
+        jlib::sys::listener server;
+        jlib::sys::socketstream client("127.0.0.1", server.port());
+
+        jlib::sys::peer who;
+        std::unique_ptr<jlib::sys::socketstream> got = server.accept_stream(who, 5);
+
+        ok("the connection is accepted", got != nullptr);
+
+        // ::accept(m_sock, 0, 0) threw this away, so nothing could log or
+        // refuse by who was on the other end.
+        ok("and its address is there", who.address == "127.0.0.1", who.address);
+        ok("with a port", who.port != 0, std::to_string(who.port));
+        ok("and it knows loopback when it sees it", who.loopback());
+    }
+    catch(std::exception& e) {
+        ok("the connection is accepted", false, e.what());
+    }
+
+    // The platform difference most likely to ship broken.  On BSD and macOS an
+    // accepted descriptor *inherits* O_NONBLOCK from the listening socket; on
+    // Linux it does not.  So a server that polls -- and therefore makes its
+    // listener non-blocking -- would hand every handler on macOS a
+    // non-blocking socket, and every read would fail with EAGAIN, while working
+    // perfectly in the Linux container.  Asserted rather than discovered.
+    try {
+        jlib::sys::listener server;
+
+        server.set_blocking(false);
+
+        ok("a non-blocking listener accepts nothing when nothing is waiting",
+           server.accept(0) == -1);
+
+        jlib::sys::socketstream client("127.0.0.1", server.port());
+
+        jlib::sys::peer who;
+        const int fd = server.accept(who, 5);
+
+        ok("but accepts a connection that is", fd >= 0);
+
+        if(fd >= 0) {
+            const int flags = ::fcntl(fd, F_GETFL, 0);
+
+            ok("and the descriptor it hands back is blocking, on every platform",
+               flags != -1 && !(flags & O_NONBLOCK),
+               flags == -1 ? "fcntl failed" : "");
+
+            ::close(fd);
+        }
+    }
+    catch(std::exception& e) {
+        ok("a non-blocking listener behaves", false, e.what());
+    }
+}
+
+static void a_pipe_closes_what_it_opened() {
+    std::cout << "a pipe closes what it opened\n";
+
+    // The destructor deleted the descriptor array and left both files open, so
+    // a process making pipes in a loop ran out of descriptors rather than
+    // memory -- and Servent and ASServent each hold one for their lifetime.
+    // Five thousand is well past any soft limit this would have hit.
+    bool ran_out = false;
+    std::string why;
+
+    try {
+        for(int i = 0; i < 5000; i++) {
+            jlib::sys::pipe p;
+
+            if(p.get_reader() < 0 || p.get_writer() < 0) {
+                ran_out = true;
+                break;
+            }
+        }
+    }
+    catch(std::exception& e) {
+        ran_out = true;
+        why = e.what();
+    }
+
+    ok("five thousand pipes come and go without exhausting the table",
+       !ran_out, why);
+}
+
 static void a_read_can_be_bounded() {
     std::cout << "a read can be bounded\n";
 
@@ -224,6 +315,8 @@ int main() {
     a_listener_accepts_a_connection();
     a_connect_that_will_never_answer_gives_up();
     an_ipv6_literal_resolves();
+    a_listener_says_who_connected();
+    a_pipe_closes_what_it_opened();
     a_read_can_be_bounded();
 
     // What a green run does not establish: that the connect timeout is

--- a/tests/sys_sync_test.cc
+++ b/tests/sys_sync_test.cc
@@ -324,6 +324,141 @@ static void a_job_that_throws() {
        std::to_string(after.load()) + "/4");
 }
 
+static void how_deep_the_queue_is() {
+    std::cout << "\nhow deep the queue is:\n";
+
+    // One worker, held up, so what is posted behind it stays queued and
+    // countable.  Without a way to ask, a caller cannot bound how far ahead of
+    // its pool it runs -- which for a server means accepted connections piling
+    // up as held descriptors.
+    sys::sync<bool> go(false);
+
+    {
+        sys::job_queue q(1);
+
+        q.post([&go] {
+            std::unique_lock<std::mutex> lock(go.mutex());
+
+            go.wait(lock, [&go] { return go(); });
+        });
+
+        // Let the worker take that one, so it is running rather than queued.
+        for(int i = 0; i < 100 && q.size() != 0; i++)
+            std::this_thread::sleep_for(std::chrono::milliseconds(5));
+
+        ok("a job that has been taken is not queued", q.size() == 0,
+           std::to_string(q.size()));
+
+        for(int i = 0; i < 5; i++) q.post([] {});
+
+        ok("and five posted behind it are", q.size() == 5,
+           std::to_string(q.size()));
+
+        // The depth is what is *waiting*.  A busy pool does not make the queue
+        // look full, which is what stops an accept loop stalling against work
+        // already under way.
+        go.set(true);
+
+        ok("waiting for room returns once they drain",
+           q.wait([](std::size_t d) { return d == 0; }));
+
+        ok("and the queue is empty", q.size() == 0, std::to_string(q.size()));
+    }
+
+    // The predicate is the caller's, so "room for one more" and "nothing
+    // waiting" are the same call with different lambdas.
+    {
+        sys::job_queue q(2);
+
+        ok("an empty queue satisfies a cap at once",
+           q.wait([](std::size_t d) { return d < 4; }));
+    }
+
+    // With no pool nothing is ever queued, so the depth is 0 and can never
+    // change.  Blocking would be a deadlock with no second party: it answers
+    // pred(0) instead.
+    {
+        sys::job_queue q(0);
+
+        ok("with no pool it answers rather than blocking",
+           q.wait([](std::size_t d) { return d == 0; }));
+
+        ok("and says no to a predicate that cannot hold, rather than hanging",
+           !q.wait([](std::size_t d) { return d > 0; }));
+    }
+
+    // A stopped queue must release a waiter, or stop() has stopped nothing for
+    // that thread.  This is what the exit term in the wait's own predicate
+    // buys, and the return value is how the caller tells the two apart.
+    {
+        sys::job_queue q(1);
+        sys::sync<bool> held(false);
+
+        q.post([&held] {
+            std::unique_lock<std::mutex> lock(held.mutex());
+
+            held.wait(lock, [&held] { return held(); });
+        });
+
+        for(int i = 0; i < 100 && q.size() != 0; i++)
+            std::this_thread::sleep_for(std::chrono::milliseconds(5));
+
+        q.post([] {});
+
+        std::atomic<bool> answered{false};
+        std::atomic<bool> said{true};
+
+        std::thread waiter([&q, &answered, &said] {
+            said = q.wait([](std::size_t d) { return d == 0; });
+            answered = true;
+        });
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+        ok("a waiter with work still queued is blocked", !answered.load());
+
+        q.stop(false);
+
+        held.set(true);
+        waiter.join();
+
+        ok("stop() releases it", answered.load());
+        ok("and it says it was stopped rather than satisfied", !said.load());
+
+        q.join();
+    }
+
+    // The timed form gives up and says so.
+    {
+        sys::job_queue q(1);
+        sys::sync<bool> held(false);
+
+        q.post([&held] {
+            std::unique_lock<std::mutex> lock(held.mutex());
+
+            held.wait(lock, [&held] { return held(); });
+        });
+
+        for(int i = 0; i < 100 && q.size() != 0; i++)
+            std::this_thread::sleep_for(std::chrono::milliseconds(5));
+
+        q.post([] {});
+
+        const auto start = std::chrono::steady_clock::now();
+
+        const bool got = q.wait([](std::size_t d) { return d == 0; },
+                                std::chrono::milliseconds(100));
+
+        const double took = seconds_since(start);
+
+        ok("the timed form gives up", !got);
+        ok("after about as long as it was given", took >= 0.08 && took < 2.0,
+           std::to_string(took) + "s");
+
+        held.set(true);
+    }
+}
+
 static void a_pool_of_none_runs_inline() {
     std::cout << "\na pool of none runs inline:\n";
 
@@ -405,6 +540,7 @@ int main() {
     the_destructor_drains();
     stopping_with_and_without_a_drain();
     a_job_that_throws();
+    how_deep_the_queue_is();
     a_pool_of_none_runs_inline();
 
     // What a green run does not establish.
@@ -412,7 +548,7 @@ int main() {
     // Not the absence of the lost wakeup this fixed.  A worker used to test
     // m_exit outside the lock and then wait, so a stop() landing in between
     // was a notification it never saw and a join() that never returned -- a
-    // window a few instructions wide.  What the predicate loop buys is that
+    // window a few instructions wide.  What the predicate form buys is that
     // the race cannot happen; no timing test can show it gone, and one that
     // claimed to would be worse than this paragraph.
     //
@@ -420,6 +556,12 @@ int main() {
     // assertion; "finished faster than serial would" has a wide margin and is
     // still a wall-clock claim on a machine that may be busy.  A failure there
     // means look at the machine before looking at the code.
+    //
+    // Not the wakeup on pop, directly.  "A waiter blocked with work queued is
+    // released when the queue drains" exercises it -- without the notify the
+    // section above would hang rather than fail -- but a test that hangs is a
+    // test that stops make check instead of failing it, so the timed form is
+    // what keeps that section honest.
     //
     // Not sync<T> in anger.  A handful of threads and one condition variable
     // is the whole of what is exercised above; the ringbuffer test is where the

--- a/tests/sys_tls_server_test.cc
+++ b/tests/sys_tls_server_test.cc
@@ -1,0 +1,380 @@
+/* -*- mode: C++ c-basic-offset: 4 -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// The accepting end of a TLS connection, which jlib could not be until now.
+//
+// basic_tlsbuf called SSL_connect unconditionally and there was no way to give
+// an SSL_CTX a certificate and a key, so two tests hand-rolled SSL_CTX_new,
+// SSL_new and SSL_accept around jlib's own listener -- and one of them wrote
+// down that it was working around a gap rather than fixing one.  This is the
+// gap closed, tested before anything is built on top of it: sys::listener and
+// sys::tlsstream, no sys::server yet.
+//
+// Entirely local, and that is the point.  The certificate is generated at
+// runtime, SSL_CERT_FILE points the client's trust store at it, and both ends
+// are in this process -- so server-side TLS is provable on a developer's
+// machine and not only in the build container, which is exactly what the old
+// arrangement could not do.
+//
+// The verification is real.  Nothing here is turned off; the handshake
+// succeeds because the certificate is genuinely trusted for this run.
+
+#include "certificate.hh"
+
+#include <jlib/sys/listener.hh>
+#include <jlib/sys/socketstream.hh>
+#include <jlib/sys/sslstream.hh>
+#include <jlib/sys/tls.hh>
+
+#include <openssl/ssl.h>
+
+#include <cstdio>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <thread>
+
+namespace sys = jlib::sys;
+
+static int failures = 0;
+
+static void ok(const std::string& what, bool good, const std::string& detail = "") {
+    if(!good) ++failures;
+    std::cout << (good ? "  ok   " : "  FAIL ") << what;
+    if(!detail.empty()) std::cout << ": " << detail;
+    std::cout << "\n";
+}
+
+/** Serve one TLS connection: read a line, echo it back, close. */
+static void echo_once(sys::listener& l, const sys::tls_context& ctx,
+                      std::string* saw = 0, bool* handshook = 0)
+{
+    try {
+        const int fd = l.accept(10);
+
+        if(fd < 0) return;
+
+        sys::tlsstream s(sys::tls_server, ctx, sys::adopt, fd, "", 0, 10);
+
+        if(handshook) *handshook = true;
+
+        std::string line;
+        std::getline(s, line);
+
+        if(saw) *saw = line;
+
+        s << "you said: " << line << "\r\n" << std::flush;
+        s.close();
+    }
+    catch(std::exception& e) {
+        if(saw) *saw = std::string("server threw: ") + e.what();
+    }
+}
+
+static void a_context_reads_a_certificate(const std::string& cert,
+                                          const std::string& key)
+{
+    std::cout << "\na context reads a certificate:\n";
+
+    bool made = false;
+
+    try {
+        sys::tls_context ctx = sys::tls_context::server(cert, key);
+
+        made = !ctx.empty() && ctx.get() != 0;
+    }
+    catch(std::exception& e) {
+        ok("a server context builds", false, e.what());
+    }
+
+    ok("a server context builds", made);
+
+    ok("an empty one knows it is empty", sys::tls_context().empty() &&
+       !static_cast<bool>(sys::tls_context()));
+
+    // A refcount, which is the whole reason this type exists: basic_tlsbuf
+    // built one SSL_CTX per connection and freed it in close(), and a server
+    // reading its certificate and key once per connection is both slow and
+    // wrong.
+    {
+        sys::tls_context a = sys::tls_context::server(cert, key);
+        sys::tls_context b = a;
+
+        ok("copying one shares the context", a.get() == b.get() && a.get() != 0);
+    }
+
+    // Now rather than on the first client to connect, where it reads as a
+    // handshake failure and the certificate is the last thing anyone looks at.
+    bool threw = false;
+    std::string message;
+
+    try {
+        std::string other_cert = "mismatch_cert.pem", other_key = "mismatch_key.pem";
+
+        if(make_cert(other_cert, other_key, "elsewhere", "DNS:elsewhere")) {
+            sys::tls_context::server(cert, other_key);
+        }
+        else {
+            threw = true;   // could not set the case up; do not fail for it
+            message = "skipped";
+        }
+
+        std::remove(other_cert.c_str());
+        std::remove(other_key.c_str());
+    }
+    catch(std::exception& e) {
+        threw = true;
+        message = e.what();
+    }
+
+    ok("a key that does not match the certificate is refused at once", threw,
+       message);
+
+    threw = false;
+
+    try { sys::tls_context::server("no-such-file.pem", key); }
+    catch(std::exception&) { threw = true; }
+
+    ok("and so is a certificate that is not there", threw);
+}
+
+static void a_client_and_a_server_in_one_process(const std::string& cert,
+                                                 const std::string& key)
+{
+    std::cout << "\na client and a server, in one process:\n";
+
+    sys::tls_context ctx = sys::tls_context::server(cert, key);
+    sys::listener l;
+
+    std::string saw;
+    std::thread server([&l, &ctx, &saw] { echo_once(l, ctx, &saw); });
+
+    try {
+        // "localhost", because that is the name the generated certificate
+        // covers -- see the SAN in certificate.hh.
+        sys::tlsstream client("localhost", l.port());
+
+        client << "hello over TLS\r\n" << std::flush;
+
+        std::string line;
+        std::getline(client, line);
+
+        while(!line.empty() && line.back() == '\r') line.pop_back();
+
+        ok("the handshake completes and the line comes back",
+           line == "you said: hello over TLS", line);
+
+        ok("and the server read what was sent", saw == "hello over TLS\r" ||
+           saw == "hello over TLS", saw);
+
+        client.close();
+    }
+    catch(std::exception& e) {
+        ok("the handshake completes and the line comes back", false, e.what());
+    }
+
+    server.join();
+}
+
+static void the_certificate_has_to_be_the_right_one(const std::string& cert,
+                                                    const std::string& key)
+{
+    std::cout << "\nthe certificate has to be the right one:\n";
+
+    sys::tls_context ctx = sys::tls_context::server(cert, key);
+    sys::listener l;
+
+    bool handshook = false;
+    std::thread server([&l, &ctx, &handshook] { echo_once(l, ctx, 0, &handshook); });
+
+    bool threw = false;
+
+    try {
+        // 127.0.0.1, where the certificate says DNS:localhost and nothing
+        // else.  certificate.hh omits an IP SAN on purpose, which is what
+        // makes this provable -- and without this assertion a passing test
+        // shows only that bytes moved, not that anything was verified.
+        sys::tlsstream client("127.0.0.1", l.port());
+
+        client << "should not get here\r\n" << std::flush;
+    }
+    catch(std::exception&) { threw = true; }
+
+    ok("a name the certificate does not cover is refused", threw);
+
+    server.join();
+}
+
+static void an_untrusted_certificate_is_refused(const std::string& cert,
+                                                const std::string& key)
+{
+    std::cout << "\nan untrusted certificate is refused:\n";
+
+    const char* const had = std::getenv("SSL_CERT_FILE");
+    const std::string keep = had ? had : "";
+
+    ::unsetenv("SSL_CERT_FILE");
+
+    sys::tls_context ctx = sys::tls_context::server(cert, key);
+    sys::listener l;
+
+    std::thread server([&l, &ctx] { echo_once(l, ctx); });
+
+    bool threw = false;
+
+    try {
+        sys::tlsstream client("localhost", l.port());
+
+        client << "should not get here\r\n" << std::flush;
+    }
+    catch(std::exception&) { threw = true; }
+
+    ok("a certificate nothing trusts is refused", threw);
+
+    server.join();
+
+    if(keep.empty()) ::unsetenv("SSL_CERT_FILE");
+    else             ::setenv("SSL_CERT_FILE", keep.c_str(), 1);
+
+    // And it works again once the trust is back, which proves the section
+    // above turned something off rather than breaking the arrangement.
+    sys::listener again;
+    std::string saw;
+    std::thread second([&again, &ctx, &saw] { echo_once(again, ctx, &saw); });
+
+    bool worked = false;
+
+    try {
+        sys::tlsstream client("localhost", again.port());
+
+        client << "again\r\n" << std::flush;
+
+        std::string line;
+        std::getline(client, line);
+
+        worked = line.find("again") != std::string::npos;
+    }
+    catch(std::exception&) {}
+
+    second.join();
+
+    ok("and accepted again once the trust store is back", worked);
+}
+
+static void a_plaintext_client_does_not_take_the_server_with_it(
+    const std::string& cert, const std::string& key)
+{
+    std::cout << "\na plaintext client does not take the server with it:\n";
+
+    sys::tls_context ctx = sys::tls_context::server(cert, key);
+    sys::listener l;
+
+    // A handshake failure has to be survivable, because the whole point of a
+    // server is that it goes on serving.  This is that assertion at the level
+    // of one connection; sys_server_test makes it again at the level of a loop.
+    std::string first;
+    std::thread server([&l, &ctx, &first] { echo_once(l, ctx, &first); });
+
+    try {
+        sys::socketstream plain("127.0.0.1", l.port());
+
+        plain << "GET / HTTP/1.1\r\n\r\n" << std::flush;
+        plain.close();
+    }
+    catch(std::exception&) {}
+
+    server.join();
+
+    ok("the server reports the failure rather than crashing",
+       first.find("server threw") == 0, first);
+
+    // Then a real one, on a new listener, with the same context -- which is
+    // the part that would break if the failed handshake had damaged it.
+    sys::listener again;
+    std::string saw;
+    std::thread second([&again, &ctx, &saw] { echo_once(again, ctx, &saw); });
+
+    bool worked = false;
+
+    try {
+        sys::tlsstream client("localhost", again.port());
+
+        client << "still here\r\n" << std::flush;
+
+        std::string line;
+        std::getline(client, line);
+
+        worked = line.find("still here") != std::string::npos;
+    }
+    catch(std::exception&) {}
+
+    second.join();
+
+    ok("and the same context serves the next connection", worked);
+}
+
+int main() {
+    std::cout << std::unitbuf;
+
+    const std::string cert = "tls_server_cert.pem";
+    const std::string key = "tls_server_key.pem";
+
+    if(!make_cert(cert, key)) {
+        std::cerr << "could not generate a test certificate, skipping" << std::endl;
+
+        return 77;
+    }
+
+    ::setenv("SSL_CERT_FILE", cert.c_str(), 1);
+
+    a_context_reads_a_certificate(cert, key);
+    a_client_and_a_server_in_one_process(cert, key);
+    the_certificate_has_to_be_the_right_one(cert, key);
+    an_untrusted_certificate_is_refused(cert, key);
+    a_plaintext_client_does_not_take_the_server_with_it(cert, key);
+
+    std::remove(cert.c_str());
+    std::remove(key.c_str());
+
+    // What a green run does not establish.
+    //
+    // Not a real peer.  Both ends here are jlib, handshaking against a
+    // certificate this test generated with the trust store pointed at it, so
+    // this proves the accepting path and the verification and says nothing
+    // about a public CA chain or a client jlib did not write.  The live tests
+    // -- dovecot, nginx, tinyproxy -- are where jlib's *client* meets software
+    // somebody else wrote, and none of them exercises this direction.
+    //
+    // Not client certificates.  A server context here asks for none and would
+    // not examine one; mutual TLS is out of scope and deliberately not half
+    // implemented.
+    //
+    // Not the delayed handshake on this side.  tlsstream takes a delay flag for
+    // the accepting path, and STARTTLS-as-a-server is not exercised anywhere.
+    //
+    // Not the protocol floor.  The context asks for TLS 1.2 as a minimum and
+    // nothing here proves a 1.1 client would be turned away -- doing so would
+    // mean building a deliberately obsolete client by hand, and the assertion
+    // that was here instead was a hardcoded true, which proves less than
+    // nothing because it looks like coverage.
+    std::cout << "\n" << (failures ? "FAILED" : "PASSED") << ": " << failures
+              << " failure(s)\n";
+
+    return failures ? 1 : 0;
+}

--- a/tests/sys_tls_sigpipe_test.cc
+++ b/tests/sys_tls_sigpipe_test.cc
@@ -39,6 +39,7 @@
 #include <jlib/sys/listener.hh>
 #include <jlib/sys/sslstream.hh>
 #include <jlib/sys/sys.hh>
+#include <jlib/sys/tls.hh>
 
 #include <openssl/err.h>
 #include <openssl/pem.h>
@@ -128,27 +129,32 @@ int main() {
     }
 
     // The server: accept, complete the handshake, then drop the connection.
-    SSL_CTX* ctx = SSL_CTX_new(TLS_server_method());
+    //
+    // This was twenty lines of raw OpenSSL -- SSL_CTX_new(TLS_server_method),
+    // SSL_new, SSL_set_fd, SSL_accept and a descriptor closed by hand -- because
+    // basic_tlsbuf could only ever call SSL_connect.  It is jlib's own now
+    // (#112), including the part that makes this test what it is: reset() drops
+    // the connection *without* a close_notify, which is what SSL_free with no
+    // SSL_shutdown in front of it was doing here.
     bool served = false;
 
-    if(ctx) {
-        SSL_CTX_use_certificate_file(ctx, cert.c_str(), SSL_FILETYPE_PEM);
-        SSL_CTX_use_PrivateKey_file(ctx, key.c_str(), SSL_FILETYPE_PEM);
-
+    try {
         const int peer = l->accept();
-        if(peer >= 0) {
-            SSL* ssl = SSL_new(ctx);
-            if(ssl) {
-                SSL_set_fd(ssl, peer);
-                served = (SSL_accept(ssl) == 1);
 
-                // Away without a close_notify, which is how a server that has
-                // gone down leaves things.
-                SSL_free(ssl);
-            }
-            ::close(peer);
+        if(peer >= 0) {
+            jlib::sys::tlsstream server(jlib::sys::tls_server,
+                                        jlib::sys::tls_context::server(cert, key),
+                                        jlib::sys::adopt, peer, "", 0, 10);
+
+            served = true;
+
+            // Away without a close_notify, which is how a server that has gone
+            // down leaves things.
+            server.reset();
         }
-        SSL_CTX_free(ctx);
+    }
+    catch(std::exception& e) {
+        std::cerr << "the test server did not come up: " << e.what() << std::endl;
     }
 
     l->close();

--- a/tests/util_http_test.cc
+++ b/tests/util_http_test.cc
@@ -341,6 +341,88 @@ static void reading_a_body() {
     }
 }
 
+/** Did parsing this request head throw? */
+static bool refused_request(const std::string& head) {
+    try {
+        http::parse_request_head(head);
+
+        return false;
+    }
+    catch(http::error&) {
+        return true;
+    }
+}
+
+static void a_request_head_reads_the_same_way() {
+    std::cout << "\na request head reads the same way:\n";
+
+    const http::Request r = http::parse_request_head(
+        "POST /token?a=1 HTTP/1.1\r\n"
+        "Host: accounts.example.com\r\n"
+        "Content-Type: application/x-www-form-urlencoded\r\n"
+        "Content-Length: 9\r\n"
+        "\r\n");
+
+    ok("the method is there", r.method() == "POST", r.method());
+
+    // Query and all: a target with the query stripped is a different request,
+    // and for half the requests jlib makes the query is the whole message.
+    ok("the target is as it arrived", r.target() == "/token?a=1", r.target());
+    ok("the version too", r.version() == "HTTP/1.1", r.version());
+    ok("Host is where HTTP/1.1 requires it",
+       r.host() == "accounts.example.com", r.host());
+    ok("and the field section reads",
+       r.fields().get("Content-Type") == "application/x-www-form-urlencoded");
+    ok("with its framing", r.body_framing() == http::framing::length &&
+       r.content_length() == 9);
+
+    // **The one difference from a response.**  RFC 9112 6.3: a request with
+    // neither framing field has no body.  A response with neither runs to the
+    // close -- and reading a request that way means waiting out a client that
+    // is itself waiting for an answer, which is a hang rather than a body.
+    const http::Request bare = http::parse_request_head("GET / HTTP/1.1\r\nHost: x\r\n\r\n");
+
+    ok("a request with no framing fields has no body, where a response would "
+       "read to the close",
+       bare.body_framing() == http::framing::none);
+
+    const http::Request chunked = http::parse_request_head(
+        "POST /x HTTP/1.1\r\nHost: x\r\nTransfer-Encoding: chunked\r\n\r\n");
+
+    ok("and chunked is chunked", chunked.body_framing() == http::framing::chunked);
+
+    // For the same reason: a coding that is not chunked leaves the server with
+    // no way to know where the request ends.
+    ok("but a Transfer-Encoding that does not end in chunked is refused",
+       refused_request("POST /x HTTP/1.1\r\nHost: x\r\n"
+                       "Transfer-Encoding: gzip\r\n\r\n"));
+
+    // Everything the response side refuses, refused here too -- the field
+    // section and the framing checks are one piece of code now.
+    ok("both Content-Length and Transfer-Encoding",
+       refused_request("POST /x HTTP/1.1\r\nContent-Length: 5\r\n"
+                       "Transfer-Encoding: chunked\r\n\r\n"));
+    ok("two Content-Lengths that disagree",
+       refused_request("POST /x HTTP/1.1\r\nContent-Length: 5\r\n"
+                       "Content-Length: 6\r\n\r\n"));
+    ok("obs-fold", refused_request("GET / HTTP/1.1\r\nX: one\r\n  two\r\n\r\n"));
+    ok("whitespace before the colon",
+       refused_request("GET / HTTP/1.1\r\nHost : x\r\n\r\n"));
+    ok("a bare LF as a line ending", refused_request("GET / HTTP/1.1\nHost: x\n\n"));
+    ok("something that is not a request line at all",
+       refused_request("HTTP/1.1 200 OK\r\n\r\n"));
+    ok("and a target that is not one",
+       refused_request("GET not a target HTTP/1.1\r\n\r\n"));
+
+    // Off a stream, which is how a server gets one.
+    std::istringstream is("GET /x HTTP/1.1\r\nHost: y\r\n\r\nleftovers");
+
+    const http::Request read = http::read_request_head(is);
+
+    ok("read off a stream, leaving the body behind",
+       read.target() == "/x" && is.peek() == 'l');
+}
+
 static void a_relative_reference_parses_now() {
     std::cout << "\na relative reference parses now:\n";
 
@@ -375,6 +457,7 @@ int main() {
     what_rfc_9112_section_6_refuses();
     reading_a_head_off_a_stream();
     reading_a_body();
+    a_request_head_reads_the_same_way();
     a_relative_reference_parses_now();
 
     // What a green run does not establish.
@@ -393,8 +476,10 @@ int main() {
     // sys_proxy_live_test runs the same reader against tinyproxy, which is one
     // real server and not a survey.
     //
-    // Anything about requests.  read_head parses a response; request-line and
-    // the four request-target forms compile and are unexercised.
+    // The four request-target forms beyond origin-form.  absolute-form (a
+    // proxy's GET http://host/path), authority-form (CONNECT) and
+    // asterisk-form (OPTIONS *) all compile and none is exercised, because
+    // nothing here is a proxy.
     std::cout << "\n" << (failures ? "FAILED" : "PASSED") << ": " << failures
               << " failure(s)\n";
 


### PR DESCRIPTION
# jlib gets a server side

Closes #112.

Twenty-six years of a library that could open a connection and never answer one.
This adds the accepting half — `sys::listener`, `sys::tls_context`,
`sys::server`, and `net::http::server` on top — and then deletes the three
places that had hand-rolled pieces of it.

## What was missing, and the bug the gap caused

`basic_tlsbuf` called `SSL_connect` unconditionally, and there was no way to
give an `SSL_CTX` a certificate. So two tests hand-rolled the accepting half of
a handshake, and `tests/httpserver.hh` said in its own header that it was
working around a gap rather than fixing one.

That gap cost a real bug, not just duplication. With no server-side streambuf
there was no `istream`, so `httpserver.hh` could not call
`util::http::read_head()` and hand-rolled a byte-at-a-time reader — one that
recorded connections carrying no complete head as though they were requests.
The fix is not a better byte loop; it is having a stream at all.

## `tls_context` is the actual change

`basic_tlsbuf` built an `SSL_CTX` per connection. That is affordable for a
client making one call and is not what a server does — a server reads its
certificate and key off disk once, at startup, and every connection after that
is `SSL_new` against a context that already exists.

`sys::tls_context` is a refcounted `SSL_CTX` with two named constructors,
`client()` and `server(cert, key)`. An empty one means plaintext, which is what
lets `sys::server` take TLS as a parameter rather than as a subclass.

## `sys::server` owns no threads of its own

`job_queue(0)` runs a job on the thread that posts it and `job_queue(N)` runs it
on a pool, with the same semantics either way. So the server posts, and the
number decides:

```cpp
m_jobs.post([this, held, from] { serve(held->release(), from); });
```

One line, whichever mode. An earlier draft of this branch carried one branch
calling the handler inline and another dispatching it, with a live count, a
mutex and a condition variable to go with them. The acceptance test for the
rewrite was that `serve_one()` contain no `threads == 0` fork anywhere, and it
does not.

`tests/sys_server_test.cc` asserts this rather than trusting it:
`std::this_thread::get_id()` inside the handler equals the caller's with
`threads = 0` and differs with `threads = 1`. Two paths became one only if both
halves hold.

## What this costs

Three losses, named here because they are the parts a reader should disagree
with if they are going to disagree with anything.

**The back-pressure story inverts.** A `job_queue` is a second queue, and
accepting ahead of capacity completes a handshake for a client that cannot yet
be served and holds a descriptor while it waits — strictly worse against a flood
than leaving it in the listen backlog. What restores the old property is that
the accept loop waits on the queue's depth *before* it polls, so the overflow
stays in the kernel's backlog, where a connection is supposed to wait and where
the backlog refuses it with behaviour every client understands. The cap is
load-bearing, not a tuning knob.

**`max_queued` and `threads` are two numbers with two jobs.** `max_queued`
bounds how far the accept loop may run ahead; `threads` bounds concurrency. A
job that has been popped is running, not queued, and is not counted — so a busy
pool does not make the queue look full and stall the accept loop against work
already under way. The consequence, and only the consequence, is a bound of
`max_queued + threads` connection descriptors. The header labours this because
blurring the two is how somebody later removes the cap as redundant and finds
the descriptor bound was load-bearing.

**`run()` is one-shot.** `job_queue::stop()` is irreversible — the workers have
exited and nothing respawns them — so a restarted server would accept
connections and silently drop every one. `run()` after `stop()` returns
immediately. A decision rather than an accident.

And `~server` can block for as long as the queued connections take to serve.
That drain is what stops an accepted connection being silently discarded, and
`io_timeout` is what keeps it finite — which is why it does not default to
never.

## The descriptor rides in a `shared_ptr`

The stream is built **inside** the job, because constructing a `tlsstream`
performs `SSL_accept` and doing that on the accept thread lets one slow client
stall everything. So the descriptor travels in the closure.

`job_queue::post` takes `std::function<void()>`, which requires a *copyable*
callable — the move-only `held_fd` that a `std::thread` would have accepted does
not compile here. `std::move_only_function` would solve it and is not available:
measured under `-std=c++20`, `__cpp_lib_move_only_function` is undefined on both
Apple clang and the container's gcc 13. Hand-rolling move-only type erasure is
more code than `job_queue` contains.

So the job captures `std::shared_ptr<held_fd>`. Two things worth writing down:
the indirection does real work rather than merely satisfying copyability — a
`held_fd` captured by value into a non-mutable lambda is const, and `release()`
would not compile — and the `shared_ptr` is **not shared**, refcount 1 for its
whole life, so nobody goes looking for a second owner.

What it buys is that all three drop paths close the descriptor by RAII:
`post()` returning early because the queue stopped, a worker abandoning queued
jobs on `stop(false)`, and `post()` itself throwing. A bare `int` leaks in all
three, and a `stop()` landing between the `accept()` and the `post()` is exactly
that race.

## Two additions to `job_queue`, and one to `sync<T>`

```cpp
std::size_t size() const;                      // depth, not work in flight

template<typename Predicate> bool wait(Predicate);
template<typename Predicate> bool wait(Predicate, std::chrono::nanoseconds);
```

A generic predicate rather than a `wait_for_room(n)`: the queue holds the depth
and the lock, and that is all it should own. What counts as full is the
caller's policy, so the server's admission control is one lambda at the one
place with an opinion. The wait's own predicate ORs in `m_exit`, which is what
lets `stop()` release an accept thread parked in it — and why the return value
distinguishes "the predicate held" from "we were stopped".

`sync<T>` gains const `mutex()` / `operator std::mutex&()` (`m_lock` was already
`mutable`, and `get()` is const and hands it to `safe_get`, so this is the
declared intent rather than a widening) and a timed predicate wait, which
`serve_one(timeout)` needs or a full queue makes it block past its own contract.

### `notify_one` becomes `notify_all`, and why that is not a bug fix

Nothing previously signalled when a job *left* the queue. The worker loop now
notifies after popping, under the lock — not after running the job, which would
make the cap bound work in flight rather than queue depth and make the accept
thread wait on handler duration.

One condition variable then serves two predicates, and they are
**anti-correlated**: a push makes the worker's predicate true and the poster's
no more true; a pop does the reverse. `notify_one` can hand the wakeup to a
thread whose predicate is false, which re-sleeps and consumes it. Both
directions are lost wakeups — a pop waking a worker deadlocks the accept loop
against an idle pool.

`notify_one` was *correct* before this branch, precisely because there was one
predicate. Adding the second invalidated it. The escape, if the extra wakeups
ever measure, is a second condition variable guarded by the same mutex — which
is what the const `mutex()` above makes reachable, and the comment says so, so
nobody redoes the analysis.

## `stop(bool drain = true)`, and why `join()` does not stop

Both servers expose it. Queued work only: a handler already running finishes
either way, which is the same line `max_queued` draws against `threads`.
`false` drops those connections with no answer at all — not a 503, not a
status-then-close, just a close — so it is for shutting down under duress.

`join()` deliberately does **not** stop on the caller's behalf, and an earlier
version of this branch did. `job_queue::stop()` assigns its drain flag every
time rather than first-wins, so a `stop(true)` inside `join()` would silently
upgrade a caller's `stop(false)` back to draining. The order is `stop()` then
`join()`, which is what the destructor does.

The trap this leaves is documented in both headers because it is a bad one: a
join without a stop hangs, and hangs **only with a pool**. With `threads == 0`
there is nothing to retire and `join()` returns at once, so a serial server
survives the wrong order and a pooled one deadlocks on it — a failure mode you
would otherwise discover by adding a thread later.

That is not hypothetical. Removing the stop from `sys_server_test` reproduces
it exactly, caught with `sample`:

```
main
  jlib::sys::server::join()
    std::thread::join() -> __ulock_wait
[4 x pool worker]
  jlib::sys::job_queue::start()
    std::condition_variable::wait -> __psynch_cvwait
```

The same mutation in `net_http_server_test` hangs at exactly the pooled section
and nowhere else, so the ordering fix is load-bearing rather than tidiness.

## `net::http::server`

Reads a request against the same RFC 9112 grammar the client's responses go
through. One request per connection and `Connection: close`, always — no
keep-alive, because keep-alive framing is where request smuggling lives and a
server has strictly more to lose there than a client.

A response is accumulated whole rather than streamed, which is what lets a
handler that throws still be answered with a 500 — and serialising it is inside
the same `try`, because `str()` refuses a field a handler built that cannot be
sent, and without that the client would get a bare close, indistinguishable from
a crash.

Routing is exact: no prefixes, no wildcards, no trailing-slash equivalence.
Percent-encoding is decoded first, because RFC 3986 2.1 makes `%65` and `e` the
same character — but a target whose path contains an encoded separator (`%2F`)
is refused rather than decoded, since decoding one changes how many segments the
path has, and that is the shape of a traversal bug.

`server_options` and `server_policy` are at namespace scope rather than nested.
A default argument is a complete-class context, so `const options& o =
options()` on a member of the class that nests `options` does not compile; an
earlier version routed around it with a second constructor. Defining the structs
first removes the problem, and `server::options` still spells.

## Repairs carried along

Found while building on this code, and each one is a real leak or crash rather
than a tidy-up:

- `sys::pipe` leaked both descriptors and could double-close on copy.
- Three `open()` methods leaked `m_buf` — `sslstream`, `proxystream`,
  `sslproxystream`.
- `basic_socketstream`'s accessors null-dereferenced.
- An `SSL*` leaked on every failed handshake.
- An accepted descriptor inherits `O_NONBLOCK` on macOS and BSD but **not** on
  Linux. That is the divergence most likely to ship broken: every handler would
  have misbehaved on one platform while passing in the container.

## The de-duplication is the proof

`tests/httpserver.hh` lost its hand-rolled `SSL_accept`, its own descriptor
ownership and its byte-at-a-time head reader; `sys_tls_sigpipe_test` lost twenty
lines of raw OpenSSL; `oauth::redirect_receiver` stopped parsing a request line
by hand. All three pass **unchanged**, along with `net_http_test`,
`net_oauth_test` and `net_oauth_authorize_test` that run on top of them.

That is what makes this a de-duplication rather than a rewrite: the code that
was deleted was doing something, and the same tests still say it is being done.

## Tests

`sys_server_test` and `net_http_server_test` are new; `sys_tls_server_test`
covers the handshake against a runtime-generated certificate.

Named assertions worth listing: peak concurrency above one and bounded by
`threads`; the cap holding with nothing dropped, the overflow having waited in
the backlog; a busy pool **not** blocking the accept loop, which is the direct
test that running jobs are not counted as queued; `stop()` releasing an accept
thread parked in admission control; `stop()` from inside a handler; a handler
that throws reaching `on_error` while the loop keeps serving; and `~server` not
returning until an in-flight handler has finished.

`stop(false)` is exercised at both layers, with the same numbers on both
platforms — 0.40 s to join, 1 of 3 handlers run, 1 of 3 clients answered. The
timing is the assertion that draining is about *queued* work and not about
cancelling a handler mid-flight: it waits for the one in flight and not for the
two behind it.

**What a green run does not establish**, and it is written into both files:

- That this is safe on a public port. The bound is `max_queued + threads`
  descriptors and a read timeout, and that is all — and this design accepts
  ahead of capacity, which the previous one did not. Both headers say it is for
  a loopback redirect and a test harness and should stay one. The way a narrow
  thing becomes a broad one is by nobody writing down that it was meant to be
  narrow.
- Interoperability. Both ends of `net_http_server_test` were written by the same
  hand from the same grammar, so they agree about things a stranger would not,
  and a disagreement between jlib and the world would show up as two green
  ticks. `net_http_live_test` keeps driving the client at a real nginx, and no
  live test was converted to the in-process shape.
- That a handler is safe to write. Every handler in these tests touches only its
  own arguments and atomics; one sharing anything else is on its own and nothing
  here would notice.
- That an abandoned connection's descriptor is closed at the OS level. It is
  inferred from the client seeing an immediate EOF, which is what a close looks
  like from the far end but also what process exit looks like. Only a descriptor
  count would say it properly.
- The timing assertions under load are wall-clock claims on a machine that may
  be busy. They carry wide margins, and a failure means look at the machine
  before looking at the code.

## Numbers

macOS (Apple clang, arm64): 55 pass, 4 skip, 0 fail.
Linux container (gcc 13): 59 pass, 1 skip, 0 fail.

`sys_server_test` runs in 4.2 s, `net_http_server_test` in 2.9 s. Pooled
sections reach peak 4 on both platforms; eight 150 ms requests complete in
0.31 s against the 1.2 s serial handling would take.

Both live-test pairs stay green, including `net_pop3_live_test` and
`sys_proxy_live_test` — the only coverage of `basic_sslproxybuf`, which shares
the `basic_tlsbuf` this branch changes.
