### PR TITLE
Keep tensors on the GPU

### DIFF
--- a/jlib/math/matrix.hh
+++ b/jlib/math/matrix.hh
@@ -561,7 +561,13 @@ template<typename T>
 inline
 matrix<T> operator+(const matrix<T>& a, const matrix<T>& b) {
     if(a.M != b.M || a.N != b.N)
-        throw matrix<T>::mismatch();
+        // typename, and mismatched rather than mismatch.  Without the first
+        // this does not compile at all -- which nothing noticed, because
+        // adding two matrices had never been instantiated anywhere in the
+        // library or its tests.  The second is for the message: operator* and
+        // operator^ two hundred lines up both report the shapes, and a bare
+        // std::exception from the third binary operator is no use to anyone.
+        throw typename matrix<T>::mismatched(a.M, a.N, b.M, b.N);
 
     matrix<T> ret(a.M, a.N);
     for(uint i = 0; i < a.M; i++) {

--- a/jlib/metal/Makefile.am
+++ b/jlib/metal/Makefile.am
@@ -5,7 +5,7 @@ AM_CPPFLAGS = -I$(top_srcdir)
 
 lib_LTLIBRARIES = libjmetal.la
 
-libjmetal_la_SOURCES = device.mm gemm.mm
+libjmetal_la_SOURCES = device.mm gemm.mm tensor.mm
 noinst_HEADERS       = impl.hh
 libjmetal_la_LDFLAGS = -version-info $(LIBJ_SO_VERSION) -release $(JLIB_RELEASE) -no-undefined
 libjmetal_la_LIBADD  = $(METAL_LIBS)
@@ -15,4 +15,4 @@ libjmetal_la_LIBADD  = $(METAL_LIBS)
 libjmetal_la_OBJCXXFLAGS = $(AM_OBJCXXFLAGS) -fobjc-arc -std=c++20
 
 libjmetalincludedir = $(includedir)/jlib-1.2/jlib/metal
-libjmetalinclude_HEADERS = device.hh gemm.hh
+libjmetalinclude_HEADERS = device.hh gemm.hh tensor.hh

--- a/jlib/metal/device.hh
+++ b/jlib/metal/device.hh
@@ -96,6 +96,8 @@ private:
     std::unique_ptr<impl> m_impl;
 
     friend class matrix_multiply;
+    friend class tensor;
+    friend class stream;
 };
 
 }

--- a/jlib/metal/tensor.hh
+++ b/jlib/metal/tensor.hh
@@ -1,0 +1,198 @@
+/* -*- mode: C++ c-basic-offset: 4 -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef JLIB_METAL_TENSOR_HH
+#define JLIB_METAL_TENSOR_HH
+
+#include <jlib/metal/device.hh>
+
+#include <jlib/math/matrix.hh>
+
+#include <memory>
+#include <string>
+
+namespace jlib {
+namespace metal {
+
+/**
+ * Which nonlinearity a kernel applies.
+ *
+ * Deliberately its own enum rather than ai::activation.  jlib/metal builds
+ * after jlib/ai and could name it, but a GPU backend depending on the neural
+ * library is the wrong way round: this layer knows about numbers, not about
+ * networks.  Four enumerators is a cheap duplication and the values are
+ * asserted equal in the test.
+ */
+enum class activation { sigmoid, tanh, relu, leaky_relu };
+
+/** The slope a leaky ReLU keeps below zero.  Matches ai::LEAK. */
+inline constexpr float LEAK = 0.01f;
+
+/**
+ * A matrix that lives on the GPU.
+ *
+ * The whole reason this exists.  gemm.hh takes math::matrix, so every call
+ * uploads its operands, computes, waits, and downloads the result -- and a
+ * training step makes about eight of those, so the data crosses the boundary
+ * sixteen times per step to do work that never needed to leave.  Profiling a
+ * Metal-accelerated network showed the time inside matrix_multiply rather than
+ * in the arithmetic around it, which is what that costs.
+ *
+ * A tensor is uploaded once and stays.  read() is deliberately explicit and
+ * deliberately awkward: it is the expensive thing, and it should look like it.
+ *
+ * Column-major, matching math::matrix -- see stream::multiply for why that
+ * costs nothing.
+ */
+class tensor {
+public:
+    class exception : public std::exception {
+    public:
+        exception(const std::string& msg = "") {
+            m_msg = "jlib::metal::tensor exception" + (msg.empty() ? "" : ": " + msg);
+        }
+        virtual ~exception() {}
+        virtual const char* what() const noexcept { return m_msg.c_str(); }
+    protected:
+        std::string m_msg;
+    };
+
+    /** Uninitialised, on the device. */
+    tensor(std::shared_ptr<device> d, unsigned int rows, unsigned int cols);
+
+    /** Uploaded from the host. */
+    tensor(std::shared_ptr<device> d, const math::matrix<float>& m);
+
+    ~tensor();
+
+    tensor(const tensor&) = delete;
+    tensor& operator=(const tensor&) = delete;
+
+    tensor(tensor&&);
+    tensor& operator=(tensor&&);
+
+    unsigned int rows() const { return m_rows; }
+    unsigned int cols() const { return m_cols; }
+    unsigned int size() const { return m_rows * m_cols; }
+
+    /**
+     * Copy back to the host.
+     *
+     * Only correct after the work that wrote it has completed -- see
+     * stream::wait().  Reading a tensor a stream is still building is a race,
+     * and nothing here can detect it for you.
+     */
+    math::matrix<float> read() const;
+
+    /** Copy in from the host, overwriting. */
+    void write(const math::matrix<float>& m);
+
+private:
+    std::shared_ptr<device> m_device;
+
+    unsigned int m_rows = 0;
+    unsigned int m_cols = 0;
+
+    struct impl;
+    std::unique_ptr<impl> m_impl;
+
+    friend class stream;
+};
+
+/**
+ * A sequence of GPU work, encoded once and waited on once.
+ *
+ * This is the point of the module.  Every operation here encodes into the same
+ * command buffer, so a whole forward and backward pass costs one dispatch and
+ * one synchronisation rather than one of each per multiply.
+ *
+ * Nothing has happened until wait() returns.  A tensor read before that holds
+ * whatever it held before, which is the one sharp edge in the design and the
+ * price of not stalling between every operation.
+ */
+class stream {
+public:
+    class exception : public std::exception {
+    public:
+        exception(const std::string& msg = "") {
+            m_msg = "jlib::metal::stream exception" + (msg.empty() ? "" : ": " + msg);
+        }
+        virtual ~exception() {}
+        virtual const char* what() const noexcept { return m_msg.c_str(); }
+    protected:
+        std::string m_msg;
+    };
+
+    explicit stream(std::shared_ptr<device> d = device::shared());
+
+    ~stream();
+
+    stream(const stream&) = delete;
+    stream& operator=(const stream&) = delete;
+
+    /** c = alpha * a * b + beta * c. */
+    void multiply(const tensor& a, const tensor& b, tensor& c,
+                  float alpha = 1.0f, float beta = 0.0f);
+
+    /** c = alpha * a^T * b + beta * c, without materialising the transpose. */
+    void multiply_tn(const tensor& a, const tensor& b, tensor& c,
+                     float alpha = 1.0f, float beta = 0.0f);
+
+    /** c = alpha * a * b^T + beta * c. */
+    void multiply_nt(const tensor& a, const tensor& b, tensor& c,
+                     float alpha = 1.0f, float beta = 0.0f);
+
+    /** out = f(in). */
+    void activate(activation kind, const tensor& in, tensor& out);
+
+    /** out = f'(x), taken from f's own output.  See ai::activation. */
+    void slope(activation kind, const tensor& out_of_layer, tensor& out);
+
+    /** c = a * b, elementwise. */
+    void hadamard(const tensor& a, const tensor& b, tensor& c);
+
+    /** c = a - b. */
+    void subtract(const tensor& a, const tensor& b, tensor& c);
+
+    /** y += alpha * x. */
+    void add_scaled(float alpha, const tensor& x, tensor& y);
+
+    /** Commit everything encoded so far and block until the GPU is done. */
+    void wait();
+
+    /** How many operations are waiting.  Zero after wait(). */
+    unsigned int pending() const;
+
+private:
+    /** Open a compute encoder if there is not one already. */
+    void open();
+
+    /** Close any open compute encoder, for an op that encodes directly. */
+    void close();
+
+    std::shared_ptr<device> m_device;
+
+    struct impl;
+    std::unique_ptr<impl> m_impl;
+};
+
+}
+}
+
+#endif // JLIB_METAL_TENSOR_HH

