### PR TITLE
Stop the plot path allocating per vertex: hoist the modelview product, rewrite change(), halve the heap traffic

### DIFF
--- a/jlib/math/Plot.hh
+++ b/jlib/math/Plot.hh
@@ -151,8 +151,27 @@ protected:
      */
     mutable std::vector< math::matrix<T> > m_project;
 
+    /**
+     * projection.top() * modelview.top(), built once and kept.
+     *
+     * transform() built this per vertex, and it is a (D+1)-square matrix
+     * multiplied by another: O(D^3) for every corner.  At D=14 that is 3375
+     * multiply-adds against 2475 for the whole reduction chain underneath it,
+     * so the setup cost more than the work it was setting up.
+     *
+     * A vector for the same reason m_project is one -- matrix has no default
+     * constructor -- and empty means "not built".  Discarded wherever the
+     * stacks move: push(), pop(), multiply(), setClip() and change().  Nothing
+     * outside this class touches either stack, which is what makes that list
+     * complete rather than hopeful.
+     */
+    mutable std::vector< math::matrix<T> > m_mvp;
+
     /** Build m_project if it is empty. */
     void build_projections() const;
+
+    /** Build m_mvp if it is empty. */
+    void build_mvp() const;
 
     std::vector< std::pair<T,T> > clip;
     // Held by pointer so a shape keeps its type.  These used to be stored by
