### PR TITLE
Give jlib a Metal GEMM: float only, MPS-backed, and measured against the CPU multiply it beats

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -39,6 +39,12 @@ dnl Toolchain
 dnl ------------------------------------------------------------------
 
 AC_PROG_CXX
+
+dnl Objective-C++, for jlib/metal.  Metal's API is Objective-C, so its .mm
+dnl files need this even though nothing else in the tree does -- and automake
+dnl refuses to emit rules for a .mm without it.  Harmless where there is no
+dnl Objective-C++ compiler: the module that uses it is gated on HAVE_METAL.
+AC_PROG_OBJCXX
 AM_PROG_AR
 LT_INIT
 AC_LANG([C++])
@@ -273,6 +279,41 @@ AC_SUBST([CUDA_LIBS])
 AM_CONDITIONAL([HAVE_CUDA], [test "x$have_cuda" = xyes])
 
 dnl ------------------------------------------------------------------
+dnl Metal (Apple GPU compute), for jlib/metal
+dnl ------------------------------------------------------------------
+
+dnl Frameworks rather than headers: Metal and MetalPerformanceShaders ship
+dnl with the OS and have no pkg-config.  The compile test also settles whether
+dnl the toolchain can build Objective-C++ at all, which is what jlib/metal is
+dnl written in -- the headers there are plain C++ so nothing else has to be.
+dnl
+dnl Note this buys float and half only.  Metal Shading Language has no double
+dnl ("'double' is not supported in Metal", straight from the compiler), which
+dnl is why jlib/metal offers gemm<float> and nothing wider.
+
+AC_ARG_WITH([metal],
+  [AS_HELP_STRING([--without-metal],
+                  [do not build the Metal GPU backend even on macOS])],
+  [want_metal=$withval], [want_metal=yes])
+
+have_metal=no
+AS_IF([test "x$want_metal" != xno],
+  [AC_MSG_CHECKING([for Metal and MetalPerformanceShaders])
+   jlib_save_LIBS="$LIBS"
+   LIBS="$LIBS -framework Metal -framework MetalPerformanceShaders -framework Foundation"
+   AC_LINK_IFELSE(
+     [AC_LANG_PROGRAM([[]], [[]])],
+     [have_metal=yes], [have_metal=no])
+   LIBS="$jlib_save_LIBS"
+   AC_MSG_RESULT([$have_metal])])
+
+AS_IF([test "x$have_metal" = xyes],
+  [METAL_LIBS="-framework Metal -framework MetalPerformanceShaders -framework Foundation"],
+  [METAL_LIBS=""])
+AC_SUBST([METAL_LIBS])
+AM_CONDITIONAL([HAVE_METAL], [test "x$have_metal" = xyes])
+
+dnl ------------------------------------------------------------------
 dnl Installed pkg-config file
 dnl ------------------------------------------------------------------
 
@@ -286,6 +327,7 @@ AS_IF([test "x$have_glfw" = xyes], [jlib_libs="-ljglfw $jlib_libs"])
 AS_IF([test "x$have_glu"  = xyes], [jlib_libs="-ljglu $jlib_libs"])
 AS_IF([test "x$have_gl"   = xyes], [jlib_libs="-ljgl $jlib_libs"])
 AS_IF([test "x$have_cuda" = xyes], [jlib_libs="-ljcuda $jlib_libs"])
+AS_IF([test "x$have_metal" = xyes], [jlib_libs="-ljmetal $jlib_libs"])
 
 AC_SUBST([JLIB_PC_CFLAGS], ["-I\${includedir}/jlib-$jlib_release"])
 AC_SUBST([JLIB_PC_LIBS],   ["-L\${libdir} $jlib_libs"])
