### PR TITLE
Give jhardhyper a dimension floor of three, where its reduction target already was

### DIFF
--- a/jlib/apps/jhardhyper.cc
+++ b/jlib/apps/jhardhyper.cc
@@ -1175,7 +1175,22 @@ void HyperPlot<T,Plot>::key_pressed(unsigned char key, int x, int y) {
     } else if(key == 'e' || key == 'd') {
         uint d = (key == 'e' ? this->D + 1 : this->D - 1);
 
-        if(d < 1)
+        // Three, not one.  This app reduces N to three and hands real 3-D to
+        // GL; below three there is nothing to reduce and nothing to hand over,
+        // so the state is meaningless rather than merely unsupported.
+        //
+        // It was also unsafe.  The reduction stops at d > 3, so a vertex
+        // arrives at draw_point with whatever D the plot is set to, and
+        // vertex::data() points at D+1 doubles -- the coordinates plus the
+        // homogeneous w.  glVertex4dv reads four of them, so D=2 read one
+        // past the end and D=1 read two.  From the default D=5, pressing 'd'
+        // three times reached it.
+        //
+        // The other hyper apps keep their floor at 1: they reduce all the way
+        // to two and go through pixel pairs, where those dimensions both mean
+        // something and are safe.  This is jhardhyper's constraint, not the
+        // library's, which is why it is here and not in Hyper.hh.
+        if(d < 3)
             return;
 
         initialize(d);
@@ -1372,8 +1387,21 @@ public:
 
 int main(int argc, char** argv) {
     uint D = 5;
+
     if(argc > 1) {
-        D = atoi(argv[1]);
+        const int d = atoi(argv[1]);
+
+        // Same floor as the d key, and for the same reason -- but reachable
+        // here without pressing anything, and atoi answers 0 for a word, so
+        // `jhardhyper foo` was as far out of bounds as `jhardhyper 2`.
+        if(d < 3) {
+            std::cerr << argv[0] << ": dimension must be at least 3"
+                      << " (this reduces N to three and draws that; below"
+                      << " three there is nothing to reduce)\n";
+            exit(1);
+        }
+
+        D = static_cast<uint>(d);
     }
 
     try {

--- a/tests/math_value_test.cc
+++ b/tests/math_value_test.cc
@@ -159,6 +159,34 @@ static void a_vertex_is_a_value() {
     }
 }
 
+static void data_points_at_d_plus_one() {
+    std::cout << "\ndata() points at D+1 components:\n";
+
+    // The invariant jhardhyper's dimension floor rests on.  vertex(n) builds
+    // an (n+1)x1 column -- n coordinates and a homogeneous 1 -- so data()
+    // addresses D+1 doubles and no more.  A fixed-arity read of four, which
+    // is what glVertex4dv does, therefore needs D >= 3.
+    for(uint d = 1; d <= 5; d++) {
+        vertex<double> v(d);
+
+        for(uint i = 0; i < d; i++)
+            v[i] = i + 1;
+
+        bool placed = true;
+
+        for(uint i = 0; i < d; i++)
+            if(v.data()[i] != double(i + 1)) placed = false;
+
+        ok("D=" + std::to_string(d) + ": every coordinate is where data() says",
+           placed);
+
+        // Index D is the homogeneous coordinate, and reaching it is what says
+        // the buffer really holds D+1 rather than D.
+        ok("  and index D is the homogeneous 1", v.data()[d] == 1.0,
+           std::to_string(v.data()[d]));
+    }
+}
+
 static void the_jhypermusic_case() {
     std::cout << "\nthe case from the field:\n";
 
@@ -280,6 +308,7 @@ int main() {
 
     a_matrix_is_a_value();
     a_vertex_is_a_value();
+    data_points_at_d_plus_one();
     the_jhypermusic_case();
     transpose_is_a_value_too();
     the_submatrix_constructor_works();


### PR DESCRIPTION
# jhardhyper refuses to run below three dimensions

Closes the out-of-bounds read recorded in #24, ahead of the #20/#24/#28 arc
rather than inside it, because it is reachable by a keystroke today.

## The read

`vertex<T>::data()` addresses D+1 doubles -- the D coordinates and the
homogeneous 1 that `vertex(n)` puts at index n. `glVertex4dv` reads four of
them. jhardhyper's reduction stops at `d > 3`, so a vertex reaches `draw_point`
carrying whatever D the plot is set to, and below three that read runs off the
end: **D=2 reads one past, D=1 reads two.**

Both ways in allowed it. `key_pressed` guarded only `if(d < 1) return`, so from
the default D=5 pressing `d` three times reached it. And `main` did

```cpp
D = atoi(argv[1]);
```

with no validation at all, so `jhardhyper 2` went straight there -- as did
`jhardhyper foo`, since `atoi` answers 0 for a word.

## Why a floor rather than a guard

The first plan here was to guard the six `glVertex4dv` sites. The better
argument is that the state is meaningless rather than merely unsafe: this app
exists to reduce N to three and hand real 3-D to the GPU, and below three there
is nothing to reduce and nothing to hand over. `d > 3` in the reduction loop had
already decided that; the entry points just never said so.

So the floor goes where the constraint is, and D=3 is exactly the boundary --
the reduction loop does not run, the vertex keeps three coordinates plus its w,
and `data()` holds the four that `glVertex4dv` wants.

**The other hyper apps keep their floor at 1**, deliberately. jhyper,
jglfwhyper and jglxhyper reduce all the way to two and go through
`std::pair<uint,uint>` pixel pairs, where D=1 and D=2 both mean something and
neither is unsafe. `Hyper.hh` is untouched.

## It really is jhardhyper only

Worth checking rather than assuming, since a whole-tree bug would want a
different fix. Every other `gl*v` call in the tree -- `glColor3fv`,
`glMaterialfv`, `glLightfv` in jglfwhyper, jglxhyper, jgltorus, jglxbox and
`gl/lights.cc` -- takes a fixed-size array declared at the call site. Every
other `.data()` is `std::string`'s or a fixed-size crypto type. `vertex::data()`
reaches a fixed-arity GL call in exactly six places, all in `jhardhyper.cc`.

That is a consequence of the fork rather than luck: jhardhyper is the only code
that receives vertices, because it is the only code that built a vertex-taking
draw path. Everything else is protected by going through pixel pairs -- which
is also why **#24 will spread this hazard to every backend** the moment it gives
them vertex-taking draw calls. The floor here does not cover that; whoever does
#24 inherits the problem for glfw, glx and anything Metal.

## The invariant is now asserted

`tests/math_value_test.cc` gains a section checking what the floor rests on:
that `vertex(n)` places its coordinates at `data()[0..n-1]` and the homogeneous
1 at `data()[n]`, for n from 1 to 5. Reaching index D is what says the buffer
holds D+1 rather than D, which is the fact that makes three the boundary.

The floor itself is not asserted. The apps have no tests and this one wants a
window, so the two entry points were checked by hand:

```
  jhardhyper 2     exit=1
  jhardhyper foo   exit=1
```

The `d` key path was verified by reading -- `HardPlot` derives from
`HyperPlot<T, PlotType>`, whose `key_pressed` is the one carrying the new guard.

**What a green run does not establish**: that the guard fires. Nothing here
presses a key, and a test that could would need a GL context.

## Numbers

macOS: 60 pass, 4 skip, 0 fail. Linux container: 64 pass, 1 skip, 0 fail.

One thing not done: there is no upper bound on the dimension either. `atoi`
accepts 25, which is 33 million vertices and an effective hang. That is a
usability failure rather than a memory-safety one, so it is left alone rather
than folded into a fix for the latter.