@@ -287,7 +306,9 @@ inline
 math::vertex<T> Plot<T>::transform(const math::vertex<T>& vertex) const {
     math::vertex<T> ret(D);
 
-    ret = (projection.top() * modelview.top() * vertex());
+    build_mvp();
+
+    ret = (m_mvp.front() * vertex());
 
     // The outermost step: divided unless the mode is fully orthographic.
     if(m_projection != projection_mode::orthographic) {
@@ -378,6 +399,7 @@ inline
 void Plot<T>::setClip(const std::vector< std::pair<T,T> >& c) {
     clip = c;
     m_project.clear();
+    m_mvp.clear();
 }
 
 
@@ -397,7 +419,18 @@ void Plot<T>::build_projections() const {
 
 template<typename T>
 inline
+void Plot<T>::build_mvp() const {
+    if(!m_mvp.empty())
+        return;
+
+    m_mvp.push_back(projection.top() * modelview.top());
+}
+
+template<typename T>
+inline
 void Plot<T>::push() {
+    m_mvp.clear();
+
     switch(current) {
     case MODELVIEW:
         modelview.push(modelview.top());
@@ -412,6 +445,8 @@ void Plot<T>::push() {
 template<typename T>
 inline
 void Plot<T>::pop() {
+    m_mvp.clear();
+
     switch(current) {
     case MODELVIEW:
         modelview.pop();
@@ -426,6 +461,8 @@ void Plot<T>::pop() {
 template<typename T>
 inline
 void Plot<T>::multiply(const math::matrix<T>& m) {
+    m_mvp.clear();
+
     switch(current) {
     case MODELVIEW:
         modelview.top() = modelview.top() * m;
@@ -459,6 +496,8 @@ void Plot<T>::change(uint n) {
     }
     modelview.push(math::matrix<T>::identity(D+1));
     projection.push(math::matrix<T>::identity(D+1));
+
+    m_mvp.clear();
 
     if(D > 2) {
         set(PROJECTION);

--- a/jlib/math/buffer.hh
+++ b/jlib/math/buffer.hh
@@ -142,7 +142,11 @@ buffer<T>::buffer()
 template<typename T>
 inline
 buffer<T>::buffer(unsigned int s) 
-    : mbuf(new array<T>(s)),
+      // make_shared, not shared_ptr(new): constructing a shared_ptr from a
+      // raw pointer allocates a control block *beside* the object, so every
+      // buffer cost three allocations -- the array, its new T[], and the
+      // block.  make_shared folds the block into the array's own allocation.
+    : mbuf(std::make_shared< array<T> >(s)),
       moff(0),
       msize(s)
 {
@@ -191,7 +195,7 @@ template<typename T>
 inline
 void buffer<T>::resize(unsigned int s) {
     if(!mbuf || moff || size() < s) {
-        mbuf = typename array<T>::ptr(new array<T>(s));
+        mbuf = std::make_shared< array<T> >(s);   // see the constructor
         moff = 0;
     } 
     msize = s;

--- a/jlib/math/matrix.hh
+++ b/jlib/math/matrix.hh
@@ -725,6 +725,24 @@ matrix<T>& matrix<T>::operator=(const matrix<T>& m) {
     // from somewhere it would write through instead of taking a copy.  A fresh
     // matrix owns its buffer alone, and handing that buffer over is the whole
     // of the assignment.
+    // In place when the shape already fits, which is the common case and the
+    // one the plot path hits every step.  Through a temporary otherwise,
+    // because rep.resize() keeps the array it already has when that one is big
+    // enough and would leave M*N disagreeing with the storage.
+    //
+    // Safe in place only because matrices no longer share with each other
+    // (#76).  The one remaining way to get a second handle on rep is
+    // operator buffer<T>(), which returns by value and whose two callers take
+    // .data() from the temporary and drop it -- so nothing outlives this.
+    if(M == m.M && N == m.N) {
+        const uint n = M * N;
+
+        for(uint i = 0; i < n; i++)
+            rep[i] = m.rep[i];
+
+        return *this;
+    }
+
     matrix<T> tmp(m);
 
     M = tmp.M;
@@ -1335,9 +1353,26 @@ void vertex<T>::normalize() {
 template<typename T>
 inline
 void vertex<T>::change(uint n) {
-    vertex<T> ncol(n);
-    ncol = *this;
-    col = ncol;
+    if(n == D)
+        return;
+
+    // One allocation, where this was five.  It used to build a whole vertex,
+    // element-assign into it, then assign that through operator matrix<T>()
+    // -- a conversion by value -- into col, which allocated again.  The plot
+    // path calls this once per reduction step per vertex, so it was the
+    // single largest source of allocation in a frame.
+    matrix<T> ncol(n + 1, 1);
+
+    const uint keep = (n < D) ? n : D;
+
+    for(uint i = 0; i < keep; i++)
+        ncol(i, 0) = col(i, 0);
+
+    // The homogeneous coordinate the constructor would have set.
+    ncol(n, 0) = 1;
+
+    col = std::move(ncol);
+
     D = n;
 }
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -44,6 +44,7 @@ endif
 TESTS = \
 	math_test \
 	math_value_test \
+	math_plot_alloc_test \
 	math_object_test \
 	tensor_test \
 \
@@ -260,6 +261,9 @@ math_test_LDADD   = $(JUTIL_LA)
 
 math_value_test_SOURCES = math_value_test.cc
 math_value_test_LDADD   = $(JUTIL_LA)
+
+math_plot_alloc_test_SOURCES = math_plot_alloc_test.cc
+math_plot_alloc_test_LDADD   = $(JUTIL_LA)
 
 math_object_test_SOURCES = math_object_test.cc
 math_object_test_LDADD   = $(JUTIL_LA)

--- a/tests/math_plot_alloc_test.cc
+++ b/tests/math_plot_alloc_test.cc
@@ -1,0 +1,190 @@
+/* -*- mode: C++ c-basic-offset: 4 -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// How much the plot path allocates, and that it still gets the same answer.
+//
+// Counting allocations rather than timing them, deliberately.  The cost here
+// was never arithmetic -- at D=14 the reduction is about 40 MFLOP a frame and
+// it was taking 55ms, which is a couple of percent of what a core does -- so
+// the number that means anything is how many times it goes to the heap.  It is
+// also exact, where a wall-clock threshold on a shared machine is a coin toss.
+//
+// The bounds below are deliberately loose.  They are not a performance target;
+// they are there to fail if someone reintroduces a per-vertex temporary, which
+// moves these by tens rather than by ones.
+
+#include <jlib/math/Plot.hh>
+#include <jlib/math/matrix.hh>
+
+#include <cstdlib>
+#include <iostream>
+#include <new>
+#include <string>
+#include <vector>
+
+static std::size_t allocs = 0;
+
+void* operator new(std::size_t n) { ++allocs; return std::malloc(n); }
+void* operator new[](std::size_t n) { ++allocs; return std::malloc(n); }
+void operator delete(void* p) noexcept { std::free(p); }
+void operator delete[](void* p) noexcept { std::free(p); }
+void operator delete(void* p, std::size_t) noexcept { std::free(p); }
+void operator delete[](void* p, std::size_t) noexcept { std::free(p); }
+
+using namespace jlib::math;
+
+static int failures = 0;
+
+static void ok(const std::string& what, bool good, const std::string& detail = "") {
+    if(!good) ++failures;
+    std::cout << (good ? "  ok   " : "  FAIL ") << what;
+    if(!detail.empty()) std::cout << ": " << detail;
+    std::cout << "\n";
+}
+
+/** Plot is abstract; this reaches the protected transform() and draws nothing. */
+struct probe : public Plot<double> {
+    probe(uint d, std::vector<std::pair<double,double> > c)
+        : Plot<double>(d, c, 1024, 768) {}
+
+    void draw_point(std::pair<uint,uint>, uint) {}
+    void draw_line(std::pair<uint,uint>, std::pair<uint,uint>, uint, uint) {}
+
+    vertex<double> run(const vertex<double>& v) const { return transform(v); }
+};
+
+static double per_corner(uint D, Plot<double>::projection_mode mode,
+                         std::vector<vertex<double> >& out)
+{
+    std::vector<std::pair<double,double> > clip;
+
+    for(uint i = 0; i < D; i++)
+        clip.push_back(std::make_pair(-10.0, 10.0));
+
+    cuboid<double> shape(D);
+    probe p(D, clip);
+
+    p.set_projection_mode(mode);
+
+    // Warm the cached projections and the modelview product, so this counts
+    // the steady state rather than the first frame.
+    p.run(shape[0]);
+
+    out.clear();
+
+    const std::size_t before = allocs;
+
+    for(uint i = 0; i < shape.size(); i++)
+        out.push_back(p.run(shape[i]));
+
+    const std::size_t used = allocs - before;
+
+    // out.push_back allocates too; subtract the vector's own growth by
+    // measuring it separately would be fiddly, so reserve up front instead.
+    return double(used) / shape.size();
+}
+
+static void the_reduction_does_not_allocate_per_step() {
+    std::cout << "\nthe reduction does not allocate per step:\n";
+
+    const uint D = 9;
+
+    std::vector<vertex<double> > mixed, persp;
+
+    mixed.reserve(1 << D);
+    persp.reserve(1 << D);
+
+    const double m = per_corner(D, Plot<double>::projection_mode::mixed, mixed);
+    const double p = per_corner(D, Plot<double>::projection_mode::perspective, persp);
+
+    // Measured at 28 and 42 when this was written, against 39 and 75 before
+    // the pass.  The bound is what a regression would blow through, not a
+    // target: reinstating one per-vertex temporary costs D-3 allocations a
+    // corner, which is six here.
+    ok("mixed stays under 35 allocations per corner", m < 35,
+       std::to_string(m));
+
+    ok("perspective stays under 52", p < 52, std::to_string(p));
+
+    // Perspective reduces all the way down; mixed keeps its dimensionality.
+    // Both are deliberate -- see transform() -- and getting them the wrong way
+    // round is the bug that made every step after the first orthographic.
+    ok("perspective reduces to two dimensions",
+       !persp.empty() && persp.front().D == 2,
+       persp.empty() ? "none" : std::to_string(persp.front().D));
+
+    ok("and mixed does not", !mixed.empty() && mixed.front().D == D,
+       mixed.empty() ? "none" : std::to_string(mixed.front().D));
+}
+
+static void the_answer_did_not_change() {
+    std::cout << "\nthe answer did not change:\n";
+
+    // Captured from master before the allocation pass and asserted here, so a
+    // future optimisation that is merely fast has to stay correct too.  A
+    // cuboid's corners are +/-1 on every axis, so these are exact in binary
+    // and comparing them without a tolerance is honest rather than lucky.
+    std::vector<vertex<double> > persp;
+
+    persp.reserve(1 << 9);
+
+    per_corner(9, Plot<double>::projection_mode::perspective, persp);
+
+    ok("the first corner is where it was",
+       persp.size() > 2 && persp[0][0] == 1.0 && persp[0][1] == 1.0,
+       persp.empty() ? "none"
+                     : std::to_string(persp[0][0]) + ", " + std::to_string(persp[0][1]));
+
+    ok("and so is the second",
+       persp.size() > 2 && persp[1][0] == -1.0 && persp[1][1] == 1.0,
+       persp.size() < 2 ? "none"
+                        : std::to_string(persp[1][0]) + ", " + std::to_string(persp[1][1]));
+
+    ok("and the third", persp.size() > 2 && persp[2][0] == 1.0 && persp[2][1] == -1.0,
+       persp.size() < 3 ? "none"
+                        : std::to_string(persp[2][0]) + ", " + std::to_string(persp[2][1]));
+}
+
+int main() {
+    std::cout << std::unitbuf;
+
+    the_reduction_does_not_allocate_per_step();
+    the_answer_did_not_change();
+
+    // What a green run does not establish.
+    //
+    // That the plot path is fast, or that anything renders correctly.  This
+    // counts heap traffic through transform() and checks three corners land
+    // where they used to; it never draws, and the apps that exercise this for
+    // real -- jhyper, jglfwhyper, jhardhyper, jhypermusic -- are looked at
+    // rather than asserted.
+    //
+    // Not the remaining allocations, which are real and are the point of the
+    // next branch: the per-step vertex and the by-value return are still
+    // there, and removing them means a batched transform writing into caller
+    // storage.  That is also the shape Metal needs, which is why the two are
+    // one piece of work rather than two.
+    //
+    // Not jhardhyper, which overrides transform() with its own copy of this
+    // loop (#28) and therefore gets none of this.
+    std::cout << "\n" << (failures ? "FAILED" : "PASSED") << ": " << failures
+              << " failure(s)\n";
+
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
# The plot path stops allocating per vertex

Part of #47, and the prerequisite for the Metal work rather than a detour from
it.

## Measured first

The plan was to move the D->3 reduction onto the GPU, which is newly worth
doing on Apple Silicon because unified memory removes the transfer. Measuring
the CPU side first said something else. One frame of `Plot<T>::transform()`,
every corner of a cuboid, under a counting `operator new`:

```
  D=14, 16384 corners, perspective:  2,408,489 allocations   125 MB   0.0563s
```

That is an 18 fps ceiling from the projection alone, against roughly **40
MFLOP** of actual arithmetic in that frame -- about 0.7 GFLOP/s, a couple of
percent of what one core should manage. Practically all of the time was heap
traffic.

Which also blocked the GPU plan rather than motivating it: handing anything to
Metal needs the geometry contiguous, and it was 16384 separately heap-allocated
vertices. Marshalling those would have cost more than the arithmetic being
offloaded.

## Four changes, each measured on its own

```
                                            allocs/corner    MB    best of 5
  master                                        147.0      125.0    0.0563s
  make_shared in buffer                          98.0      118.9    0.0496s
  cache projection x modelview                   96.0       90.0    0.0287s
  rewrite change(), in-place operator=           72.0       68.3    0.0231s
```

**2.4x faster, allocations halved**, and the D=14 ceiling goes 18 -> 45 fps.

### `buffer` allocated three times per buffer

`mbuf(new array<T>(s))` builds a `shared_ptr` from a raw pointer, so every
buffer cost three allocations: the `array`, its `new T[]`, and a control block
placed beside them. `make_shared` folds the block into the array's own
allocation.

### The modelview product was rebuilt per vertex

```cpp
ret = (projection.top() * modelview.top() * vertex());
```

That leading product is a (D+1)-square matrix times another -- O(D^3), and
frame-invariant. At D=14 it is 3375 multiply-adds per corner against 2475 for
the *entire* reduction chain underneath it, so the setup cost more than the work
it set up. It is cached now, discarded in `push()`, `pop()`, `multiply()`,
`setClip()` and `change()`. Nothing outside `Plot<T>` touches either stack,
which is what makes that list complete rather than hopeful.

This was the single biggest win: 42% on its own.

### `vertex::change()` allocated five times to move one number

It built a whole vertex, element-assigned into it, then assigned that through
`operator matrix<T>()` -- a conversion *by value* -- into `col`, which allocated
again. The plot path calls it once per reduction step per vertex. One
allocation now.

### `matrix::operator=` copies in place when the shape already fits

The temporary I added in #76 was defensive: `rep.resize()` keeps the array it
already has when that one is big enough, so assigning into a shared `rep` would
write through. But after #76 matrices no longer share with each other, and the
one remaining way to get a second handle is `operator buffer<T>()`, whose two
callers take `.data()` from the temporary and drop it. So in place is safe when
the dimensions match, which is the case the plot path hits every step.

## The answer did not change

Output is **bit-identical to master** at D=8, 11 and 14, in both mixed and
perspective modes. Cuboid corners are +/-1 on every axis, so those comparisons
are exact in binary rather than approximately equal.

## `tests/math_plot_alloc_test.cc`

Counts allocations rather than timing them. The cost here was never arithmetic,
so heap traffic is the number that means anything -- and it is exact, where a
wall-clock threshold on a shared machine is a coin toss.

Bounds are loose on purpose: they exist to fail when someone reintroduces a
per-vertex temporary, which moves them by tens. Verified by mutation --
restoring the old `change()` takes perspective from 42 to 56 and fails the
bound, while mixed stays at 28 because `change()` only runs in perspective mode.

It also pins three transformed corners against values captured from master, so
a future pass that is merely fast still has to be right.

**What a green run does not establish**, in the file: that the plot path is
fast, or that anything renders correctly. It never draws, and the apps that
exercise this for real are looked at rather than asserted.

## What is left, and why it is the next branch

72 allocations per corner remain: the per-step vertex, and `transform()`
returning by value. Removing them means a **batched** transform writing into
caller-provided storage -- which is also exactly the contiguous layout Metal
wants, so the two are one piece of work rather than two.

That was deliberately not done here, because `transform()` is `virtual` and
`jhardhyper::HPlot` overrides it with its own copy of the reduction loop (#28).
A batched path in the base class does nothing for the app that needs it most,
so the batch API and the fork want deciding together rather than one being
guessed at now.

## Numbers

macOS: 59 pass, 4 skip, 0 fail. Linux container: 63 pass, 1 skip, 0 fail.

Measurement note: the first `make_shared` sample read *slower* and was an
outlier -- five runs showed a 12% gain. Every figure above is best-of-five.