@@ -305,6 +347,7 @@ AC_CONFIG_FILES([Makefile
     jlib/x/Makefile
     jlib/ai/Makefile
     jlib/cuda/Makefile
+    jlib/metal/Makefile
     jlib/apps/Makefile
     tests/Makefile
     jlib/jlib-1.2.pc
@@ -330,6 +373,7 @@ AC_MSG_NOTICE([
     glfw ................. $have_glfw
     ImageMagick++ ........ $have_magick
     cuda ................. $have_cuda
+    metal ................ $have_metal
 
   windowing
     x11 .................. $have_x

--- a/jlib/Makefile.am
+++ b/jlib/Makefile.am
@@ -4,7 +4,13 @@ else
 cuda_subdirs =
 endif
 
-SUBDIRS = sys util crypt media net math x gl glu glx glfw ai $(cuda_subdirs) apps
+if HAVE_METAL
+metal_subdirs = metal
+else
+metal_subdirs =
+endif
+
+SUBDIRS = sys util crypt media net math x gl glu glx glfw ai $(cuda_subdirs) $(metal_subdirs) apps
 EXTRA_DIST = jlib-1.2.pc.in
 
 pkgconfigdir		= $(libdir)/pkgconfig

--- a/jlib/metal/Makefile.am
+++ b/jlib/metal/Makefile.am
@@ -1,0 +1,18 @@
+# Objective-C++, because Metal's API is Objective-C.  The headers installed
+# here are plain C++ -- see device.hh -- so nothing that includes them has to
+# be compiled as Objective-C++.
+AM_CPPFLAGS = -I$(top_srcdir)
+
+lib_LTLIBRARIES = libjmetal.la
+
+libjmetal_la_SOURCES = device.mm gemm.mm
+noinst_HEADERS       = impl.hh
+libjmetal_la_LDFLAGS = -version-info $(LIBJ_SO_VERSION) -release $(JLIB_RELEASE) -no-undefined
+libjmetal_la_LIBADD  = $(METAL_LIBS)
+
+# ARC, so the Objective-C objects behind the opaque handles are released
+# without a retain/release in every path.
+libjmetal_la_OBJCXXFLAGS = $(AM_OBJCXXFLAGS) -fobjc-arc -std=c++20
+
+libjmetalincludedir = $(includedir)/jlib-1.2/jlib/metal
+libjmetalinclude_HEADERS = device.hh gemm.hh

--- a/jlib/metal/device.hh
+++ b/jlib/metal/device.hh
@@ -1,0 +1,104 @@
+/* -*- mode: C++ c-basic-offset: 4 -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef JLIB_METAL_DEVICE_HH
+#define JLIB_METAL_DEVICE_HH
+
+#include <cstddef>
+#include <exception>
+#include <memory>
+#include <string>
+
+namespace jlib {
+namespace metal {
+
+/**
+ * The GPU, and a queue to give it work.
+ *
+ * **This header is plain C++ on purpose.**  Metal's API is Objective-C, so
+ * everything behind here is compiled as Objective-C++ -- but a caller in
+ * jlib/ai or jlib/math must not have to be.  So the Objective-C objects live
+ * behind an opaque pointer and nothing in this file mentions them.
+ *
+ * ## What Metal buys and what it does not
+ *
+ * Float and half.  **Not double**: Metal Shading Language has no such type,
+ * and the compiler says so outright -- "'double' is not supported in Metal".
+ * That is why gemm.hh offers float and stops, where jlib/cuda/gemm.hh has a
+ * double specialisation on top of cuBLAS.  Any caller that needs fp64 stays
+ * on the CPU, and no amount of API design changes that.
+ *
+ * ## Unified memory
+ *
+ * On Apple silicon the CPU and GPU address the same physical memory, so a
+ * buffer allocated shared is readable from both without a copy or an explicit
+ * transfer.  That is what makes small and medium work worth offloading here
+ * when it would not be across a PCIe bus, and it is why buffer() hands back a
+ * pointer you can simply write to.
+ *
+ * There is still a synchronisation point: the GPU's writes are visible after
+ * the command buffer completes, which is what wait() is for.  Unified memory
+ * removes the copy, not the ordering.
+ */
+class device {
+public:
+    class exception : public std::exception {
+    public:
+        exception(const std::string& msg = "") {
+            m_msg = "jlib::metal::device exception" + (msg.empty() ? "" : ": " + msg);
+        }
+        virtual ~exception() {}
+        virtual const char* what() const noexcept { return m_msg.c_str(); }
+    protected:
+        std::string m_msg;
+    };
+
+    /**
+     * The system default device, or throws if there is none.
+     *
+     * Shared: a process wants one of these, not one per caller.  Building a
+     * device and a command queue is not free and neither is worth repeating.
+     */
+    static std::shared_ptr<device> shared();
+
+    ~device();
+
+    device(const device&) = delete;
+    device& operator=(const device&) = delete;
+
+    /** The GPU's name, for a caller that wants to say which one it found. */
+    std::string name() const;
+
+    /** Whether this device shares memory with the CPU rather than copying. */
+    bool unified() const;
+
+private:
+    device();
+
+    // The Objective-C objects, which this header will not name.  See device.mm.
+    struct impl;
+    std::unique_ptr<impl> m_impl;
+
+    friend class matrix_multiply;
+};
+
+}
+}
+
+#endif // JLIB_METAL_DEVICE_HH

--- a/jlib/metal/device.mm
+++ b/jlib/metal/device.mm
@@ -1,0 +1,68 @@
+/* -*- mode: ObjC++ c-basic-offset: 4 -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <jlib/metal/device.hh>
+#include <jlib/metal/impl.hh>
+
+namespace jlib {
+namespace metal {
+
+device::device()
+    : m_impl(new impl)
+{
+    m_impl->gpu = MTLCreateSystemDefaultDevice();
+
+    if(m_impl->gpu == nil)
+        throw exception("no Metal device");
+
+    m_impl->queue = [m_impl->gpu newCommandQueue];
+
+    if(m_impl->queue == nil)
+        throw exception("could not create a command queue");
+}
+
+device::~device() = default;
+
+std::shared_ptr<device> device::shared() {
+    // Built on first use and kept.  A device and a queue are not free to make
+    // and there is no reason for a process to hold two.  weak_ptr rather than
+    // a plain static, so a caller that drops the last reference really does
+    // release the GPU objects rather than holding them until exit.
+    static std::weak_ptr<device> held;
+
+    std::shared_ptr<device> d = held.lock();
+
+    if(!d) {
+        d.reset(new device);
+        held = d;
+    }
+
+    return d;
+}
+
+std::string device::name() const {
+    return std::string([[m_impl->gpu name] UTF8String]);
+}
+
+bool device::unified() const {
+    return [m_impl->gpu hasUnifiedMemory];
+}
+
+}
+}

--- a/jlib/metal/gemm.hh
+++ b/jlib/metal/gemm.hh
@@ -1,0 +1,109 @@
+/* -*- mode: C++ c-basic-offset: 4 -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef JLIB_METAL_GEMM_HH
+#define JLIB_METAL_GEMM_HH
+
+#include <jlib/metal/device.hh>
+
+#include <jlib/math/matrix.hh>
+
+#include <memory>
+
+namespace jlib {
+namespace metal {
+
+/**
+ * C = alpha * A * B + beta * C, on the GPU.
+ *
+ * **Float only.**  Metal Shading Language has no double -- the compiler
+ * refuses it in as many words -- so there is no `gemm<double>` here and there
+ * cannot be one, where jlib/cuda/gemm.hh has one because cuBLAS supports fp64.
+ * A caller that needs fp64 stays on the CPU; see math::operator*.
+ *
+ * That is less of a restriction than it looks for the work this is for.
+ * Nothing trains or runs inference in fp64, and an LLM is fp16 or bf16.
+ *
+ * ## Why an object rather than a function
+ *
+ * Because the setup is worth keeping. Building the MPS kernel and wrapping
+ * the buffers costs more than the multiply for small matrices, so a caller
+ * that multiplies the same shapes repeatedly -- which is what a training loop
+ * is -- should pay for it once. `operator()` on a live object reuses
+ * everything the shape allows.
+ *
+ * ## Why MPS rather than a kernel of our own
+ *
+ * MPSMatrixMultiplication is a tuned GEMM that ships with the OS, and a
+ * hand-written one would lose to it. There are no .metal files in this
+ * library and no shader compilation in the build for exactly that reason.
+ * A custom kernel is worth writing when MPS has no equivalent, not before.
+ */
+class matrix_multiply {
+public:
+    class exception : public std::exception {
+    public:
+        exception(const std::string& msg = "") {
+            m_msg = "jlib::metal::matrix_multiply exception" +
+                (msg.empty() ? "" : ": " + msg);
+        }
+        virtual ~exception() {}
+        virtual const char* what() const noexcept { return m_msg.c_str(); }
+    protected:
+        std::string m_msg;
+    };
+
+    explicit matrix_multiply(std::shared_ptr<device> d = device::shared());
+
+    ~matrix_multiply();
+
+    matrix_multiply(const matrix_multiply&) = delete;
+    matrix_multiply& operator=(const matrix_multiply&) = delete;
+
+    /**
+     * C = alpha * A * B + beta * C.
+     *
+     * Shapes are checked: A is MxK, B is KxN, C is MxN, and a mismatch throws
+     * rather than reading past anything.
+     *
+     * Synchronous -- it waits for the GPU before returning, so C holds the
+     * result when it does. Unified memory removes the copy, not the ordering.
+     */
+    void operator()(const math::matrix<float>& a,
+                    const math::matrix<float>& b,
+                    math::matrix<float>& c,
+                    float alpha = 1.0f, float beta = 0.0f);
+
+    /** C = A * B, sized for the caller. */
+    math::matrix<float> operator()(const math::matrix<float>& a,
+                                   const math::matrix<float>& b);
+
+private:
+    struct impl;
+    std::unique_ptr<impl> m_impl;
+};
+
+/** One multiply, for a caller with no loop to amortise the setup over. */
+math::matrix<float> multiply(const math::matrix<float>& a,
+                             const math::matrix<float>& b);
+
+}
+}
+
+#endif // JLIB_METAL_GEMM_HH