--- a/jlib/metal/tensor.mm
+++ b/jlib/metal/tensor.mm
@@ -1,0 +1,555 @@
+/* -*- mode: ObjC++ c-basic-offset: 4 -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <jlib/metal/tensor.hh>
+#include <jlib/metal/impl.hh>
+
+#include <cstring>
+#include <sstream>
+#include <vector>
+
+namespace jlib {
+namespace metal {
+
+namespace {
+
+/**
+ * The elementwise kernels, compiled at load.
+ *
+ * Source rather than a precompiled .metallib, deliberately for now: a
+ * metallib means .metal files and a compile step in the build, and this is
+ * four small kernels.  It costs one compile the first time a stream is made,
+ * measured below a tenth of a second, and it keeps the build ordinary.
+ * Precompiling is the right answer once there are enough kernels to matter.
+ *
+ * The activation codes match jlib::metal::activation, and the test asserts
+ * they match jlib::ai::activation too.
+ */
+const char* const KERNELS = R"METAL(
+#include <metal_stdlib>
+using namespace metal;
+
+constant float LEAK = 0.01f;
+
+inline float apply(uint kind, float x) {
+    switch(kind) {
+    case 0: return 1.0f / (1.0f + exp(-x));
+    case 1: return tanh(x);
+    case 2: return (x > 0.0f) ? x : 0.0f;
+    default: return (x > 0.0f) ? x : LEAK * x;
+    }
+}
+
+inline float slope_of(uint kind, float s) {
+    switch(kind) {
+    case 0: return s * (1.0f - s);
+    case 1: return 1.0f - s * s;
+    case 2: return (s > 0.0f) ? 1.0f : 0.0f;
+    default: return (s > 0.0f) ? 1.0f : LEAK;
+    }
+}
+
+kernel void k_activate(device const float* in [[buffer(0)]],
+                       device float* out [[buffer(1)]],
+                       constant uint& kind [[buffer(2)]],
+                       constant uint& n [[buffer(3)]],
+                       uint i [[thread_position_in_grid]])
+{
+    if(i < n) out[i] = apply(kind, in[i]);
+}
+
+kernel void k_slope(device const float* in [[buffer(0)]],
+                    device float* out [[buffer(1)]],
+                    constant uint& kind [[buffer(2)]],
+                    constant uint& n [[buffer(3)]],
+                    uint i [[thread_position_in_grid]])
+{
+    if(i < n) out[i] = slope_of(kind, in[i]);
+}
+
+kernel void k_hadamard(device const float* a [[buffer(0)]],
+                       device const float* b [[buffer(1)]],
+                       device float* c [[buffer(2)]],
+                       constant uint& n [[buffer(3)]],
+                       uint i [[thread_position_in_grid]])
+{
+    if(i < n) c[i] = a[i] * b[i];
+}
+
+kernel void k_subtract(device const float* a [[buffer(0)]],
+                       device const float* b [[buffer(1)]],
+                       device float* c [[buffer(2)]],
+                       constant uint& n [[buffer(3)]],
+                       uint i [[thread_position_in_grid]])
+{
+    if(i < n) c[i] = a[i] - b[i];
+}
+
+kernel void k_add_scaled(device const float* x [[buffer(0)]],
+                         device float* y [[buffer(1)]],
+                         constant float& alpha [[buffer(2)]],
+                         constant uint& n [[buffer(3)]],
+                         uint i [[thread_position_in_grid]])
+{
+    if(i < n) y[i] = y[i] + alpha * x[i];
+}
+)METAL";
+
+}
+
+// ------------------------------------------------------------------ tensor
+
+struct tensor::impl {
+    id<MTLBuffer> buf = nil;
+};
+
+tensor::tensor(std::shared_ptr<device> d, unsigned int rows, unsigned int cols)
+    : m_device(d),
+      m_rows(rows),
+      m_cols(cols),
+      m_impl(new impl)
+{
+    if(!d)
+        throw exception("no device");
+
+    const NSUInteger bytes = (NSUInteger)rows * cols * sizeof(float);
+
+    // Never zero: Metal refuses a zero-length buffer, and a 0xN tensor is a
+    // legitimate thing to carry around even though nothing reads it.
+    m_impl->buf = [d->m_impl->gpu newBufferWithLength:(bytes ? bytes : sizeof(float))
+                                              options:MTLResourceStorageModeShared];
+
+    if(m_impl->buf == nil)
+        throw exception("could not allocate a device buffer");
+}
+
+tensor::tensor(std::shared_ptr<device> d, const math::matrix<float>& m)
+    : tensor(d, m.M, m.N)
+{
+    write(m);
+}
+
+tensor::~tensor() = default;
+
+tensor::tensor(tensor&&) = default;
+tensor& tensor::operator=(tensor&&) = default;
+
+math::matrix<float> tensor::read() const {
+    math::matrix<float> out(m_rows, m_cols);
+
+    if(size() == 0)
+        return out;
+
+    std::memcpy(static_cast<math::buffer<float> >(out).data(),
+                [m_impl->buf contents], size() * sizeof(float));
+
+    return out;
+}
+
+void tensor::write(const math::matrix<float>& m) {
+    if(m.M != m_rows || m.N != m_cols) {
+        std::ostringstream o;
+        o << "cannot write [" << m.M << "," << m.N << "] into ["
+          << m_rows << "," << m_cols << "]";
+        throw exception(o.str());
+    }
+
+    if(size() == 0)
+        return;
+
+    std::memcpy([m_impl->buf contents],
+                static_cast<const math::buffer<float> >(m).data(),
+                size() * sizeof(float));
+}
+
+// ------------------------------------------------------------------ stream
+
+struct stream::impl {
+    id<MTLCommandBuffer> cmd = nil;
+    id<MTLComputeCommandEncoder> enc = nil;
+
+    id<MTLComputePipelineState> activate = nil;
+    id<MTLComputePipelineState> slope = nil;
+    id<MTLComputePipelineState> hadamard = nil;
+    id<MTLComputePipelineState> subtract = nil;
+    id<MTLComputePipelineState> add_scaled = nil;
+
+    unsigned int pending = 0;
+};
+
+namespace {
+
+/**
+ * The compiled kernels, built once per device and kept.
+ *
+ * A library and five pipeline states are not free to build and are identical
+ * every time, so a process that makes a stream per training step should not
+ * pay for them per step.
+ */
+struct pipelines {
+    id<MTLComputePipelineState> activate = nil;
+    id<MTLComputePipelineState> slope = nil;
+    id<MTLComputePipelineState> hadamard = nil;
+    id<MTLComputePipelineState> subtract = nil;
+    id<MTLComputePipelineState> add_scaled = nil;
+};
+
+pipelines& compiled(id<MTLDevice> gpu) {
+    static pipelines p;
+    static bool done = false;
+
+    if(done)
+        return p;
+
+    NSError* err = nil;
+
+    id<MTLLibrary> lib =
+        [gpu newLibraryWithSource:[NSString stringWithUTF8String:KERNELS]
+                          options:nil
+                            error:&err];
+
+    if(lib == nil) {
+        const char* what = (err != nil)
+            ? [[err localizedDescription] UTF8String] : "unknown";
+        throw stream::exception(std::string("could not compile the kernels: ") + what);
+    }
+
+    struct { const char* name; __strong id<MTLComputePipelineState>* into; } wanted[] = {
+        { "k_activate",   &p.activate },
+        { "k_slope",      &p.slope },
+        { "k_hadamard",   &p.hadamard },
+        { "k_subtract",   &p.subtract },
+        { "k_add_scaled", &p.add_scaled },
+    };
+
+    for(auto& w : wanted) {
+        id<MTLFunction> fn = [lib newFunctionWithName:[NSString stringWithUTF8String:w.name]];
+
+        if(fn == nil)
+            throw stream::exception(std::string("no kernel called ") + w.name);
+
+        *w.into = [gpu newComputePipelineStateWithFunction:fn error:&err];
+
+        if(*w.into == nil)
+            throw stream::exception(std::string("could not build a pipeline for ") + w.name);
+    }
+
+    done = true;
+
+    return p;
+}
+
+}
+
+stream::stream(std::shared_ptr<device> d)
+    : m_device(d),
+      m_impl(new impl)
+{
+    if(!d)
+        throw exception("no device");
+
+    pipelines& p = compiled(d->m_impl->gpu);
+
+    m_impl->activate = p.activate;
+    m_impl->slope = p.slope;
+    m_impl->hadamard = p.hadamard;
+    m_impl->subtract = p.subtract;
+    m_impl->add_scaled = p.add_scaled;
+}
+
+stream::~stream() {
+    // Anything encoded and never waited on is abandoned rather than run: a
+    // stream going out of scope unfinished means the caller changed its mind
+    // or is unwinding, and neither wants the GPU touching those buffers after
+    // the tensors have gone.
+    if(m_impl->enc != nil)
+        [m_impl->enc endEncoding];
+}
+
+unsigned int stream::pending() const { return m_impl->pending; }
+
+void stream::open() {
+    if(m_impl->cmd == nil)
+        m_impl->cmd = [m_device->m_impl->queue commandBuffer];
+
+    if(m_impl->enc == nil)
+        m_impl->enc = [m_impl->cmd computeCommandEncoder];
+}
+
+void stream::close() {
+    // MPS encodes into the command buffer directly rather than into a compute
+    // encoder, so an open one has to be ended first.  The next elementwise op
+    // opens another.
+    if(m_impl->enc != nil) {
+        [m_impl->enc endEncoding];
+        m_impl->enc = nil;
+    }
+
+    if(m_impl->cmd == nil)
+        m_impl->cmd = [m_device->m_impl->queue commandBuffer];
+}
+
+// -------------------------------------------------------- encoding helpers
+
+namespace {
+
+/** One thread per element, rounded up to the pipeline's preferred width. */
+void dispatch(id<MTLComputeCommandEncoder> enc,
+              id<MTLComputePipelineState> pipe,
+              unsigned int n)
+{
+    const NSUInteger width = [pipe threadExecutionWidth];
+    const NSUInteger groups = (n + width - 1) / width;
+
+    [enc dispatchThreadgroups:MTLSizeMake(groups, 1, 1)
+        threadsPerThreadgroup:MTLSizeMake(width, 1, 1)];
+}
+
+void same_shape(const tensor& a, const tensor& b, const char* what) {
+    if(a.rows() != b.rows() || a.cols() != b.cols()) {
+        std::ostringstream o;
+        o << what << ": [" << a.rows() << "," << a.cols() << "] against ["
+          << b.rows() << "," << b.cols() << "]";
+        throw stream::exception(o.str());
+    }
+}
+
+}
+
+void stream::activate(activation kind, const tensor& in, tensor& out) {
+    same_shape(in, out, "activate");
+
+    open();
+
+    const unsigned int n = in.size();
+    const unsigned int k = static_cast<unsigned int>(kind);
+
+    [m_impl->enc setComputePipelineState:m_impl->activate];
+    [m_impl->enc setBuffer:in.m_impl->buf offset:0 atIndex:0];
+    [m_impl->enc setBuffer:out.m_impl->buf offset:0 atIndex:1];
+    [m_impl->enc setBytes:&k length:sizeof(k) atIndex:2];
+    [m_impl->enc setBytes:&n length:sizeof(n) atIndex:3];
+
+    dispatch(m_impl->enc, m_impl->activate, n);
+
+    m_impl->pending++;
+}
+
+void stream::slope(activation kind, const tensor& out_of_layer, tensor& out) {
+    same_shape(out_of_layer, out, "slope");
+
+    open();
+
+    const unsigned int n = out_of_layer.size();
+    const unsigned int k = static_cast<unsigned int>(kind);
+
+    [m_impl->enc setComputePipelineState:m_impl->slope];
+    [m_impl->enc setBuffer:out_of_layer.m_impl->buf offset:0 atIndex:0];
+    [m_impl->enc setBuffer:out.m_impl->buf offset:0 atIndex:1];
+    [m_impl->enc setBytes:&k length:sizeof(k) atIndex:2];
+    [m_impl->enc setBytes:&n length:sizeof(n) atIndex:3];
+
+    dispatch(m_impl->enc, m_impl->slope, n);
+
+    m_impl->pending++;
+}
+
+void stream::hadamard(const tensor& a, const tensor& b, tensor& c) {
+    same_shape(a, b, "hadamard");
+    same_shape(a, c, "hadamard");
+
+    open();
+
+    const unsigned int n = a.size();
+
+    [m_impl->enc setComputePipelineState:m_impl->hadamard];
+    [m_impl->enc setBuffer:a.m_impl->buf offset:0 atIndex:0];
+    [m_impl->enc setBuffer:b.m_impl->buf offset:0 atIndex:1];
+    [m_impl->enc setBuffer:c.m_impl->buf offset:0 atIndex:2];
+    [m_impl->enc setBytes:&n length:sizeof(n) atIndex:3];
+
+    dispatch(m_impl->enc, m_impl->hadamard, n);
+
+    m_impl->pending++;
+}
+
+void stream::subtract(const tensor& a, const tensor& b, tensor& c) {
+    same_shape(a, b, "subtract");
+    same_shape(a, c, "subtract");
+
+    open();
+
+    const unsigned int n = a.size();
+
+    [m_impl->enc setComputePipelineState:m_impl->subtract];
+    [m_impl->enc setBuffer:a.m_impl->buf offset:0 atIndex:0];
+    [m_impl->enc setBuffer:b.m_impl->buf offset:0 atIndex:1];
+    [m_impl->enc setBuffer:c.m_impl->buf offset:0 atIndex:2];
+    [m_impl->enc setBytes:&n length:sizeof(n) atIndex:3];
+
+    dispatch(m_impl->enc, m_impl->subtract, n);
+
+    m_impl->pending++;
+}
+
+void stream::add_scaled(float alpha, const tensor& x, tensor& y) {
+    same_shape(x, y, "add_scaled");
+
+    open();
+
+    const unsigned int n = x.size();
+
+    [m_impl->enc setComputePipelineState:m_impl->add_scaled];
+    [m_impl->enc setBuffer:x.m_impl->buf offset:0 atIndex:0];
+    [m_impl->enc setBuffer:y.m_impl->buf offset:0 atIndex:1];
+    [m_impl->enc setBytes:&alpha length:sizeof(alpha) atIndex:2];
+    [m_impl->enc setBytes:&n length:sizeof(n) atIndex:3];
+
+    dispatch(m_impl->enc, m_impl->add_scaled, n);
+
+    m_impl->pending++;
+}
+
+// ----------------------------------------------------------------- multiply
+
+namespace {
+
+/**
+ * MPS is row-major and math::matrix is column-major, so every operand is read
+ * as its own transpose and the operands are swapped -- (A B)^T = B^T A^T.  The
+ * same argument as gemm.mm, which has it at length; the difference here is
+ * that the buffers already live on the device, so there is nothing to copy.
+ */
+void encode_gemm(id<MTLCommandBuffer> cmd, id<MTLDevice> gpu,
+                 id<MTLBuffer> ba, unsigned int arows, unsigned int acols, bool ta,
+                 id<MTLBuffer> bb, unsigned int brows, unsigned int bcols, bool tb,
+                 id<MTLBuffer> bc, unsigned int crows, unsigned int ccols,
+                 float alpha, float beta)
+{
+    // In the transposed world the left operand is B and the right is A.
+    const NSUInteger M = crows, N = ccols;
+    const NSUInteger K = ta ? arows : acols;
+
+    MPSMatrixDescriptor* da =
+        [MPSMatrixDescriptor matrixDescriptorWithRows:acols columns:arows
+                                             rowBytes:arows * sizeof(float)
+                                             dataType:MPSDataTypeFloat32];
+    MPSMatrixDescriptor* db =
+        [MPSMatrixDescriptor matrixDescriptorWithRows:bcols columns:brows
+                                             rowBytes:brows * sizeof(float)
+                                             dataType:MPSDataTypeFloat32];
+    MPSMatrixDescriptor* dc =
+        [MPSMatrixDescriptor matrixDescriptorWithRows:ccols columns:crows
+                                             rowBytes:crows * sizeof(float)
+                                             dataType:MPSDataTypeFloat32];
+
+    MPSMatrix* ma = [[MPSMatrix alloc] initWithBuffer:ba descriptor:da];
+    MPSMatrix* mb = [[MPSMatrix alloc] initWithBuffer:bb descriptor:db];
+    MPSMatrix* mc = [[MPSMatrix alloc] initWithBuffer:bc descriptor:dc];
+
+    // Reading column-major as row-major already transposes, so a requested
+    // transpose is the *absence* of one in this world and vice versa.
+    MPSMatrixMultiplication* k =
+        [[MPSMatrixMultiplication alloc] initWithDevice:gpu
+                                         transposeLeft:tb
+                                        transposeRight:ta
+                                            resultRows:N
+                                         resultColumns:M
+                                       interiorColumns:K
+                                                 alpha:alpha
+                                                  beta:beta];
+
+    [k encodeToCommandBuffer:cmd leftMatrix:mb rightMatrix:ma resultMatrix:mc];
+}
+
+}
+
+void stream::multiply(const tensor& a, const tensor& b, tensor& c,
+                      float alpha, float beta)
+{
+    if(a.cols() != b.rows() || c.rows() != a.rows() || c.cols() != b.cols())
+        throw exception("multiply: shapes do not meet");
+
+    close();
+
+    encode_gemm(m_impl->cmd, m_device->m_impl->gpu,
+                a.m_impl->buf, a.rows(), a.cols(), false,
+                b.m_impl->buf, b.rows(), b.cols(), false,
+                c.m_impl->buf, c.rows(), c.cols(), alpha, beta);
+
+    m_impl->pending++;
+}
+
+void stream::multiply_tn(const tensor& a, const tensor& b, tensor& c,
+                         float alpha, float beta)
+{
+    if(a.rows() != b.rows() || c.rows() != a.cols() || c.cols() != b.cols())
+        throw exception("multiply_tn: shapes do not meet");
+
+    close();
+
+    encode_gemm(m_impl->cmd, m_device->m_impl->gpu,
+                a.m_impl->buf, a.rows(), a.cols(), true,
+                b.m_impl->buf, b.rows(), b.cols(), false,
+                c.m_impl->buf, c.rows(), c.cols(), alpha, beta);
+
+    m_impl->pending++;
+}
+
+void stream::multiply_nt(const tensor& a, const tensor& b, tensor& c,
+                         float alpha, float beta)
+{
+    if(a.cols() != b.cols() || c.rows() != a.rows() || c.cols() != b.rows())
+        throw exception("multiply_nt: shapes do not meet");
+
+    close();
+
+    encode_gemm(m_impl->cmd, m_device->m_impl->gpu,
+                a.m_impl->buf, a.rows(), a.cols(), false,
+                b.m_impl->buf, b.rows(), b.cols(), true,
+                c.m_impl->buf, c.rows(), c.cols(), alpha, beta);
+
+    m_impl->pending++;
+}
+
+void stream::wait() {
+    if(m_impl->enc != nil) {
+        [m_impl->enc endEncoding];
+        m_impl->enc = nil;
+    }
+
+    if(m_impl->cmd == nil) {
+        m_impl->pending = 0;
+        return;
+    }
+
+    [m_impl->cmd commit];
+    [m_impl->cmd waitUntilCompleted];
+
+    const bool failed = ([m_impl->cmd status] == MTLCommandBufferStatusError);
+
+    m_impl->cmd = nil;
+    m_impl->pending = 0;
+
+    if(failed)
+        throw exception("the command buffer failed");
+}
+
+}
+}

