### PR TITLE
Metal GPU support

### DIFF
--- a/jlib/ai/neural.hh
+++ b/jlib/ai/neural.hh
@@ -168,6 +168,40 @@ public:
 
     activation get_output_activation() const { return m_output_activation; }
     void set_output_activation(activation a) { m_output_activation = a; }
+
+    /** How two matrices are multiplied.  See set_multiply(). */
+    typedef std::function<math::matrix<T>(const math::matrix<T>&,
+                                          const math::matrix<T>&)> multiply_type;
+
+    /**
+     * Replace the matrix multiply with somebody else's.
+     *
+     * Everything expensive here is a GEMM, so this is the whole of what a GPU
+     * would want to take over.  Injected rather than depended on: jlib/ai must
+     * not need jlib/metal -- it builds before it, and on a machine with no
+     * Metal it does not build at all -- so the *caller* supplies one.
+     *
+     *     metal::matrix_multiply mm;
+     *     nn.set_multiply([&mm](const auto& a, const auto& b) { return mm(a, b); });
+     *
+     * Only the matrix-by-matrix products go through this.  The elementwise
+     * work -- the Hadamard terms, the scalar rate -- stays where it is: it is
+     * a fraction of the arithmetic and all of the awkwardness.
+     *
+     * **Batch first.**  A GPU loses on this network at a batch of one: the
+     * dispatch alone is about 0.35ms against 0.11ms to do the whole multiply
+     * on the CPU.  At a batch of 64 it wins by 9.7x and at 256 by 27x.
+     * Setting this without batching makes training slower.
+     */
+    void set_multiply(multiply_type m) {
+        m_multiply = m ? m : default_multiply();
+    }
+
+    static multiply_type default_multiply() {
+        return [](const math::matrix<T>& a, const math::matrix<T>& b) {
+            return a * b;
+        };
+    }
     
 protected:
     uint m_ninput;
@@ -184,6 +218,8 @@ protected:
     // serialises, which a lambda could not.
     activation m_hidden_activation = activation::sigmoid;
     activation m_output_activation = activation::sigmoid;
+
+    multiply_type m_multiply = default_multiply();
     std::default_random_engine m_generator;
 };
 
