### PR TITLE
Make matrix and vertex values: copying copies, transpose materialises, and jhypermusic drops its workaround

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,8 @@ or `cuda`.
 - `jjoystick`, `jjoy2xev` — Linux joystick → X events, with `*-{axes,buttons}-*.map`
   data files for WoW / KSP / SW:TOR on PS3 and X360 pads.
 - `jnote`, `jmelody`, `jm3u`, `jpoisoned`, `jcublas`.
-- `jhypermusic.cc` and `jneural.cc` are **not** in `bin_PROGRAMS` — scratch files.
+- `jneural.cc` is **not** in `bin_PROGRAMS` — a scratch file. (`jhypermusic` is
+  built, under the media conditional.)
 
 ## Build
 
@@ -194,9 +195,7 @@ The HTTP arc left #104 (proxy authentication — and `rfc9110.hh` already record
 that `credentials`/`challenge` need reordering under ordered choice before it
 can work) and #105 (SOCKS5). Otherwise what is left is the graphics chain that would let one `HyperPlot` serve both
 apps (#20 → #24 → #28), tessellation and face enumeration for the remaining
-shapes (#31, #35), two `math` bugs (#53, and #76 — `vertex` and `matrix` share
-storage when copied but deep-copy when assigned, which is why `jhypermusic`
-reported exactly zero Doppler for months), and some efficiency and API tidying
+shapes (#31, #35), some efficiency and API tidying
 (#47, #69).
 
 Three habits from this work worth keeping. **Measure before diagnosing** —

--- a/jlib/apps/jhypermusic.cc
+++ b/jlib/apps/jhypermusic.cc
@@ -153,17 +153,15 @@ public:
             m_voices.push_back(v);
             m_mix.add(v, 0.0);
 
-            // Constructed fresh, then assigned -- never copy-constructed from
-            // the shape.  See own() below: a copied vertex shares its storage,
-            // and two corners sharing one buffer is how the Doppler came out as
-            // exactly zero.
-            m_at.push_back(math::vertex<double>(d));
-            m_was.push_back(math::vertex<double>(d));
-            m_shown.push_back(math::vertex<double>(d));
-
-            m_at.back() = m_shape[i];
-            m_was.back() = m_shape[i];
-            m_shown.back() = m_shape[i];
+            // Plainly, now that a vertex is a value (#76).  This was three
+            // fresh vertices followed by three assignments, with a comment
+            // explaining that copy-constructing from the shape would make all
+            // three corners share one buffer -- which is how the Doppler came
+            // out as exactly zero.  The workaround referred the reader to an
+            // own() that had already been deleted.
+            m_at.push_back(m_shape[i]);
+            m_was.push_back(m_shape[i]);
+            m_shown.push_back(m_shape[i]);
 
             m_level.push_back(0);
             m_level_shown.push_back(0);
@@ -319,14 +317,13 @@ public:
     {
         std::lock_guard<std::mutex> lock(m_pose);
 
-        // Sized with vertices of their own before anything is assigned, for
-        // the same reason: at = m_shown would share, and the drawing thread
-        // would be reading the buffers the audio thread is writing.
-        while(at.size() < m_shown.size())
-            at.push_back(math::vertex<double>(m_shape.D));
-
-        for(std::size_t k = 0; k < m_shown.size(); k++)
-            at[k] = m_shown[k];
+        // A real snapshot, in one line.  This grew the vector with fresh
+        // vertices and then assigned element by element, because `at =
+        // m_shown` used to make the two share -- which meant the drawing
+        // thread read the buffers the audio thread was writing, under a lock
+        // that was therefore protecting nothing.  Copying is copying now, so
+        // the lock does what it looks like it does.
+        at = m_shown;
 
         level = m_level_shown;
     }

--- a/jlib/math/matrix.hh
+++ b/jlib/math/matrix.hh
@@ -72,7 +72,30 @@ public:
     };
 
     matrix(uint rows, uint cols);
+
+    /** The roff,coff-anchored rows x cols submatrix of m, by value. */
     matrix(uint rows, uint cols, const matrix<T>& m, uint roff, uint coff);
+
+    /**
+     * A matrix is a value.
+     *
+     * It was not, before: neither of these was declared, so both were implicit
+     * and both copied the *handle* -- rep is a buffer, and a buffer holds a
+     * shared_ptr to the storage.  Two matrices, one array, and writing through
+     * either changed both.  vertex made it worse by declaring an element-wise
+     * operator= on top, so copying aliased and assigning did not.
+     *
+     * buffer keeps its reference semantics: tensor slices with it (see
+     * tensor.hh's operator[]) and that is what it is for.  What changes is that
+     * matrix no longer exposes them by accident.
+     */
+    matrix(const matrix<T>& m);
+    matrix<T>& operator=(const matrix<T>& m);
+
+    // Declaring a copy suppresses these, and a buffer moves for the price of a
+    // shared_ptr, so they are worth having back.
+    matrix(matrix<T>&& m) = default;
+    matrix<T>& operator=(matrix<T>&& m) = default;
 
     T& operator()(uint r, uint c);
     const T& operator()(uint r, uint c) const;
@@ -118,8 +141,6 @@ protected:
     // use buffer in column-major mode so we can pass data off to GL without copying
     // also, this lets us represent a column vector simply
     buffer<T> rep;
-
-    bool transposed = false;
 };
 
 
@@ -174,6 +195,23 @@ class vertex {
 public:
     vertex(uint n);
     vertex(const std::vector<T>& v);
+
+    /**
+     * A vertex is a value too, and this is where the bug in #76 actually bit.
+     *
+     * operator= below was already element-wise, so assigning copied; only
+     * copy-construction aliased, and the two read identically at the call
+     * site.  jhypermusic pushed the same vertex into two vectors, assigned one
+     * to the other expecting a snapshot, and got a no-op -- every corner
+     * reported exactly zero radial velocity for months.
+     *
+     * Note that operator= still copies min(D, v.D) elements and does not
+     * resize: it means "take these values into my shape", and change() below
+     * depends on that.  Only construction is being made to match.
+     */
+    vertex(const vertex<T>& v);
+    vertex(vertex<T>&& v) = default;
+    vertex<T>& operator=(vertex<T>&& v) = default;
 
     T& operator[](uint i);
     const T& operator[](uint i) const;
@@ -647,8 +685,53 @@ matrix<T>::matrix(uint rows, uint cols)
 template<typename T>
 inline
 matrix<T>::matrix(uint rows, uint cols, const matrix<T>& m, uint roff, uint coff)
+    : M(rows),
+      N(cols),
+      rep(rows*cols)
 {
+    // Closes #53.  The body was empty *and* there was no initialiser list, so
+    // M and N were uninitialised and rep was a null buffer -- calling this was
+    // undefined behaviour rather than a no-op.  Nothing called it, which is
+    // the only reason that never showed.
+    if(roff + rows > m.M || coff + cols > m.N)
+        throw typename matrix<T>::mismatched(rows, cols, m.M, m.N);
 
+    for(uint r = 0; r < rows; r++)
+        for(uint c = 0; c < cols; c++)
+            (*this)(r,c) = m(r + roff, c + coff);
+}
+
+template<typename T>
+inline
+matrix<T>::matrix(const matrix<T>& m)
+    : M(m.M),
+      N(m.N),
+      rep(m.M * m.N)
+{
+    const uint n = M * N;
+
+    for(uint i = 0; i < n; i++)
+        rep[i] = m.rep[i];
+}
+
+template<typename T>
+inline
+matrix<T>& matrix<T>::operator=(const matrix<T>& m) {
+    if(this == &m)
+        return *this;
+
+    // Through a temporary rather than rep.resize(): resize() keeps the array
+    // it already has when that one is big enough, so on a rep still shared
+    // from somewhere it would write through instead of taking a copy.  A fresh
+    // matrix owns its buffer alone, and handing that buffer over is the whole
+    // of the assignment.
+    matrix<T> tmp(m);
+
+    M = tmp.M;
+    N = tmp.N;
+    rep = tmp.rep;
+
+    return *this;
 }
 
 
@@ -675,20 +758,14 @@ void matrix<T>::foreach_index(std::function<void (uint,uint,T&)> handler) {
 template<typename T>
 inline
 T& matrix<T>::operator()(uint r, uint c) {
-    if(!transposed)
-	return rep[c * M + r];
-    else
-	return rep[r * N + c];
+    return rep[c * M + r];
 }
 
 
 template<typename T>
 inline
 const T& matrix<T>::operator()(uint r, uint c) const {
-    if(!transposed)
-	return rep[c * M + r];
-    else
-	return rep[r * N + c];
+    return rep[c * M + r];
 }
 
 
@@ -747,10 +824,20 @@ matrix<T>::operator const buffer<T>() const {
 template<typename T>
 inline
 matrix<T> matrix<T>::transpose() const {
+    // Materialised, where this used to hand back a view onto the same storage
+    // with a flag flipped.  That was an O(1) transpose and it was the third
+    // sharing rule in this file: writing to a transpose wrote through to its
+    // source.  Every caller in the tree uses the result read-only as an
+    // operand to *, so nothing wanted the aliasing -- and since the copy is
+    // O(MN) feeding a multiply that is O(MNK), it costs nothing that shows.
+    //
+    // Dropping the flag also takes a branch out of operator(), which is the
+    // most-called function here.
     matrix<T> ret(N, M);
 
-    ret.rep = rep;
-    ret.transposed = !transposed;
+    for(uint r = 0; r < M; r++)
+        for(uint c = 0; c < N; c++)
+            ret(c, r) = (*this)(r, c);
 
     return ret;
 }
@@ -1130,6 +1217,14 @@ vertex<T>::vertex(uint n)
       col(n+1,1)
 {
     col(n,0) = 1;
+}
+
+template<typename T>
+inline
+vertex<T>::vertex(const vertex<T>& v)
+    : D(v.D),
+      col(v.col)     // deep, now that matrix's copy is
+{
 }
 
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -43,6 +43,7 @@ endif
 
 TESTS = \
 	math_test \
+	math_value_test \
 	math_object_test \
 	tensor_test \
 \
@@ -256,6 +257,9 @@ x_window_test_LDADD   = $(JX_LA)
 
 math_test_SOURCES = math_test.cc
 math_test_LDADD   = $(JUTIL_LA)
+
+math_value_test_SOURCES = math_value_test.cc
+math_value_test_LDADD   = $(JUTIL_LA)
 
 math_object_test_SOURCES = math_object_test.cc
 math_object_test_LDADD   = $(JUTIL_LA)

--- a/tests/math_value_test.cc
+++ b/tests/math_value_test.cc
@@ -1,0 +1,306 @@
+/* -*- mode: C++ c-basic-offset: 4 -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// matrix and vertex are values.
+//
+// They were not.  rep is a buffer and a buffer holds a shared_ptr, so copying
+// a matrix copied the handle: two matrices, one array.  vertex then declared
+// an element-wise operator= on top, so copying aliased and assigning did not,
+// and the two read identically at the call site.
+//
+// Every assertion here fails against the old code.  That is the point of the
+// file -- the semantics are not observable except by writing through one
+// handle and reading the other, which is exactly what nobody does on purpose.
+
+#include <jlib/math/matrix.hh>
+#include <jlib/math/tensor.hh>
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+using jlib::math::matrix;
+using jlib::math::vertex;
+using jlib::math::buffer;
+using jlib::math::tensor;
+
+static int failures = 0;
+
+static void ok(const std::string& what, bool good, const std::string& detail = "") {
+    if(!good) ++failures;
+    std::cout << (good ? "  ok   " : "  FAIL ") << what;
+    if(!detail.empty()) std::cout << ": " << detail;
+    std::cout << "\n";
+}
+
+static void a_matrix_is_a_value() {
+    std::cout << "\na matrix is a value:\n";
+
+    {
+        matrix<double> a(2,2);
+        a(0,0) = 1;
+
+        matrix<double> b = a;
+        b(0,0) = 99;
+
+        ok("copy-construction copies", a(0,0) == 1,
+           "a(0,0) = " + std::to_string(a(0,0)));
+    }
+
+    {
+        matrix<double> a(2,2);
+        a(0,0) = 1;
+
+        matrix<double> b(2,2);
+        b = a;
+        b(0,0) = 99;
+
+        ok("assignment copies", a(0,0) == 1,
+           "a(0,0) = " + std::to_string(a(0,0)));
+    }
+
+    {
+        // The one that used to be true by accident: both were shallow, so
+        // matrix at least agreed with itself.  It has to keep agreeing.
+        matrix<double> a(2,2);
+        a(0,0) = 7;
+
+        matrix<double> viacopy = a;
+        matrix<double> viaassign(2,2);
+        viaassign = a;
+
+        ok("and both do the same thing",
+           viacopy(0,0) == 7 && viaassign(0,0) == 7);
+    }
+
+    {
+        matrix<double> a(3,3);
+        a(1,1) = 5;
+
+        a = a;   // NOLINT: self-assignment is the assertion
+
+        ok("self-assignment leaves it intact", a(1,1) == 5,
+           std::to_string(a(1,1)));
+    }
+
+    {
+        // Moves were suppressed by declaring a copy, so they are declared back.
+        matrix<double> a(2,2);
+        a(0,1) = 3;
+
+        matrix<double> b = std::move(a);
+
+        ok("moving carries the values", b(0,1) == 3, std::to_string(b(0,1)));
+    }
+}
+
+static void a_vertex_is_a_value() {
+    std::cout << "\na vertex is a value:\n";
+
+    {
+        vertex<double> a(3);
+        a[0] = 1;
+
+        vertex<double> b = a;
+        b[0] = 99;
+
+        ok("copy-construction copies", a[0] == 1, std::to_string(a[0]));
+    }
+
+    {
+        vertex<double> a(3);
+        a[0] = 1;
+
+        vertex<double> b(3);
+        b = a;
+        b[0] = 99;
+
+        ok("assignment copies", a[0] == 1, std::to_string(a[0]));
+    }
+
+    {
+        // Not changed, and pinned so that it is not changed by accident:
+        // operator= takes values into the shape this already has.  change()
+        // depends on the truncation.
+        vertex<double> big(4);
+        for(int i = 0; i < 4; i++) big[i] = i + 1;
+
+        vertex<double> small(2);
+        small = big;
+
+        ok("assignment does not resize", small.D == 2, std::to_string(small.D));
+        ok("and takes what fits", small[0] == 1 && small[1] == 2);
+    }
+
+    {
+        vertex<double> a(3);
+        a[0] = 1; a[1] = 2; a[2] = 3;
+
+        a.change(5);
+
+        ok("change() keeps the values it can", a.D == 5 && a[0] == 1 && a[2] == 3,
+           "D = " + std::to_string(a.D));
+    }
+}
+
+static void the_jhypermusic_case() {
+    std::cout << "\nthe case from the field:\n";
+
+    // jhypermusic kept the current and previous pose of every corner so it
+    // could work out a radial velocity.  Both vectors were filled from the
+    // same source, so under the old semantics all three aliased -- the
+    // snapshot was a no-op and every corner reported exactly zero velocity
+    // while the shape visibly turned on screen.
+    std::vector<vertex<double>> at, was;
+
+    vertex<double> shape(3);
+    shape[0] = 1;
+
+    at.push_back(shape);
+    was.push_back(shape);
+
+    was[0] = at[0];        // snapshot the old pose
+    at[0][0] = 42;         // then move
+
+    ok("a vector of vertices holds independent elements", was[0][0] == 1,
+       "was[0][0] = " + std::to_string(was[0][0]));
+
+    ok("and the source is untouched too", shape[0] == 1,
+       "shape[0] = " + std::to_string(shape[0]));
+
+    const double velocity = at[0][0] - was[0][0];
+
+    ok("so a difference of two poses is not identically zero", velocity == 41,
+       std::to_string(velocity));
+}
+
+static void transpose_is_a_value_too() {
+    std::cout << "\ntranspose is a value too:\n";
+
+    matrix<int> a(2,3);
+    int n = 0;
+    for(unsigned r = 0; r < 2; r++)
+        for(unsigned c = 0; c < 3; c++)
+            a(r,c) = ++n;
+
+    matrix<int> t = a.transpose();
+
+    ok("the shape is transposed", t.M == 3 && t.N == 2,
+       std::to_string(t.M) + "x" + std::to_string(t.N));
+
+    bool same = true;
+    for(unsigned r = 0; r < 2; r++)
+        for(unsigned c = 0; c < 3; c++)
+            if(t(c,r) != a(r,c)) same = false;
+
+    ok("and so are the values", same);
+
+    t(0,0) = 999;
+
+    // It used to hand back a view with a flag flipped, so this wrote through.
+    ok("writing to it does not write through to the source", a(0,0) == 1,
+       "a(0,0) = " + std::to_string(a(0,0)));
+
+    ok("transposing twice is the original", a.transpose().transpose() == a);
+}
+
+static void the_submatrix_constructor_works() {
+    std::cout << "\nthe submatrix constructor works:\n";
+
+    // #53.  Empty body and no initialiser list, so M and N were uninitialised
+    // and rep was null -- undefined behaviour, not a no-op.  Nothing called it.
+    matrix<int> a(4,4);
+    int n = 0;
+    for(unsigned r = 0; r < 4; r++)
+        for(unsigned c = 0; c < 4; c++)
+            a(r,c) = ++n;
+
+    matrix<int> s(2,2,a,1,1);
+
+    ok("it has the size asked for", s.M == 2 && s.N == 2,
+       std::to_string(s.M) + "x" + std::to_string(s.N));
+
+    ok("anchored where asked", s(0,0) == a(1,1) && s(1,1) == a(2,2),
+       std::to_string(s(0,0)) + "," + std::to_string(s(1,1)));
+
+    s(0,0) = 777;
+
+    ok("and it is a copy, not a window", a(1,1) != 777,
+       "a(1,1) = " + std::to_string(a(1,1)));
+
+    bool threw = false;
+    try { matrix<int> bad(3,3,a,2,2); }
+    catch(std::exception&) { threw = true; }
+
+    ok("a submatrix that runs off the end is refused", threw);
+}
+
+static void buffer_keeps_its_reference_semantics() {
+    std::cout << "\nbuffer keeps its reference semantics:\n";
+
+    // Deliberately unchanged.  tensor slices with it -- operator[] builds a
+    // sub-view with buffer(b, offset, size) -- and that is what buffer is for.
+    // What changed is that matrix no longer leaks those semantics by accident.
+    buffer<double> a(4);
+    a[0] = 1;
+
+    buffer<double> b = a;
+    b[0] = 99;
+
+    ok("a buffer copy still shares", a[0] == 99, std::to_string(a[0]));
+
+    buffer<unsigned int> meta(2);
+    meta[0] = 2; meta[1] = 2;
+
+    tensor<double> t(meta);
+    t[0][0] = 5;
+
+    ok("and a tensor slice still writes through to its parent",
+       t[0][0] == 5, std::to_string(t[0][0]));
+}
+
+int main() {
+    std::cout << std::unitbuf;
+
+    a_matrix_is_a_value();
+    a_vertex_is_a_value();
+    the_jhypermusic_case();
+    transpose_is_a_value_too();
+    the_submatrix_constructor_works();
+    buffer_keeps_its_reference_semantics();
+
+    // What a green run does not establish.
+    //
+    // That nothing depended on the old aliasing.  The whole suite passes and
+    // the tree builds, but the apps that use this most -- jhyper, jglfwhyper,
+    // jhardhyper, jhypermusic -- are rendered rather than asserted, and a
+    // wrong transform there looks like a picture rather than a failure.
+    // jhypermusic reporting a non-zero Doppler again is the check that wants
+    // a pair of ears.
+    //
+    // Not the cost.  Copies are real now where they used to be free, and the
+    // plot path copies per frame (#47).  A backprop-shaped benchmark measured
+    // 0.24ms/step before and after, because a materialised transpose is O(MN)
+    // feeding a multiply that is O(MNK) -- but that is one shape, not the
+    // plot path.
+    std::cout << "\n" << (failures ? "FAILED" : "PASSED") << ": " << failures
+              << " failure(s)\n";
+
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
# `matrix` and `vertex` are values

Closes #76. Closes #53.

`matrix` stores its elements in a `buffer`, and a `buffer` holds a `shared_ptr`
to the storage. Neither `matrix` nor `vertex` declared a copy constructor, so
copying one copied the *handle*: two objects, one array, and writing through
either changed both.

## Ground truth first, because the issue was half right

The issue says both types share when copied and deep-copy when assigned. Only
half of that survived contact with a probe:

```
                   copy-construct   copy-assign
  matrix               ALIAS           ALIAS
  vertex               ALIAS           copy
```

`matrix` declared neither operator, so both were implicit and both shallow --
surprising, but at least self-consistent. `vertex` is the incoherent one: it
declared an element-wise `operator=` on top of an implicit sharing copy, so
copying aliased and assigning did not, and **the two read identically at the
call site**. That is the whole reason this survived: nothing about
`vertex<double> b = a;` looks different from `b = a;`.

## What changed

`matrix` gets a real copy constructor and copy assignment, plus the moves that
declaring a copy suppresses. `vertex` gets a copy constructor; its `operator=`
is left alone, because it means "take these values into my shape" and
`change()` depends on the truncation -- that is pinned by a test now rather
than left implicit.

`buffer` is deliberately unchanged. It is a view -- offset, size, shared array
-- and `tensor::operator[]` slices with it. That is what it is for. What
changed is that `matrix` no longer leaks those semantics by accident.

### `transpose()` was the third sharing rule

```cpp
matrix<T> matrix<T>::transpose() const {
    matrix<T> ret(N, M);
    ret.rep = rep;                  // shares
    ret.transposed = !transposed;
    return ret;
}
```

An O(1) transpose that returned a view: writing to a transpose wrote through to
its source. Leaving that while making everything else a value would have been
the same trap in a smaller place, so it materialises now.

Every `transpose()` caller in the tree uses the result read-only as an operand
to `*`, so nothing wanted the aliasing. And the cost is nil, because the copy
is O(MN) feeding a multiply that is O(MNK). Measured on the shape
`jlib/ai/neural.hh` actually runs -- a 200x784 backprop step:

```
  before:  0.24 ms/step
  after:   0.24 ms/step
```

Dropping the flag also removes a branch from `operator()`, which is the
most-called function in the header.

### #53 came with it

```cpp
matrix<T>::matrix(uint rows, uint cols, const matrix<T>& m, uint roff, uint coff)
{
}
```

Empty body *and* no initialiser list, so `M` and `N` were uninitialised and
`rep` was null -- calling it was undefined behaviour, not a no-op. Nothing
called it, which is the only reason that never showed. It is implemented,
bounds-checked and tested. Fixing it here rather than separately because
leaving a UB constructor beside three new correct ones in the same file is
worse than the small scope creep.

## The payoff: jhypermusic drops two workarounds

The app that this bug was found in had already been worked around, twice, and
both workarounds go:

```cpp
-  // Constructed fresh, then assigned -- never copy-constructed from the
-  // shape.  See own() below: a copied vertex shares its storage, and two
-  // corners sharing one buffer is how the Doppler came out as exactly zero.
-  m_at.push_back(math::vertex<double>(d));
-  ...six lines...
+  m_at.push_back(m_shape[i]);
```

(The comment referred the reader to an `own()` that had already been deleted.)

The second one is a **threading fix**, not a tidy-up. `pose()` takes a snapshot
under a lock so the drawing thread and the audio thread do not collide:

```cpp
-  while(at.size() < m_shown.size())
-      at.push_back(math::vertex<double>(m_shape.D));
-  for(std::size_t k = 0; k < m_shown.size(); k++)
-      at[k] = m_shown[k];
+  at = m_shown;
```

The plain version was avoided because `at = m_shown` used to make the two
vectors share -- which meant the drawing thread read the buffers the audio
thread was writing, under a lock that was therefore protecting nothing. Copying
is copying now, so the lock does what it looks like it does.

## `tests/math_value_test.cc`

New. Every assertion in it fails against the old code, which is the point: the
semantics are not observable except by writing through one handle and reading
the other, and nobody does that on purpose.

Sections: matrix copy, assign, self-assign and move; vertex copy and assign,
with the non-resizing `operator=` and `change()` pinned; the jhypermusic case
as a standalone reproduction; transpose as a value and as a correct transpose;
the #53 submatrix constructor including its out-of-range refusal; and
`buffer`/`tensor` still sharing, so the thing that was *supposed* to share
still does.

**What a green run does not establish**, in the file: that nothing depended on
the old aliasing. The suite passes and the tree builds, but the apps that lean
on this hardest -- jhyper, jglfwhyper, jhardhyper, jhypermusic -- are rendered
rather than asserted, and a wrong transform there looks like a picture rather
than a failure. **jhypermusic reporting a non-zero Doppler again is the check
that wants a pair of ears**, and I have not run it: it needs a window and an
audio device.

Also not the cost in the plot path. Copies are real now where they were free,
and the plot path copies per frame (#47). The benchmark above is one shape.

## Numbers

macOS: 58 pass, 4 skip, 0 fail. Linux container: 62 pass, 1 skip, 0 fail.

`CLAUDE.md` corrected in passing: it claimed `jhypermusic.cc` is not in
`bin_PROGRAMS`, and it is -- under the media conditional.
