### PR TITLE
Give ASServent's worker an owner: join it in reset(), stop it in the destructor, and test that it is gone

### DIFF
--- a/jlib/net/ASImapBox.cc
+++ b/jlib/net/ASImapBox.cc
@@ -37,6 +37,12 @@ namespace jlib {
         {
         }
 
+        ASImapBox::~ASImapBox() {
+            // Before m_sock and the Imap4 half go: the worker reaches both
+            // through the on_*() overrides declared here.
+            stop();
+        }
+
         
         void ASImapBox::on_init() {
             if(m_sock) {

--- a/jlib/net/ASImapBox.hh
+++ b/jlib/net/ASImapBox.hh
@@ -36,6 +36,17 @@ namespace jlib {
         public:
             ASImapBox(jlib::util::URL url, bool idle = false);
 
+            /**
+             * Stops the worker before this object's own state goes away.
+             *
+             * ~ASServent stops it too, but by then the on_*() overrides the
+             * worker calls through handle(Request) have already been
+             * destroyed -- and they are pure virtual in ASMailBox, so that is
+             * a pure virtual call rather than merely a race.  See
+             * ASServent::stop().
+             */
+            virtual ~ASImapBox();
+
             virtual void on_init();
 
             virtual void on_set_password(const std::string& password);

--- a/jlib/net/ASMBox.cc
+++ b/jlib/net/ASMBox.cc
@@ -48,6 +48,12 @@ namespace jlib {
             
         }
 
+        ASMBox::~ASMBox() {
+            // Before m_is goes: the worker reaches it through the on_*()
+            // overrides declared here.
+            stop();
+        }
+
         
         void ASMBox::on_init() {
             push(MailBoxResponse(MailBoxResponse::STATUS, "Initializing"));

--- a/jlib/net/ASMBox.hh
+++ b/jlib/net/ASMBox.hh
@@ -36,6 +36,17 @@ namespace jlib {
         public:
             ASMBox(jlib::util::URL url);
 
+            /**
+             * Stops the worker before this object's own state goes away.
+             *
+             * ~ASServent stops it too, but by then the on_*() overrides the
+             * worker calls through handle(Request) have already been
+             * destroyed -- and they are pure virtual in ASMailBox, so that is
+             * a pure virtual call rather than merely a race.  See
+             * ASServent::stop().
+             */
+            virtual ~ASMBox();
+
             virtual void on_init();
 
             virtual void on_set_password(const std::string& password);

--- a/jlib/net/ASMailBox.cc
+++ b/jlib/net/ASMailBox.cc
@@ -132,7 +132,11 @@ namespace jlib {
         }
 
         ASMailBox::~ASMailBox() {
-
+            // The worker calls handle(Request), which dispatches to the
+            // on_*() overrides.  A leaf class must stop it before its own
+            // members go; this is the same backstop ~ASServent is, one layer
+            // down, and is not a substitute for the leaf doing it.
+            stop();
         }
 
         void ASMailBox::handle(const MailBoxRequest& request) {

--- a/jlib/sys/ASServent.hh
+++ b/jlib/sys/ASServent.hh
@@ -26,6 +26,7 @@
 #include <jlib/sys/auto.hh>
 
 #include <exception>
+#include <iostream>
 #include <string>
 #include <sstream>
 #include <map>
@@ -86,6 +87,20 @@ public:
     
     void reset();
     
+    /**
+     * Stop the worker and wait for it to finish.
+     *
+     * A derived class must call this from its own destructor.  ~ASServent
+     * calls it too, but by then the derived part of the object is already
+     * gone, so anything the worker touches that a subclass owns must be shut
+     * down earlier than that -- and handle(Request) is pure virtual here, so
+     * a worker still running when the derived destructor has finished is a
+     * pure virtual call, not merely a data race.
+     *
+     * Idempotent, and safe on an ASServent that was never run().
+     */
+    void stop();
+    
     void start();
     
     /**
@@ -113,8 +128,16 @@ protected:
     
     pipe m_request_pipe;
     pipe m_response_pipe;
-    std::thread* m_worker = nullptr;
+    std::thread m_worker;
     std::mutex m_lock;
+
+    // The loop's own flag, and stop()'s fallback for when the EXIT byte cannot
+    // be written.  start() used to test a *local* bool, so the pipe was the
+    // only way to end the loop -- and the request pipe is opened non-blocking,
+    // so a full one makes write_int throw and there was no second way to ask.
+    // That would turn the leak this fixes into a hang in join().  Named to
+    // match Servent::m_bunny, which is the same flag for the same reason.
+    sync<bool> m_bunny;
     sys::sync<std::priority_queue<Request> > m_requests;
     sys::sync<std::queue<Response> > m_responses;
 };
@@ -123,7 +146,8 @@ template<typename Request, typename Response>
 inline
 ASServent<Request,Response>::ASServent()
     : m_request_pipe(false,false),
-      m_response_pipe(false,false)
+      m_response_pipe(false,false),
+      m_bunny(true)
 {
     
 }
@@ -131,7 +155,12 @@ ASServent<Request,Response>::ASServent()
 template<typename Request, typename Response>
 inline
 ASServent<Request,Response>::~ASServent() {
-    
+    // Backstop only.  By the time this runs the derived part of the object is
+    // already destroyed, so subclasses owning anything the worker touches must
+    // call stop() from their own destructor.  Without this the worker outlived
+    // the object entirely, which is strictly worse than the narrow window that
+    // remains.
+    stop();
 }
     
 template<typename Request, typename Response>
@@ -164,19 +193,42 @@ template<typename Request, typename Response>
 inline
 void 
 ASServent<Request,Response>::reset() {
-    if(m_worker) {
+    // Joined, not merely asked to leave.  Dropping the old worker left two of
+    // them reading the same request pipe until the first noticed EXIT, and
+    // which one served a given request was a race.
+    stop();
+
+    m_bunny = true;
+
+    m_worker = std::thread([this](){ this->start(); });
+}
+
+template<typename Request, typename Response>
+inline
+void 
+ASServent<Request,Response>::stop() {
+    if(!m_worker.joinable())
+        return;
+
+    try {
         m_request_pipe.write_int(EXIT);
-        m_worker = 0;
     }
-    m_worker = new std::thread([this](){ this->start(); });
+    catch(std::exception& e) {
+        // The request pipe is non-blocking and may be full, or already
+        // unwritable.  Ask the loop to leave directly rather than joining a
+        // thread that was never told to.
+        std::cerr << "jlib::sys::ASServent::stop(): " << e.what() << std::endl;
+        m_bunny = false;
+    }
+
+    m_worker.join();
 }
     
 template<typename Request, typename Response>
 inline
 void 
 ASServent<Request,Response>::start() {
-    bool cont = true;
-    while(cont) {
+    while(m_bunny) {
         try {
             while(m_request_pipe.poll()) {
                 if(getenv("JLIB_SYS_ASSERVENT_DEBUG"))
@@ -186,7 +238,7 @@ ASServent<Request,Response>::start() {
                 if(id == NEW_REQUEST) {
                     
                 } else if(id == EXIT) {
-                    cont = false;
+                    m_bunny = false;
                     break;
                 }
             }

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -66,6 +66,7 @@ TESTS = \
 	net_same_address_test \
  \
 	sys_sync_test \
+	sys_asservent_test \
 	sys_run_test \
 	sys_socket_test \
 	sys_sigpipe_test \
@@ -196,6 +197,9 @@ sys_run_test_LDADD              = $(JSYS_LA) $(JUTIL_LA)
 
 sys_sync_test_SOURCES = sys_sync_test.cc
 sys_sync_test_LDADD   = $(JSYS_LA)
+
+sys_asservent_test_SOURCES = sys_asservent_test.cc
+sys_asservent_test_LDADD   = $(JSYS_LA)
 
 sys_socket_test_SOURCES = sys_socket_test.cc
 sys_socket_test_LDADD   = $(JSYS_LA)

--- a/tests/sys_asservent_test.cc
+++ b/tests/sys_asservent_test.cc
@@ -1,0 +1,300 @@
+/* -*- mode: C++ c-basic-offset: 4 -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Who owns ASServent's worker thread.
+//
+// The class has been in the tree since 2002 and had no test at all, which is
+// how reset() came to drop a std::thread without joining it and how the
+// destructor came to be empty.  Everything here is about the thread's
+// lifetime; the request and response *plumbing* is exercised only as far as
+// it takes to prove which thread is running.
+
+#include <jlib/sys/ASServent.hh>
+
+#include <chrono>
+#include <iostream>
+#include <mutex>
+#include <set>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace sys = jlib::sys;
+
+static int failures = 0;
+
+static void ok(const std::string& what, bool good, const std::string& detail = "") {
+    if(!good) ++failures;
+    std::cout << (good ? "  ok   " : "  FAIL ") << what;
+    if(!detail.empty()) std::cout << ": " << detail;
+    std::cout << "\n";
+}
+
+static double seconds_since(std::chrono::steady_clock::time_point t) {
+    return std::chrono::duration<double>(std::chrono::steady_clock::now() - t).count();
+}
+
+/** Request and response have to be distinct types: handle() is overloaded. */
+struct job {
+    int n = 0;
+
+    // ASServent queues requests by priority, so Request needs this.
+    bool operator<(const job& o) const { return n < o.n; }
+};
+
+struct answer {
+    int n = 0;
+};
+
+/**
+ * Records what ran and, more to the point, *where*.
+ *
+ * The thread id is the whole test: a leaked worker is not visible as a leak
+ * from in here, but it is visible as a second id serving requests after a
+ * reset() that was supposed to have retired it.
+ */
+class counter : public sys::ASServent<job, answer> {
+public:
+    virtual ~counter() {
+        // The contract ASServent::stop() documents.  Without this the base
+        // destructor would still join, but only after m_ids and m_served --
+        // which handle() touches -- had already been destroyed.
+        stop();
+    }
+
+    virtual void handle(const job& j) {
+        std::lock_guard<std::mutex> lock(m_lock);
+
+        m_ids.insert(std::this_thread::get_id());
+        m_served.push_back(j.n);
+    }
+
+    virtual void handle(const answer&) {}
+
+    std::size_t handled() const {
+        std::lock_guard<std::mutex> lock(m_lock);
+
+        return m_served.size();
+    }
+
+    std::set<std::thread::id> ids() const {
+        std::lock_guard<std::mutex> lock(m_lock);
+
+        return m_ids;
+    }
+
+    std::vector<int> served() const {
+        std::lock_guard<std::mutex> lock(m_lock);
+
+        return m_served;
+    }
+
+    void forget() {
+        std::lock_guard<std::mutex> lock(m_lock);
+
+        m_ids.clear();
+        m_served.clear();
+    }
+
+private:
+    mutable std::mutex m_lock;
+    std::set<std::thread::id> m_ids;
+    std::vector<int> m_served;
+};
+
+/** Poll a predicate rather than sleeping a guessed interval. */
+template<typename Predicate>
+static bool within(double seconds, Predicate pred) {
+    const auto start = std::chrono::steady_clock::now();
+
+    while(seconds_since(start) < seconds) {
+        if(pred()) return true;
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(2));
+    }
+
+    return pred();
+}
+
+static void a_worker_serves_what_is_pushed() {
+    std::cout << "\na worker serves what is pushed:\n";
+
+    counter c;
+
+    ok("stop() on one that was never run is harmless", (c.stop(), true));
+
+    c.run();
+
+    for(int i = 0; i < 5; i++) c.push(job{i});
+
+    ok("every request reaches the worker", within(5, [&c] { return c.handled() == 5; }),
+       std::to_string(c.handled()) + "/5");
+
+    const std::set<std::thread::id> ids = c.ids();
+
+    ok("on exactly one thread", ids.size() == 1, std::to_string(ids.size()));
+
+    ok("and not on this one",
+       ids.size() == 1 && *ids.begin() != std::this_thread::get_id());
+}
+
+static void reset_retires_the_worker_it_replaces() {
+    std::cout << "\nreset() retires the worker it replaces:\n";
+
+    counter c;
+
+    c.run();
+
+    c.push(job{0});
+
+    ok("the first worker serves", within(5, [&c] { return c.handled() == 1; }));
+
+    // Five rounds, because the old failure was a race rather than a certainty:
+    // reset() wrote EXIT and spawned a replacement without joining, so both
+    // workers were reading the same pipe and *either* could take the byte.  If
+    // the new one took it, it exited immediately and the requests below were
+    // never served at all.
+    const int rounds = 5;
+    const int each = 10;
+
+    for(int round = 0; round < rounds; round++) {
+        c.forget();
+        c.reset();
+
+        for(int i = 0; i < each; i++) c.push(job{i});
+
+        const bool all = within(5, [&c, each] { return c.handled() == std::size_t(each); });
+
+        ok("round " + std::to_string(round + 1) + " is served by the new worker", all,
+           std::to_string(c.handled()) + "/" + std::to_string(each));
+
+        const std::set<std::thread::id> ids = c.ids();
+
+        // The direct assertion.  Two ids here means the worker reset() was
+        // supposed to have retired is still alive and still taking requests.
+        ok("  and by one worker only", ids.size() == 1, std::to_string(ids.size()));
+    }
+}
+
+static void the_destructor_waits_for_the_worker() {
+    std::cout << "\nthe destructor waits for the worker:\n";
+
+    std::chrono::steady_clock::time_point start;
+
+    {
+        counter c;
+
+        c.run();
+
+        c.push(job{1});
+
+        ok("the worker is running", within(5, [&c] { return c.handled() == 1; }));
+
+        // Last statement in the scope, so what follows measures the
+        // destructor and nothing else.
+        start = std::chrono::steady_clock::now();
+    }
+
+    const double took = seconds_since(start);
+
+    // The assertion is that this returns at all.  Before the fix it returned
+    // instantly and left the thread running on a destroyed object; a
+    // destructor that joined without asking the loop to leave would never
+    // return.  Both failures are visible here, at opposite ends.
+    ok("it returns, and promptly", took < 2.0, std::to_string(took) + "s");
+}
+
+static void stopping_twice_is_allowed() {
+    std::cout << "\nstopping twice is allowed:\n";
+
+    counter c;
+
+    c.run();
+
+    c.push(job{1});
+
+    within(5, [&c] { return c.handled() == 1; });
+
+    c.stop();
+
+    const std::size_t after_first = c.handled();
+
+    ok("stop() ends the worker", after_first == 1, std::to_string(after_first));
+
+    c.stop();
+
+    ok("and a second stop() is a no-op rather than a hang", true);
+
+    // A queue with no worker: accepted, and served by whoever runs next.
+    c.push(job{2});
+
+    ok("a request pushed with no worker is not served",
+       !within(0.3, [&c] { return c.handled() == 2; }),
+       std::to_string(c.handled()));
+
+    c.reset();
+
+    ok("and is picked up when one is started again",
+       within(5, [&c] { return c.handled() == 2; }),
+       std::to_string(c.handled()));
+}
+
+int main() {
+    std::cout << std::unitbuf;
+
+    a_worker_serves_what_is_pushed();
+    reset_retires_the_worker_it_replaces();
+    the_destructor_waits_for_the_worker();
+    stopping_twice_is_allowed();
+
+    // What a green run does not establish.
+    //
+    // That no thread outlives its ASServent.  Nothing here sees a leaked
+    // worker directly; it is inferred from a *second* thread id serving after
+    // a reset that should have retired the first, which is evidence and not
+    // proof.  A sanitizer build is what would show the use-after-free, and the
+    // structural guarantee is that m_worker is now a std::thread rather than a
+    // raw pointer, so assigning over a joinable one calls std::terminate
+    // instead of leaking quietly.
+    //
+    // In particular this cannot count workers by their ids.  An id may be
+    // reused once its thread has ended, and in practice every round of
+    // reset() here gets the same one back -- which is consistent with the old
+    // worker having been joined first, and is also exactly what the standard
+    // permits an implementation to do for any reason.  So the per-round
+    // "one worker only" is the assertion; a tally across rounds would be
+    // testing the allocator.
+    //
+    // Not the pure virtual call the base destructor still permits.  ~ASServent
+    // joins, but a subclass that does not stop() in its own destructor can
+    // still have its worker inside handle() when the derived part is gone.
+    // Every subclass here and in net/ does stop(); nothing enforces it.
+    //
+    // Not the response half.  push(Response) and the handle() pump on the
+    // response pipe are untouched by this branch and untested by this file.
+    //
+    // Not the stop() fallback path, where write_int(EXIT) throws on a full
+    // pipe and m_bunny is what ends the loop.  Filling a pipe that only the
+    // worker reads means racing the worker, and a test that has to win a race
+    // to pass is worse than the comment saying it is untested.
+    std::cout << "\n" << (failures ? "FAILED" : "PASSED") << ": " << failures
+              << " failure(s)\n";
+
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
# `ASServent` owns its worker thread

Closes #116.

`ASServent` has been in the tree since 2002 with no test at all, and it showed:
`reset()` dropped a `std::thread` without joining it, and the destructor was
empty.

```cpp
void reset() {
    if(m_worker) {
        m_request_pipe.write_int(EXIT);
        m_worker = 0;                 // not joined, not deleted
    }
    m_worker = new std::thread([this](){ this->start(); });
}

~ASServent() {
}
```

## Three faults, and the worst one is not the leak

**The worker outlived the object.** `~ASServent` neither signalled EXIT nor
joined, so a destroyed `ASServent` left a thread running `start()` — touching
`m_request_pipe`, `m_requests` and `m_responses`, and calling `handle()`, which
is pure virtual, on an object whose lifetime had ended.

**`reset()` left two workers on one pipe.** The old worker was asked to leave
and then abandoned, so until it happened to read EXIT, two threads were polling
the same request pipe. Which of them served a given request was a race — and
worse, *which of them read the EXIT byte* was a race too.

**`m_worker = 0` on a raw `std::thread*`** leaked the object even when nothing
else went wrong. `std::thread`'s destructor calls `std::terminate` on a joinable
thread; assigning over a raw pointer is precisely how that check gets
sidestepped.

## The fix is the sibling class

`sys::Servent` already had all of this right, so this is symmetry rather than
invention: a plain `std::thread m_worker` instead of a pointer, a `stop()` that
checks `joinable()`, writes EXIT and joins, and a destructor that calls it with
the same backstop comment `~Servent` carries.

```cpp
void stop() {
    if(!m_worker.joinable())
        return;

    try { m_request_pipe.write_int(EXIT); }
    catch(std::exception& e) {
        std::cerr << "jlib::sys::ASServent::stop(): " << e.what() << std::endl;
        m_bunny = false;
    }

    m_worker.join();
}
```

**`m_bunny` is not decoration.** `start()` used to test a *local* `bool`, so the
pipe was the only way to end the loop — and the request pipe is opened
non-blocking, so a full one makes `write_int` throw and there was no second way
to ask. Adding `join()` without adding the flag would have converted a leak into
a hang, which is a worse bug than the one being fixed. `Servent` has the same
flag under the same name for the same reason.

## The contract, which a base destructor cannot enforce

`~ASServent` joining is necessary and not sufficient. By the time it runs, the
derived part of the object is gone — and `handle(Request)` is pure virtual here,
so a worker still inside it is a pure virtual call, not merely a data race. The
rule is the one `Servent.hh` already states: **a derived class must call
`stop()` from its own destructor**, and the base is a backstop.

So the three subclasses now do:

- `ASMailBox::~ASMailBox()` — the worker reaches the `on_*()` overrides through
  `handle(Request)`.
- `ASImapBox::~ASImapBox()` — before `m_sock` and the `Imap4` half go.
- `ASMBox::~ASMBox()` — before `m_is` goes.

Neither leaf class had a destructor at all before this.

## `tests/sys_asservent_test.cc`

New, and the first test this class has ever had — which is the answer to how the
bug survived twenty-four years.

The load-bearing section is `reset() retires the worker it replaces`: five
rounds of `reset()`, ten requests each, asserting every request is served and
that **one** thread id served them. Reverting `reset()` to the old behaviour
fails it immediately, in both of the ways the issue predicted:

```
FAIL round 1 is served by the new worker: 0/10
FAIL   and by one worker only: 0
FAIL round 2 is served by the new worker: 20/10
```

Round 1 serves nothing because the *new* worker took the EXIT byte and exited;
round 2 overshoots because round 1's requests were still queued. Two workers,
one queue.

Also: the destructor returns and returns promptly (a destructor that joined
without asking the loop to leave would never return, so both failure modes are
visible at opposite ends of one assertion); `stop()` is idempotent and safe on
an `ASServent` that was never run; and a request pushed with no worker waits
rather than being lost.

**One assertion was written, failed, and deleted rather than fixed.** It counted
distinct `std::thread::id`s across rounds, expecting a new one each time. Ids may
be reused once a thread has ended, and in practice every round here gets the
same one back — which is *consistent* with the old worker having been joined
first, and is also just what the implementation is allowed to do. The per-round
"one worker only" is the real assertion; a tally across rounds would have been
testing the allocator. The reasoning is in the file so nobody adds it back.

**What a green run does not establish**, written into the test: that no thread
outlives its `ASServent`. Nothing here sees a leaked worker directly — it is
inferred from a second id serving after a reset that should have retired the
first, which is evidence and not proof. A sanitizer build is what would show the
use-after-free. The structural guarantee is that `m_worker` is a `std::thread`
now, so assigning over a joinable one calls `std::terminate` instead of leaking
quietly. Also untested: the response half, and `stop()`'s fallback path, which
needs `write_int` to throw on a full pipe — and a test that has to win a race to
pass is worse than the comment saying it is untested.

## Found but not fixed

**#119**: `start()` never blocks. It polls the request pipe with a one
millisecond timeout and then re-checks the queue, so an idle worker wakes about
a thousand times a second. Measured at 0.04s of CPU over three seconds of doing
nothing — roughly 1.3% of a core, permanently, for any process holding one.
Fixing it properly means first fixing `push(Request)`, which swallows
`pipe::would_block` and can queue a request with no pipe write, so a blocking
poll could sleep through one. That is a different change to a different part of
the class, and this branch does not touch the loop body.

## Numbers

macOS: 56 pass, 4 skip, 0 fail. Linux container: 60 pass, 1 skip, 0 fail.
`sys_asservent_test` runs in 1.6s.

Nothing in the tree constructs an `ASMailBox` today — `jlib-mail` uses the
synchronous path — so this is a latent bug being closed rather than a live one.
It is reachable the moment anything uses the async mailbox, which is what the
class is for.