--- a/jlib/metal/tensor.mm
+++ b/jlib/metal/tensor.mm
@@ -32,11 +32,18 @@ namespace {
 /**
  * The elementwise kernels, compiled at load.
  *
- * Source rather than a precompiled .metallib, deliberately for now: a
- * metallib means .metal files and a compile step in the build, and this is
- * four small kernels.  It costs one compile the first time a stream is made,
- * measured below a tenth of a second, and it keeps the build ordinary.
- * Precompiling is the right answer once there are enough kernels to matter.
+ * Source rather than a precompiled .metallib: that would mean .metal files and
+ * a compile step in the build, and this is five small kernels.
+ *
+ * Measured, on an M5: **0.8 to 2.6 ms**, once, on the first stream a process
+ * makes.  Every stream after it is free -- the library and the five pipeline
+ * states are built once and kept.  The spread is the system's own shader
+ * cache warming across runs; the 2.6ms is the coldest observed.
+ *
+ * So precompiling would buy about a millisecond of startup, which is not a
+ * reason to put a shader toolchain in the build.  That changes if the kernel
+ * count grows a lot, or if something needs to run where compiling at load is
+ * not allowed.
  *
  * The activation codes match jlib::metal::activation, and the test asserts
  * they match jlib::ai::activation too.

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -45,7 +45,7 @@ endif
 # itself also exits 77 if there is no device, which covers a machine that has
 # the frameworks and no hardware.
 if HAVE_METAL
-METAL_TESTS = metal_gemm_test
+METAL_TESTS = metal_gemm_test metal_tensor_test
 endif
 
 TESTS = \
@@ -298,3 +298,6 @@ crypt_groth_test_LDADD   = $(JUTIL_LA) $(JCRYPT_LA) $(SODIUM_LIBS)
 
 metal_gemm_test_SOURCES = metal_gemm_test.cc
 metal_gemm_test_LDADD   = $(top_builddir)/jlib/metal/libjmetal.la $(METAL_LIBS)
+
+metal_tensor_test_SOURCES = metal_tensor_test.cc
+metal_tensor_test_LDADD   = $(top_builddir)/jlib/metal/libjmetal.la $(JUTIL_LA) $(JSYS_LA) $(METAL_LIBS)

--- a/tests/metal_tensor_test.cc
+++ b/tests/metal_tensor_test.cc
@@ -1,0 +1,362 @@
+/* -*- mode: C++ c-basic-offset: 4 -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Tensors that stay on the GPU, and the operations over them.
+//
+// The oracle throughout is the CPU: math::operator* and ai::activate, which
+// are naive and therefore hard to be wrong in the same way twice.
+//
+// The transposed multiplies get the most attention.  math::matrix is
+// column-major and MPS is row-major, so every operand is read as its own
+// transpose and the operands are swapped -- and on a square matrix of random
+// numbers a wrongly-transposed answer looks exactly as plausible as a right
+// one.  Everything below is deliberately rectangular.
+
+#include <jlib/metal/tensor.hh>
+#include <jlib/metal/device.hh>
+
+#include <jlib/ai/neural.hh>
+#include <jlib/math/matrix.hh>
+
+#include <cmath>
+#include <iostream>
+#include <random>
+#include <string>
+
+namespace metal = jlib::metal;
+namespace ai = jlib::ai;
+
+using jlib::math::matrix;
+
+static int failures = 0;
+
+static void ok(const std::string& what, bool good, const std::string& detail = "") {
+    if(!good) ++failures;
+    std::cout << (good ? "  ok   " : "  FAIL ") << what;
+    if(!detail.empty()) std::cout << ": " << detail;
+    std::cout << "\n";
+}
+
+static std::mt19937 gen(20260830);
+
+static matrix<float> random_matrix(uint m, uint n) {
+    std::uniform_real_distribution<float> d(-1.0f, 1.0f);
+
+    matrix<float> a(m, n);
+
+    for(uint r = 0; r < m; r++)
+        for(uint c = 0; c < n; c++)
+            a(r, c) = d(gen);
+
+    return a;
+}
+
+static double worst(const matrix<float>& a, const matrix<float>& b) {
+    if(a.M != b.M || a.N != b.N) return 1e9;
+
+    double w = 0;
+
+    for(uint r = 0; r < a.M; r++)
+        for(uint c = 0; c < a.N; c++)
+            w = std::max(w, std::fabs(double(a(r,c)) - double(b(r,c))));
+
+    return w;
+}
+
+static void the_enums_agree() {
+    std::cout << "\nthe enums agree:\n";
+
+    // metal has its own activation enum so that a GPU backend does not depend
+    // on the neural library.  The duplication is only safe while the values
+    // match, and the kernels switch on the raw number.
+    ok("sigmoid", (int)metal::activation::sigmoid == (int)ai::activation::sigmoid);
+    ok("tanh", (int)metal::activation::tanh == (int)ai::activation::tanh);
+    ok("relu", (int)metal::activation::relu == (int)ai::activation::relu);
+    ok("leaky_relu", (int)metal::activation::leaky_relu == (int)ai::activation::leaky_relu);
+    // Compared as float, which is the precision that exists on the GPU.
+    // ai::LEAK is a double 0.01 and metal::LEAK is a float 0.01f, and
+    // double(0.01f) is not 0.01 -- so the widening comparison is false while
+    // the values agree everywhere they are used.  The activation test above
+    // is the one that would notice if they really diverged.
+    ok("and so does the leak", metal::LEAK == float(ai::LEAK),
+       std::to_string(metal::LEAK) + " against " + std::to_string(float(ai::LEAK)));
+}
+
+static void a_tensor_round_trips(std::shared_ptr<metal::device> dev) {
+    std::cout << "\na tensor round trips:\n";
+
+    // Rectangular, so a row/column mix-up in the upload cannot hide.
+    const matrix<float> m = random_matrix(3, 7);
+
+    metal::tensor t(dev, m);
+
+    ok("the shape survives", t.rows() == 3 && t.cols() == 7,
+       std::to_string(t.rows()) + "x" + std::to_string(t.cols()));
+
+    ok("and every value", worst(m, t.read()) == 0.0,
+       std::to_string(worst(m, t.read())));
+
+    const matrix<float> other = random_matrix(3, 7);
+
+    t.write(other);
+
+    ok("writing replaces it", worst(other, t.read()) == 0.0);
+
+    bool threw = false;
+    try { t.write(random_matrix(7, 3)); }
+    catch(std::exception&) { threw = true; }
+
+    ok("and a wrong shape is refused", threw);
+}
+
+static void the_elementwise_ops(std::shared_ptr<metal::device> dev) {
+    std::cout << "\nthe elementwise ops:\n";
+
+    const matrix<float> a = random_matrix(5, 9);
+    const matrix<float> b = random_matrix(5, 9);
+
+    metal::tensor ta(dev, a), tb(dev, b), tc(dev, 5, 9);
+
+    metal::stream s(dev);
+
+    s.hadamard(ta, tb, tc);
+    s.wait();
+
+    matrix<float> want(5, 9);
+    for(uint r = 0; r < 5; r++)
+        for(uint c = 0; c < 9; c++)
+            want(r,c) = a(r,c) * b(r,c);
+
+    ok("hadamard", worst(want, tc.read()) < 1e-6,
+       std::to_string(worst(want, tc.read())));
+
+    s.subtract(ta, tb, tc);
+    s.wait();
+
+    for(uint r = 0; r < 5; r++)
+        for(uint c = 0; c < 9; c++)
+            want(r,c) = a(r,c) - b(r,c);
+
+    ok("subtract", worst(want, tc.read()) < 1e-6);
+
+    // y += alpha * x, which is the weight update.
+    metal::tensor ty(dev, b);
+
+    s.add_scaled(0.25f, ta, ty);
+    s.wait();
+
+    for(uint r = 0; r < 5; r++)
+        for(uint c = 0; c < 9; c++)
+            want(r,c) = b(r,c) + 0.25f * a(r,c);
+
+    ok("add_scaled", worst(want, ty.read()) < 1e-6,
+       std::to_string(worst(want, ty.read())));
+}
+
+static void the_activations_match_the_cpu(std::shared_ptr<metal::device> dev) {
+    std::cout << "\nthe activations match the CPU:\n";
+
+    // Spanning zero, since three of the four change behaviour there and the
+    // relu family is defined by what it does on each side.
+    matrix<float> x(1, 8);
+    x(0,0) = -3.0f; x(0,1) = -1.0f; x(0,2) = -0.25f; x(0,3) = 0.0f;
+    x(0,4) = 0.25f; x(0,5) = 1.0f;  x(0,6) = 3.0f;   x(0,7) = 8.0f;
+
+    const struct { metal::activation m; ai::activation a; const char* name; } kinds[] = {
+        { metal::activation::sigmoid,    ai::activation::sigmoid,    "sigmoid" },
+        { metal::activation::tanh,       ai::activation::tanh,       "tanh" },
+        { metal::activation::relu,       ai::activation::relu,       "relu" },
+        { metal::activation::leaky_relu, ai::activation::leaky_relu, "leaky_relu" },
+    };
+
+    metal::stream s(dev);
+
+    for(const auto& k : kinds) {
+        metal::tensor in(dev, x), out(dev, 1, 8), sl(dev, 1, 8);
+
+        s.activate(k.m, in, out);
+        s.wait();
+
+        const matrix<float> want = ai::activate(k.a, x);
+        const matrix<float> got = out.read();
+
+        // 1e-6 rather than exact: the GPU's exp and tanh are its own, and are
+        // allowed to differ from libm in the last bits.
+        ok(std::string(k.name), worst(want, got) < 1e-6,
+           std::to_string(worst(want, got)));
+
+        s.slope(k.m, out, sl);
+        s.wait();
+
+        ok(std::string("  and its slope"),
+           worst(ai::activate_slope(k.a, want), sl.read()) < 1e-6,
+           std::to_string(worst(ai::activate_slope(k.a, want), sl.read())));
+    }
+}
+
+static void the_multiplies(std::shared_ptr<metal::device> dev) {
+    std::cout << "\nthe multiplies:\n";
+
+    // 4x6 by 6x3 -- every dimension different, so a transpose error cannot
+    // produce a correctly shaped answer by accident.
+    const matrix<float> a = random_matrix(4, 6);
+    const matrix<float> b = random_matrix(6, 3);
+
+    metal::tensor ta(dev, a), tb(dev, b), tc(dev, 4, 3);
+
+    metal::stream s(dev);
+
+    s.multiply(ta, tb, tc);
+    s.wait();
+
+    ok("a * b", worst(a * b, tc.read()) < 1e-5,
+       std::to_string(worst(a * b, tc.read())));
+
+    // a^T * b, without materialising the transpose.
+    const matrix<float> at = random_matrix(6, 4);
+
+    metal::tensor tat(dev, at), tc2(dev, 4, 3);
+
+    s.multiply_tn(tat, tb, tc2);
+    s.wait();
+
+    ok("a^T * b", worst(at.transpose() * b, tc2.read()) < 1e-5,
+       std::to_string(worst(at.transpose() * b, tc2.read())));
+
+    // a * b^T.
+    const matrix<float> bt = random_matrix(3, 6);
+
+    metal::tensor tbt(dev, bt), tc3(dev, 4, 3);
+
+    s.multiply_nt(ta, tbt, tc3);
+    s.wait();
+
+    ok("a * b^T", worst(a * bt.transpose(), tc3.read()) < 1e-5,
+       std::to_string(worst(a * bt.transpose(), tc3.read())));
+
+    // beta, which is what makes an accumulate possible.
+    metal::tensor acc(dev, a * b);
+
+    s.multiply(ta, tb, acc, 1.0f, 1.0f);
+    s.wait();
+
+    ok("and beta accumulates", worst((a * b) + (a * b), acc.read()) < 1e-5,
+       std::to_string(worst((a * b) + (a * b), acc.read())));
+
+    bool threw = false;
+    try { metal::tensor bad(dev, 9, 9); s.multiply(ta, tb, bad); }
+    catch(std::exception&) { threw = true; }
+
+    ok("a result of the wrong shape is refused", threw);
+}
+
+static void many_ops_one_wait(std::shared_ptr<metal::device> dev) {
+    std::cout << "\nmany ops, one wait:\n";
+
+    // The reason the module exists.  A forward layer is a multiply and an
+    // activation; doing both without a synchronisation between them is what
+    // keeps the data on the device.
+    const matrix<float> w = random_matrix(6, 4);
+    const matrix<float> x = random_matrix(4, 5);
+
+    metal::tensor tw(dev, w), tx(dev, x), tz(dev, 6, 5), ta(dev, 6, 5);
+
+    metal::stream s(dev);
+
+    s.multiply(tw, tx, tz);
+    s.activate(metal::activation::relu, tz, ta);
+
+    ok("nothing has run yet", s.pending() == 2, std::to_string(s.pending()));
+
+    s.wait();
+
+    ok("and afterwards nothing is pending", s.pending() == 0,
+       std::to_string(s.pending()));
+
+    const matrix<float> want = ai::activate(ai::activation::relu, w * x);
+
+    ok("the layer is right", worst(want, ta.read()) < 1e-5,
+       std::to_string(worst(want, ta.read())));
+
+    // Interleaving matters: MPS encodes into the command buffer and the
+    // elementwise kernels into a compute encoder, so the stream has to close
+    // and reopen one around the other.  Doing it several times over is the
+    // case that would break if it did not.
+    metal::tensor t2(dev, 6, 5), t3(dev, 6, 5);
+
+    s.multiply(tw, tx, tz);
+    s.activate(metal::activation::sigmoid, tz, t2);
+    s.multiply(tw, tx, t3);
+    s.hadamard(t2, t3, t3);
+    s.wait();
+
+    matrix<float> expect(6, 5);
+    const matrix<float> wx = w * x;
+    const matrix<float> sig = ai::activate(ai::activation::sigmoid, wx);
+
+    for(uint r = 0; r < 6; r++)
+        for(uint c = 0; c < 5; c++)
+            expect(r,c) = sig(r,c) * wx(r,c);
+
+    ok("and so is a multiply/elementwise/multiply/elementwise chain",
+       worst(expect, t3.read()) < 1e-5,
+       std::to_string(worst(expect, t3.read())));
+}
+
+int main() {
+    std::cout << std::unitbuf;
+
+    std::shared_ptr<metal::device> dev;
+
+    try {
+        dev = metal::device::shared();
+    }
+    catch(std::exception& e) {
+        std::cout << "  skip  no Metal device: " << e.what() << "\n";
+        return 77;
+    }
+
+    std::cout << "  device: " << dev->name() << "\n";
+
+    the_enums_agree();
+    a_tensor_round_trips(dev);
+    the_elementwise_ops(dev);
+    the_activations_match_the_cpu(dev);
+    the_multiplies(dev);
+    many_ops_one_wait(dev);
+
+    // What a green run does not establish.
+    //
+    // That this is faster.  Nothing here is timed; the whole argument for
+    // keeping tensors on the device is about not synchronising between
+    // operations, and that shows up in a training loop rather than in an
+    // assertion.
+    //
+    // Not the sharp edge: reading a tensor before wait() gives whatever it
+    // held before, and nothing detects it.  A test for it would be a test
+    // that the GPU is slower than the CPU, which is not a property worth
+    // asserting.
+    //
+    // Not concurrency.  One stream, one thread.  Two streams over the same
+    // tensors would need ordering nothing here provides.
+    std::cout << "\n" << (failures ? "FAILED" : "PASSED") << ": " << failures
+              << " failure(s)\n";
+
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
# Tensors that stay on the GPU

`gemm.hh` takes `math::matrix`, so every call uploads its operands, computes,
waits, and downloads the result. A training step makes about eight of those, so
the data crosses the boundary sixteen times per step to do work that never
needed to leave.

Profiling a Metal-accelerated network said so plainly:

```
  4195  jlib::metal::matrix_multiply::operator()
  2100  jlib::ai::NeuralNetwork<float>::query
     1  jlib::ai::activate<float>
```

The elementwise work is *one sample*. It was never Amdahl -- it was eight GPU
stalls per step, each with the dispatch floor and three buffer allocations.

## What this adds

`metal::tensor` is a matrix that lives in an `MTLBuffer` and stays there.
`read()` is deliberately explicit and deliberately awkward, because it is the
expensive thing and should look like it.

`metal::stream` encodes work into one command buffer and waits once:

```cpp
metal::stream s(dev);

s.multiply(w, x, z);
s.activate(metal::activation::relu, z, a);

s.wait();          // nothing has happened until this returns
```

Operations: `multiply`, `multiply_tn` (a^T b) and `multiply_nt` (a b^T) via
MPS, and `activate`, `slope`, `hadamard`, `subtract` and `add_scaled` as
kernels. That is every operation `NeuralNetwork::train` performs, which is the
point -- a whole forward and backward pass can be encoded without a
synchronisation in the middle of it.

## Measured

The same arithmetic, four layers, batch 512, done both ways:

```
  weights      stall per op    one wait per pass
  128x128         3.196 ms           1.601 ms    2.00x
  256x256         3.047 ms           0.469 ms    6.50x
  512x512         8.498 ms           1.081 ms    7.86x
```

**Up to 7.9x**, with identical arithmetic. Only the round trips are gone.

## Choices worth arguing with

**Runtime shader compilation, not a metallib.** Five small kernels compiled
from a source string at first use, measured at **0.8 to 2.6 ms** on an M5 --
once per process, with every stream after it free. The spread is the system's
own shader cache warming across runs.

I had written "below a tenth of a second" in the comment before measuring it.
It was true and useless: at about a millisecond, precompiling would buy nothing
worth putting a shader toolchain in the build for. The comment carries the real
figures now.

**Its own `activation` enum.** `jlib/metal` builds after `jlib/ai` and could
name `ai::activation`, but a GPU backend depending on the neural library is
the wrong way round: this layer knows about numbers, not about networks. Four
enumerators is a cheap duplication, and the test asserts the values match.

**`transposeLeft`/`transposeRight` are swapped in `encode_gemm`.** Reading a
column-major buffer as row-major already transposes it, so a *requested*
transpose is the absence of one in that world. The same argument `gemm.mm`
makes at length, with the difference that nothing is copied here.

## Two bugs found on the way

**`math::operator+(matrix, matrix)` has never compiled.** Line 564 threw
`matrix<T>::mismatch()` without `typename`, which is ill-formed in a dependent
context -- and nothing noticed, because adding two matrices had never been
instantiated anywhere in the library or its tests. Every other throw in the
file has the `typename`. Fixed, and upgraded to `mismatched`, which carries
the shapes: `operator*` and `operator^` both report them and a bare
`std::exception` from the third binary operator is no use to anyone.

**`metal::LEAK` and `ai::LEAK` are not the same number.** One is `0.01f` and
the other `0.01`, and `double(0.01f) != 0.01`. The first version of the test
compared them widened to double and failed. They agree at float, which is the
only precision the GPU has, so that is what the assertion says now -- and the
activation comparison against the CPU is what would catch a real divergence.

## Tests

`tests/metal_tensor_test.cc`: the enums agree with `ai`'s; a tensor round trips
and refuses a wrong shape; each elementwise op against a hand-written CPU loop;
all four activations and their slopes against `ai::activate`, over inputs
spanning zero since three of the four change behaviour there; the three
multiplies against `math::operator*`; and a multiply/elementwise chain
interleaved four deep, which is the case that breaks if the stream mishandles
closing an MPS encode against an open compute encoder.

Everything is rectangular with all dimensions different. On a square matrix of
random numbers a wrongly-transposed answer looks exactly as plausible as a
right one.

**What a green run does not establish**: that it is faster -- nothing here is
timed, and the numbers above live in this write-up. Not the sharp edge, either:
reading a tensor before `wait()` gives whatever it held before, and nothing
detects it. A test for that would be a test that the GPU is slower than the
CPU. And not concurrency: one stream, one thread.

## Not done

`NeuralNetwork` does not use any of this yet -- it still holds `math::matrix`
and goes through the `set_multiply` hook, so it still stalls per multiply. That
wiring is the next branch, and it is a larger change than it sounds: the
network would hold tensors rather than matrices, which touches construction,
serialisation and `query` as well as `train`.

## Numbers

macOS: 63 pass, 4 skip, 0 fail. Linux container: 65 pass, 1 skip, 0 fail, with
the Metal tests absent and the `operator+` fix exercised by everything else.