--- a/jlib/metal/gemm.mm
+++ b/jlib/metal/gemm.mm
@@ -1,0 +1,196 @@
+/* -*- mode: ObjC++ c-basic-offset: 4 -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <jlib/metal/gemm.hh>
+#include <jlib/metal/impl.hh>
+
+#include <cstring>
+#include <sstream>
+
+namespace jlib {
+namespace metal {
+
+struct matrix_multiply::impl {
+    std::shared_ptr<device> dev;
+
+    // The kernel is built for a shape and reused while the shape holds, which
+    // is the whole reason this is an object.  A training loop multiplies the
+    // same sizes thousands of times.
+    MPSMatrixMultiplication* kernel = nil;
+
+    NSUInteger rows = 0, columns = 0, interior = 0;
+    double alpha = 0, beta = 0;
+};
+
+matrix_multiply::matrix_multiply(std::shared_ptr<device> d)
+    : m_impl(new impl)
+{
+    if(!d)
+        throw exception("no device");
+
+    m_impl->dev = d;
+}
+
+matrix_multiply::~matrix_multiply() = default;
+
+void matrix_multiply::operator()(const math::matrix<float>& a,
+                                 const math::matrix<float>& b,
+                                 math::matrix<float>& c,
+                                 float alpha, float beta)
+{
+    if(a.N != b.M || c.M != a.M || c.N != b.N) {
+        std::ostringstream o;
+        o << "cannot multiply [" << a.M << "," << a.N << "] by ["
+          << b.M << "," << b.N << "] into [" << c.M << "," << c.N << "]";
+        throw exception(o.str());
+    }
+
+    const NSUInteger M = a.M, K = a.N, N = b.N;
+
+    if(M == 0 || K == 0 || N == 0)
+        return;
+
+    // math::matrix is column-major -- element (r,c) lives at rep[c * M + r],
+    // which the header says is so the data can go to GL without copying.  MPS
+    // is row-major.  Rather than transpose anything, read each buffer as the
+    // row-major matrix it already is: a column-major MxN read row-major as
+    // NxM *is* that matrix's transpose, for free.
+    //
+    // So with Ar = A^T (K x M) and Br = B^T (N x K), the identity
+    //
+    //     (A B)^T = B^T A^T
+    //
+    // says Br * Ar is C^T as an N x M row-major matrix -- and C^T read back
+    // row-major into a column-major MxN buffer is C.  No transpose, no copy,
+    // one multiply with the operands swapped.
+    id<MTLDevice> gpu = m_impl->dev->m_impl->gpu;
+
+    const NSUInteger left_rows = N, left_cols = K;    // B^T
+    const NSUInteger right_rows = K, right_cols = M;  // A^T
+    const NSUInteger out_rows = N, out_cols = M;      // C^T
+
+    const float* pa = static_cast<const math::buffer<float> >(a).data();
+    const float* pb = static_cast<const math::buffer<float> >(b).data();
+    float* pc = static_cast<math::buffer<float> >(c).data();
+
+    // Copied into shared buffers rather than aliased.  newBufferWithBytesNoCopy
+    // would be a genuine zero copy on unified memory, but it requires the
+    // pointer to be page aligned and the length a page multiple, and
+    // math::array allocates with new T[].  Making math::buffer able to
+    // allocate page-aligned is the follow-up that turns this into no copy at
+    // all; until then the copy is honest and small.
+    const NSUInteger asize = (NSUInteger)a.M * a.N * sizeof(float);
+    const NSUInteger bsize = (NSUInteger)b.M * b.N * sizeof(float);
+    const NSUInteger csize = (NSUInteger)c.M * c.N * sizeof(float);
+
+    id<MTLBuffer> ba = [gpu newBufferWithBytes:pa length:asize
+                                       options:MTLResourceStorageModeShared];
+    id<MTLBuffer> bb = [gpu newBufferWithBytes:pb length:bsize
+                                       options:MTLResourceStorageModeShared];
+
+    // beta != 0 means C is read as well as written, so it has to go up.
+    id<MTLBuffer> bc = (beta != 0.0f)
+        ? [gpu newBufferWithBytes:pc length:csize
+                          options:MTLResourceStorageModeShared]
+        : [gpu newBufferWithLength:csize options:MTLResourceStorageModeShared];
+
+    if(ba == nil || bb == nil || bc == nil)
+        throw exception("could not allocate a device buffer");
+
+    MPSMatrixDescriptor* da =
+        [MPSMatrixDescriptor matrixDescriptorWithRows:right_rows
+                                              columns:right_cols
+                                             rowBytes:right_cols * sizeof(float)
+                                             dataType:MPSDataTypeFloat32];
+    MPSMatrixDescriptor* db =
+        [MPSMatrixDescriptor matrixDescriptorWithRows:left_rows
+                                              columns:left_cols
+                                             rowBytes:left_cols * sizeof(float)
+                                             dataType:MPSDataTypeFloat32];
+    MPSMatrixDescriptor* dc =
+        [MPSMatrixDescriptor matrixDescriptorWithRows:out_rows
+                                              columns:out_cols
+                                             rowBytes:out_cols * sizeof(float)
+                                             dataType:MPSDataTypeFloat32];
+
+    MPSMatrix* ma = [[MPSMatrix alloc] initWithBuffer:ba descriptor:da];
+    MPSMatrix* mb = [[MPSMatrix alloc] initWithBuffer:bb descriptor:db];
+    MPSMatrix* mc = [[MPSMatrix alloc] initWithBuffer:bc descriptor:dc];
+
+    if(m_impl->kernel == nil ||
+       m_impl->rows != out_rows || m_impl->columns != out_cols ||
+       m_impl->interior != K ||
+       m_impl->alpha != alpha || m_impl->beta != beta)
+    {
+        m_impl->kernel =
+            [[MPSMatrixMultiplication alloc] initWithDevice:gpu
+                                             transposeLeft:NO
+                                            transposeRight:NO
+                                                resultRows:out_rows
+                                             resultColumns:out_cols
+                                           interiorColumns:K
+                                                     alpha:alpha
+                                                      beta:beta];
+
+        m_impl->rows = out_rows;
+        m_impl->columns = out_cols;
+        m_impl->interior = K;
+        m_impl->alpha = alpha;
+        m_impl->beta = beta;
+    }
+
+    id<MTLCommandBuffer> cmd = [m_impl->dev->m_impl->queue commandBuffer];
+
+    [m_impl->kernel encodeToCommandBuffer:cmd
+                               leftMatrix:mb
+                              rightMatrix:ma
+                             resultMatrix:mc];
+
+    [cmd commit];
+
+    // Unified memory removes the copy, not the ordering: the GPU's writes are
+    // visible when the command buffer completes and not before.
+    [cmd waitUntilCompleted];
+
+    if([cmd status] == MTLCommandBufferStatusError)
+        throw exception("the command buffer failed");
+
+    std::memcpy(pc, [bc contents], csize);
+}
+
+math::matrix<float> matrix_multiply::operator()(const math::matrix<float>& a,
+                                                const math::matrix<float>& b)
+{
+    math::matrix<float> c(a.M, b.N);
+
+    (*this)(a, b, c);
+
+    return c;
+}
+
+math::matrix<float> multiply(const math::matrix<float>& a,
+                             const math::matrix<float>& b)
+{
+    matrix_multiply mm;
+
+    return mm(a, b);
+}
+
+}
+}

--- a/jlib/metal/impl.hh
+++ b/jlib/metal/impl.hh
@@ -1,0 +1,43 @@
+/* -*- mode: ObjC++ c-basic-offset: 4 -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef JLIB_METAL_IMPL_HH
+#define JLIB_METAL_IMPL_HH
+
+// Objective-C++ only, and deliberately not installed: this is the one place
+// the Metal types are named, so that device.hh and gemm.hh can stay plain C++
+// and be included from anywhere.  Anything including this must be a .mm.
+
+#import <Metal/Metal.h>
+#import <MetalPerformanceShaders/MetalPerformanceShaders.h>
+
+#include <jlib/metal/device.hh>
+
+namespace jlib {
+namespace metal {
+
+struct device::impl {
+    id<MTLDevice> gpu = nil;
+    id<MTLCommandQueue> queue = nil;
+};
+
+}
+}
+
+#endif // JLIB_METAL_IMPL_HH

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -41,6 +41,13 @@ if HAVE_X
 X_TESTS = x_window_test
 endif
 
+# Metal is macOS-only and needs a GPU, so it is gated the same way.  The test
+# itself also exits 77 if there is no device, which covers a machine that has
+# the frameworks and no hardware.
+if HAVE_METAL
+METAL_TESTS = metal_gemm_test
+endif
+
 TESTS = \
 	math_test \
 	math_value_test \
@@ -94,6 +101,7 @@ TESTS = \
 	util_abnf_compile_test \
  \
 	$(X_TESTS) \
+	$(METAL_TESTS) \
 	$(MEDIA_TESTS) \
 	$(CURVE_TESTS)
 
@@ -283,3 +291,6 @@ crypt_schnorr_test_LDADD   = $(JUTIL_LA) $(JCRYPT_LA) $(SODIUM_LIBS)
 
 crypt_groth_test_SOURCES = crypt_groth_test.cc
 crypt_groth_test_LDADD   = $(JUTIL_LA) $(JCRYPT_LA) $(SODIUM_LIBS)
+
+metal_gemm_test_SOURCES = metal_gemm_test.cc
+metal_gemm_test_LDADD   = $(top_builddir)/jlib/metal/libjmetal.la $(METAL_LIBS)

--- a/tests/metal_gemm_test.cc
+++ b/tests/metal_gemm_test.cc
@@ -1,0 +1,243 @@
+/* -*- mode: C++ c-basic-offset: 4 -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// The GPU multiply, against the CPU one.
+//
+// math::operator* is the oracle here.  It is naive and slow, which is exactly
+// what makes it a good reference: there is nothing clever in it to be wrong in
+// the same way twice.
+//
+// Not compared exactly.  MPS is free to sum in whatever order suits the
+// hardware and does, so the last bits differ from a left-to-right CPU loop.
+// The tolerance below scales with the interior dimension because that is what
+// the error accumulates over.
+
+#include <jlib/metal/gemm.hh>
+#include <jlib/metal/device.hh>
+
+#include <jlib/math/matrix.hh>
+
+#include <cmath>
+#include <iostream>
+#include <random>
+#include <string>
+
+namespace metal = jlib::metal;
+
+using jlib::math::matrix;
+
+static int failures = 0;
+
+static void ok(const std::string& what, bool good, const std::string& detail = "") {
+    if(!good) ++failures;
+    std::cout << (good ? "  ok   " : "  FAIL ") << what;
+    if(!detail.empty()) std::cout << ": " << detail;
+    std::cout << "\n";
+}
+
+static matrix<float> random_matrix(uint m, uint n, std::mt19937& gen) {
+    std::uniform_real_distribution<float> d(-1.0f, 1.0f);
+
+    matrix<float> a(m, n);
+
+    for(uint r = 0; r < m; r++)
+        for(uint c = 0; c < n; c++)
+            a(r, c) = d(gen);
+
+    return a;
+}
+
+/** Largest absolute difference, and where. */
+static double worst(const matrix<float>& a, const matrix<float>& b) {
+    double w = 0;
+
+    for(uint r = 0; r < a.M; r++)
+        for(uint c = 0; c < a.N; c++)
+            w = std::max(w, std::fabs(double(a(r,c)) - double(b(r,c))));
+
+    return w;
+}
+
+static void it_agrees_with_the_cpu(metal::matrix_multiply& mm) {
+    std::cout << "\nit agrees with the CPU:\n";
+
+    std::mt19937 gen(20260830);
+
+    // Deliberately not square, and deliberately not all the same, because a
+    // row/column mix-up is invisible on a square matrix and this code reads
+    // one layout as another on purpose.
+    const uint shapes[][3] = {
+        {  1,   1,   1 },
+        {  2,   3,   4 },
+        {  4,   3,   2 },
+        {  1,  16,   1 },
+        { 16,   1,  16 },
+        { 32,  64, 128 },
+        {200, 784,   1 },   // the shape jlib/ai's backprop actually runs
+    };
+
+    for(const uint* s : shapes) {
+        const uint M = s[0], K = s[1], N = s[2];
+
+        const matrix<float> a = random_matrix(M, K, gen);
+        const matrix<float> b = random_matrix(K, N, gen);
+
+        const matrix<float> cpu = a * b;
+        const matrix<float> gpu = mm(a, b);
+
+        const std::string shape = std::to_string(M) + "x" + std::to_string(K) +
+            " * " + std::to_string(K) + "x" + std::to_string(N);
+
+        if(gpu.M != M || gpu.N != N) {
+            ok(shape + " has the right shape", false,
+               std::to_string(gpu.M) + "x" + std::to_string(gpu.N));
+            continue;
+        }
+
+        const double w = worst(cpu, gpu);
+
+        // Scaled by the interior dimension: that is how many products are
+        // summed, and so how far float rounding can drift between two
+        // orderings.  1e-6 per term is loose for float and tight enough that
+        // a transposed result or a wrong stride would blow straight through.
+        const double tol = 1e-6 * K + 1e-6;
+
+        ok(shape, w <= tol,
+           "worst |cpu-gpu| = " + std::to_string(w) + ", tol " + std::to_string(tol));
+    }
+}
+
+static void it_is_not_secretly_transposed(metal::matrix_multiply& mm) {
+    std::cout << "\nit is not secretly transposed:\n";
+
+    // The layout argument in gemm.mm reads a column-major matrix as a
+    // row-major transpose and swaps the operands.  If that reasoning is wrong
+    // the result comes back transposed, and on a square matrix of random
+    // numbers that is exactly as plausible as being right.  So: an asymmetric
+    // product whose answer is known by hand.
+    matrix<float> a(2, 3);
+    a(0,0) = 1; a(0,1) = 2; a(0,2) = 3;
+    a(1,0) = 4; a(1,1) = 5; a(1,2) = 6;
+
+    matrix<float> b(3, 2);
+    b(0,0) = 7;  b(0,1) = 8;
+    b(1,0) = 9;  b(1,1) = 10;
+    b(2,0) = 11; b(2,1) = 12;
+
+    const matrix<float> c = mm(a, b);
+
+    // [1 2 3; 4 5 6] * [7 8; 9 10; 11 12] = [58 64; 139 154]
+    ok("the shape is 2x2", c.M == 2 && c.N == 2,
+       std::to_string(c.M) + "x" + std::to_string(c.N));
+
+    ok("c(0,0) = 58", std::fabs(c(0,0) - 58.0f) < 1e-3, std::to_string(c(0,0)));
+    ok("c(0,1) = 64", std::fabs(c(0,1) - 64.0f) < 1e-3, std::to_string(c(0,1)));
+    ok("c(1,0) = 139", std::fabs(c(1,0) - 139.0f) < 1e-3, std::to_string(c(1,0)));
+    ok("c(1,1) = 154", std::fabs(c(1,1) - 154.0f) < 1e-3, std::to_string(c(1,1)));
+}
+
+static void alpha_and_beta(metal::matrix_multiply& mm) {
+    std::cout << "\nalpha and beta:\n";
+
+    matrix<float> a(2, 2);
+    a(0,0) = 1; a(0,1) = 0;
+    a(1,0) = 0; a(1,1) = 1;      // identity, so the arithmetic is obvious
+
+    matrix<float> b(2, 2);
+    b(0,0) = 1; b(0,1) = 2;
+    b(1,0) = 3; b(1,1) = 4;
+
+    matrix<float> c(2, 2);
+    c(0,0) = 10; c(0,1) = 20;
+    c(1,0) = 30; c(1,1) = 40;
+
+    // C = 2*A*B + 3*C = 2*B + 3*C
+    mm(a, b, c, 2.0f, 3.0f);
+
+    ok("beta reads the existing C", std::fabs(c(0,0) - (2*1 + 3*10)) < 1e-3,
+       std::to_string(c(0,0)) + " wanted 32");
+    ok("and alpha scales the product", std::fabs(c(1,1) - (2*4 + 3*40)) < 1e-3,
+       std::to_string(c(1,1)) + " wanted 128");
+}
+
+static void it_refuses_a_mismatch(metal::matrix_multiply& mm) {
+    std::cout << "\nit refuses a mismatch:\n";
+
+    matrix<float> a(2, 3), b(4, 5);
+
+    bool threw = false;
+
+    try { mm(a, b); }
+    catch(std::exception&) { threw = true; }
+
+    ok("inner dimensions that do not meet are refused", threw);
+
+    matrix<float> good_b(3, 2), wrong_c(5, 5);
+
+    threw = false;
+
+    try { mm(a, good_b, wrong_c); }
+    catch(std::exception&) { threw = true; }
+
+    ok("and so is a result of the wrong shape", threw);
+}
+
+int main() {
+    std::cout << std::unitbuf;
+
+    std::shared_ptr<metal::device> dev;
+
+    try {
+        dev = metal::device::shared();
+    }
+    catch(std::exception& e) {
+        // 77 is SKIP.  A machine with no Metal device is not a failure.
+        std::cout << "  skip  no Metal device: " << e.what() << "\n";
+        return 77;
+    }
+
+    std::cout << "  device: " << dev->name()
+              << (dev->unified() ? " (unified memory)" : " (discrete)") << "\n";
+
+    metal::matrix_multiply mm(dev);
+
+    it_agrees_with_the_cpu(mm);
+    it_is_not_secretly_transposed(mm);
+    alpha_and_beta(mm);
+    it_refuses_a_mismatch(mm);
+
+    // What a green run does not establish.
+    //
+    // That this is faster.  Nothing here is timed, and for small matrices it
+    // certainly is not: building the MPS kernel and staging two buffers costs
+    // more than multiplying a 4x4.  Where the crossover sits is a measurement
+    // nobody has taken yet, and until someone does, "GPU" is a claim about
+    // where the work happened rather than about how long it took.
+    //
+    // Not zero copy.  The operands are copied into shared buffers, because
+    // newBufferWithBytesNoCopy needs page-aligned memory and math::array
+    // allocates with new T[].  Unified memory means that copy is cheap and
+    // local, not that it is absent.
+    //
+    // Not double, which Metal does not have and cannot be made to have.
+    std::cout << "\n" << (failures ? "FAILED" : "PASSED") << ": " << failures
+              << " failure(s)\n";
+
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
# A Metal GEMM

`jlib/metal`: a GPU matrix multiply on Apple silicon, gated by configure the
way `--with-cuda` gates the CUDA module. **The float GEMM only** -- the neural
code does not move to it here, and the measurement below is why.

## Metal has no double, and that is not negotiable

Asked the compiler rather than the documentation:

```
$ xcrun metal -c d.metal
d.metal:3:22: error: 'double' is not supported in Metal
```

Float compiles. So there is a `gemm<float>` and there cannot be a
`gemm<double>`, where `jlib/cuda/gemm.hh` has one because cuBLAS supports
fp64. Every neural app in the tree instantiates `NeuralNetwork<double>`, so
**no existing caller can use this** until the precision question is settled.

That is a smaller loss than it sounds -- nothing trains or runs inference in
fp64, and an LLM is fp16 or bf16 -- but it is a decision, not a detail, and it
belongs in front of the code rather than behind it.

## Shape of the module

`device.hh` and `gemm.hh` are **plain C++**. Metal's API is Objective-C, so the
implementation is Objective-C++, but a caller in `jlib/ai` or `jlib/math` must
not have to be. The Objective-C types are named in exactly one place --
`impl.hh`, which is `noinst` and never installed -- and the public headers hold
an opaque `unique_ptr<impl>`.

`device::shared()` keeps one device and queue per process behind a `weak_ptr`,
so a caller that drops the last reference really releases the GPU objects
rather than holding them to exit.

`matrix_multiply` is an object rather than a function because the MPS kernel is
worth keeping: it is rebuilt only when the shape or the scalars change, which
for a training loop is once.

MPS rather than a kernel of our own, as agreed: `MPSMatrixMultiplication` is a
tuned GEMM that ships with the OS and a hand-written one would lose to it.
There are no `.metal` files and no shader compilation in the build.

## Column-major meets row-major without transposing anything

`math::matrix` is column-major -- `rep[c * M + r]`, which its header says is so
data can go to GL without copying. MPS is row-major. Rather than transpose:

> a column-major MxN buffer read row-major as NxM **is** that matrix's
> transpose, for free

so with `Ar = A^T` and `Br = B^T`, the identity `(AB)^T = B^T A^T` says
`Br * Ar` is `C^T` as an NxM row-major matrix -- and `C^T` written back into a
column-major MxN buffer is `C`. One multiply, operands swapped, no transpose
and no shuffling.

That reasoning is exactly the kind that is wrong half the time, so the test
does not check it on square random matrices where a transposed answer is as
plausible as a right one. It checks `[1 2 3; 4 5 6] * [7 8; 9 10; 11 12]`
against `[58 64; 139 154]`, computed by hand.

## Measured, because "GPU" is otherwise a claim about where and not how long

```
  shape                    cpu        gpu   speedup
  32x32*32x32           0.010ms    0.345ms     0.0x
  128x128*128x128       0.982ms    0.360ms     2.7x
  256x256*256x256       9.556ms    0.481ms    19.9x
  512x512*512x512      88.422ms    1.078ms    82.0x
  1024x1024*1024x1024 1067.548ms   6.309ms   169.2x

  200x784*784x1         0.110ms    0.445ms     0.2x
  200x784*784x64        6.810ms    0.701ms     9.7x
  200x784*784x256      27.243ms    0.992ms    27.5x
```

About 0.35ms of fixed cost per call, so the crossover is near 128x128 and
anything smaller is slower on the GPU than off it.

**The last three rows are the finding.** `200x784` is the shape
`jlib/ai/neural.hh` actually runs, and it runs it with one sample at a time --
the `N=1` row, where the GPU is five times *slower*. Batch to 64 and it is
9.7x faster; to 256 and it is 27x.

So moving `NeuralNetwork` to float is necessary and **not sufficient**: without
mini-batching it would be a regression, and batching is a change to the
training loop rather than to a type. That is why this branch stops at the GEMM.

The CPU column is also worth reading honestly: 1067ms for a 1024-cube is about
2 GFLOP/s, which says `math::operator*` is naive rather than that the GPU is
fast. A blocked, SIMD CPU multiply would close much of that gap and is a
cheaper thing to write than everything above it.

## Build

`AC_PROG_OBJCXX` is new -- automake refuses to emit rules for a `.mm` without
it -- and is harmless where there is no Objective-C++ compiler, since the
module that needs it is gated. Detection is a link test against Metal,
MetalPerformanceShaders and Foundation rather than a header check, because
those frameworks ship with the OS and have no pkg-config.

Linux is untouched: `jlib/metal/Makefile` is generated the way
`jlib/cuda/Makefile` always is, but `metal_subdirs` is empty so nothing builds
and `metal_gemm_test` never enters the suite.

## Tests

`tests/metal_gemm_test.cc`, against `math::operator*` as the oracle -- naive
and slow, which is what makes it good: there is nothing clever in it to be
wrong the same way twice. Seven shapes including 1x1, deliberately non-square
ones, and the backprop shape; the hand-computed transpose check; alpha and
beta; and refusal of mismatched dimensions.

Not compared exactly. MPS sums in whatever order suits the hardware, so the
tolerance scales with the interior dimension, which is what the error
accumulates over. Worst observed was 2e-5 against a 7.85e-4 bound at K=784.

Exits 77 (SKIP) when there is no device, so a Mac without a GPU is not a
failure.

**What a green run does not establish**, in the file: that it is faster --
nothing there is timed, and the numbers above live in this write-up rather than
in an assertion, because a wall-clock threshold on a shared machine is a coin
toss. Nor is it zero copy: the operands are copied into shared buffers, since
`newBufferWithBytesNoCopy` needs page-aligned memory and `math::array`
allocates with `new T[]`. Unified memory makes that copy cheap and local, not
absent -- making `math::buffer` able to allocate page-aligned is the follow-up
that removes it.

## Numbers

macOS: 61 pass, 4 skip, 0 fail, including `metal_gemm_test` on an Apple M5.
Linux container: 64 pass, 1 skip, 0 fail, with the module correctly absent.
