### PR TITLE
Take every gradient at the weights the step started from, which is what four hidden layers were waiting for

### DIFF
--- a/jlib/ai/neural.hh
+++ b/jlib/ai/neural.hh
@@ -346,18 +346,34 @@ math::matrix<T> NeuralNetwork<T>::train(math::matrix<T> inputs, math::matrix<T> 
     math::matrix<T> output_errors = targets - final_outputs;
     //std::cout << "output_errors[" << output_errors.M << "," << output_errors.N << "] \n" << output_errors << std::endl;
 
+    // Captured before the update, not after.  Closes #130.
+    //
+    // This read m_who *after* adding its own step, so the error arriving at
+    // every layer below had been propagated through weights that already
+    // moved -- and the deep loop repeated it, once per layer.
+    // Backpropagation evaluates every gradient at the weights the step
+    // started from and applies them afterwards.
+    //
+    // It was first measured on a one-hidden-layer network, where the effect
+    // is about 0.1% of a step, and dismissed on that basis.  That was the
+    // wrong measurement: an error that compounds once per layer compounds
+    // least at one layer.  At three and four it is the difference between
+    // learning and not.
+    math::matrix<T> deep = m_who;
+
     m_who += rate * (((output_errors ^ activate_slope(m_output_activation, final_outputs))
                       * deep_outputs.transpose()));
 
     math::matrix<T> deep_errors = output_errors;
-    math::matrix<T> deep = m_who;
-    
-    //for(auto x = m_deep.rbegin(); x != m_deep.rend(); x++) {
+
     for(int i = m_deep.size() - 1; i >= 0; i--) {
         deep_errors = deep.transpose() * deep_errors;
+
+        math::matrix<T> before = m_deep[i];
+
         m_deep[i] += rate * (((deep_errors ^ activate_slope(m_hidden_activation, deep_outputs_cache[i]))
                               * deep_inputs_cache[i].transpose()));
-        deep = m_deep[i];
+        deep = before;
     }
 
     math::matrix<T> hidden_errors = deep.transpose() * deep_errors;

--- a/tests/ai_neural_test.cc
+++ b/tests/ai_neural_test.cc
@@ -180,20 +180,15 @@ static void it_is_the_mean_of_the_samples() {
     const std::vector<double> db = delta(before, weights(b));
     const std::vector<double> dboth = delta(before, weights(both));
 
-    // The output layer's step is exactly the average of the two single steps,
+    // Every layer's step is exactly the average of the two single steps,
     // because all three gradients are taken at the same weights.
     //
-    // The hidden layer's is only close, and that is not a rounding story: it
-    // is 1.5e-6 where the output layer is 5.6e-17.  train() updates m_who and
-    // *then* backpropagates through the updated m_who, so the hidden gradient
-    // is not evaluated at the weights the step started from.  Textbook
-    // backprop takes every gradient at the same weights and applies them
-    // afterwards.  See the issue filed alongside this branch -- it predates
-    // batching, and changing it would change how every existing network
-    // trains, so it is recorded rather than fixed here.
-    //
-    // The split is asserted rather than glossed, so that if anyone does fix
-    // it, this test says which half was already right.
+    // The hidden half of this used to be only *close* -- 1.5e-6 where the
+    // output layer was 5.6e-17 -- because train() updated m_who and then
+    // backpropagated through the updated m_who (#130).  The two halves are
+    // still asserted separately rather than together: the output layer was
+    // right all along, and keeping them apart is what made the difference
+    // between them visible in the first place.
     std::vector<double> mean_who, batch_who, mean_wih, batch_wih;
 
     for(std::size_t i = 0; i < da.size(); i++) {
@@ -209,9 +204,11 @@ static void it_is_the_mean_of_the_samples() {
     ok("the output layer's step is exactly the average", wo < 1e-14,
        "worst difference " + std::to_string(wo));
 
-    ok("the hidden layer's is close but not exact", wi > 1e-12 && wi < 1e-3,
-       "worst difference " + std::to_string(wi) +
-       " -- backprop goes through the already-updated m_who");
+    // 1e-14 rather than 0: the two sides reach the same value by different
+    // routes -- one averages two products, the other averages inside the
+    // gradient -- so last-bit rounding is allowed and 1.5e-6 is not.
+    ok("and so is the hidden layer's, which it was not before #130", wi < 1e-14,
+       "worst difference " + std::to_string(wi));
 
     // And it is not the same as taking them one after the other, which is a
     // different algorithm rather than a slower version of the same one.


### PR DESCRIPTION
# Backpropagate through the weights the step started from

Closes #130.

`train()` applied each layer's update and then read that layer's weights to
propagate the error further back:

```cpp
m_who += rate * (...);
math::matrix<T> deep = m_who;        // after the update
```

and the deep loop repeated it, once per layer. So the error arriving at every
layer below had been propagated through weights that had already moved.
Backpropagation evaluates every gradient at the weights the step started from
and applies them afterwards.

The fix captures before updating -- one extra matrix copy per layer per step,
which against the multiplies around it is nothing.

## I dismissed this, and the dismissal was the interesting part

#130 was filed with a measurement: on a one-hidden-layer network the deviation
is about **0.1% of one step**, first-order in the learning rate. I called it a
perturbed descent direction rather than a wrong one and said it would not make
deep networks train.

That was the wrong measurement. **An error that compounds once per layer
compounds least at one layer**, and one layer is where I measured it. The
quantity I reported was true and had no bearing on the question I used it to
answer.

Measured at depth, MNIST, relu hidden layers, 64 wide, two epochs:

```
                    before                     after
  rate:     0.003   0.001  0.0003     0.003   0.001  0.0003
  3 x 64     9.8%    9.8%  88.08%    96.06%  94.29%  88.34%
  4 x 64     9.8%    9.8%   9.80%     9.80%   9.80%  70.21%
  6 x 64     9.8%    9.8%   9.80%     9.80%   9.80%   9.80%
```

**Three hidden layers: 88.08% to 96.06%**, and it now trains at a learning rate
ten times larger -- 0.003 was previously chance. **Four hidden layers: chance to
70.21%.** The wall the activation work in #131 could not break moves out by one
layer as soon as this is fixed.

So the three problems in this area were not comparable in size after all. The
fan-in initialisation was worth 4.6 points at two layers; the activation moved
the cliff from two layers to three; this moves it from three to four and is
worth eight points at three. It was the largest of them and I had it ranked last.

## The test was already written to catch this

`it_is_the_mean_of_the_samples` asserted that a batch of two is the average of
two single steps -- exactly true for the output layer, and 1.5e-6 out for the
hidden layer. That split was asserted rather than glossed, specifically so that
whoever fixed this would see which half was already right.

It failed on this branch, which is what it was for. It now asserts both halves
exact, with a 1e-14 bound rather than zero: the two sides reach the same value
by different routes -- one averages two products, the other averages inside the
gradient -- so last-bit rounding is allowed and 1.5e-6 is not.

## What this does not fix

Six layers is still chance at every rate tried. That is a third thing, after
the initialisation and the activation, and #131 now carries the list of what
has been ruled out for it: learning rate across eight values, dead units
(leaky_relu tracks plain relu at depth), He initialisation, and training time.

Also worth recording, from a sweep run while this was being measured: at four
layers a **widening** architecture beats a uniform one by a wide margin --
64-128-128-64 reaches 92.85% where 64-64-64-64 reaches 70.21%, and at a
learning rate three times larger. Uniform widths are also the one case where
the `m_deep` half of the fan-in bug was invisible, since `1/sqrt(n[i])` and
`1/sqrt(n[i-1])` coincide there. Anyone benchmarking this network should vary
the widths.

## Caveats on the numbers

Two epochs, one seed, one width, and `jneural-alpha` is default-seeded, so each
cell is a single deterministic run rather than an average. The direction and
magnitude are not in doubt -- chance to 70% is not a sampling artefact -- but
they are not benchmarks.

## Numbers

macOS: 62 pass, 4 skip, 0 fail. Linux container: 65 pass, 1 skip, 0 fail.