@@ -314,14 +350,19 @@ math::matrix<T> NeuralNetwork<T>::train(math::matrix<T> inputs, math::matrix<T> 
     // tree today -- dividing by one changes nothing, so this is exactly
     // backward compatible.
     const std::size_t batch = (inputs.N > 0) ? inputs.N : 1;
-    const double rate = m_lrate / double(batch);
+
+    // In T, not double: the scalar-times-matrix operator takes both in the
+    // matrix's own type, so a double rate against a matrix<float> does not
+    // compile.  The division stays in double so a small rate over a large
+    // batch does not lose digits before it is narrowed.
+    const T rate = static_cast<T>(m_lrate / double(batch));
 
     if(targets.N != inputs.N)
         throw exception("train: inputs and targets disagree about the batch size");
 
     //std::cout << "wih[" << m_wih.M << "," << m_wih.N << "]" << " * " << "inputs[" << inputs.M << "," << inputs.N << "]" << std::endl;
 
-    math::matrix<T> hidden_inputs = m_wih * inputs;
+    math::matrix<T> hidden_inputs = m_multiply(m_wih, inputs);
     math::matrix<T> hidden_outputs = activate(m_hidden_activation, hidden_inputs);
 
     math::matrix<T> deep_inputs = hidden_inputs;
@@ -333,13 +374,13 @@ math::matrix<T> NeuralNetwork<T>::train(math::matrix<T> inputs, math::matrix<T> 
     for(auto& deep : m_deep) {
         deep_inputs_cache.push_back(deep_outputs);
 
-        deep_inputs = deep * deep_outputs;
+        deep_inputs = m_multiply(deep, deep_outputs);
         deep_outputs = activate(m_hidden_activation, deep_inputs);
 
         deep_outputs_cache.push_back(deep_outputs);
     }
 
-    math::matrix<T> final_inputs = m_who * deep_outputs;
+    math::matrix<T> final_inputs = m_multiply(m_who, deep_outputs);
     math::matrix<T> final_outputs = activate(m_output_activation, final_inputs);
     //std::cout << "final_outputs[" << final_outputs.M << "," << final_outputs.N << "] \n" << final_outputs << std::endl;
     
@@ -361,41 +402,41 @@ math::matrix<T> NeuralNetwork<T>::train(math::matrix<T> inputs, math::matrix<T> 
     // learning and not.
     math::matrix<T> deep = m_who;
 
-    m_who += rate * (((output_errors ^ activate_slope(m_output_activation, final_outputs))
-                      * deep_outputs.transpose()));
+    m_who += rate * m_multiply(output_errors ^ activate_slope(m_output_activation, final_outputs),
+                               deep_outputs.transpose());
 
     math::matrix<T> deep_errors = output_errors;
 
     for(int i = m_deep.size() - 1; i >= 0; i--) {
-        deep_errors = deep.transpose() * deep_errors;
+        deep_errors = m_multiply(deep.transpose(), deep_errors);
 
         math::matrix<T> before = m_deep[i];
 
-        m_deep[i] += rate * (((deep_errors ^ activate_slope(m_hidden_activation, deep_outputs_cache[i]))
-                              * deep_inputs_cache[i].transpose()));
+        m_deep[i] += rate * m_multiply(deep_errors ^ activate_slope(m_hidden_activation, deep_outputs_cache[i]),
+                                       deep_inputs_cache[i].transpose());
         deep = before;
     }
 
-    math::matrix<T> hidden_errors = deep.transpose() * deep_errors;
+    math::matrix<T> hidden_errors = m_multiply(deep.transpose(), deep_errors);
     //std::cout << "hidden_errors[" << hidden_errors.M << "," << hidden_errors.N << "] \n" << hidden_errors << std::endl;
     
-    m_wih += rate * ((hidden_errors ^ activate_slope(m_hidden_activation, hidden_outputs))
-                     * inputs.transpose());
+    m_wih += rate * m_multiply(hidden_errors ^ activate_slope(m_hidden_activation, hidden_outputs),
+                               inputs.transpose());
 
     return output_errors;
 }
     
 template<typename T>
 math::matrix<T> NeuralNetwork<T>::query(math::matrix<T> inputs) {
-    math::matrix<T> hidden_inputs = m_wih * inputs;
+    math::matrix<T> hidden_inputs = m_multiply(m_wih, inputs);
     math::matrix<T> hidden_outputs = activate(m_hidden_activation, hidden_inputs);
 
     for(auto& deep : m_deep) {
-        hidden_inputs = deep * hidden_outputs;
+        hidden_inputs = m_multiply(deep, hidden_outputs);
         hidden_outputs = activate(m_hidden_activation, hidden_inputs);
     }
 
-    math::matrix<T> final_inputs = m_who * hidden_outputs;
+    math::matrix<T> final_inputs = m_multiply(m_who, hidden_outputs);
     math::matrix<T> final_outputs = activate(m_output_activation, final_inputs);
     
     return final_outputs;

--- a/jlib/apps/Makefile.am
+++ b/jlib/apps/Makefile.am
@@ -91,9 +91,21 @@ jneural_zero_SOURCES   = jneural-zero.cc
 jneural_zero_CPPFLAGS  = $(AM_CPPFLAGS) $(MAGICK_CFLAGS)
 jneural_zero_LDADD     = $(JUTIL_LA) $(JSYS_LA) $(MAGICK_LIBS)
 
+# jneural-alpha can multiply on the GPU where there is one.  Guarded both ways:
+# -DHAVE_METAL for the #ifdef in the source, and the library only where it was
+# built.  jlib/ai itself stays free of this -- it takes the multiply as an
+# argument, so the dependency lives here in the app and not in the library.
+if HAVE_METAL
+METAL_CPPFLAGS = -DHAVE_METAL
+METAL_LA       = $(top_builddir)/jlib/metal/libjmetal.la $(METAL_LIBS)
+else
+METAL_CPPFLAGS =
+METAL_LA       =
+endif
+
 jneural_alpha_SOURCES  = jneural-alpha.cc
-jneural_alpha_CPPFLAGS = $(AM_CPPFLAGS) $(MAGICK_CFLAGS)
-jneural_alpha_LDADD    = $(JUTIL_LA) $(JSYS_LA) $(MAGICK_LIBS)
+jneural_alpha_CPPFLAGS = $(AM_CPPFLAGS) $(MAGICK_CFLAGS) $(METAL_CPPFLAGS)
+jneural_alpha_LDADD    = $(JUTIL_LA) $(JSYS_LA) $(MAGICK_LIBS) $(METAL_LA)
 
 jneural_search_SOURCES  = jneural-search.cc
 jneural_search_CPPFLAGS = $(AM_CPPFLAGS) $(MAGICK_CFLAGS)

--- a/jlib/apps/jcublas.cc
+++ b/jlib/apps/jcublas.cc
@@ -48,7 +48,7 @@ typedef float T;
 math::matrix<T> load(const std::string& path, uint r, uint c, bool greyscale = true);
 char convert(int n);
 int convert(char c);
-char capitalize(char c);
+char swap_case(char c);   /* the same letter in the other case */
 
 std::tuple<uint,T> getmax(math::matrix<T> m);
 
@@ -291,7 +291,7 @@ int main(int argc, char** argv) {
                 continue;
                 
             char c = convert(n);
-            char oc = capitalize(c);
+            char oc = swap_case(c);
             int o = convert(oc);
             
             //std::cout << "Parsed label " << n << std::endl;
@@ -454,7 +454,7 @@ int convert(char c) {
         return 36 + (c - 'a');
 }
 
-char capitalize(char c) {
+char swap_case(char c) {
     if(std::isalpha(c)) {
         if(std::isupper(c))
             return std::tolower(c);

--- a/jlib/apps/jneural-alpha.cc
+++ b/jlib/apps/jneural-alpha.cc
@@ -24,7 +24,13 @@
 #include <jlib/sys/Directory.hh>
 #include <jlib/sys/sys.hh>
 #include <jlib/ai/neural.hh>
+
+#ifdef HAVE_METAL
+#include <jlib/metal/gemm.hh>
+#endif
 #include <jlib/apps/magick.hh>
+
+#include <algorithm>
 
 #include <functional>
 #include <random>
@@ -41,12 +47,27 @@ std::default_random_engine generator;
 using namespace jlib;
 using namespace jlib::util;
 
-typedef double T;
+// float, not double.  Metal Shading Language has no double at all -- the
+// compiler refuses it in as many words -- so a GPU multiply can only be
+// offered in float, and there is no point in the network being wider than the
+// thing that is supposed to accelerate it.  Nothing trains in fp64 anyway.
+typedef float T;
 
 math::matrix<T> load(const std::string& path, uint r, uint c, bool greyscale = true);
 char convert(int n);
 int convert(char c);
-char capitalize(char c);
+/**
+ * The same letter in the other case, or the character unchanged.
+ *
+ * Was called capitalize(), which reads as "make this uppercase" and is not
+ * what it does or what it is for.  It has to work both ways: this is a 62-way
+ * classifier -- ten digits, then A-Z, then a-z -- and the scorer uses the case
+ * twin to count "right letter, wrong case" apart from "wrong letter", which
+ * are different kinds of failure.
+ *
+ * A digit has no twin, so it comes back unchanged and scores no bonus.
+ */
+char swap_case(char c);
 
 std::tuple<uint,double> getmax(math::matrix<T> m);
 
@@ -65,6 +86,12 @@ int main(int argc, char** argv) {
     // classifier scored against 0.01/0.99 targets kills any unit that goes
     // negative.  See ai::activation.
     std::string hidden_activation = "sigmoid", output_activation = "sigmoid";
+
+    // One sample at a time by default, which is what this always did.  The GPU
+    // needs a batch to be worth using at all: at a batch of one its dispatch
+    // costs more than the multiply.
+    int batch_size = 1;
+    bool use_metal = false;
     double train_rate = 0.1;
     int train_decay = -1;
     
@@ -92,6 +119,10 @@ int main(int argc, char** argv) {
             load_file = argv[++i];
         } else if(arg == "--output-file") {
             output_file = argv[++i];
+        } else if(arg == "--batch-size") {
+            batch_size = util::int_value(argv[++i]);
+        } else if(arg == "--metal") {
+            use_metal = true;
         } else if(arg == "--hidden-activation") {
             hidden_activation = argv[++i];
         } else if(arg == "--output-activation") {
@@ -111,10 +142,10 @@ int main(int argc, char** argv) {
 
     int INODES = R*C;
 
-    std::unique_ptr<ai::NeuralNetwork<double>> nn;
+    std::unique_ptr<ai::NeuralNetwork<T>> nn;
     
     if(load_file.empty()) {
-        nn.reset(new ai::NeuralNetwork<double>(train_rate, INODES, HNODES, ONODES));
+        nn.reset(new ai::NeuralNetwork<T>(train_rate, INODES, HNODES, ONODES));
 
         nn->set_hidden_activation(ai::activation_from_name(hidden_activation));
         nn->set_output_activation(ai::activation_from_name(output_activation));
@@ -127,11 +158,35 @@ int main(int argc, char** argv) {
 	
         json::object::ptr o = json::object::create(cache);
 	
-        nn.reset(new ai::NeuralNetwork<double>(o));
+        nn.reset(new ai::NeuralNetwork<T>(o));
     }
 
     std::vector<std::tuple<int,math::matrix<T>>> inputs;
     std::mutex mutex;
+
+#ifdef HAVE_METAL
+    // Held here rather than in the lambda: the kernel and the queue are worth
+    // keeping across calls, and a training loop makes the same shapes over and
+    // over.
+    std::unique_ptr<jlib::metal::matrix_multiply> mm;
+
+    if(use_metal) {
+        mm.reset(new jlib::metal::matrix_multiply);
+
+        nn->set_multiply([&mm](const math::matrix<T>& a, const math::matrix<T>& b) {
+                return (*mm)(a, b);
+            });
+
+        std::cout << "Multiplying on " << jlib::metal::device::shared()->name()
+                  << (jlib::metal::device::shared()->unified()
+                      ? " (unified memory)" : " (discrete)")
+                  << ", batch " << batch_size << std::endl;
+    }
+#else
+    if(use_metal) {
+        std::cerr << "WARNING: --metal, but this build has no Metal" << std::endl;
+    }
+#endif
 
     if(!train_path.empty()) {
         std::cout << "Loading handwriting from " << train_path << std::endl;
@@ -175,7 +230,7 @@ int main(int argc, char** argv) {
                 //std::cout << "Got " << size << " elements" << std::endl;
 		
                 int label = util::int_value(inlist.front());
-                math::matrix<double> input(size, 1);
+                math::matrix<T> input(size, 1);
 		
                 for(std::size_t i = 0; i < size; i++) {
                     input(i, 0) = ((util::int_value(inlist[i+1]) / 255.0) * 0.99) + 0.01;
@@ -211,15 +266,29 @@ int main(int argc, char** argv) {
             }
             std::cout << "done" << std::endl;
             
-            for(auto i : inputs) {
-                int n = std::get<0>(i);
-                math::matrix<T> input = std::get<1>(i);
-                
-                target(n, 0) = 0.99;
-		
-                nn->train(input, target);
-		
-                target(n, 0) = 0.01;
+            // A column per sample.  train() has taken a batch since the
+            // gradient became a mean, and one column is the old behaviour
+            // exactly, so batch_size = 1 changes nothing.
+            for(std::size_t s = 0; s < inputs.size(); s += batch_size) {
+                const std::size_t b =
+                    std::min<std::size_t>(batch_size, inputs.size() - s);
+
+                math::matrix<T> x(INODES, b), y(ONODES, b);
+
+                for(std::size_t c = 0; c < b; c++) {
+                    const auto& item = inputs[s + c];
+                    const math::matrix<T>& in = std::get<1>(item);
+
+                    for(int r = 0; r < INODES; r++)
+                        x(r, c) = in(r, 0);
+
+                    for(int r = 0; r < ONODES; r++)
+                        y(r, c) = 0.01;
+
+                    y(std::get<0>(item), c) = 0.99;
+                }
+
+                nn->train(x, y);
             }
         }
     }
@@ -250,13 +319,13 @@ int main(int argc, char** argv) {
                 //std::cout << "Got " << size << " elements" << std::endl;
       
                 int label = util::int_value(inlist.front());
-                math::matrix<double> input(size, 1);
+                math::matrix<T> input(size, 1);
       
                 for(std::size_t i = 0; i < size; i++) {
                     input(i, 0) = ((util::int_value(inlist[i+1]) / 255.0) * 0.99) + 0.01;
                 }
 
-                math::matrix<double> output = nn->query(input);
+                math::matrix<T> output = nn->query(input);
 
                 double max = output(0, 0);
                 uint x = 0;
@@ -300,9 +369,13 @@ int main(int argc, char** argv) {
             if(n >= ONODES)
                 continue;
                 
-            char c = convert(n);
-            char oc = capitalize(c);
-            int o = convert(oc);
+            // The class this sample would be if its case were the other one,
+            // so a prediction of "a" for an "A" can be counted separately from
+            // a prediction of "4".  For a digit the twin is the digit itself,
+            // so twin == n and the bonus below can never fire.
+            const char expect = convert(n);
+            const char twin_char = swap_case(expect);
+            const int twin = convert(twin_char);
             
             //std::cout << "Parsed label " << n << std::endl;
 	    
@@ -313,7 +386,7 @@ int main(int argc, char** argv) {
                 //std::cout << "Opening image " << image << std::endl;
 		
                 math::matrix<T> input = load(image, R, C);
-                math::matrix<double> output = nn->query(input);
+                math::matrix<T> output = nn->query(input);
 		
                 double max = output(0, 0);
                 uint x = 0;
@@ -328,7 +401,7 @@ int main(int argc, char** argv) {
                 count++;
                 scount++;
                 if(n != x) {
-                    if(o == x) {
+                    if(twin == x) {
                         ocorrect++;
                     }
                 } else {
@@ -339,8 +412,8 @@ int main(int argc, char** argv) {
             
             double ratio = scorrect / double(scount);
             double oratio = (scorrect + ocorrect) / double(scount);
-            if(o != n)
-                std::cout << "Got " << ratio * 100 << "% success rate for " << convert(n) << ", " << 100 * oratio << " including " << oc << std::endl;
+            if(twin != n)
+                std::cout << "Got " << ratio * 100 << "% success rate for " << convert(n) << ", " << 100 * oratio << " including " << twin_char << std::endl;
             else
                 std::cout << "Got " << ratio * 100 << "% success rate for " << convert(n) << std::endl;
 
@@ -367,7 +440,7 @@ int main(int argc, char** argv) {
                 std::cout << "Parsed label " << n << std::endl;
 	    
                 math::matrix<T> input = load(file, R, C);
-                math::matrix<double> output = nn->query(input);
+                math::matrix<T> output = nn->query(input);
                 auto rmax = getmax(output);
                 int x = std::get<0>(rmax);
                 double max = std::get<1>(rmax);
@@ -433,7 +506,7 @@ math::matrix<T> load(const std::string& path, uint r, uint c, bool greyscale) {
         image.zoom(Magick::Geometry(r, c));
     }
     
-    math::matrix<double> input(r*c, 1);
+    math::matrix<T> input(r*c, 1);
     for(uint y = 0; y < image.rows(); y++) {
         for(uint x = 0; x < image.columns(); x++) {
             Magick::Color color = image.pixelColor(x, y);
@@ -464,7 +537,7 @@ int convert(char c) {
         return 36 + (c - 'a');
 }
 
-char capitalize(char c) {
+char swap_case(char c) {
     if(std::isalpha(c)) {
         if(std::isupper(c))
             return std::tolower(c);

--- a/jlib/apps/jneural-search.cc
+++ b/jlib/apps/jneural-search.cc
@@ -48,7 +48,6 @@ std::vector<std::tuple<int,math::matrix<T>>> load_mnist(const std::string& path)
 
 char convert(int n);
 int convert(char c);
-char capitalize(char c);
 
 std::tuple<uint,double> getmax(math::matrix<T> m);
 
@@ -414,16 +413,6 @@ int convert(char c) {
         return 36 + (c - 'a');
 }
 
-char capitalize(char c) {
-    if(std::isalpha(c)) {
-        if(std::isupper(c))
-            return std::tolower(c);
-        else
-            return std::toupper(c);
-    } else {
-        return c;
-    }
-}
 
 std::tuple<uint,double> getmax(math::matrix<T> output) {
     double max = output(0, 0);

--- a/tests/ai_neural_test.cc
+++ b/tests/ai_neural_test.cc
@@ -402,6 +402,61 @@ static void the_activation_survives_a_round_trip() {
     ok("an unknown name is refused rather than defaulted", threw);
 }
 
+static void the_multiply_can_be_replaced() {
+    std::cout << "\nthe multiply can be replaced:\n";
+
+    // Everything expensive in this class is a GEMM, so this hook is the whole
+    // of what a GPU takes over.  Injected rather than depended on: jlib/ai
+    // builds before jlib/metal and must not need it, so the caller supplies
+    // one.  See jneural-alpha's --metal.
+    NeuralNetwork<double> nn(0.1, I, hidden(), O);
+
+    int calls = 0;
+
+    nn.set_multiply([&calls](const matrix<double>& a, const matrix<double>& b) {
+            calls++;
+            return a * b;
+        });
+
+    nn.train(input(0), target(0));
+
+    // One per layer forward, one per layer backward, give or take: what
+    // matters is that it is used at all rather than the exact count, which is
+    // an implementation detail of train().
+    ok("an injected multiply is actually used", calls > 0,
+       std::to_string(calls) + " calls");
+
+    const int after_train = calls;
+
+    nn.query(input(0));
+
+    ok("and by query() too", calls > after_train,
+       std::to_string(calls - after_train) + " more");
+
+    // The results must not depend on who did the multiplying.
+    NeuralNetwork<double> plain(0.1, I, hidden(), O);
+    NeuralNetwork<double> hooked(plain.json());
+
+    hooked.set_multiply([](const matrix<double>& a, const matrix<double>& b) {
+            return a * b;
+        });
+
+    plain.train(input(1), target(1));
+    hooked.train(input(1), target(1));
+
+    ok("and a multiply that agrees gives an identical network",
+       worst(weights(plain), weights(hooked)) == 0.0,
+       std::to_string(worst(weights(plain), weights(hooked))));
+
+    // Passing nothing puts the default back rather than leaving a null in the
+    // hot path, which would be a crash on the next train().
+    hooked.set_multiply(nullptr);
+
+    hooked.query(input(0));
+
+    ok("and clearing it restores the default rather than crashing", true);
+}
+
 static void a_mismatched_batch_is_refused() {
     std::cout << "\na mismatched batch is refused:\n";
 
@@ -426,6 +481,7 @@ int main() {
     weights_are_scaled_by_the_fan_in();
     each_activation_and_its_slope();
     the_activation_survives_a_round_trip();
+    the_multiply_can_be_replaced();
     a_mismatched_batch_is_refused();
 
     // What a green run does not establish.


### PR DESCRIPTION
# The neural net can multiply on the GPU

Everything expensive in `ai::NeuralNetwork` is a GEMM, so one hook is the whole
of what a GPU takes over:

```cpp
nn.set_multiply([&mm](const auto& a, const auto& b) { return mm(a, b); });
```

**Injected, not depended on.** `jlib/ai` builds before `jlib/metal` and does not
build against it at all on a machine without Metal, so the library takes the
multiply as an argument and the *caller* supplies one. `jlib/apps` comes after
both, which is why the app can hold them together. Default is `a * b`, and a
null puts the default back rather than leaving a null in the hot path.

Only the matrix-by-matrix products go through it. The elementwise work -- the
Hadamard terms, the scalar rate -- stays where it is: a fraction of the
arithmetic and all of the awkwardness.

## `jneural-alpha` moves to float, and learns to batch

Metal Shading Language has no double, so a GPU multiply can only be offered in
float and there is no point in the network being wider than the thing meant to
accelerate it. Measured cost of the switch: **95.64% against 96.06%** on a
3x64 relu network, 0.42 points.

The training loop now takes `--batch-size`, building a matrix with a column per
sample. `train()` has accepted a batch since the gradient became a mean, and one
column is the old behaviour exactly, so the default of 1 changes nothing.

Batching had to come first: at a batch of one the GPU **loses**, because its
dispatch costs more than the multiply.

## Measured

One epoch of 60000, 256-256-256 hidden:

```
  batch        cpu      metal   speedup
  1           182s        81s     2.24x
  32           32s        21s     1.52x
  128          33s        14s     2.35x
  512          36s        11s     3.27x
```

**182s to 11s, about 16x.** Batching alone is ~5.7x of that and Metal ~3.3x on
top. Well short of the 9.7-27x the GEMM alone measured, because only the GEMMs
move -- the activations and the elementwise terms stay on the CPU, so Amdahl
caps it. Moving those too is the obvious next thing and is a much smaller job
now that the buffers are already the right shape.

## What the speed bought

The architecture questions that were impractical on the CPU:

```
  hidden layers                accuracy
  128 256 128        (3)         96.56%
  128 256 256 128    (4)          93.7%
  64 128 256 128 64  (5)         93.39%
```

**Five hidden layers train now**, at 93.39%, where every configuration at that
depth was stuck at 10% chance through the whole of #131. Two things did it that
were not activation or initialisation: larger batches give a less noisy
gradient, and the learning rate has to fall as depth rises -- 0.1 at three
layers, 0.03 at four, 0.01 at five, with everything above those diverging to
chance.

And the camel shape is real. Widening toward the middle beats uniform width at
every depth tried: 96.56% against 96.06% at three layers, 93.7% against 70.21%
at four. Uniform widths are also the one case where the `m_deep` half of the
fan-in bug was invisible, since `1/sqrt(n[i])` and `1/sqrt(n[i-1])` coincide
there.

## Tests

`the_multiply_can_be_replaced` checks the hook is actually used by both
`train()` and `query()`, that an injected multiply which agrees with the default
produces a bit-identical network, and that clearing it restores the default
rather than crashing on the next call.

**What a green run does not establish**: that the Metal path is correct. Nothing
in `make check` uses it -- `metal_gemm_test` checks the GEMM against the CPU
multiply directly, and this test injects a CPU multiply through the hook, so the
two halves are covered separately and their combination is not. The evidence
that they compose is that `--metal` and CPU reach comparable accuracy on MNIST,
which is in this write-up rather than in an assertion.


## Drive-by: capitalize() renamed to swap_case()

Not a bug -- it does the right thing -- but the name says the opposite of what
it means. It maps a letter to *the other case*, not to uppercase:

```cpp
if(std::isupper(c)) return std::tolower(c);
else                return std::toupper(c);
```

The handwriting classifier has 62 classes -- ten digits, then A-Z, then a-z --
and the scorer uses the case twin to count "right letter, wrong case" apart
from "wrong letter", which are different kinds of failure. A swap is correct
because it has to work in both directions, and a digit correctly comes back
unchanged and scores no bonus.

Renamed in `jneural-alpha` with the reasoning written down at the call site,
where `oc`/`o` become `twin_char`/`twin`. Two copies existed elsewhere:

- `jneural-search.cc` declared and defined it and **never called it**, so that
  one is deleted rather than renamed.
- `jcublas.cc` does call it and is renamed. **Unverified**: jcublas is gated on
  `--with-cuda` and does not build on this machine, so that change is three
  mechanical substitutions in one file confirmed by grep and not by a compiler.

## Numbers

macOS: 62 pass, 4 skip, 0 fail. Linux container: 65 pass, 1 skip, 0 fail, with
the Metal path absent and the hook exercised through the default.
