### PR TITLE
Make the training gradient a mean over the batch, so the learning rate stops scaling with batch size

### DIFF
--- a/jlib/ai/neural.hh
+++ b/jlib/ai/neural.hh
@@ -23,6 +23,7 @@
 #include <jlib/util/json.hh>
 
 #include <functional>
+#include <string>
 #include <random>
 #include <fstream>
 #include <tuple>
@@ -35,6 +36,18 @@ namespace ai {
 template<typename T>
 class NeuralNetwork {
 public:
+    class exception : public std::exception {
+    public:
+        exception(const std::string& msg = "") {
+            m_msg = "jlib::ai::NeuralNetwork exception" +
+                (msg.empty() ? std::string() : ": " + msg);
+        }
+        virtual ~exception() {}
+        virtual const char* what() const noexcept { return m_msg.c_str(); }
+    protected:
+        std::string m_msg;
+    };
+
     NeuralNetwork(double lrate, uint ninput, const std::vector<uint>& hidden, uint noutput);
 
     NeuralNetwork(util::json::object::ptr p);
@@ -169,6 +182,28 @@ NeuralNetwork<T>::NeuralNetwork(util::json::object::ptr p)
     
 template<typename T>
 math::matrix<T> NeuralNetwork<T>::train(math::matrix<T> inputs, math::matrix<T> targets){
+    // A column per sample.  Every step below is already written in matrix
+    // terms that carry a batch: m_wih * inputs is (H x I)(I x B) = H x B, the
+    // Hadamard terms stay elementwise, and multiplying by a transpose
+    // contracts the batch away to leave a gradient of the weight's own shape.
+    // So this took a batch before anything here was changed -- it just summed
+    // the gradient over one.
+    //
+    // Summing makes the step size scale with the batch, which was measured:
+    // a batch of two identical samples moved the weights 1.9992 times as far
+    // as one sample, and as far as two sequential steps. At a batch of 64 that
+    // is a 64x step and divergence.
+    //
+    // So the gradient is a mean, which is what makes the learning rate mean
+    // something independent of the batch size. At B = 1 -- every caller in the
+    // tree today -- dividing by one changes nothing, so this is exactly
+    // backward compatible.
+    const std::size_t batch = (inputs.N > 0) ? inputs.N : 1;
+    const double rate = m_lrate / double(batch);
+
+    if(targets.N != inputs.N)
+        throw exception("train: inputs and targets disagree about the batch size");
+
     //std::cout << "wih[" << m_wih.M << "," << m_wih.N << "]" << " * " << "inputs[" << inputs.M << "," << inputs.N << "]" << std::endl;
 
     math::matrix<T> hidden_inputs = m_wih * inputs;
@@ -196,7 +231,7 @@ math::matrix<T> NeuralNetwork<T>::train(math::matrix<T> inputs, math::matrix<T> 
     math::matrix<T> output_errors = targets - final_outputs;
     //std::cout << "output_errors[" << output_errors.M << "," << output_errors.N << "] \n" << output_errors << std::endl;
 
-    m_who += m_lrate * (((output_errors ^ final_outputs ^ (1.0 - final_outputs)) * deep_outputs.transpose()));
+    m_who += rate * (((output_errors ^ final_outputs ^ (1.0 - final_outputs)) * deep_outputs.transpose()));
 
     math::matrix<T> deep_errors = output_errors;
     math::matrix<T> deep = m_who;
@@ -204,14 +239,14 @@ math::matrix<T> NeuralNetwork<T>::train(math::matrix<T> inputs, math::matrix<T> 
     //for(auto x = m_deep.rbegin(); x != m_deep.rend(); x++) {
     for(int i = m_deep.size() - 1; i >= 0; i--) {
         deep_errors = deep.transpose() * deep_errors;
-        m_deep[i] += m_lrate * (((deep_errors ^ deep_outputs_cache[i] ^ (1.0 - deep_outputs_cache[i])) * deep_inputs_cache[i].transpose()));
+        m_deep[i] += rate * (((deep_errors ^ deep_outputs_cache[i] ^ (1.0 - deep_outputs_cache[i])) * deep_inputs_cache[i].transpose()));
         deep = m_deep[i];
     }
 
     math::matrix<T> hidden_errors = deep.transpose() * deep_errors;
     //std::cout << "hidden_errors[" << hidden_errors.M << "," << hidden_errors.N << "] \n" << hidden_errors << std::endl;
     
-    m_wih += m_lrate * ((hidden_errors ^ hidden_outputs ^ (1.0 - hidden_outputs)) * inputs.transpose());
+    m_wih += rate * ((hidden_errors ^ hidden_outputs ^ (1.0 - hidden_outputs)) * inputs.transpose());
 
     return output_errors;
 }

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -53,6 +53,7 @@ TESTS = \
 	math_value_test \
 	math_plot_alloc_test \
 	math_dump_test \
+	ai_neural_test \
 	math_object_test \
 	tensor_test \
 \
@@ -276,6 +277,9 @@ math_plot_alloc_test_LDADD   = $(JUTIL_LA)
 
 math_dump_test_SOURCES = math_dump_test.cc
 math_dump_test_LDADD   = $(JUTIL_LA)
+
+ai_neural_test_SOURCES = ai_neural_test.cc
+ai_neural_test_LDADD   = $(JUTIL_LA) $(JSYS_LA)
 
 math_object_test_SOURCES = math_object_test.cc
 math_object_test_LDADD   = $(JUTIL_LA)

--- a/tests/ai_neural_test.cc
+++ b/tests/ai_neural_test.cc
@@ -1,0 +1,272 @@
+/* -*- mode: C++ c-basic-offset: 4 -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Training a batch.
+//
+// jlib/ai had no test at all, which is how it came to be in the tree since
+// 2020 with a training step whose behaviour changed with the batch size and
+// nothing saying so.
+//
+// The weights are compared through json(), which is the only way out of the
+// class.  That is a little indirect, but it is exact -- comparing what query()
+// returns would put a sigmoid between the assertion and the thing asserted.
+
+#include <jlib/ai/neural.hh>
+
+#include <cmath>
+#include <iostream>
+#include <string>
+#include <vector>
+
+using jlib::ai::NeuralNetwork;
+using jlib::math::matrix;
+
+namespace json = jlib::util::json;
+
+static int failures = 0;
+
+static void ok(const std::string& what, bool good, const std::string& detail = "") {
+    if(!good) ++failures;
+    std::cout << (good ? "  ok   " : "  FAIL ") << what;
+    if(!detail.empty()) std::cout << ": " << detail;
+    std::cout << "\n";
+}
+
+static const uint I = 4, H = 5, O = 3;
+
+static std::vector<uint> hidden() { return std::vector<uint>{ H }; }
+
+/** Every weight, flattened, so two networks can be compared number by number. */
+static std::vector<double> weights(NeuralNetwork<double>& nn) {
+    json::object::ptr p = nn.json();
+
+    std::vector<double> out;
+
+    for(uint i = 0; i < H * I; i++) out.push_back(p->obj("wih")->get(i));
+    for(uint i = 0; i < O * H; i++) out.push_back(p->obj("who")->get(i));
+
+    return out;
+}
+
+static std::vector<double> delta(const std::vector<double>& a,
+                                 const std::vector<double>& b) {
+    std::vector<double> d;
+
+    for(std::size_t i = 0; i < a.size() && i < b.size(); i++)
+        d.push_back(b[i] - a[i]);
+
+    return d;
+}
+
+static double worst(const std::vector<double>& a, const std::vector<double>& b) {
+    double w = 0;
+
+    for(std::size_t i = 0; i < a.size() && i < b.size(); i++)
+        w = std::max(w, std::fabs(a[i] - b[i]));
+
+    return w;
+}
+
+/** Sample k, made up but distinct. */
+static matrix<double> input(uint k, uint n = 1) {
+    matrix<double> x(I, n);
+
+    for(uint c = 0; c < n; c++)
+        for(uint r = 0; r < I; r++)
+            x(r, c) = 0.1 * double(r + 1) + 0.07 * double(k + c);
+
+    return x;
+}
+
+static matrix<double> target(uint k, uint n = 1) {
+    matrix<double> t(O, n);
+
+    for(uint c = 0; c < n; c++)
+        for(uint r = 0; r < O; r++)
+            t(r, c) = 0.2 + 0.1 * double((r + k + c) % 3);
+
+    return t;
+}
+
+static void a_batch_is_accepted() {
+    std::cout << "\na batch is accepted:\n";
+
+    NeuralNetwork<double> nn(0.1, I, hidden(), O);
+
+    const matrix<double> e1 = nn.train(input(0), target(0));
+
+    ok("one sample gives one column of errors", e1.M == O && e1.N == 1,
+       std::to_string(e1.M) + "x" + std::to_string(e1.N));
+
+    const matrix<double> e4 = nn.train(input(0, 4), target(0, 4));
+
+    ok("four samples give four", e4.M == O && e4.N == 4,
+       std::to_string(e4.M) + "x" + std::to_string(e4.N));
+
+    const matrix<double> q = nn.query(input(0, 4));
+
+    ok("and query answers a batch too", q.M == O && q.N == 4,
+       std::to_string(q.M) + "x" + std::to_string(q.N));
+}
+
+static void the_gradient_is_a_mean() {
+    std::cout << "\nthe gradient is a mean:\n";
+
+    NeuralNetwork<double> start(0.1, I, hidden(), O);
+
+    // Identical starting weights, via the serialisation the class already had.
+    NeuralNetwork<double> one(start.json());
+    NeuralNetwork<double> many(start.json());
+
+    const std::vector<double> before = weights(start);
+
+    ok("the json round-trip preserves the weights",
+       worst(before, weights(one)) == 0.0,
+       std::to_string(worst(before, weights(one))));
+
+    one.train(input(0), target(0));
+
+    // Eight copies of the same sample.  A mean gradient over identical
+    // gradients is that gradient, so this must move exactly as far as one.
+    matrix<double> x(I, 8), t(O, 8);
+
+    for(uint c = 0; c < 8; c++) {
+        for(uint r = 0; r < I; r++) x(r, c) = input(0)(r, 0);
+        for(uint r = 0; r < O; r++) t(r, c) = target(0)(r, 0);
+    }
+
+    many.train(x, t);
+
+    const double w = worst(weights(one), weights(many));
+
+    // Summing instead would move it eight times as far, so the bound does not
+    // need to be tight to be decisive.
+    ok("a batch of eight identical samples moves as far as one", w < 1e-12,
+       "worst weight difference " + std::to_string(w));
+}
+
+static void it_is_the_mean_of_the_samples() {
+    std::cout << "\nit is the mean of the samples:\n";
+
+    NeuralNetwork<double> start(0.1, I, hidden(), O);
+
+    NeuralNetwork<double> a(start.json());
+    NeuralNetwork<double> b(start.json());
+    NeuralNetwork<double> both(start.json());
+
+    const std::vector<double> before = weights(start);
+
+    a.train(input(0), target(0));
+    b.train(input(1), target(1));
+    both.train(input(0, 2), target(0, 2));
+
+    const std::vector<double> da = delta(before, weights(a));
+    const std::vector<double> db = delta(before, weights(b));
+    const std::vector<double> dboth = delta(before, weights(both));
+
+    // The output layer's step is exactly the average of the two single steps,
+    // because all three gradients are taken at the same weights.
+    //
+    // The hidden layer's is only close, and that is not a rounding story: it
+    // is 1.5e-6 where the output layer is 5.6e-17.  train() updates m_who and
+    // *then* backpropagates through the updated m_who, so the hidden gradient
+    // is not evaluated at the weights the step started from.  Textbook
+    // backprop takes every gradient at the same weights and applies them
+    // afterwards.  See the issue filed alongside this branch -- it predates
+    // batching, and changing it would change how every existing network
+    // trains, so it is recorded rather than fixed here.
+    //
+    // The split is asserted rather than glossed, so that if anyone does fix
+    // it, this test says which half was already right.
+    std::vector<double> mean_who, batch_who, mean_wih, batch_wih;
+
+    for(std::size_t i = 0; i < da.size(); i++) {
+        const bool is_wih = i < H * I;
+
+        (is_wih ? mean_wih : mean_who).push_back(0.5 * (da[i] + db[i]));
+        (is_wih ? batch_wih : batch_who).push_back(dboth[i]);
+    }
+
+    const double wo = worst(mean_who, batch_who);
+    const double wi = worst(mean_wih, batch_wih);
+
+    ok("the output layer's step is exactly the average", wo < 1e-14,
+       "worst difference " + std::to_string(wo));
+
+    ok("the hidden layer's is close but not exact", wi > 1e-12 && wi < 1e-3,
+       "worst difference " + std::to_string(wi) +
+       " -- backprop goes through the already-updated m_who");
+
+    // And it is not the same as taking them one after the other, which is a
+    // different algorithm rather than a slower version of the same one.
+    NeuralNetwork<double> seq(start.json());
+
+    seq.train(input(0), target(0));
+    seq.train(input(1), target(1));
+
+    const double s = worst(weights(both), weights(seq));
+
+    ok("and is not the same as two sequential steps", s > 1e-12,
+       "difference " + std::to_string(s));
+}
+
+static void a_mismatched_batch_is_refused() {
+    std::cout << "\na mismatched batch is refused:\n";
+
+    NeuralNetwork<double> nn(0.1, I, hidden(), O);
+
+    bool threw = false;
+
+    try { nn.train(input(0, 4), target(0, 2)); }
+    catch(std::exception&) { threw = true; }
+
+    // Four inputs and two targets used to reach the subtraction and throw
+    // there, from math::matrix, about a shape nobody had mentioned.
+    ok("inputs and targets must agree about the batch size", threw);
+}
+
+int main() {
+    std::cout << std::unitbuf;
+
+    a_batch_is_accepted();
+    the_gradient_is_a_mean();
+    it_is_the_mean_of_the_samples();
+    a_mismatched_batch_is_refused();
+
+    // What a green run does not establish.
+    //
+    // That the network learns anything.  Nothing here trains to convergence or
+    // checks an error goes down; these are assertions about one step, which is
+    // where the batch semantics live.  Whether MNIST still converges is a
+    // question for jneural-alpha and a dataset, not for a unit test.
+    //
+    // Not float.  Everything here is NeuralNetwork<double>, because that is
+    // what the apps use.  The class is a template and float should behave the
+    // same, but "should" is not a test, and the Metal path that wants float is
+    // not wired up yet.
+    //
+    // Not the speed.  Batching measured 2.5x faster on the CPU at a batch of
+    // 32 for a 784-200-10 network, which is in the branch write-up rather than
+    // asserted here, because a wall-clock bound on a shared machine is a coin
+    // toss.
+    std::cout << "\n" << (failures ? "FAILED" : "PASSED") << ": " << failures
+              << " failure(s)\n";
+
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
# Training takes a batch, and the learning rate stops depending on its size

The prerequisite for the Metal work: the GEMM measured 9.7x faster than the CPU
at the shape `jlib/ai` runs, but only with a batch of 64. At the batch of one
the network actually trains with, the GPU is five times *slower*. So batching
comes first, and it turned out to be almost entirely a semantics problem rather
than a code one.

## train() already took a batch

Every step in it is written in matrix terms that carry one: `m_wih * inputs` is
(H x I)(I x B) = H x B, the Hadamard terms stay elementwise, and multiplying by
a transpose contracts the batch away to leave a gradient of the weight's own
shape. Feeding it a 4x2 input returned a 3x2 error matrix without complaint,
before anything here was changed.

What it did with the batch was sum the gradient. Measured, from identical
starting weights:

```
  after 1 sample              delta -0.00064775
  after a batch of 2 identical delta -0.00129499   ratio 1.9992
  after 2 sequential steps     delta -0.00128997   ratio 1.9915
```

A batch of two moved the weights exactly twice as far as one sample. So the
step size scaled with the batch, and a batch of 64 at the same `m_lrate` would
be a 64x step and divergence -- which is the sort of thing that gets diagnosed
as "batching doesn't work" rather than as "the learning rate meant something
different".

## The gradient is a mean now

One line: divide by `inputs.N`. At B = 1 -- every caller in the tree today --
dividing by one changes nothing, so this is **exactly** backward compatible,
and the single-sample figures above are unchanged to the last digit.

After it, a batch of two identical samples moves precisely as far as one
sample: ratio 1.0000.

`train()` also throws now when inputs and targets disagree about the batch
size, instead of reaching the subtraction and throwing from `math::matrix`
about a shape nobody mentioned. That needed `NeuralNetwork` to grow the nested
`exception` the house style gives every class and this one never had.

## Measured

Batching is worth having on the CPU alone, before any GPU is involved -- 512
samples through 784-200-10, one epoch:

```
  batch      time    vs B=1
  1        0.197s      1.0x
  8        0.089s      2.2x
  32       0.080s      2.5x
  64       0.085s      2.3x
  256      0.098s      2.0x
```

2.5x at a batch of 32, then flat. Modest because `math::operator*` is naive and
does not reward blocking the way a tuned multiply would -- the same finding as
the Metal branch's CPU column.

## tests/ai_neural_test.cc

`jlib/ai` had no test at all, which is how a training step whose behaviour
changed with the batch size sat in the tree since 2020 with nothing saying so.

Weights are compared through `json()`, which is the only way out of the class.
Indirect, but exact -- comparing `query()` output would put a sigmoid between
the assertion and the thing asserted.

## Found on the way, and not fixed here

**#130: backprop goes through weights it has already updated.** `train()`
updates `m_who` and then reads `m_who` to backpropagate, and the `m_deep` loop
does the same at every layer. Textbook backprop takes every gradient at the
same weights and applies them afterwards.

This showed up because the mean-of-gradients property is exact arithmetic, so
it makes a sharp instrument. Splitting the comparison by layer:

```
  who (output layer): worst |batch - mean| = 5.551e-17    exact
  wih (hidden layer): worst |batch - mean| = 1.535e-06    not
```

Quantified before filing: at lrate 0.1 the largest `wih` update is 1.449e-03,
so the deviation is about **0.1% of one step**, first-order in the learning
rate and vanishing as it shrinks. A perturbed descent direction rather than a
wrong one, which is why networks trained under it anyway. Recorded rather than
fixed, because the fix changes the arithmetic of every training step and there
is no convergence test in the tree to say whether that is better or worse.

The test asserts the split as it stands -- output layer exactly, hidden layer
approximately -- so whoever fixes it can see which half was already right.

**Vanishing gradients, which is a much larger effect and is not filed yet.**
Largest weight change per layer, input end first:

```
  1 hidden layer    6.42e-03  8.83e-03                          ratio 0.73
  3 hidden layers   1.38e-03  ...  7.79e-03                     ratio 0.18
  6 hidden layers   4.67e-04  ...  7.83e-03                     ratio 0.06
```

At six layers the input end receives 17x less update than the output end,
decaying 2-3x per hop -- the sigmoid derivative maxes at 0.25 and is usually
well below. The extra depth is parameters that barely train.

Compounding it, the initialisation uses `pow(fan, -0.5)` on the **fan-out**
where Xavier wants fan-in: `m_wih` uses H when its fan-in is I, and `m_who`
uses O when its fan-in is H -- about 4.5x too large for 784-200-10. Oversized
weights push sigmoids toward saturation, where the derivative approaches zero,
which makes the vanishing worse.

Neither is in this branch. Both are worth their own issue and their own
measurements against a real dataset.

**What a green run does not establish**, in the test file: that the network
learns anything. Nothing here trains to convergence; these are assertions about
one step, which is where the batch semantics live. Nor float -- everything is
`NeuralNetwork<double>`, because that is what the apps use, and the Metal path
that wants float is not wired up yet.

## Numbers

macOS: 62 pass, 4 skip, 0 fail. Linux container: 65 pass, 1 skip, 0 fail.
