### PR TITLE
Make the projection dump usable as an oracle: capture chosen frames, and survive an exit that never flushed

### DIFF
--- a/jlib/math/dump.hh
+++ b/jlib/math/dump.hh
@@ -26,6 +26,7 @@
 #include <cstdlib>
 #include <fstream>
 #include <iomanip>
+#include <memory>
 #include <string>
 
 namespace jlib {
@@ -37,9 +38,23 @@ namespace math {
  *
  * Set JLIB_PLOT_DUMP to a path and the first frame's source and transformed
  * vertices are written there, then the file is closed and every later call is
- * a no-op.  One frame only, because the objects rotate: two runs are only
- * comparable at the same rotation, and frame zero is the one state both
+ * a no-op.  One frame by default, because the objects rotate: two runs are
+ * only comparable at the same rotation, and frame zero is the one state both
  * pipelines are guaranteed to share.
+ *
+ * Two more variables widen that when frame zero is not the interesting one:
+ *
+ *   JLIB_PLOT_DUMP_SKIP    frames to pass over before capturing (default 0)
+ *   JLIB_PLOT_DUMP_FRAMES  frames to capture once started (default 1)
+ *
+ * Each captured frame is preceded by a "frame N" line, N counting from zero
+ * over the whole run, so a reader can split the file without guessing.
+ *
+ * The rotation caveat does not go away by skipping: comparing frame 300 of two
+ * runs only means something if both are deterministic up to frame 300.  What
+ * skipping is for is state that only exists after something has happened --
+ * a keypress that changes the dimension, say, where frame zero is by
+ * definition the state before the thing being investigated (#124).
  *
  * This exists because "does it look right" is a poor oracle for a projection
  * chain.  The perspective divide being a no-op after the first step, and half
@@ -49,23 +64,84 @@ namespace math {
  */
 namespace dump {
 
-inline std::ofstream* stream() {
-    static bool tried = false;
-    static std::ofstream* out = 0;
+/** Everything the dump remembers between calls. */
+struct state {
+    // Owned, where this was a leaked `new std::ofstream`.  The leak was not
+    // the problem; the lost output was.  Only frame_done() flushed, and a
+    // process that exits without reaching one -- a crash, an exit(0) from a
+    // key handler, or any caller that transforms without drawing -- left the
+    // buffer unwritten and the file empty.  A static's destructor runs on a
+    // normal exit, so the dump survives one now.
+    std::unique_ptr<std::ofstream> out;
 
-    if(!tried) {
-        tried = true;
+    unsigned long skip = 0;      // frames to pass over before capturing
+    unsigned long want = 1;      // frames to capture once started
+    unsigned long seen = 0;      // frames begun, captured or not
+    unsigned long kept = 0;      // frames written in full
+
+    bool open = false;           // a frame's marker has been written
+    bool tried = false;          // the environment has been read
+};
+
+inline unsigned long from_env(const char* name, unsigned long fallback) {
+    const char* v = std::getenv(name);
+
+    if(v == 0 || v[0] == '\0')
+        return fallback;
+
+    const long n = std::strtol(v, 0, 10);
+
+    return (n < 0) ? fallback : static_cast<unsigned long>(n);
+}
+
+inline state& current() {
+    static state s;
+
+    if(!s.tried) {
+        s.tried = true;
+
         const char* path = std::getenv("JLIB_PLOT_DUMP");
+
         if(path != 0 && path[0] != '\0') {
-            out = new std::ofstream(path);
-            if(!out->good()) {
-                delete out;
-                out = 0;
-            }
+            s.out.reset(new std::ofstream(path));
+
+            if(!s.out->good())
+                s.out.reset();
         }
+
+        s.skip = from_env("JLIB_PLOT_DUMP_SKIP", 0);
+        s.want = from_env("JLIB_PLOT_DUMP_FRAMES", 1);
     }
 
-    return out;
+    return s;
+}
+
+/** True while this frame is one of the ones being captured. */
+inline bool capturing() {
+    state& s = current();
+
+    return s.out && s.seen >= s.skip && s.kept < s.want;
+}
+
+/**
+ * Forget everything and re-read the environment.
+ *
+ * For tests, which need more than one configuration per process and would
+ * otherwise be stuck with whichever one ran first.
+ */
+inline void reset() {
+    state& s = current();
+
+    if(s.out) {
+        s.out->flush();
+        s.out->close();
+    }
+
+    s = state();
+}
+
+inline std::ofstream* stream() {
+    return capturing() ? current().out.get() : 0;
 }
 
 inline bool active() {
@@ -77,11 +153,27 @@ inline bool active() {
  * at other rotations, do not append to it.
  */
 inline void frame_done() {
-    std::ofstream* out = stream();
-    if(out != 0) {
-        out->flush();
-        out->close();
+    state& s = current();
+
+    if(!s.out)
+        return;
+
+    // A frame counts as captured only if something was actually written to
+    // it.  A plot that drew nothing this frame should not consume one of the
+    // frames asked for.
+    if(s.open) {
+        s.open = false;
+        s.kept++;
+
+        s.out->flush();
+
+        if(s.kept >= s.want) {
+            s.out->close();
+            s.out.reset();
+        }
     }
+
+    s.seen++;
 }
 
 /**
@@ -95,6 +187,15 @@ inline void vertex(const std::string& tag,
     std::ofstream* out = stream();
     if(out == 0 || !out->is_open())
         return;
+
+    state& s = current();
+
+    // Lazily, so the marker sits immediately above the frame's first vertex
+    // and a frame that drew nothing leaves no trace at all.
+    if(!s.open) {
+        s.open = true;
+        *out << "frame " << s.seen << "\n";
+    }
 
     *out << tag << "  src";
     for(unsigned int i = 0; i < src.D; i++)

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -45,6 +45,7 @@ TESTS = \
 	math_test \
 	math_value_test \
 	math_plot_alloc_test \
+	math_dump_test \
 	math_object_test \
 	tensor_test \
 \
@@ -264,6 +265,9 @@ math_value_test_LDADD   = $(JUTIL_LA)
 
 math_plot_alloc_test_SOURCES = math_plot_alloc_test.cc
 math_plot_alloc_test_LDADD   = $(JUTIL_LA)
+
+math_dump_test_SOURCES = math_dump_test.cc
+math_dump_test_LDADD   = $(JUTIL_LA)
 
 math_object_test_SOURCES = math_object_test.cc
 math_object_test_LDADD   = $(JUTIL_LA)

--- a/tests/math_dump_test.cc
+++ b/tests/math_dump_test.cc
@@ -1,0 +1,238 @@
+/* -*- mode: C++ c-basic-offset: 4 -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// The projection dump, which is about to be an oracle.
+//
+// #20, #24 and #28 all change the projection chain, and the apps that show it
+// are looked at rather than asserted.  The plan is to capture a reference dump
+// before each change and diff it after, which only works if the dump itself is
+// trustworthy -- so it gets a test before it gets that job.
+
+#include <jlib/math/dump.hh>
+
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace dump = jlib::math::dump;
+
+using jlib::math::vertex;
+
+static int failures = 0;
+
+static void ok(const std::string& what, bool good, const std::string& detail = "") {
+    if(!good) ++failures;
+    std::cout << (good ? "  ok   " : "  FAIL ") << what;
+    if(!detail.empty()) std::cout << ": " << detail;
+    std::cout << "\n";
+}
+
+static const char* PATH = "math_dump_test.out";
+
+/** Run `frames` frames of `n` vertices each, under the given configuration. */
+static std::vector<std::string> run(const char* skip, const char* want,
+                                    int frames, int n)
+{
+    ::setenv("JLIB_PLOT_DUMP", PATH, 1);
+
+    if(skip) ::setenv("JLIB_PLOT_DUMP_SKIP", skip, 1);
+    else     ::unsetenv("JLIB_PLOT_DUMP_SKIP");
+
+    if(want) ::setenv("JLIB_PLOT_DUMP_FRAMES", want, 1);
+    else     ::unsetenv("JLIB_PLOT_DUMP_FRAMES");
+
+    dump::reset();
+
+    for(int f = 0; f < frames; f++) {
+        for(int i = 0; i < n; i++) {
+            vertex<double> src(3), dst(3);
+
+            // Distinguishable per frame and per vertex, so the file says which
+            // is which rather than merely how many.
+            src[0] = f;
+            src[1] = i;
+            dst[0] = f * 100 + i;
+
+            dump::vertex("t", src, dst);
+        }
+
+        dump::frame_done();
+    }
+
+    // Closed by frame_done() when it has what it wants; reset() closes it when
+    // the run ended early.
+    dump::reset();
+
+    std::vector<std::string> lines;
+    std::ifstream in(PATH);
+    std::string line;
+
+    while(std::getline(in, line))
+        lines.push_back(line);
+
+    return lines;
+}
+
+static int markers(const std::vector<std::string>& lines) {
+    int n = 0;
+
+    for(const std::string& l : lines)
+        if(l.compare(0, 6, "frame ") == 0) n++;
+
+    return n;
+}
+
+static void one_frame_by_default() {
+    std::cout << "\none frame by default:\n";
+
+    const std::vector<std::string> l = run(0, 0, 5, 2);
+
+    ok("five frames offered, one captured", markers(l) == 1,
+       std::to_string(markers(l)) + " frames");
+
+    ok("and it is frame zero", !l.empty() && l.front() == "frame 0",
+       l.empty() ? "empty" : l.front());
+
+    // Two vertices plus the marker.  The default is what every existing caller
+    // gets, so it is the line that must not move.
+    ok("with both its vertices", l.size() == 3, std::to_string(l.size()) + " lines");
+}
+
+static void asking_for_more_gets_more() {
+    std::cout << "\nasking for more gets more:\n";
+
+    const std::vector<std::string> l = run(0, "3", 5, 2);
+
+    ok("three frames captured", markers(l) == 3, std::to_string(markers(l)));
+
+    ok("numbered from zero, in order",
+       l.size() > 6 && l[0] == "frame 0" && l[3] == "frame 1" && l[6] == "frame 2",
+       l.size() > 6 ? l[0] + " / " + l[3] + " / " + l[6] : "too short");
+
+    // The point of capturing several: it stops after what was asked for, so a
+    // long run does not fill a disk.
+    ok("and it stops after the third", l.size() == 9,
+       std::to_string(l.size()) + " lines");
+}
+
+static void skipping_reaches_a_later_frame() {
+    std::cout << "\nskipping reaches a later frame:\n";
+
+    const std::vector<std::string> l = run("3", "2", 8, 1);
+
+    ok("two frames captured", markers(l) == 2, std::to_string(markers(l)));
+
+    // The numbering counts frames of the whole run, not of the file, which is
+    // what makes a skipped dump comparable with an unskipped one.
+    ok("numbered by the run, not by the file",
+       l.size() > 2 && l[0] == "frame 3" && l[2] == "frame 4",
+       l.size() > 2 ? l[0] + " / " + l[2] : "too short");
+
+    ok("and the skipped frames left nothing behind", l.size() == 4,
+       std::to_string(l.size()) + " lines");
+}
+
+static void a_frame_that_drew_nothing_costs_nothing() {
+    std::cout << "\na frame that drew nothing costs nothing:\n";
+
+    ::setenv("JLIB_PLOT_DUMP", PATH, 1);
+    ::unsetenv("JLIB_PLOT_DUMP_SKIP");
+    ::setenv("JLIB_PLOT_DUMP_FRAMES", "1", 1);
+
+    dump::reset();
+
+    // Two empty frames, then a real one.  If an empty frame consumed the
+    // budget the real one would never be seen -- which is the case a plot
+    // hits whenever an object list is empty for a frame or two at startup.
+    dump::frame_done();
+    dump::frame_done();
+
+    vertex<double> src(3), dst(3);
+    src[0] = 7;
+    dst[0] = 9;
+
+    dump::vertex("t", src, dst);
+    dump::frame_done();
+    dump::reset();
+
+    std::vector<std::string> lines;
+    std::ifstream in(PATH);
+    std::string line;
+
+    while(std::getline(in, line)) lines.push_back(line);
+
+    ok("the empty frames wrote nothing", markers(lines) == 1,
+       std::to_string(markers(lines)));
+
+    ok("and the budget went to the frame that drew",
+       lines.size() == 2 && lines[0] == "frame 2",
+       lines.empty() ? "empty" : lines[0]);
+}
+
+static void unset_is_off() {
+    std::cout << "\nunset is off:\n";
+
+    ::unsetenv("JLIB_PLOT_DUMP");
+
+    dump::reset();
+
+    ok("nothing is active", !dump::active());
+
+    vertex<double> src(3), dst(3);
+
+    dump::vertex("t", src, dst);   // must not crash or create a file
+    dump::frame_done();
+
+    ok("and calling it anyway is harmless", true);
+
+    dump::reset();
+}
+
+int main() {
+    std::cout << std::unitbuf;
+
+    one_frame_by_default();
+    asking_for_more_gets_more();
+    skipping_reaches_a_later_frame();
+    a_frame_that_drew_nothing_costs_nothing();
+    unset_is_off();
+
+    std::remove(PATH);
+
+    // What a green run does not establish.
+    //
+    // That a dump of two different pipelines is comparable.  This checks the
+    // framing -- how many frames, which ones, numbered how -- and never calls
+    // Plot at all, so it says nothing about whether the coordinates in a real
+    // dump mean the same thing on both sides of a change.  That is the job it
+    // is about to be given and the reason it needed a test first, not a
+    // guarantee this file provides.
+    //
+    // Nor does skipping make two runs comparable by itself: frame 300 of two
+    // runs matches only if both are deterministic to frame 300, which is a
+    // property of the app and not of the dump.
+    std::cout << "\n" << (failures ? "FAILED" : "PASSED") << ": " << failures
+              << " failure(s)\n";
+
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
# The projection dump becomes an oracle

Groundwork for #20, #24 and #28, and the diagnostic #124 asks for.

`jlib/math/dump.hh` writes the source and transformed coordinates of every
vertex through `Plot<T>::transform`, which is the right instrument for a
projection change. The next three branches all rewrite that chain, and the apps
that show it are looked at rather than asserted -- so the plan is to capture a
reference dump before each change and diff it after. That only works if the
dump is trustworthy, so it gets a test and two fixes before it gets the job.

## It was losing its output

The stream was a leaked `new std::ofstream` and only `frame_done()` ever
flushed it. `frame_done()` is called from `Plot<T>::draw()`, so **any process
that exited without drawing wrote an empty file** -- a crash, jhardhyper's `q`
key going straight to `exit(0)`, or any caller that transforms without
drawing. A benchmark I pointed at it produced 0 bytes and I assumed I had
misconfigured it.

Owned by a `unique_ptr` in a function-local static now, so a normal exit flushes
it. The leak was incidental; the lost output was the bug, and it is a fair guess
at why the facility has gone unused.

```
  before:  0 lines
  after:  36 lines, byte-identical across two runs
```

That last property is the one that matters: an oracle that is not reproducible
is not an oracle.

## It could only ever see frame zero

`stream()` guarded with a `static bool tried` and `frame_done()` closed the
file, so the first frame was the only frame -- and everything interesting about
#124 happens after a keypress.

Two new variables, both optional:

```
  JLIB_PLOT_DUMP_SKIP     frames to pass over before capturing (default 0)
  JLIB_PLOT_DUMP_FRAMES   frames to capture once started      (default 1)
```

The defaults reproduce the old behaviour exactly, which matters because the
header already argues for one frame and the argument is still right: the objects
rotate, so two runs are only comparable at the same rotation, and frame zero is
the state both pipelines are guaranteed to share. What skipping is for is state
that only exists after something has happened -- and frame zero is by definition
before it.

Each captured frame is preceded by a `frame N` line, N counting over the whole
run rather than over the file, so a skipped dump and an unskipped one line up.
Nothing parses this format; I checked before changing it.

A frame that drew nothing does not consume the budget, so a plot whose object
list is empty for a frame or two at startup still captures what was asked for.

## `tests/math_dump_test.cc`

New, and the facility's first test. Sections: the default captures exactly frame
zero; asking for three gets three, in order, then stops; skipping reaches a
later frame and numbers it by the run; empty frames cost nothing; and an unset
variable leaves everything inert.

`dump::reset()` is new and exists for this test -- the state is a function-local
static read once from the environment, so without it a process could only ever
exercise one configuration. It is documented as being for tests.

**What a green run does not establish**, in the file: that a dump of two
different pipelines is comparable. This checks the framing -- how many frames,
which ones, numbered how -- and never calls `Plot` at all, so it says nothing
about whether the coordinates mean the same thing on both sides of a change.
That is the job it is about to be given, and the reason it needed a test first.

Nor does skipping make two runs comparable by itself: frame 300 of two runs
matches only if both are deterministic to frame 300, which is a property of the
app and not of the dump.

## Numbers

macOS: 60 pass, 4 skip, 0 fail. Linux container: 64 pass, 1 skip, 0 fail.

One process note, since it nearly went in the write-up wrong: the first Linux
run reported 63 passes from a **stale image**, because the `docker build` ran
from the wrong directory and failed while `docker run` quietly used the previous
one. The figures above are from a rebuilt image, and the test count going 64 to
65 is what confirms the new test is actually in it.
