### PR TITLE
Make the activation selectable with its derivative, and get three hidden layers training instead of guessing

### DIFF
--- a/jlib/ai/neural.hh
+++ b/jlib/ai/neural.hh
@@ -33,6 +33,85 @@
 namespace jlib {
 namespace ai {
 
+/**
+ * Which nonlinearity a layer applies.
+ *
+ * Every one of these has a derivative expressible in terms of its own
+ * *output*, which is the fact that makes them interchangeable here: train()
+ * already caches each layer's output to build `out * (1 - out)`, so nothing
+ * needs the pre-activation kept as well.
+ *
+ *   sigmoid      s (1 - s)
+ *   tanh         1 - s^2
+ *   relu         s > 0 ? 1 : 0          -- output > 0 exactly when input was
+ *   leaky_relu   s > 0 ? 1 : LEAK       -- likewise, since LEAK is positive
+ */
+enum class activation { sigmoid, tanh, relu, leaky_relu };
+
+/** The slope a leaky ReLU keeps below zero. */
+inline constexpr double LEAK = 0.01;
+
+inline std::string name_of(activation a) {
+    switch(a) {
+    case activation::sigmoid:    return "sigmoid";
+    case activation::tanh:       return "tanh";
+    case activation::relu:       return "relu";
+    case activation::leaky_relu: return "leaky_relu";
+    }
+
+    return "sigmoid";
+}
+
+inline activation activation_from_name(const std::string& s) {
+    if(s == "sigmoid")    return activation::sigmoid;
+    if(s == "tanh")       return activation::tanh;
+    if(s == "relu")       return activation::relu;
+    if(s == "leaky_relu") return activation::leaky_relu;
+
+    throw std::runtime_error("unknown activation '" + s + "'");
+}
+
+template<typename T>
+math::matrix<T> activate(activation a, const math::matrix<T>& in) {
+    math::matrix<T> out(in.M, in.N);
+
+    for(uint r = 0; r < in.M; r++) {
+        for(uint c = 0; c < in.N; c++) {
+            const T x = in(r, c);
+
+            switch(a) {
+            case activation::sigmoid:    out(r,c) = T(1) / (T(1) + std::exp(-x)); break;
+            case activation::tanh:       out(r,c) = std::tanh(x);                 break;
+            case activation::relu:       out(r,c) = (x > 0) ? x : T(0);           break;
+            case activation::leaky_relu: out(r,c) = (x > 0) ? x : T(LEAK) * x;    break;
+            }
+        }
+    }
+
+    return out;
+}
+
+/** The derivative, from the output rather than the input.  See activation. */
+template<typename T>
+math::matrix<T> activate_slope(activation a, const math::matrix<T>& out) {
+    math::matrix<T> d(out.M, out.N);
+
+    for(uint r = 0; r < out.M; r++) {
+        for(uint c = 0; c < out.N; c++) {
+            const T s = out(r, c);
+
+            switch(a) {
+            case activation::sigmoid:    d(r,c) = s * (T(1) - s);        break;
+            case activation::tanh:       d(r,c) = T(1) - s * s;          break;
+            case activation::relu:       d(r,c) = (s > 0) ? T(1) : T(0); break;
+            case activation::leaky_relu: d(r,c) = (s > 0) ? T(1) : T(LEAK); break;
+            }
+        }
+    }
+
+    return d;
+}
+
 template<typename T>
 class NeuralNetwork {
 public:
@@ -66,6 +145,29 @@ public:
     std::default_random_engine& get_generator();
 
     void set_rate(double rate);
+
+    /**
+     * Which nonlinearity the hidden layers use, and which the output uses.
+     *
+     * Both default to sigmoid, so a network that says nothing behaves exactly
+     * as it did before these existed.
+     *
+     * **They are separate on purpose.**  ReLU is what lets a deep network
+     * train -- the sigmoid's derivative peaks at 0.25, so the gradient is
+     * attenuated at every hop and at three hidden layers nothing reaches the
+     * input end (#131).  But ReLU on the *output* is wrong for a classifier
+     * scored against targets of 0.01 and 0.99: its derivative is zero
+     * wherever the output is, so an output unit that goes negative stops
+     * learning and never comes back.
+     *
+     * Hidden relu with a sigmoid output is the ordinary arrangement, and it is
+     * what the measurements in #131 were taken with.
+     */
+    activation get_hidden_activation() const { return m_hidden_activation; }
+    void set_hidden_activation(activation a) { m_hidden_activation = a; }
+
+    activation get_output_activation() const { return m_output_activation; }
+    void set_output_activation(activation a) { m_output_activation = a; }
     
 protected:
     uint m_ninput;
@@ -75,7 +177,13 @@ protected:
     math::matrix<T> m_wih;
     math::matrix<T> m_who;
     std::vector<math::matrix<T>> m_deep;
-    std::function<math::matrix<T>(math::matrix<T>)> m_activation_function;
+    // Was a std::function holding a sigmoid, with the matching derivative
+    // written out by hand in train() as `out ^ (1 - out)`.  The function was
+    // replaceable and the derivative was not, so replacing it silently trained
+    // against the wrong slope.  A pair of enums keeps them together and
+    // serialises, which a lambda could not.
+    activation m_hidden_activation = activation::sigmoid;
+    activation m_output_activation = activation::sigmoid;
     std::default_random_engine m_generator;
 };
 
@@ -133,14 +241,6 @@ NeuralNetwork<T>::NeuralNetwork(double lrate, uint ninput, const std::vector<uin
             });
     }
 
