### PR TITLE
Scale the initial weights by the fan in rather than the fan out, worth 4.6 points at two hidden layers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,11 @@ m4/lt~obsolete.m4
 *.la
 *.deps
 *.libs
+
+# MNIST, for measuring what #131 changes.  Fetched rather than vendored:
+# mnist_train.csv is 110MB, and jneural-alpha takes its path on the command
+# line, so there is no reason for it to be in the tree.
+#
+#   curl -O https://pjreddie.com/media/files/mnist_train.csv
+#   curl -O https://pjreddie.com/media/files/mnist_test.csv
+mnist_*.csv

--- a/jlib/ai/neural.hh
+++ b/jlib/ai/neural.hh
@@ -91,14 +91,27 @@ NeuralNetwork<T>::NeuralNetwork(double lrate, uint ninput, const std::vector<uin
     if(m_nhidden.empty())
         throw std::runtime_error("Need at least one hidden layer");
     
-    T hbound = pow(m_nhidden[0], -0.5);
+    // Fan-in, not fan-out.  1/sqrt(fan) is the right heuristic and was always
+    // the intent, but each of the three below passed the wrong dimension:
+    // m_wih is (hidden x input), so the number of weights feeding each hidden
+    // unit is m_ninput, not m_nhidden[0].  See #131 -- with 784 inputs and 200
+    // hidden this was twice as wide as it should be, and m_who below was four
+    // and a half times.
+    //
+    // Weights that are too large push the sigmoids toward their flat ends,
+    // where the derivative approaches zero, which starves the backward pass on
+    // top of the attenuation it already suffers per layer.
+    T hbound = pow(m_ninput, -0.5);
     std::uniform_real_distribution<T> hdist(-hbound, hbound);
         
     m_wih.foreach([&](T& x) {
             x = hdist(m_generator);
         });
         
-    T obound = pow(m_noutput, -0.5);
+    // m_who is (output x hidden): the fan-in is the hidden layer feeding it,
+    // not the number of classes coming out.  This was the worst of the three
+    // and the one the backward pass starts from.
+    T obound = pow(m_nhidden.back(), -0.5);
     std::uniform_real_distribution<T> odist(-obound, obound);
         
     m_who.foreach([&](T& x) {
@@ -107,7 +120,11 @@ NeuralNetwork<T>::NeuralNetwork(double lrate, uint ninput, const std::vector<uin
 
     for(int i = 1; i < m_nhidden.size(); i++) {
         // add a deep matrix from [i-1] to [i]
-	T dbound = pow(m_nhidden[i], -0.5);
+	// m_deep[i-1] is (n[i] x n[i-1]), so the fan-in is the layer below.
+	// Identical to the old expression when every hidden layer is the same
+	// width, which is why the case people try first is the case this got
+	// right.
+	T dbound = pow(m_nhidden[i-1], -0.5);
 	std::uniform_real_distribution<T> ddist(-dbound, dbound);
 	
 	m_deep.push_back(math::matrix<T>(m_nhidden[i], m_nhidden[i-1]));

--- a/tests/ai_neural_test.cc
+++ b/tests/ai_neural_test.cc
@@ -226,6 +226,61 @@ static void it_is_the_mean_of_the_samples() {
        "difference " + std::to_string(s));
 }
 
+static void weights_are_scaled_by_the_fan_in() {
+    std::cout << "\nweights are scaled by the fan in:\n";
+
+    // 1/sqrt(fan-in) is the heuristic, and the fan-in of a weight matrix is
+    // the layer feeding it, not the layer it feeds.  Deliberately asymmetric
+    // sizes: with equal widths the two readings coincide, which is exactly why
+    // the wrong one survived (#131).
+    const uint ni = 100, no = 4;
+    const std::vector<uint> deep{ 25, 9 };
+
+    NeuralNetwork<double> nn(0.1, ni, deep, no);
+
+    json::object::ptr p = nn.json();
+
+    double wih = 0, who = 0, d0 = 0;
+
+    for(uint i = 0; i < deep.front() * ni; i++)
+        wih = std::max(wih, std::fabs(double(p->obj("wih")->get(i))));
+
+    for(uint i = 0; i < no * deep.back(); i++)
+        who = std::max(who, std::fabs(double(p->obj("who")->get(i))));
+
+    for(uint i = 0; i < deep[1] * deep[0]; i++)
+        d0 = std::max(d0, std::fabs(double(p->obj("deep")->obj(0)->get(i))));
+
+    // Each bound, and the one the old code would have used.  The gap between
+    // them is what makes these assertions worth anything: 1/sqrt(100) = 0.1
+    // against 1/sqrt(25) = 0.2, and 1/sqrt(9) = 0.333 against 1/sqrt(4) = 0.5.
+    ok("wih is bounded by 1/sqrt(inputs)", wih <= std::pow(double(ni), -0.5),
+       std::to_string(wih) + " <= " + std::to_string(std::pow(double(ni), -0.5)));
+
+    ok("  and not by 1/sqrt(first hidden), which is looser",
+       wih <= std::pow(double(deep.front()), -0.5) &&
+       std::pow(double(ni), -0.5) < std::pow(double(deep.front()), -0.5));
+
+    ok("who is bounded by 1/sqrt(last hidden)",
+       who <= std::pow(double(deep.back()), -0.5),
+       std::to_string(who) + " <= " + std::to_string(std::pow(double(deep.back()), -0.5)));
+
+    ok("  and not by 1/sqrt(outputs), which is looser",
+       who <= std::pow(double(no), -0.5) &&
+       std::pow(double(deep.back()), -0.5) < std::pow(double(no), -0.5));
+
+    ok("a deep layer is bounded by 1/sqrt(the layer below)",
+       d0 <= std::pow(double(deep[0]), -0.5),
+       std::to_string(d0) + " <= " + std::to_string(std::pow(double(deep[0]), -0.5)));
+
+    // A bound nothing reaches is not a bound anyone can check, so the
+    // distribution has to actually fill it.  Uniform over the range, so the
+    // largest of a few hundred draws sits close to the edge.
+    ok("and the range is used rather than merely respected",
+       wih > 0.8 * std::pow(double(ni), -0.5),
+       std::to_string(wih));
+}
+
 static void a_mismatched_batch_is_refused() {
     std::cout << "\na mismatched batch is refused:\n";
 
@@ -247,6 +302,7 @@ int main() {
     a_batch_is_accepted();
     the_gradient_is_a_mean();
     it_is_the_mean_of_the_samples();
+    weights_are_scaled_by_the_fan_in();
     a_mismatched_batch_is_refused();
 
     // What a green run does not establish.


### PR DESCRIPTION
# Initial weights scale by the fan in

The first half of #131. `1/sqrt(fan)` was always the right heuristic and always
the intent, but each of the three matrices passed the **fan-out**:

```cpp
T hbound = pow(m_nhidden[0], -0.5);   // m_wih is H x I -- the fan-in is I
T obound = pow(m_noutput,    -0.5);   // m_who is O x H -- the fan-in is H
T dbound = pow(m_nhidden[i], -0.5);   // m_deep is n[i] x n[i-1] -- it is n[i-1]
```

For 784-64-10 that made `m_wih` about 3.5x too wide and `m_who` about 2.8x.
Oversized weights push the sigmoids toward their flat ends, where the derivative
approaches zero, which starves the backward pass on top of the per-layer
attenuation it already suffers.

`m_deep` is only wrong when the hidden layers differ in width -- with uniform
widths the two readings coincide, which is exactly why this survived.

## Measured on MNIST

60k train, 10k test, five epochs, 64-wide hidden layers. `jneural-alpha` is
default-seeded in both the weights and the epoch shuffle, so two runs of a build
are identical and any difference between two builds is the build.

```
                 fan-out (before)   fan-in (after)
  1 x 64             94.21%            94.45%       +0.24
  2 x 64             86.01%            90.63%       +4.62
  3 x 64             10.10%            10.10%        none
```

**4.6 points at two hidden layers**, more than the theory alone promised.

## A measurement I got wrong first

The initial comparison was at one epoch and said the opposite -- 1x64 up 0.86
but **2x64 down 2.48**, which read as "technically correct, empirically a wash
or worse". That was wrong: at one epoch the network is nowhere near converged,
so it measures the training trajectory rather than the result, and the ranking
flips by five epochs.

Recorded because the trap is not obvious and the wrong conclusion was one
command away from being the write-up. Anyone comparing initialisation schemes
in this codebase should go to five epochs at least.

(An earlier run also reported 9.8% for everything at five epochs, which was a
stale binary from a stash-and-rebuild with the build output silenced. Rebuilt
visibly thereafter, and both directions of the table above were re-measured with
the compile lines on screen.)

## It does not fix depth, and the depth failure is worse than #131 said

The issue says deep networks "barely train". They do not train at all:

```
  1 x 64   94.21%      3 x 64   10.10%
  2 x 64   86.01%      4 x 64   10.32%
                       6 x 64   10.32%
```

10.32% is chance for ten classes, and it is a floor rather than slow progress:
3x64 returns exactly 10.32% at one epoch and at three, and at learning rates
0.01, 0.1 and 0.5. Identical to the digit every time, which is what a network
emitting a constant looks like. The cliff is between two and three hidden
layers and initialisation does not move it.

That leaves the activation, which is #131's second half and the part that
matters. It is a bigger change than it looks: `m_activation_function` is a
`std::function` member and injectable, but the derivative is hardcoded in
`train()` as `out ^ (1.0 - out)`, which is the sigmoid's and only the
sigmoid's. The two have to start travelling together before ReLU is possible.

## Tests

`weights_are_scaled_by_the_fan_in` in `tests/ai_neural_test.cc`, with
deliberately asymmetric layer sizes -- 100 inputs, hidden 25 then 9, 4 outputs
-- because with equal widths the right and wrong readings coincide and the
assertion would pass either way. Each bound is checked against the one the old
code would have used, and the gaps are wide: 1/sqrt(100) = 0.1 against
1/sqrt(25) = 0.2 for `m_wih`, 1/sqrt(9) = 0.333 against 1/sqrt(4) = 0.5 for
`m_who`.

It also asserts the range is *used* and not merely respected -- a bound nothing
reaches is not a bound anyone can check.

**What a green run does not establish**: any of the MNIST numbers above. The
test checks the bounds, not the accuracy; nothing in `make check` trains on
real data, and the 110MB dataset has no business in the tree.

`.gitignore` gains `mnist_*.csv`, since the measurement wants the files in the
repo root and 128MB of them would otherwise be one `git add -A` from being
committed.

## Also found, not fixed

`jneural-alpha`'s MNIST path silently inherits the image-mode dimensions.
`INODES = R * C` with defaults R=90, C=120, so without `-r 28 -c 28` it builds a
10800-input network and dies with `mismatch matricies [64,10800], [784,1]` --
after loading all 60000 rows. Nothing checks the CSV's row length against the
configured input count. Noted on #131; it is the first thing anyone pointing
this at MNIST will hit.

## Numbers

macOS: 62 pass, 4 skip, 0 fail. Linux container: 65 pass, 1 skip, 0 fail.