-    // sigmoid function
-    m_activation_function = [](math::matrix<T> input) {
-        math::matrix<T> output(input.M, input.N);
-        input.foreach_index([&](uint r, uint c, T& val) {
-                output(r, c) = (1.0 / (1.0 + exp(-val))); //tanh(val);
-            });
-        return output;
-    }; 
 }
 
 
@@ -150,6 +250,12 @@ NeuralNetwork<T>::NeuralNetwork(util::json::object::ptr p)
     : m_ninput(p->get("ninput")),
       m_noutput(p->get("noutput")),
       m_lrate(p->get("lrate")),
+      m_hidden_activation(p->has("hidden_activation")
+                          ? activation_from_name(p->get("hidden_activation"))
+                          : activation::sigmoid),
+      m_output_activation(p->has("output_activation")
+                          ? activation_from_name(p->get("output_activation"))
+                          : activation::sigmoid),
       m_wih(1, 1),
       m_who(1, 1)
 {
@@ -187,14 +293,6 @@ NeuralNetwork<T>::NeuralNetwork(util::json::object::ptr p)
             x = p->obj("who")->get(r*m_nhidden.back() + c);
         });
     
-    // sigmoid function
-    m_activation_function = [](math::matrix<T> input) {
-        math::matrix<T> output(input.M, input.N);
-        input.foreach_index([&](uint r, uint c, T& val) {
-                output(r, c) = (1.0 / (1.0 + exp(-val))); //tanh(val);
-            });
-        return output;
-    }; 
 }
     
 template<typename T>
@@ -224,7 +322,7 @@ math::matrix<T> NeuralNetwork<T>::train(math::matrix<T> inputs, math::matrix<T> 
     //std::cout << "wih[" << m_wih.M << "," << m_wih.N << "]" << " * " << "inputs[" << inputs.M << "," << inputs.N << "]" << std::endl;
 
     math::matrix<T> hidden_inputs = m_wih * inputs;
-    math::matrix<T> hidden_outputs = m_activation_function(hidden_inputs);
+    math::matrix<T> hidden_outputs = activate(m_hidden_activation, hidden_inputs);
 
     math::matrix<T> deep_inputs = hidden_inputs;
     math::matrix<T> deep_outputs = hidden_outputs;
@@ -236,19 +334,20 @@ math::matrix<T> NeuralNetwork<T>::train(math::matrix<T> inputs, math::matrix<T> 
         deep_inputs_cache.push_back(deep_outputs);
 
         deep_inputs = deep * deep_outputs;
-        deep_outputs = m_activation_function(deep_inputs);
+        deep_outputs = activate(m_hidden_activation, deep_inputs);
 
         deep_outputs_cache.push_back(deep_outputs);
     }
 
     math::matrix<T> final_inputs = m_who * deep_outputs;
-    math::matrix<T> final_outputs = m_activation_function(final_inputs);
+    math::matrix<T> final_outputs = activate(m_output_activation, final_inputs);
     //std::cout << "final_outputs[" << final_outputs.M << "," << final_outputs.N << "] \n" << final_outputs << std::endl;
     
     math::matrix<T> output_errors = targets - final_outputs;
     //std::cout << "output_errors[" << output_errors.M << "," << output_errors.N << "] \n" << output_errors << std::endl;
 
-    m_who += rate * (((output_errors ^ final_outputs ^ (1.0 - final_outputs)) * deep_outputs.transpose()));
+    m_who += rate * (((output_errors ^ activate_slope(m_output_activation, final_outputs))
+                      * deep_outputs.transpose()));
 
     math::matrix<T> deep_errors = output_errors;
     math::matrix<T> deep = m_who;
@@ -256,14 +355,16 @@ math::matrix<T> NeuralNetwork<T>::train(math::matrix<T> inputs, math::matrix<T> 
     //for(auto x = m_deep.rbegin(); x != m_deep.rend(); x++) {
     for(int i = m_deep.size() - 1; i >= 0; i--) {
         deep_errors = deep.transpose() * deep_errors;
-        m_deep[i] += rate * (((deep_errors ^ deep_outputs_cache[i] ^ (1.0 - deep_outputs_cache[i])) * deep_inputs_cache[i].transpose()));
+        m_deep[i] += rate * (((deep_errors ^ activate_slope(m_hidden_activation, deep_outputs_cache[i]))
+                              * deep_inputs_cache[i].transpose()));
         deep = m_deep[i];
     }
 
     math::matrix<T> hidden_errors = deep.transpose() * deep_errors;
     //std::cout << "hidden_errors[" << hidden_errors.M << "," << hidden_errors.N << "] \n" << hidden_errors << std::endl;
     
-    m_wih += rate * ((hidden_errors ^ hidden_outputs ^ (1.0 - hidden_outputs)) * inputs.transpose());
+    m_wih += rate * ((hidden_errors ^ activate_slope(m_hidden_activation, hidden_outputs))
+                     * inputs.transpose());
 
     return output_errors;
 }
@@ -271,15 +372,15 @@ math::matrix<T> NeuralNetwork<T>::train(math::matrix<T> inputs, math::matrix<T> 
 template<typename T>
 math::matrix<T> NeuralNetwork<T>::query(math::matrix<T> inputs) {
     math::matrix<T> hidden_inputs = m_wih * inputs;
-    math::matrix<T> hidden_outputs = m_activation_function(hidden_inputs);
+    math::matrix<T> hidden_outputs = activate(m_hidden_activation, hidden_inputs);
 
     for(auto& deep : m_deep) {
         hidden_inputs = deep * hidden_outputs;
-        hidden_outputs = m_activation_function(hidden_inputs);
+        hidden_outputs = activate(m_hidden_activation, hidden_inputs);
     }
 
     math::matrix<T> final_inputs = m_who * hidden_outputs;
-    math::matrix<T> final_outputs = m_activation_function(final_inputs);
+    math::matrix<T> final_outputs = activate(m_output_activation, final_inputs);
     
     return final_outputs;
 }
@@ -291,6 +392,11 @@ util::json::object::ptr NeuralNetwork<T>::json() {
     p->add("ninput", m_ninput);
     p->add("noutput", m_noutput);
     p->add("lrate", m_lrate);
+
+    // By name rather than by number, so a saved network stays readable and a
+    // reordering of the enum cannot silently change what a file means.
+    p->add("hidden_activation", name_of(m_hidden_activation));
+    p->add("output_activation", name_of(m_output_activation));
 
     util::json::array::ptr nhidden = util::json::array::create();
     //m_nhidden.foreach([&](T& x) {

--- a/jlib/apps/jneural-alpha.cc
+++ b/jlib/apps/jneural-alpha.cc
@@ -59,6 +59,12 @@ int main(int argc, char** argv) {
     const std::string I = "img";
     uint epochs = 1, train_multi = 1;
     std::string train_path, test_train_path, test_my_path, load_file, output_file, train_mnist_path, test_mnist_path;
+
+    // Hidden and output are named separately because they want different
+    // answers: relu is what lets depth train, and relu on the output of a
+    // classifier scored against 0.01/0.99 targets kills any unit that goes
+    // negative.  See ai::activation.
+    std::string hidden_activation = "sigmoid", output_activation = "sigmoid";
     double train_rate = 0.1;
     int train_decay = -1;
     
@@ -86,6 +92,10 @@ int main(int argc, char** argv) {
             load_file = argv[++i];
         } else if(arg == "--output-file") {
             output_file = argv[++i];
+        } else if(arg == "--hidden-activation") {
+            hidden_activation = argv[++i];
+        } else if(arg == "--output-activation") {
+            output_activation = argv[++i];
         } else if(arg == "--hidden-nodes") {
             HNODES.push_back(std::stoi(argv[++i]));
         } else if(arg == "--output-nodes") {
@@ -105,6 +115,9 @@ int main(int argc, char** argv) {
     
     if(load_file.empty()) {
         nn.reset(new ai::NeuralNetwork<double>(train_rate, INODES, HNODES, ONODES));
+
+        nn->set_hidden_activation(ai::activation_from_name(hidden_activation));
+        nn->set_output_activation(ai::activation_from_name(output_activation));
     } else {
         std::cout << "Loading json output from " << load_file << std::endl;
 

--- a/tests/ai_neural_test.cc
+++ b/tests/ai_neural_test.cc
@@ -281,6 +281,130 @@ static void weights_are_scaled_by_the_fan_in() {
        std::to_string(wih));
 }
 
+static void each_activation_and_its_slope() {
+    std::cout << "\neach activation and its slope:\n";
+
+    using jlib::ai::activation;
+    using jlib::ai::activate;
+    using jlib::ai::activate_slope;
+    using jlib::ai::LEAK;
+
+    matrix<double> x(1, 4);
+    x(0,0) = -2.0; x(0,1) = -0.5; x(0,2) = 0.5; x(0,3) = 2.0;
+
+    const matrix<double> sig = activate(activation::sigmoid, x);
+    const matrix<double> rel = activate(activation::relu, x);
+    const matrix<double> lky = activate(activation::leaky_relu, x);
+    const matrix<double> tnh = activate(activation::tanh, x);
+
+    ok("sigmoid is 1/(1+exp(-x))",
+       std::fabs(sig(0,2) - 1.0/(1.0+std::exp(-0.5))) < 1e-15,
+       std::to_string(sig(0,2)));
+
+    ok("relu zeroes what is negative and passes what is not",
+       rel(0,0) == 0.0 && rel(0,1) == 0.0 && rel(0,2) == 0.5 && rel(0,3) == 2.0);
+
+    ok("leaky relu leans rather than flattens",
+       std::fabs(lky(0,0) - LEAK * -2.0) < 1e-15 && lky(0,3) == 2.0,
+       std::to_string(lky(0,0)));
+
+    ok("tanh is tanh", std::fabs(tnh(0,3) - std::tanh(2.0)) < 1e-15);
+
+    // The slope is taken from the *output*, which is what lets these be
+    // interchangeable without train() caching the pre-activations as well.
+    const matrix<double> dsig = activate_slope(activation::sigmoid, sig);
+    const matrix<double> drel = activate_slope(activation::relu, rel);
+    const matrix<double> dlky = activate_slope(activation::leaky_relu, lky);
+    const matrix<double> dtnh = activate_slope(activation::tanh, tnh);
+
+    ok("sigmoid's slope is s(1-s)",
+       std::fabs(dsig(0,2) - sig(0,2)*(1.0-sig(0,2))) < 1e-15);
+
+    ok("relu's slope is one above zero and nothing at or below",
+       drel(0,0) == 0.0 && drel(0,1) == 0.0 && drel(0,2) == 1.0 && drel(0,3) == 1.0);
+
+    // The reason leaky exists: a unit that has gone negative still has a
+    // gradient, so it can come back.  relu's cannot.
+    ok("leaky relu keeps a slope where relu has none",
+       dlky(0,0) == LEAK && drel(0,0) == 0.0,
+       std::to_string(dlky(0,0)));
+
+    ok("tanh's slope is 1 - s^2",
+       std::fabs(dtnh(0,3) - (1.0 - tnh(0,3)*tnh(0,3))) < 1e-15);
+}
+
+static void the_activation_survives_a_round_trip() {
+    std::cout << "\nthe activation survives a round trip:\n";
+
+    using jlib::ai::activation;
+
+    NeuralNetwork<double> a(0.1, I, hidden(), O);
+
+    ok("both default to sigmoid",
+       a.get_hidden_activation() == activation::sigmoid &&
+       a.get_output_activation() == activation::sigmoid);
+
+    a.set_hidden_activation(activation::relu);
+
+    // Hidden and output are set separately because they want different
+    // answers -- relu hidden with a sigmoid output is the ordinary
+    // arrangement, and relu on the output of a classifier scored against
+    // 0.01/0.99 kills any unit that goes negative.
+    NeuralNetwork<double> b(a.json());
+
+    ok("the hidden choice comes back",
+       b.get_hidden_activation() == activation::relu);
+
+    ok("and the output was not dragged along with it",
+       b.get_output_activation() == activation::sigmoid);
+
+    // Written by name, so reordering the enum cannot silently change what a
+    // saved file means.
+    json::object::ptr p = a.json();
+
+    ok("it is stored by name", std::string(p->get("hidden_activation")) == "relu",
+       std::string(p->get("hidden_activation")));
+
+    // A network saved before these fields existed must still load.  Simulated
+    // by serialising one and cutting the fields back out of the text, which is
+    // what such a file is.
+    std::string text = a.json()->str(false);
+
+    for(const char* key : { "\"hidden_activation\"", "\"output_activation\"" }) {
+        const std::size_t at = text.find(key);
+
+        if(at == std::string::npos) continue;
+
+        std::size_t end = text.find(',', at);
+
+        if(end == std::string::npos) {
+            // Last member: take the preceding comma instead.
+            end = text.rfind(',', at);
+            text.erase(end, text.find('}', at) - end);
+        }
+        else {
+            text.erase(at, end - at + 1);
+        }
+    }
+
+    ok("the fields really are gone from the text",
+       text.find("hidden_activation") == std::string::npos,
+       text.substr(0, 60) + "...");
+
+    NeuralNetwork<double> old(json::object::create(text));
+
+    ok("and a file that predates them loads as sigmoid",
+       old.get_hidden_activation() == activation::sigmoid &&
+       old.get_output_activation() == activation::sigmoid,
+       jlib::ai::name_of(old.get_hidden_activation()));
+
+    bool threw = false;
+    try { jlib::ai::activation_from_name("wibble"); }
+    catch(std::exception&) { threw = true; }
+
+    ok("an unknown name is refused rather than defaulted", threw);
+}
+
 static void a_mismatched_batch_is_refused() {
     std::cout << "\na mismatched batch is refused:\n";
 
@@ -303,6 +427,8 @@ int main() {
     the_gradient_is_a_mean();
     it_is_the_mean_of_the_samples();
     weights_are_scaled_by_the_fan_in();
+    each_activation_and_its_slope();
+    the_activation_survives_a_round_trip();
     a_mismatched_batch_is_refused();
 
     // What a green run does not establish.


### PR DESCRIPTION
# The activation and its derivative travel together

The second half of #131. `m_activation_function` was a `std::function` holding
a sigmoid and looked replaceable; the matching derivative was written out by
hand in `train()` as `out ^ (1.0 - out)` and was not. So replacing the
activation would have trained silently against the wrong slope.

`ai::activation` is an enum -- sigmoid, tanh, relu, leaky_relu -- with
`activate()` and `activate_slope()` beside it. An enum rather than a pair of
`std::function`s because it has to serialise, and a lambda cannot.

**Every one of the four has a derivative expressible from its own output**:
sigmoid `s(1-s)`, tanh `1-s²`, relu `s>0?1:0`, leaky `s>0?1:LEAK`. That is a
lucky fact and the reason this fits: `train()` already caches each layer's
output to build the sigmoid slope, so nothing needed the pre-activations kept
as well.

Hidden and output are chosen separately. Relu on the output of a classifier
scored against 0.01/0.99 targets kills any unit that goes negative -- its slope
there is zero and never recovers -- so hidden relu with a sigmoid output is the
ordinary arrangement and the one measured.

## Measured: relu wins, and the learning rate nearly hid it

MNIST, 60k/10k, 64-wide hidden layers, five epochs.

The first comparison said relu was far *worse*: 23.05% against sigmoid's 94.29%
at one hidden layer. That was the learning rate. Sigmoid squashes into [0,1]
and relu does not, so 0.1 -- the default the sigmoid was tuned around -- is far
too large for it:

```
  1 x 64, relu:  0.1 -> 34.49%   0.01 -> 95.89%   0.003 -> 94.26%   0.001 -> 91.28%
  2 x 64, relu:  0.1 ->  9.80%   0.01 ->  9.80%   0.003 -> 89.92%   0.001 -> 93.03%
```

With the rate chosen per configuration:

```
                sigmoid    relu (best rate)
  1 x 64         94.29%    95.89%  (0.01)      +1.6
  2 x 64         87.39%    93.03%  (0.001)     +5.6
  3 x 64         10.10%    88.08%  (0.0003)    chance -> working
  4 x 64         10.32%     9.80%   still chance
  6 x 64         10.32%     9.80%   still chance
```

**Three hidden layers went from chance to 88%.** The cliff moves from two
layers to three; it does not disappear.

## Four layers: what was ruled out

Four is a wall, and it survived every standard remedy:

- **Learning rate** -- swept 0.1 down to 1e-5, eight values. Best 11.35%.
- **Dead units** -- leaky_relu tracks plain relu exactly at depth: 3 works
  (87.83% at 3e-4), 4 and 6 do not. If units were dying, leaky would rescue
  them, and it does at one layer (86.4% against relu's 23.05% at rate 0.1).
- **He initialisation** -- `sqrt(2/fan)` rather than `sqrt(1/fan)`, the standard
  companion to relu. Identical results including the same 3-layer figure.
- **Training time** -- 4 x 64 at 3e-4 gives 9.8% at both 2 and 10 epochs.

So it is not vanishing gradients, not saturation, not initialisation scale and
not undertraining. Recorded on #131 with #130 named as the remaining suspect,
though at ~0.1% per step it looks far too small to produce a hard floor.

## Backward compatibility

Both activations default to sigmoid, so a network that says nothing behaves as
it did.

**Not bit-identical, though, and worth saying why.** The old expression was
`errors ^ out ^ (1 - out)` and the new one is `errors ^ slope(out)`, which is
`errors ^ (out * (1 - out))`. Floating-point multiplication is not associative:
measured over 200000 random pairs, `(e*f)*(1-f)` and `e*(f*(1-f))` differ in
33% of cases by at most **2.8e-17**. Over 300000 weight updates that compounds
to 94.29% against 94.45% -- same algorithm, different rounding, not a change in
behaviour.

Saved networks gain `hidden_activation` and `output_activation`, written **by
name** so that reordering the enum cannot silently change what a file means. A
file predating the fields loads as sigmoid, and the test proves that by
serialising a network, cutting the fields back out of the text, and reloading
it -- which is what such a file is.

## Tests

`each_activation_and_its_slope` checks all four forwards against their
definitions and all four slopes against theirs, including that leaky keeps a
slope exactly where relu has none -- the property leaky exists for.

`the_activation_survives_a_round_trip` checks the defaults, that setting the
hidden choice does not drag the output along with it, that it is stored by name,
the old-file case above, and that an unknown name is refused rather than
quietly defaulted.

`jneural-alpha` gains `--hidden-activation` and `--output-activation`.

**What a green run does not establish**: any of the MNIST numbers. The tests
check the functions and the plumbing; nothing in `make check` trains on real
data.

## Numbers

macOS: 62 pass, 4 skip, 0 fail. Linux container: 65 pass, 1 skip, 0 fail.
