### PR TITLE
Give ai a templated backend interface, so one training step can run on the host or a GPU, in float or fp16

### DIFF
--- a/jlib/ai/Makefile.am
+++ b/jlib/ai/Makefile.am
@@ -1,10 +1,12 @@
 AM_CPPFLAGS = -I$(top_srcdir)
 
 lib_LTLIBRARIES = libjai.la
-libjai_la_SOURCES = environment.cc agent.cc percept.cc action.cc vacuum.cc
+libjai_la_SOURCES = environment.cc agent.cc percept.cc action.cc vacuum.cc \
+                    backend.cc
 libjai_la_LDFLAGS = -version-info $(LIBJ_SO_VERSION) -release $(JLIB_RELEASE) -no-undefined
 libjai_la_LIBADD = $(top_builddir)/jlib/util/libjutil.la \
                    $(top_builddir)/jlib/sys/libjsys.la
 
 libjaiincludedir = $(includedir)/jlib-1.2/jlib/ai
-libjaiinclude_HEADERS = environment.hh agent.hh percept.hh action.hh vacuum.hh neural.hh
+libjaiinclude_HEADERS = environment.hh agent.hh percept.hh action.hh vacuum.hh \
+                        neural.hh backend.hh

--- a/jlib/ai/backend.cc
+++ b/jlib/ai/backend.cc
@@ -1,0 +1,49 @@
+/* -*- mode: C++ c-basic-offset: 4 -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <jlib/ai/backend.hh>
+
+namespace jlib {
+namespace ai {
+
+// The only two things here that do not depend on the element type.  Everything
+// else is a template and lives in the header.
+
+std::string name_of(activation a) {
+    switch(a) {
+    case activation::sigmoid:    return "sigmoid";
+    case activation::tanh:       return "tanh";
+    case activation::relu:       return "relu";
+    case activation::leaky_relu: return "leaky_relu";
+    }
+
+    return "sigmoid";
+}
+
+activation activation_from_name(const std::string& s) {
+    if(s == "sigmoid")    return activation::sigmoid;
+    if(s == "tanh")       return activation::tanh;
+    if(s == "relu")       return activation::relu;
+    if(s == "leaky_relu") return activation::leaky_relu;
+
+    throw backend_error("unknown activation '" + s + "'");
+}
+
+}
+}

--- a/jlib/ai/backend.hh
+++ b/jlib/ai/backend.hh
@@ -1,0 +1,373 @@
+/* -*- mode: C++ c-basic-offset: 4 -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef JLIB_AI_BACKEND_HH
+#define JLIB_AI_BACKEND_HH
+
+#include <jlib/math/matrix.hh>
+
+#include <cmath>
+#include <memory>
+#include <sstream>
+#include <string>
+
+namespace jlib {
+namespace ai {
+
+/**
+ * Which nonlinearity a layer applies.
+ *
+ * Every one has a derivative expressible in terms of its own *output*, which
+ * is what lets a backend cache one value per layer rather than two:
+ *
+ *   sigmoid      s (1 - s)
+ *   tanh         1 - s^2
+ *   relu         s > 0 ? 1 : 0
+ *   leaky_relu   s > 0 ? 1 : LEAK
+ */
+enum class activation { sigmoid, tanh, relu, leaky_relu };
+
+/**
+ * What a backend throws.
+ *
+ * At namespace scope rather than nested in backend<T>: a nested class of a
+ * template is a different type per instantiation, so a caller catching one
+ * would have to know which element type threw it, and the free functions
+ * below could not throw it at all.
+ */
+class backend_error : public std::exception {
+public:
+    backend_error(const std::string& msg = "") {
+        m_msg = "jlib::ai::backend exception" + (msg.empty() ? "" : ": " + msg);
+    }
+    virtual ~backend_error() {}
+    virtual const char* what() const noexcept { return m_msg.c_str(); }
+protected:
+    std::string m_msg;
+};
+
+/** The slope a leaky ReLU keeps below zero. */
+inline constexpr double LEAK = 0.01;
+
+std::string name_of(activation a);
+activation activation_from_name(const std::string& s);
+
+/**
+ * Where a network's numbers live and who does the arithmetic.
+ *
+ * ## Why this exists
+ *
+ * `jlib/cuda/neural.hh` is a 399-line copy of the network with the multiplies
+ * routed through cuBLAS.  It carries three bugs that have since been fixed in
+ * the original -- fan-out initialisation, backpropagation through
+ * already-updated weights, and a gradient that is not a mean -- and nobody
+ * noticed, because it does not build without CUDA (#138).  A second fork for
+ * Metal would have made a third copy and a second wrong one.
+ *
+ * So the training step exists once and the *device* is the parameter.  A
+ * backend supplies opaque tensors and the eight operations a step performs;
+ * nothing above it knows whether the numbers are in host memory or on a GPU.
+ *
+ * ## The contract that is easy to get wrong
+ *
+ * **Operations may be deferred.**  A GPU backend batches them into one
+ * submission, because synchronising per operation is what made the first Metal
+ * wiring slow -- measured at up to 7.9x. So a tensor's contents are undefined
+ * until wait() has returned, and read() before that is a bug this cannot
+ * detect for you.
+ *
+ * The CPU backend runs everything immediately and its wait() does nothing,
+ * which means code that forgets to wait works there and fails on a GPU.  Write
+ * the wait.
+ */
+template<typename T>
+class backend {
+public:
+    typedef backend_error exception;
+
+    typedef T value_type;
+
+    /** A matrix, wherever the backend keeps it. */
+    class tensor {
+    public:
+        virtual ~tensor() {}
+
+        virtual unsigned int rows() const = 0;
+        virtual unsigned int cols() const = 0;
+
+        unsigned int size() const { return rows() * cols(); }
+
+        /** Copy to the host.  Only meaningful after backend::wait(). */
+        virtual math::matrix<T> read() const = 0;
+
+        /** Copy from the host. */
+        virtual void write(const math::matrix<T>& m) = 0;
+    };
+
+    typedef std::shared_ptr<tensor> tensor_ptr;
+
+    virtual ~backend() {}
+
+    /** What this is, for a caller that wants to say where it ran. */
+    virtual std::string name() const = 0;
+
+    virtual tensor_ptr make(unsigned int rows, unsigned int cols) = 0;
+    virtual tensor_ptr make(const math::matrix<T>& m) = 0;
+
+    /** c = alpha * a * b + beta * c */
+    virtual void multiply(const tensor_ptr& a, const tensor_ptr& b,
+                          tensor_ptr& c, T alpha = T(1), T beta = T(0)) = 0;
+
+    /** c = alpha * a^T * b + beta * c */
+    virtual void multiply_tn(const tensor_ptr& a, const tensor_ptr& b,
+                             tensor_ptr& c, T alpha = T(1), T beta = T(0)) = 0;
+
+    /** c = alpha * a * b^T + beta * c */
+    virtual void multiply_nt(const tensor_ptr& a, const tensor_ptr& b,
+                             tensor_ptr& c, T alpha = T(1), T beta = T(0)) = 0;
+
+    virtual void activate(activation kind, const tensor_ptr& in, tensor_ptr& out) = 0;
+
+    /** The derivative, from the layer's own output. */
+    virtual void slope(activation kind, const tensor_ptr& out_of_layer,
+                       tensor_ptr& out) = 0;
+
+    virtual void hadamard(const tensor_ptr& a, const tensor_ptr& b, tensor_ptr& c) = 0;
+    virtual void subtract(const tensor_ptr& a, const tensor_ptr& b, tensor_ptr& c) = 0;
+
+    /** y += alpha * x */
+    virtual void add_scaled(T alpha, const tensor_ptr& x, tensor_ptr& y) = 0;
+
+    /** Everything encoded so far has finished when this returns. */
+    virtual void wait() = 0;
+};
+
+/**
+ * The default: host memory and math::matrix.
+ *
+ * Every operation runs immediately, so wait() has nothing to do.  Kept simple
+ * on purpose -- it is the reference the GPU backends are tested against, and
+ * anything clever in here would be something to be wrong about twice.
+ */
+template<typename T>
+class host_backend : public backend<T> {
+public:
+    typedef typename backend<T>::tensor_ptr tensor_ptr;
+
+    std::string name() const { return "host"; }
+
+    tensor_ptr make(unsigned int rows, unsigned int cols);
+    tensor_ptr make(const math::matrix<T>& m);
+
+    void multiply(const tensor_ptr& a, const tensor_ptr& b, tensor_ptr& c,
+                  T alpha = T(1), T beta = T(0));
+    void multiply_tn(const tensor_ptr& a, const tensor_ptr& b, tensor_ptr& c,
+                     T alpha = T(1), T beta = T(0));
+    void multiply_nt(const tensor_ptr& a, const tensor_ptr& b, tensor_ptr& c,
+                     T alpha = T(1), T beta = T(0));
+
+    void activate(activation kind, const tensor_ptr& in, tensor_ptr& out);
+    void slope(activation kind, const tensor_ptr& out_of_layer, tensor_ptr& out);
+    void hadamard(const tensor_ptr& a, const tensor_ptr& b, tensor_ptr& c);
+    void subtract(const tensor_ptr& a, const tensor_ptr& b, tensor_ptr& c);
+    void add_scaled(T alpha, const tensor_ptr& x, tensor_ptr& y);
+
+    void wait() {}
+
+    /** The matrix behind a host tensor, for the backend's own use. */
+    static math::matrix<T>& at(const tensor_ptr& t);
+};
+
+/** f(x), elementwise.  Public because the tests compare against it. */
+template<typename T>
+math::matrix<T> activate_matrix(activation a, const math::matrix<T>& in);
+
+/** f'(x) from f's output, elementwise. */
+template<typename T>
+math::matrix<T> slope_matrix(activation a, const math::matrix<T>& out);
+
+
+// ---------------------------------------------------------------------------
+// Definitions.  Templates, so they live here rather than in backend.cc, which
+// keeps only the two functions that do not depend on the element type.
+// ---------------------------------------------------------------------------
+
+template<typename T>
+math::matrix<T> activate_matrix(activation a, const math::matrix<T>& in) {
+    math::matrix<T> out(in.M, in.N);
+
+    for(uint r = 0; r < in.M; r++) {
+        for(uint c = 0; c < in.N; c++) {
+            // Through float: std::exp and std::tanh have no _Float16 overload,
+            // and a half computed in half is no more accurate than one
+            // computed in float and rounded.
+            const float x = float(in(r, c));
+
+            switch(a) {
+            case activation::sigmoid:    out(r,c) = T(1.0f / (1.0f + std::exp(-x))); break;
+            case activation::tanh:       out(r,c) = T(std::tanh(x));                 break;
+            case activation::relu:       out(r,c) = T((x > 0) ? x : 0.0f);           break;
+            case activation::leaky_relu: out(r,c) = T((x > 0) ? x : float(LEAK) * x); break;
+            }
+        }
+    }
+
+    return out;
+}
+
+template<typename T>
+math::matrix<T> slope_matrix(activation a, const math::matrix<T>& out) {
+    math::matrix<T> d(out.M, out.N);
+
+    for(uint r = 0; r < out.M; r++) {
+        for(uint c = 0; c < out.N; c++) {
+            const float s = float(out(r, c));
+
+            switch(a) {
+            case activation::sigmoid:    d(r,c) = T(s * (1.0f - s));        break;
+            case activation::tanh:       d(r,c) = T(1.0f - s * s);          break;
+            case activation::relu:       d(r,c) = T((s > 0) ? 1.0f : 0.0f); break;
+            case activation::leaky_relu: d(r,c) = T((s > 0) ? 1.0f : float(LEAK)); break;
+            }
+        }
+    }
+
+    return d;
+}
+
+/** A tensor that is just a matrix. */
+template<typename T>
+class host_tensor : public backend<T>::tensor {
+public:
+    host_tensor(unsigned int rows, unsigned int cols) : m(rows, cols) {}
+    host_tensor(const math::matrix<T>& from) : m(from) {}
+
+    unsigned int rows() const { return m.M; }
+    unsigned int cols() const { return m.N; }
+
+    math::matrix<T> read() const { return m; }
+
+    void write(const math::matrix<T>& from) {
+        if(from.M != m.M || from.N != m.N) {
+            std::ostringstream o;
+            o << "cannot write [" << from.M << "," << from.N << "] into ["
+              << m.M << "," << m.N << "]";
+            throw backend_error(o.str());
+        }
+
+        m = from;
+    }
+
+    math::matrix<T> m;
+};
+
+template<typename T>
+math::matrix<T>& host_backend<T>::at(const tensor_ptr& t) {
+    host_tensor<T>* h = dynamic_cast<host_tensor<T>*>(t.get());
+
+    // A tensor from another backend.  Checked rather than static_cast: the
+    // two are the same type at the call site, and the consequence otherwise
+    // is reading a GPU buffer as host memory.
+    if(h == 0)
+        throw backend_error("that tensor did not come from this backend");
+
+    return h->m;
+}
+
+template<typename T>
+typename backend<T>::tensor_ptr host_backend<T>::make(unsigned int rows,
+                                                      unsigned int cols)
+{
+    return tensor_ptr(new host_tensor<T>(rows, cols));
+}
+
+template<typename T>
+typename backend<T>::tensor_ptr host_backend<T>::make(const math::matrix<T>& m) {
+    return tensor_ptr(new host_tensor<T>(m));
+}
+
+namespace detail {
+
+/** out = alpha * p + beta * out, which every multiply below ends with. */
+template<typename T>
+void blend(const math::matrix<T>& p, math::matrix<T>& out, T alpha, T beta) {
+    for(uint r = 0; r < out.M; r++)
+        for(uint c = 0; c < out.N; c++)
+            out(r,c) = T(float(alpha) * float(p(r,c)) + float(beta) * float(out(r,c)));
+}
+
+}
+
+template<typename T>
+void host_backend<T>::multiply(const tensor_ptr& a, const tensor_ptr& b,
+                               tensor_ptr& c, T alpha, T beta)
+{
+    detail::blend(at(a) * at(b), at(c), alpha, beta);
+}
+
+template<typename T>
+void host_backend<T>::multiply_tn(const tensor_ptr& a, const tensor_ptr& b,
+                                  tensor_ptr& c, T alpha, T beta)
+{
+    detail::blend(at(a).transpose() * at(b), at(c), alpha, beta);
+}
+
+template<typename T>
+void host_backend<T>::multiply_nt(const tensor_ptr& a, const tensor_ptr& b,
+                                  tensor_ptr& c, T alpha, T beta)
+{
+    detail::blend(at(a) * at(b).transpose(), at(c), alpha, beta);
+}
+
+template<typename T>
+void host_backend<T>::activate(activation kind, const tensor_ptr& in, tensor_ptr& out) {
+    at(out) = activate_matrix(kind, at(in));
+}
+
+template<typename T>
+void host_backend<T>::slope(activation kind, const tensor_ptr& out_of_layer,
+                            tensor_ptr& out)
+{
+    at(out) = slope_matrix(kind, at(out_of_layer));
+}
+
+template<typename T>
+void host_backend<T>::hadamard(const tensor_ptr& a, const tensor_ptr& b, tensor_ptr& c) {
+    at(c) = at(a) ^ at(b);
+}
+
+template<typename T>
+void host_backend<T>::subtract(const tensor_ptr& a, const tensor_ptr& b, tensor_ptr& c) {
+    at(c) = at(a) - at(b);
+}
+
+template<typename T>
+void host_backend<T>::add_scaled(T alpha, const tensor_ptr& x, tensor_ptr& y) {
+    math::matrix<T>& out = at(y);
+    const math::matrix<T>& in = at(x);
+
+    for(uint r = 0; r < out.M; r++)
+        for(uint c = 0; c < out.N; c++)
+            out(r,c) = T(float(out(r,c)) + float(alpha) * float(in(r,c)));
+}
+
+}
+}
+
+#endif // JLIB_AI_BACKEND_HH

--- a/jlib/metal/Makefile.am
+++ b/jlib/metal/Makefile.am
@@ -5,14 +5,14 @@ AM_CPPFLAGS = -I$(top_srcdir)
 
 lib_LTLIBRARIES = libjmetal.la
 
-libjmetal_la_SOURCES = device.mm gemm.mm tensor.mm
+libjmetal_la_SOURCES = device.mm gemm.mm tensor.mm backend.mm
 noinst_HEADERS       = impl.hh
 libjmetal_la_LDFLAGS = -version-info $(LIBJ_SO_VERSION) -release $(JLIB_RELEASE) -no-undefined
-libjmetal_la_LIBADD  = $(METAL_LIBS)
+libjmetal_la_LIBADD  = $(top_builddir)/jlib/ai/libjai.la $(METAL_LIBS)
 
 # ARC, so the Objective-C objects behind the opaque handles are released
 # without a retain/release in every path.
 libjmetal_la_OBJCXXFLAGS = $(AM_OBJCXXFLAGS) -fobjc-arc -std=c++20
 
 libjmetalincludedir = $(includedir)/jlib-1.2/jlib/metal
-libjmetalinclude_HEADERS = device.hh gemm.hh tensor.hh
+libjmetalinclude_HEADERS = device.hh gemm.hh tensor.hh backend.hh

--- a/jlib/metal/backend.hh
+++ b/jlib/metal/backend.hh
@@ -1,0 +1,81 @@
+/* -*- mode: C++ c-basic-offset: 4 -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef JLIB_METAL_BACKEND_HH
+#define JLIB_METAL_BACKEND_HH
+
+#include <jlib/metal/tensor.hh>
+
+#include <jlib/ai/backend.hh>
+
+#include <memory>
+
+namespace jlib {
+namespace metal {
+
+/**
+ * ai::backend on the GPU.
+ *
+ * The dependency runs this way round on purpose: jlib/metal knows about
+ * jlib/ai and not the reverse, so a machine without Metal builds the neural
+ * library unchanged and a network that never asks for a GPU never links one.
+ *
+ * **Everything is deferred.**  Operations encode into one command buffer and
+ * nothing has happened until wait() returns -- which is the entire point, and
+ * measured at up to 7.9x against synchronising per operation.  A tensor read
+ * before then holds whatever it held before.
+ */
+template<typename T>
+class backend : public ai::backend<T> {
+public:
+    typedef typename ai::backend<T>::tensor_ptr tensor_ptr;
+
+    explicit backend(std::shared_ptr<device> d = device::shared());
+
+    ~backend();
+
+    std::string name() const;
+
+    tensor_ptr make(unsigned int rows, unsigned int cols);
+    tensor_ptr make(const math::matrix<T>& m);
+
+    void multiply(const tensor_ptr& a, const tensor_ptr& b, tensor_ptr& c,
+                  T alpha = T(1), T beta = T(0));
+    void multiply_tn(const tensor_ptr& a, const tensor_ptr& b, tensor_ptr& c,
+                     T alpha = T(1), T beta = T(0));
+    void multiply_nt(const tensor_ptr& a, const tensor_ptr& b, tensor_ptr& c,
+                     T alpha = T(1), T beta = T(0));
+
+    void activate(ai::activation kind, const tensor_ptr& in, tensor_ptr& out);
+    void slope(ai::activation kind, const tensor_ptr& out_of_layer, tensor_ptr& out);
+    void hadamard(const tensor_ptr& a, const tensor_ptr& b, tensor_ptr& c);
+    void subtract(const tensor_ptr& a, const tensor_ptr& b, tensor_ptr& c);
+    void add_scaled(T alpha, const tensor_ptr& x, tensor_ptr& y);
+
+    void wait();
+
+private:
+    std::shared_ptr<device> m_device;
+    std::unique_ptr<stream<T> > m_stream;
+};
+
+}
+}
+
+#endif // JLIB_METAL_BACKEND_HH

--- a/jlib/metal/backend.mm
+++ b/jlib/metal/backend.mm
@@ -1,0 +1,152 @@
+/* -*- mode: ObjC++ c-basic-offset: 4 -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <jlib/metal/backend.hh>
+
+namespace jlib {
+namespace metal {
+
+namespace {
+
+/** ai::backend<T>::tensor over a metal::tensor<T>. */
+template<typename T>
+class device_tensor : public ai::backend<T>::tensor {
+public:
+    device_tensor(std::shared_ptr<device> d, unsigned int rows, unsigned int cols)
+        : t(d, rows, cols) {}
+
+    device_tensor(std::shared_ptr<device> d, const math::matrix<T>& m)
+        : t(d, m) {}
+
+    unsigned int rows() const { return t.rows(); }
+    unsigned int cols() const { return t.cols(); }
+
+    math::matrix<T> read() const { return t.read(); }
+    void write(const math::matrix<T>& m) { t.write(m); }
+
+    metal::tensor<T> t;
+};
+
+template<typename T>
+metal::tensor<T>& at(const std::shared_ptr<typename ai::backend<T>::tensor>& p) {
+    device_tensor<T>* d = dynamic_cast<device_tensor<T>*>(p.get());
+
+    // A host tensor handed to the GPU backend.  Checked rather than
+    // static_cast: the two are the same type at the call site and the
+    // consequence otherwise is reading host memory as a device buffer.
+    if(d == 0)
+        throw ai::backend_error("that tensor did not come from this backend");
+
+    return d->t;
+}
+
+/** ai's activation and metal's are separate enums with the same values. */
+inline metal::activation as_metal(ai::activation a) {
+    return static_cast<metal::activation>(static_cast<int>(a));
+}
+
+}
+
+template<typename T>
+backend<T>::backend(std::shared_ptr<device> d)
+    : m_device(d)
+{
+    if(!d)
+        throw ai::backend_error("no device");
+
+    m_stream.reset(new stream<T>(d));
+}
+
+template<typename T>
+backend<T>::~backend() = default;
+
+template<typename T>
+std::string backend<T>::name() const {
+    return m_device->name() + (m_device->unified() ? " (unified memory)" : "");
+}
+
+template<typename T>
+typename backend<T>::tensor_ptr backend<T>::make(unsigned int rows, unsigned int cols) {
+    return tensor_ptr(new device_tensor<T>(m_device, rows, cols));
+}
+
+template<typename T>
+typename backend<T>::tensor_ptr backend<T>::make(const math::matrix<T>& m) {
+    return tensor_ptr(new device_tensor<T>(m_device, m));
+}
+
+template<typename T>
+void backend<T>::multiply(const tensor_ptr& a, const tensor_ptr& b, tensor_ptr& c,
+                          T alpha, T beta)
+{
+    m_stream->multiply(at<T>(a), at<T>(b), at<T>(c), float(alpha), float(beta));
+}
+
+template<typename T>
+void backend<T>::multiply_tn(const tensor_ptr& a, const tensor_ptr& b, tensor_ptr& c,
+                             T alpha, T beta)
+{
+    m_stream->multiply_tn(at<T>(a), at<T>(b), at<T>(c), float(alpha), float(beta));
+}
+
+template<typename T>
+void backend<T>::multiply_nt(const tensor_ptr& a, const tensor_ptr& b, tensor_ptr& c,
+                             T alpha, T beta)
+{
+    m_stream->multiply_nt(at<T>(a), at<T>(b), at<T>(c), float(alpha), float(beta));
+}
+
+template<typename T>
+void backend<T>::activate(ai::activation kind, const tensor_ptr& in, tensor_ptr& out) {
+    m_stream->activate(as_metal(kind), at<T>(in), at<T>(out));
+}
+
+template<typename T>
+void backend<T>::slope(ai::activation kind, const tensor_ptr& out_of_layer,
+                       tensor_ptr& out)
+{
+    m_stream->slope(as_metal(kind), at<T>(out_of_layer), at<T>(out));
+}
+
+template<typename T>
+void backend<T>::hadamard(const tensor_ptr& a, const tensor_ptr& b, tensor_ptr& c) {
+    m_stream->hadamard(at<T>(a), at<T>(b), at<T>(c));
+}
+
+template<typename T>
+void backend<T>::subtract(const tensor_ptr& a, const tensor_ptr& b, tensor_ptr& c) {
+    m_stream->subtract(at<T>(a), at<T>(b), at<T>(c));
+}
+
+template<typename T>
+void backend<T>::add_scaled(T alpha, const tensor_ptr& x, tensor_ptr& y) {
+    m_stream->add_scaled(float(alpha), at<T>(x), at<T>(y));
+}
+
+template<typename T>
+void backend<T>::wait() {
+    m_stream->wait();
+}
+
+// Objective-C++ cannot be a template header; see tensor.mm.
+template class backend<float>;
+template class backend<_Float16>;
+
+}
+}

--- a/jlib/metal/device.hh
+++ b/jlib/metal/device.hh
@@ -96,8 +96,12 @@ private:
     std::unique_ptr<impl> m_impl;
 
     friend class matrix_multiply;
-    friend class tensor;
-    friend class stream;
+
+    // Templates, so the friend declarations are too -- a plain `friend class
+    // tensor;` forward-declares a non-template of that name and the real
+    // definition then collides with it.
+    template<typename> friend class tensor;
+    template<typename> friend class stream;
 };
 
 }

--- a/jlib/metal/tensor.hh
+++ b/jlib/metal/tensor.hh
@@ -24,6 +24,8 @@
 
 #include <jlib/math/matrix.hh>
 
+#include <jlib/ai/backend.hh>
+
 #include <memory>
 #include <string>
 
@@ -45,6 +47,24 @@ enum class activation { sigmoid, tanh, relu, leaky_relu };
 inline constexpr float LEAK = 0.01f;
 
 /**
+ * The element types this module supports.
+ *
+ * float and _Float16, and nothing else.  Metal Shading Language has no double
+ * -- the compiler refuses it in as many words -- so metal::tensor<double> must
+ * fail with something a reader can act on rather than a page of template
+ * errors.  bfloat compiles in MSL too and is the better type for inference;
+ * adding it is a third instantiation and a third kernel name, not a design
+ * change.
+ *
+ * _Float16 is a compiler extension rather than standard C++: clang and gcc
+ * both have it, C23 standardises it, C++ has not yet.  Verified working with
+ * math::matrix on Apple clang arm64 and gcc 13 x86_64.
+ */
+template<typename T> struct supported { static constexpr bool value = false; };
+template<> struct supported<float> { static constexpr bool value = true; };
+template<> struct supported<_Float16> { static constexpr bool value = true; };
+
+/**
  * A matrix that lives on the GPU.
  *
  * The whole reason this exists.  gemm.hh takes math::matrix, so every call
@@ -60,24 +80,20 @@ inline constexpr float LEAK = 0.01f;
  * Column-major, matching math::matrix -- see stream::multiply for why that
  * costs nothing.
  */
+template<typename T>
 class tensor {
+    static_assert(supported<T>::value,
+                  "metal::tensor supports float and _Float16.  Metal Shading "
+                  "Language has no double, so there is no fp64 path to add.");
+
 public:
-    class exception : public std::exception {
-    public:
-        exception(const std::string& msg = "") {
-            m_msg = "jlib::metal::tensor exception" + (msg.empty() ? "" : ": " + msg);
-        }
-        virtual ~exception() {}
-        virtual const char* what() const noexcept { return m_msg.c_str(); }
-    protected:
-        std::string m_msg;
-    };
+    typedef ai::backend_error exception;
 
     /** Uninitialised, on the device. */
     tensor(std::shared_ptr<device> d, unsigned int rows, unsigned int cols);
 
     /** Uploaded from the host. */
-    tensor(std::shared_ptr<device> d, const math::matrix<float>& m);
+    tensor(std::shared_ptr<device> d, const math::matrix<T>& m);
 
     ~tensor();
 
@@ -98,10 +114,10 @@ public:
      * stream::wait().  Reading a tensor a stream is still building is a race,
      * and nothing here can detect it for you.
      */
-    math::matrix<float> read() const;
+    math::matrix<T> read() const;
 
     /** Copy in from the host, overwriting. */
-    void write(const math::matrix<float>& m);
+    void write(const math::matrix<T>& m);
 
 private:
     std::shared_ptr<device> m_device;
@@ -112,7 +128,7 @@ private:
     struct impl;
     std::unique_ptr<impl> m_impl;
 
-    friend class stream;
+    template<typename> friend class stream;
 };
 
 /**
@@ -126,18 +142,12 @@ private:
  * whatever it held before, which is the one sharp edge in the design and the
  * price of not stalling between every operation.
  */
+template<typename T>
 class stream {
+    static_assert(supported<T>::value, "metal::stream supports float and _Float16");
+
 public:
-    class exception : public std::exception {
-    public:
-        exception(const std::string& msg = "") {
-            m_msg = "jlib::metal::stream exception" + (msg.empty() ? "" : ": " + msg);
-        }
-        virtual ~exception() {}
-        virtual const char* what() const noexcept { return m_msg.c_str(); }
-    protected:
-        std::string m_msg;
-    };
+    typedef ai::backend_error exception;
 
     explicit stream(std::shared_ptr<device> d = device::shared());
 
@@ -147,31 +157,31 @@ public:
     stream& operator=(const stream&) = delete;
 
     /** c = alpha * a * b + beta * c. */
-    void multiply(const tensor& a, const tensor& b, tensor& c,
+    void multiply(const tensor<T>& a, const tensor<T>& b, tensor<T>& c,
                   float alpha = 1.0f, float beta = 0.0f);
 
     /** c = alpha * a^T * b + beta * c, without materialising the transpose. */
-    void multiply_tn(const tensor& a, const tensor& b, tensor& c,
+    void multiply_tn(const tensor<T>& a, const tensor<T>& b, tensor<T>& c,
                      float alpha = 1.0f, float beta = 0.0f);
 
     /** c = alpha * a * b^T + beta * c. */
-    void multiply_nt(const tensor& a, const tensor& b, tensor& c,
+    void multiply_nt(const tensor<T>& a, const tensor<T>& b, tensor<T>& c,
                      float alpha = 1.0f, float beta = 0.0f);
 
     /** out = f(in). */
-    void activate(activation kind, const tensor& in, tensor& out);
+    void activate(activation kind, const tensor<T>& in, tensor<T>& out);
 
     /** out = f'(x), taken from f's own output.  See ai::activation. */
-    void slope(activation kind, const tensor& out_of_layer, tensor& out);
+    void slope(activation kind, const tensor<T>& out_of_layer, tensor<T>& out);
 
     /** c = a * b, elementwise. */
-    void hadamard(const tensor& a, const tensor& b, tensor& c);
+    void hadamard(const tensor<T>& a, const tensor<T>& b, tensor<T>& c);
 
     /** c = a - b. */
-    void subtract(const tensor& a, const tensor& b, tensor& c);
+    void subtract(const tensor<T>& a, const tensor<T>& b, tensor<T>& c);
 
     /** y += alpha * x. */
-    void add_scaled(float alpha, const tensor& x, tensor& y);
+    void add_scaled(float alpha, const tensor<T>& x, tensor<T>& y);
 
     /** Commit everything encoded so far and block until the GPU is done. */
     void wait();

--- a/jlib/metal/tensor.mm
+++ b/jlib/metal/tensor.mm
@@ -72,61 +72,111 @@ inline float slope_of(uint kind, float s) {
     }
 }
 
-kernel void k_activate(device const float* in [[buffer(0)]],
-                       device float* out [[buffer(1)]],
+// Written once and instantiated per element type.  MSL has templates and
+// [[host_name]], so one source serves float and half and the host looks the
+// right one up by name.  The arithmetic is in float whatever T is: a half
+// computed in half is no more accurate than one computed in float and
+// rounded, and exp() in half is not obviously either.
+
+template<typename T>
+kernel void k_activate(device const T* in [[buffer(0)]],
+                       device T* out [[buffer(1)]],
                        constant uint& kind [[buffer(2)]],
                        constant uint& n [[buffer(3)]],
                        uint i [[thread_position_in_grid]])
 {
-    if(i < n) out[i] = apply(kind, in[i]);
+    if(i < n) out[i] = T(apply(kind, float(in[i])));
 }
 
-kernel void k_slope(device const float* in [[buffer(0)]],
-                    device float* out [[buffer(1)]],
+template<typename T>
+kernel void k_slope(device const T* in [[buffer(0)]],
+                    device T* out [[buffer(1)]],
                     constant uint& kind [[buffer(2)]],
                     constant uint& n [[buffer(3)]],
                     uint i [[thread_position_in_grid]])
 {
-    if(i < n) out[i] = slope_of(kind, in[i]);
+    if(i < n) out[i] = T(slope_of(kind, float(in[i])));
 }
 
-kernel void k_hadamard(device const float* a [[buffer(0)]],
-                       device const float* b [[buffer(1)]],
-                       device float* c [[buffer(2)]],
+template<typename T>
+kernel void k_hadamard(device const T* a [[buffer(0)]],
+                       device const T* b [[buffer(1)]],
+                       device T* c [[buffer(2)]],
                        constant uint& n [[buffer(3)]],
                        uint i [[thread_position_in_grid]])
 {
-    if(i < n) c[i] = a[i] * b[i];
+    if(i < n) c[i] = T(float(a[i]) * float(b[i]));
 }
 
-kernel void k_subtract(device const float* a [[buffer(0)]],
-                       device const float* b [[buffer(1)]],
-                       device float* c [[buffer(2)]],
+template<typename T>
+kernel void k_subtract(device const T* a [[buffer(0)]],
+                       device const T* b [[buffer(1)]],
+                       device T* c [[buffer(2)]],
                        constant uint& n [[buffer(3)]],
                        uint i [[thread_position_in_grid]])
 {
-    if(i < n) c[i] = a[i] - b[i];
+    if(i < n) c[i] = T(float(a[i]) - float(b[i]));
 }
 
-kernel void k_add_scaled(device const float* x [[buffer(0)]],
-                         device float* y [[buffer(1)]],
+template<typename T>
+kernel void k_add_scaled(device const T* x [[buffer(0)]],
+                         device T* y [[buffer(1)]],
                          constant float& alpha [[buffer(2)]],
                          constant uint& n [[buffer(3)]],
                          uint i [[thread_position_in_grid]])
 {
-    if(i < n) y[i] = y[i] + alpha * x[i];
+    if(i < n) y[i] = T(float(y[i]) + alpha * float(x[i]));
 }
+
+#define INSTANTIATE(NAME, T, SUFFIX)                                        \
+    template [[host_name(#NAME SUFFIX)]] kernel void NAME<T>
+
+INSTANTIATE(k_activate, float, "_f32")(device const float*, device float*,
+                                       constant uint&, constant uint&, uint);
+INSTANTIATE(k_activate, half, "_f16")(device const half*, device half*,
+                                      constant uint&, constant uint&, uint);
+INSTANTIATE(k_slope, float, "_f32")(device const float*, device float*,
+                                    constant uint&, constant uint&, uint);
+INSTANTIATE(k_slope, half, "_f16")(device const half*, device half*,
+                                   constant uint&, constant uint&, uint);
+INSTANTIATE(k_hadamard, float, "_f32")(device const float*, device const float*,
+                                       device float*, constant uint&, uint);
+INSTANTIATE(k_hadamard, half, "_f16")(device const half*, device const half*,
+                                      device half*, constant uint&, uint);
+INSTANTIATE(k_subtract, float, "_f32")(device const float*, device const float*,
+                                       device float*, constant uint&, uint);
+INSTANTIATE(k_subtract, half, "_f16")(device const half*, device const half*,
+                                      device half*, constant uint&, uint);
+INSTANTIATE(k_add_scaled, float, "_f32")(device const float*, device float*,
+                                         constant float&, constant uint&, uint);
+INSTANTIATE(k_add_scaled, half, "_f16")(device const half*, device half*,
+                                        constant float&, constant uint&, uint);
 )METAL";
+
+/** The per-type details: what MPS calls it, and what the kernels are named. */
+template<typename T> struct traits;
+
+template<> struct traits<float> {
+    static MPSDataType mps() { return MPSDataTypeFloat32; }
+    static const char* suffix() { return "_f32"; }
+};
+
+template<> struct traits<_Float16> {
+    static MPSDataType mps() { return MPSDataTypeFloat16; }
+    static const char* suffix() { return "_f16"; }
+};
 
 }
 
 // ------------------------------------------------------------------ tensor
 
-struct tensor::impl {
+template<typename T>
+struct tensor<T>::impl {
     id<MTLBuffer> buf = nil;
 };
 
-tensor::tensor(std::shared_ptr<device> d, unsigned int rows, unsigned int cols)
+template<typename T>
+tensor<T>::tensor(std::shared_ptr<device> d, unsigned int rows, unsigned int cols)
     : m_device(d),
       m_rows(rows),
       m_cols(cols),
@@ -135,41 +185,48 @@ tensor::tensor(std::shared_ptr<device> d, unsigned int rows, unsigned int cols)
     if(!d)
         throw exception("no device");
 
-    const NSUInteger bytes = (NSUInteger)rows * cols * sizeof(float);
+    const NSUInteger bytes = (NSUInteger)rows * cols * sizeof(T);
 
     // Never zero: Metal refuses a zero-length buffer, and a 0xN tensor is a
     // legitimate thing to carry around even though nothing reads it.
-    m_impl->buf = [d->m_impl->gpu newBufferWithLength:(bytes ? bytes : sizeof(float))
+    m_impl->buf = [d->m_impl->gpu newBufferWithLength:(bytes ? bytes : sizeof(T))
                                               options:MTLResourceStorageModeShared];
 
     if(m_impl->buf == nil)
         throw exception("could not allocate a device buffer");
 }
 
-tensor::tensor(std::shared_ptr<device> d, const math::matrix<float>& m)
+template<typename T>
+tensor<T>::tensor(std::shared_ptr<device> d, const math::matrix<T>& m)
     : tensor(d, m.M, m.N)
 {
     write(m);
 }
 
-tensor::~tensor() = default;
+template<typename T>
+tensor<T>::~tensor() = default;
 
-tensor::tensor(tensor&&) = default;
-tensor& tensor::operator=(tensor&&) = default;
+template<typename T>
+tensor<T>::tensor(tensor&&) = default;
 
-math::matrix<float> tensor::read() const {
-    math::matrix<float> out(m_rows, m_cols);
+template<typename T>
+tensor<T>& tensor<T>::operator=(tensor&&) = default;
+
+template<typename T>
+math::matrix<T> tensor<T>::read() const {
+    math::matrix<T> out(m_rows, m_cols);
 
     if(size() == 0)
         return out;
 
-    std::memcpy(static_cast<math::buffer<float> >(out).data(),
-                [m_impl->buf contents], size() * sizeof(float));
+    std::memcpy(static_cast<math::buffer<T> >(out).data(),
+                [m_impl->buf contents], size() * sizeof(T));
 
     return out;
 }
 
-void tensor::write(const math::matrix<float>& m) {
+template<typename T>
+void tensor<T>::write(const math::matrix<T>& m) {
     if(m.M != m_rows || m.N != m_cols) {
         std::ostringstream o;
         o << "cannot write [" << m.M << "," << m.N << "] into ["
@@ -181,13 +238,14 @@ void tensor::write(const math::matrix<float>& m) {
         return;
 
     std::memcpy([m_impl->buf contents],
-                static_cast<const math::buffer<float> >(m).data(),
-                size() * sizeof(float));
+                static_cast<const math::buffer<T> >(m).data(),
+                size() * sizeof(T));
 }
 
 // ------------------------------------------------------------------ stream
 
-struct stream::impl {
+template<typename T>
+struct stream<T>::impl {
     id<MTLCommandBuffer> cmd = nil;
     id<MTLComputeCommandEncoder> enc = nil;
 
@@ -202,13 +260,6 @@ struct stream::impl {
 
 namespace {
 
-/**
- * The compiled kernels, built once per device and kept.
- *
- * A library and five pipeline states are not free to build and are identical
- * every time, so a process that makes a stream per training step should not
- * pay for them per step.
- */
 struct pipelines {
     id<MTLComputePipelineState> activate = nil;
     id<MTLComputePipelineState> slope = nil;
@@ -217,6 +268,36 @@ struct pipelines {
     id<MTLComputePipelineState> add_scaled = nil;
 };
 
+/**
+ * The compiled kernels for one element type, built once and kept.
+ *
+ * The library is compiled once for the process -- it holds every
+ * instantiation -- and the pipeline states are per type, which is why this is
+ * a template with its own static.  Measured at 0.8 to 2.6 ms for the compile,
+ * once; see the note above KERNELS.
+ */
+id<MTLLibrary> library(id<MTLDevice> gpu) {
+    static id<MTLLibrary> lib = nil;
+
+    if(lib != nil)
+        return lib;
+
+    NSError* err = nil;
+
+    lib = [gpu newLibraryWithSource:[NSString stringWithUTF8String:KERNELS]
+                            options:nil
+                              error:&err];
+
+    if(lib == nil) {
+        const char* what = (err != nil)
+            ? [[err localizedDescription] UTF8String] : "unknown";
+        throw ai::backend_error(std::string("could not compile the kernels: ") + what);
+    }
+
+    return lib;
+}
+
+template<typename T>
 pipelines& compiled(id<MTLDevice> gpu) {
     static pipelines p;
     static bool done = false;
@@ -224,20 +305,11 @@ pipelines& compiled(id<MTLDevice> gpu) {
     if(done)
         return p;
 
+    id<MTLLibrary> lib = library(gpu);
+
     NSError* err = nil;
 
-    id<MTLLibrary> lib =
-        [gpu newLibraryWithSource:[NSString stringWithUTF8String:KERNELS]
-                          options:nil
-                            error:&err];
-
-    if(lib == nil) {
-        const char* what = (err != nil)
-            ? [[err localizedDescription] UTF8String] : "unknown";
-        throw stream::exception(std::string("could not compile the kernels: ") + what);
-    }
-
-    struct { const char* name; __strong id<MTLComputePipelineState>* into; } wanted[] = {
+    struct { const char* base; __strong id<MTLComputePipelineState>* into; } wanted[] = {
         { "k_activate",   &p.activate },
         { "k_slope",      &p.slope },
         { "k_hadamard",   &p.hadamard },
@@ -246,75 +318,24 @@ pipelines& compiled(id<MTLDevice> gpu) {
     };
 
     for(auto& w : wanted) {
-        id<MTLFunction> fn = [lib newFunctionWithName:[NSString stringWithUTF8String:w.name]];
+        const std::string name = std::string(w.base) + traits<T>::suffix();
+
+        id<MTLFunction> fn =
+            [lib newFunctionWithName:[NSString stringWithUTF8String:name.c_str()]];
 
         if(fn == nil)
-            throw stream::exception(std::string("no kernel called ") + w.name);
+            throw ai::backend_error("no kernel called " + name);
 
         *w.into = [gpu newComputePipelineStateWithFunction:fn error:&err];
 
         if(*w.into == nil)
-            throw stream::exception(std::string("could not build a pipeline for ") + w.name);
+            throw ai::backend_error("could not build a pipeline for " + name);
     }
 
     done = true;
 
     return p;
 }
-
-}
-
-stream::stream(std::shared_ptr<device> d)
-    : m_device(d),
-      m_impl(new impl)
-{
-    if(!d)
-        throw exception("no device");
-
-    pipelines& p = compiled(d->m_impl->gpu);
-
-    m_impl->activate = p.activate;
-    m_impl->slope = p.slope;
-    m_impl->hadamard = p.hadamard;
-    m_impl->subtract = p.subtract;
-    m_impl->add_scaled = p.add_scaled;
-}
-
-stream::~stream() {
-    // Anything encoded and never waited on is abandoned rather than run: a
-    // stream going out of scope unfinished means the caller changed its mind
-    // or is unwinding, and neither wants the GPU touching those buffers after
-    // the tensors have gone.
-    if(m_impl->enc != nil)
-        [m_impl->enc endEncoding];
-}
-
-unsigned int stream::pending() const { return m_impl->pending; }
-
-void stream::open() {
-    if(m_impl->cmd == nil)
-        m_impl->cmd = [m_device->m_impl->queue commandBuffer];
-
-    if(m_impl->enc == nil)
-        m_impl->enc = [m_impl->cmd computeCommandEncoder];
-}
-
-void stream::close() {
-    // MPS encodes into the command buffer directly rather than into a compute
-    // encoder, so an open one has to be ended first.  The next elementwise op
-    // opens another.
-    if(m_impl->enc != nil) {
-        [m_impl->enc endEncoding];
-        m_impl->enc = nil;
-    }
-
-    if(m_impl->cmd == nil)
-        m_impl->cmd = [m_device->m_impl->queue commandBuffer];
-}
-
-// -------------------------------------------------------- encoding helpers
-
-namespace {
 
 /** One thread per element, rounded up to the pipeline's preferred width. */
 void dispatch(id<MTLComputeCommandEncoder> enc,
@@ -328,18 +349,73 @@ void dispatch(id<MTLComputeCommandEncoder> enc,
         threadsPerThreadgroup:MTLSizeMake(width, 1, 1)];
 }
 
-void same_shape(const tensor& a, const tensor& b, const char* what) {
+template<typename T>
+void same_shape(const tensor<T>& a, const tensor<T>& b, const char* what) {
     if(a.rows() != b.rows() || a.cols() != b.cols()) {
         std::ostringstream o;
         o << what << ": [" << a.rows() << "," << a.cols() << "] against ["
           << b.rows() << "," << b.cols() << "]";
-        throw stream::exception(o.str());
+        throw ai::backend_error(o.str());
     }
 }
 
 }
 
-void stream::activate(activation kind, const tensor& in, tensor& out) {
+template<typename T>
+stream<T>::stream(std::shared_ptr<device> d)
+    : m_device(d),
+      m_impl(new impl)
+{
+    if(!d)
+        throw exception("no device");
+
+    pipelines& p = compiled<T>(d->m_impl->gpu);
+
+    m_impl->activate = p.activate;
+    m_impl->slope = p.slope;
+    m_impl->hadamard = p.hadamard;
+    m_impl->subtract = p.subtract;
+    m_impl->add_scaled = p.add_scaled;
+}
+
+template<typename T>
+stream<T>::~stream() {
+    // Anything encoded and never waited on is abandoned rather than run: a
+    // stream going out of scope unfinished means the caller changed its mind
+    // or is unwinding, and neither wants the GPU touching those buffers after
+    // the tensors have gone.
+    if(m_impl->enc != nil)
+        [m_impl->enc endEncoding];
+}
+
+template<typename T>
+unsigned int stream<T>::pending() const { return m_impl->pending; }
+
+template<typename T>
+void stream<T>::open() {
+    if(m_impl->cmd == nil)
+        m_impl->cmd = [m_device->m_impl->queue commandBuffer];
+
+    if(m_impl->enc == nil)
+        m_impl->enc = [m_impl->cmd computeCommandEncoder];
+}
+
+template<typename T>
+void stream<T>::close() {
+    // MPS encodes into the command buffer directly rather than into a compute
+    // encoder, so an open one has to be ended first.  The next elementwise op
+    // opens another.
+    if(m_impl->enc != nil) {
+        [m_impl->enc endEncoding];
+        m_impl->enc = nil;
+    }
+
+    if(m_impl->cmd == nil)
+        m_impl->cmd = [m_device->m_impl->queue commandBuffer];
+}
+
+template<typename T>
+void stream<T>::activate(metal::activation kind, const tensor<T>& in, tensor<T>& out) {
     same_shape(in, out, "activate");
 
     open();
@@ -358,7 +434,10 @@ void stream::activate(activation kind, const tensor& in, tensor& out) {
     m_impl->pending++;
 }
 
-void stream::slope(activation kind, const tensor& out_of_layer, tensor& out) {
+template<typename T>
+void stream<T>::slope(metal::activation kind, const tensor<T>& out_of_layer,
+                      tensor<T>& out)
+{
     same_shape(out_of_layer, out, "slope");
 
     open();
@@ -377,7 +456,8 @@ void stream::slope(activation kind, const tensor& out_of_layer, tensor& out) {
     m_impl->pending++;
 }
 
-void stream::hadamard(const tensor& a, const tensor& b, tensor& c) {
+template<typename T>
+void stream<T>::hadamard(const tensor<T>& a, const tensor<T>& b, tensor<T>& c) {
     same_shape(a, b, "hadamard");
     same_shape(a, c, "hadamard");
 
@@ -396,7 +476,8 @@ void stream::hadamard(const tensor& a, const tensor& b, tensor& c) {
     m_impl->pending++;
 }
 
-void stream::subtract(const tensor& a, const tensor& b, tensor& c) {
+template<typename T>
+void stream<T>::subtract(const tensor<T>& a, const tensor<T>& b, tensor<T>& c) {
     same_shape(a, b, "subtract");
     same_shape(a, c, "subtract");
 
@@ -415,7 +496,8 @@ void stream::subtract(const tensor& a, const tensor& b, tensor& c) {
     m_impl->pending++;
 }
 
-void stream::add_scaled(float alpha, const tensor& x, tensor& y) {
+template<typename T>
+void stream<T>::add_scaled(float alpha, const tensor<T>& x, tensor<T>& y) {
     same_shape(x, y, "add_scaled");
 
     open();
@@ -443,28 +525,29 @@ namespace {
  * same argument as gemm.mm, which has it at length; the difference here is
  * that the buffers already live on the device, so there is nothing to copy.
  */
+template<typename T>
 void encode_gemm(id<MTLCommandBuffer> cmd, id<MTLDevice> gpu,
                  id<MTLBuffer> ba, unsigned int arows, unsigned int acols, bool ta,
                  id<MTLBuffer> bb, unsigned int brows, unsigned int bcols, bool tb,
                  id<MTLBuffer> bc, unsigned int crows, unsigned int ccols,
                  float alpha, float beta)
 {
-    // In the transposed world the left operand is B and the right is A.
     const NSUInteger M = crows, N = ccols;
     const NSUInteger K = ta ? arows : acols;
+    const MPSDataType dt = traits<T>::mps();
 
     MPSMatrixDescriptor* da =
         [MPSMatrixDescriptor matrixDescriptorWithRows:acols columns:arows
-                                             rowBytes:arows * sizeof(float)
-                                             dataType:MPSDataTypeFloat32];
+                                             rowBytes:arows * sizeof(T)
+                                             dataType:dt];
     MPSMatrixDescriptor* db =
         [MPSMatrixDescriptor matrixDescriptorWithRows:bcols columns:brows
-                                             rowBytes:brows * sizeof(float)
-                                             dataType:MPSDataTypeFloat32];
+                                             rowBytes:brows * sizeof(T)
+                                             dataType:dt];
     MPSMatrixDescriptor* dc =
         [MPSMatrixDescriptor matrixDescriptorWithRows:ccols columns:crows
-                                             rowBytes:crows * sizeof(float)
-                                             dataType:MPSDataTypeFloat32];
+                                             rowBytes:crows * sizeof(T)
+                                             dataType:dt];
 
     MPSMatrix* ma = [[MPSMatrix alloc] initWithBuffer:ba descriptor:da];
     MPSMatrix* mb = [[MPSMatrix alloc] initWithBuffer:bb descriptor:db];
@@ -487,55 +570,59 @@ void encode_gemm(id<MTLCommandBuffer> cmd, id<MTLDevice> gpu,
 
 }
 
-void stream::multiply(const tensor& a, const tensor& b, tensor& c,
-                      float alpha, float beta)
+template<typename T>
+void stream<T>::multiply(const tensor<T>& a, const tensor<T>& b, tensor<T>& c,
+                         float alpha, float beta)
 {
     if(a.cols() != b.rows() || c.rows() != a.rows() || c.cols() != b.cols())
         throw exception("multiply: shapes do not meet");
 
     close();
 
-    encode_gemm(m_impl->cmd, m_device->m_impl->gpu,
-                a.m_impl->buf, a.rows(), a.cols(), false,
-                b.m_impl->buf, b.rows(), b.cols(), false,
-                c.m_impl->buf, c.rows(), c.cols(), alpha, beta);
+    encode_gemm<T>(m_impl->cmd, m_device->m_impl->gpu,
+                   a.m_impl->buf, a.rows(), a.cols(), false,
+                   b.m_impl->buf, b.rows(), b.cols(), false,
+                   c.m_impl->buf, c.rows(), c.cols(), alpha, beta);
 
     m_impl->pending++;
 }
 
-void stream::multiply_tn(const tensor& a, const tensor& b, tensor& c,
-                         float alpha, float beta)
+template<typename T>
+void stream<T>::multiply_tn(const tensor<T>& a, const tensor<T>& b, tensor<T>& c,
+                            float alpha, float beta)
 {
     if(a.rows() != b.rows() || c.rows() != a.cols() || c.cols() != b.cols())
         throw exception("multiply_tn: shapes do not meet");
 
     close();
 
-    encode_gemm(m_impl->cmd, m_device->m_impl->gpu,
-                a.m_impl->buf, a.rows(), a.cols(), true,
-                b.m_impl->buf, b.rows(), b.cols(), false,
-                c.m_impl->buf, c.rows(), c.cols(), alpha, beta);
+    encode_gemm<T>(m_impl->cmd, m_device->m_impl->gpu,
+                   a.m_impl->buf, a.rows(), a.cols(), true,
+                   b.m_impl->buf, b.rows(), b.cols(), false,
+                   c.m_impl->buf, c.rows(), c.cols(), alpha, beta);
 
     m_impl->pending++;
 }
 
-void stream::multiply_nt(const tensor& a, const tensor& b, tensor& c,
-                         float alpha, float beta)
+template<typename T>
+void stream<T>::multiply_nt(const tensor<T>& a, const tensor<T>& b, tensor<T>& c,
+                            float alpha, float beta)
 {
     if(a.cols() != b.cols() || c.rows() != a.rows() || c.cols() != b.rows())
         throw exception("multiply_nt: shapes do not meet");
 
     close();
 
-    encode_gemm(m_impl->cmd, m_device->m_impl->gpu,
-                a.m_impl->buf, a.rows(), a.cols(), false,
-                b.m_impl->buf, b.rows(), b.cols(), true,
-                c.m_impl->buf, c.rows(), c.cols(), alpha, beta);
+    encode_gemm<T>(m_impl->cmd, m_device->m_impl->gpu,
+                   a.m_impl->buf, a.rows(), a.cols(), false,
+                   b.m_impl->buf, b.rows(), b.cols(), true,
+                   c.m_impl->buf, c.rows(), c.cols(), alpha, beta);
 
     m_impl->pending++;
 }
 
-void stream::wait() {
+template<typename T>
+void stream<T>::wait() {
     if(m_impl->enc != nil) {
         [m_impl->enc endEncoding];
         m_impl->enc = nil;
@@ -557,6 +644,13 @@ void stream::wait() {
     if(failed)
         throw exception("the command buffer failed");
 }
+
+// Objective-C++ cannot be a template header, so the instantiations live here.
+// Adding bfloat would be a third line, a third kernel name, and nothing else.
+template class tensor<float>;
+template class tensor<_Float16>;
+template class stream<float>;
+template class stream<_Float16>;
 
 }
 }

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -45,7 +45,12 @@ endif
 # itself also exits 77 if there is no device, which covers a machine that has
 # the frameworks and no hardware.
 if HAVE_METAL
-METAL_TESTS = metal_gemm_test metal_tensor_test
+METAL_TESTS    = metal_gemm_test metal_tensor_test
+METAL_CPPFLAGS = -DHAVE_METAL
+METAL_LA       = $(top_builddir)/jlib/metal/libjmetal.la $(METAL_LIBS)
+else
+METAL_CPPFLAGS =
+METAL_LA       =
 endif
 
 TESTS = \
@@ -54,6 +59,7 @@ TESTS = \
 	math_plot_alloc_test \
 	math_dump_test \
 	ai_neural_test \
+	ai_backend_test \
 	math_object_test \
 	tensor_test \
 \
@@ -301,3 +307,7 @@ metal_gemm_test_LDADD   = $(top_builddir)/jlib/metal/libjmetal.la $(METAL_LIBS)
 
 metal_tensor_test_SOURCES = metal_tensor_test.cc
 metal_tensor_test_LDADD   = $(top_builddir)/jlib/metal/libjmetal.la $(JUTIL_LA) $(JSYS_LA) $(METAL_LIBS)
+
+ai_backend_test_SOURCES  = ai_backend_test.cc
+ai_backend_test_CPPFLAGS = $(AM_CPPFLAGS) $(METAL_CPPFLAGS)
+ai_backend_test_LDADD    = $(top_builddir)/jlib/ai/libjai.la $(JUTIL_LA) $(JSYS_LA) $(METAL_LA)

--- a/tests/ai_backend_test.cc
+++ b/tests/ai_backend_test.cc
@@ -1,0 +1,237 @@
+/* -*- mode: C++ c-basic-offset: 4 -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// One sequence of operations, every backend, every element type.
+//
+// This is the test the abstraction exists for.  jlib/cuda/neural.hh is a fork
+// of the network that silently missed three fixes because nothing compared it
+// against the original (#138); the point of ai::backend is that there is one
+// algorithm and the device is a parameter, and the point of this file is to
+// keep the parameters honest about each other.
+//
+// The host backend is the oracle: it is naive, immediate, and made of
+// math::matrix, so there is nothing clever in it to be wrong about twice.
+
+#include <jlib/ai/backend.hh>
+
+#ifdef HAVE_METAL
+#include <jlib/metal/backend.hh>
+#endif
+
+#include <cmath>
+#include <iostream>
+#include <memory>
+#include <random>
+#include <string>
+#include <vector>
+
+namespace ai = jlib::ai;
+
+using jlib::math::matrix;
+
+static int failures = 0;
+
+static void ok(const std::string& what, bool good, const std::string& detail = "") {
+    if(!good) ++failures;
+    std::cout << (good ? "  ok   " : "  FAIL ") << what;
+    if(!detail.empty()) std::cout << ": " << detail;
+    std::cout << "\n";
+}
+
+template<typename T>
+static matrix<T> random_matrix(uint m, uint n, std::mt19937& gen) {
+    // A modest range on purpose.  fp16 has about three decimal digits and
+    // tops out near 65504; a comparison that overflowed one type and not the
+    // other would be measuring the range rather than the arithmetic.
+    std::uniform_real_distribution<float> d(-1.0f, 1.0f);
+
+    matrix<T> a(m, n);
+
+    for(uint r = 0; r < m; r++)
+        for(uint c = 0; c < n; c++)
+            a(r, c) = T(d(gen));
+
+    return a;
+}
+
+template<typename T>
+static double worst(const matrix<T>& a, const matrix<T>& b) {
+    if(a.M != b.M || a.N != b.N) return 1e9;
+
+    double w = 0;
+
+    for(uint r = 0; r < a.M; r++)
+        for(uint c = 0; c < a.N; c++)
+            w = std::max(w, std::fabs(double(float(a(r,c))) - double(float(b(r,c)))));
+
+    return w;
+}
+
+/**
+ * A forward layer and the start of a backward one, which between them use
+ * every operation the interface has.
+ */
+template<typename T>
+static matrix<T> exercise(ai::backend<T>& b, const matrix<T>& w,
+                          const matrix<T>& x, const matrix<T>& target)
+{
+    typename ai::backend<T>::tensor_ptr tw = b.make(w);
+    typename ai::backend<T>::tensor_ptr tx = b.make(x);
+    typename ai::backend<T>::tensor_ptr tt = b.make(target);
+
+    typename ai::backend<T>::tensor_ptr z = b.make(w.M, x.N);
+    typename ai::backend<T>::tensor_ptr a = b.make(w.M, x.N);
+    typename ai::backend<T>::tensor_ptr e = b.make(w.M, x.N);
+    typename ai::backend<T>::tensor_ptr s = b.make(w.M, x.N);
+    typename ai::backend<T>::tensor_ptr g = b.make(w.M, w.N);
+
+    b.multiply(tw, tx, z);                          // z = w x
+    b.activate(ai::activation::sigmoid, z, a);      // a = f(z)
+    b.subtract(tt, a, e);                           // e = target - a
+    b.slope(ai::activation::sigmoid, a, s);         // s = f'(a)
+    b.hadamard(e, s, e);                            // e = e * s
+    b.multiply_nt(e, tx, g);                        // g = e x^T
+    b.add_scaled(T(0.5), g, tw);                    // w += 0.5 g
+
+    b.wait();
+
+    return tw->read();
+}
+
+template<typename T>
+static void one_type(const char* name, std::vector<ai::backend<T>*>& backends) {
+    std::cout << "\n" << name << ":\n";
+
+    std::mt19937 gen(20260830);
+
+    // Rectangular and all different, because a transpose error cannot make a
+    // correctly shaped answer by accident that way.
+    const matrix<T> w = random_matrix<T>(5, 3, gen);
+    const matrix<T> x = random_matrix<T>(3, 7, gen);
+    const matrix<T> t = random_matrix<T>(5, 7, gen);
+
+    std::vector<matrix<T> > results;
+
+    for(ai::backend<T>* b : backends) {
+        results.push_back(exercise(*b, w, x, t));
+
+        ok(std::string("  ") + b->name() + " ran the sequence",
+           results.back().M == 5 && results.back().N == 3,
+           std::to_string(results.back().M) + "x" + std::to_string(results.back().N));
+    }
+
+    for(std::size_t i = 1; i < results.size(); i++) {
+        const double d = worst(results[0], results[i]);
+
+        // Loose for fp16, which carries about three decimal digits, and the
+        // sequence above has a multiply, a sigmoid and another multiply in it.
+        // The bound is there to catch a wrong operation, not to measure
+        // rounding: a transposed multiply or a swapped operand moves this by
+        // whole numbers.
+        const double tol = (sizeof(T) == 2) ? 2e-2 : 1e-5;
+
+        ok(std::string("  ") + backends[i]->name() + " agrees with " + backends[0]->name(),
+           d < tol, "worst " + std::to_string(d) + ", tolerance " + std::to_string(tol));
+    }
+}
+
+static void a_tensor_from_the_wrong_backend_is_refused() {
+    std::cout << "\na tensor from the wrong backend is refused:\n";
+
+#ifdef HAVE_METAL
+    ai::host_backend<float> host;
+
+    std::shared_ptr<jlib::metal::backend<float> > gpu;
+
+    try { gpu.reset(new jlib::metal::backend<float>); }
+    catch(std::exception&) { std::cout << "  skip  no device\n"; return; }
+
+    ai::backend<float>::tensor_ptr h = host.make(2, 2);
+    ai::backend<float>::tensor_ptr d = gpu->make(2, 2);
+
+    bool threw = false;
+
+    // The two are the same static type, so nothing but a runtime check stands
+    // between this and reading a GPU buffer as host memory.
+    try { ai::backend<float>::tensor_ptr o = gpu->make(2,2); gpu->multiply(h, d, o); }
+    catch(std::exception&) { threw = true; }
+
+    ok("a host tensor handed to the GPU backend", threw);
+
+    threw = false;
+
+    try { ai::backend<float>::tensor_ptr o = host.make(2,2); host.multiply(d, h, o); }
+    catch(std::exception&) { threw = true; }
+
+    ok("and a device tensor handed to the host backend", threw);
+#else
+    std::cout << "  skip  no Metal in this build, so there is only one backend\n";
+#endif
+}
+
+int main() {
+    std::cout << std::unitbuf;
+
+    {
+        ai::host_backend<float> h;
+        std::vector<ai::backend<float>*> b{ &h };
+
+#ifdef HAVE_METAL
+        std::shared_ptr<jlib::metal::backend<float> > g;
+        try { g.reset(new jlib::metal::backend<float>); b.push_back(g.get()); }
+        catch(std::exception& e) { std::cout << "  (no Metal device: " << e.what() << ")\n"; }
+        one_type<float>("float", b);
+#else
+        one_type<float>("float", b);
+#endif
+    }
+
+    {
+        ai::host_backend<_Float16> h;
+        std::vector<ai::backend<_Float16>*> b{ &h };
+
+#ifdef HAVE_METAL
+        std::shared_ptr<jlib::metal::backend<_Float16> > g;
+        try { g.reset(new jlib::metal::backend<_Float16>); b.push_back(g.get()); }
+        catch(std::exception&) {}
+#endif
+        one_type<_Float16>("_Float16", b);
+    }
+
+    a_tensor_from_the_wrong_backend_is_refused();
+
+    // What a green run does not establish.
+    //
+    // That either backend is right, only that they agree.  The host one is
+    // written to be obvious rather than fast for that reason, but two
+    // implementations of the same misunderstanding would still pass this.
+    // metal_tensor_test compares the GPU against hand-written CPU loops, which
+    // is the other half of the argument.
+    //
+    // Not fp16's suitability for training.  It is exercised here because the
+    // interface carries it, and gradients underflow in fp16 -- training in it
+    // needs loss scaling and an fp32 master copy of the weights, neither of
+    // which exists.  fp16 is for inference.
+    //
+    // Not double, which Metal has no type for and cannot be given one.
+    std::cout << "\n" << (failures ? "FAILED" : "PASSED") << ": " << failures
+              << " failure(s)\n";
+
+    return failures ? 1 : 0;
+}

--- a/tests/metal_tensor_test.cc
+++ b/tests/metal_tensor_test.cc
@@ -31,7 +31,7 @@
 #include <jlib/metal/tensor.hh>
 #include <jlib/metal/device.hh>
 
-#include <jlib/ai/neural.hh>
+#include <jlib/ai/backend.hh>
 #include <jlib/math/matrix.hh>
 
 #include <cmath>
@@ -104,7 +104,7 @@ static void a_tensor_round_trips(std::shared_ptr<metal::device> dev) {
     // Rectangular, so a row/column mix-up in the upload cannot hide.
     const matrix<float> m = random_matrix(3, 7);
 
-    metal::tensor t(dev, m);
+    metal::tensor<float> t(dev, m);
 
     ok("the shape survives", t.rows() == 3 && t.cols() == 7,
        std::to_string(t.rows()) + "x" + std::to_string(t.cols()));
@@ -131,9 +131,9 @@ static void the_elementwise_ops(std::shared_ptr<metal::device> dev) {
     const matrix<float> a = random_matrix(5, 9);
     const matrix<float> b = random_matrix(5, 9);
 
-    metal::tensor ta(dev, a), tb(dev, b), tc(dev, 5, 9);
+    metal::tensor<float> ta(dev, a), tb(dev, b), tc(dev, 5, 9);
 
-    metal::stream s(dev);
+    metal::stream<float> s(dev);
 
     s.hadamard(ta, tb, tc);
     s.wait();
@@ -156,7 +156,7 @@ static void the_elementwise_ops(std::shared_ptr<metal::device> dev) {
     ok("subtract", worst(want, tc.read()) < 1e-6);
 
     // y += alpha * x, which is the weight update.
-    metal::tensor ty(dev, b);
+    metal::tensor<float> ty(dev, b);
 
     s.add_scaled(0.25f, ta, ty);
     s.wait();
@@ -185,15 +185,15 @@ static void the_activations_match_the_cpu(std::shared_ptr<metal::device> dev) {
         { metal::activation::leaky_relu, ai::activation::leaky_relu, "leaky_relu" },
     };
 
-    metal::stream s(dev);
+    metal::stream<float> s(dev);
 
     for(const auto& k : kinds) {
-        metal::tensor in(dev, x), out(dev, 1, 8), sl(dev, 1, 8);
+        metal::tensor<float> in(dev, x), out(dev, 1, 8), sl(dev, 1, 8);
 
         s.activate(k.m, in, out);
         s.wait();
 
-        const matrix<float> want = ai::activate(k.a, x);
+        const matrix<float> want = ai::activate_matrix(k.a, x);
         const matrix<float> got = out.read();
 
         // 1e-6 rather than exact: the GPU's exp and tanh are its own, and are
@@ -205,8 +205,8 @@ static void the_activations_match_the_cpu(std::shared_ptr<metal::device> dev) {
         s.wait();
 
         ok(std::string("  and its slope"),
-           worst(ai::activate_slope(k.a, want), sl.read()) < 1e-6,
-           std::to_string(worst(ai::activate_slope(k.a, want), sl.read())));
+           worst(ai::slope_matrix(k.a, want), sl.read()) < 1e-6,
+           std::to_string(worst(ai::slope_matrix(k.a, want), sl.read())));
     }
 }
 
@@ -218,9 +218,9 @@ static void the_multiplies(std::shared_ptr<metal::device> dev) {
     const matrix<float> a = random_matrix(4, 6);
     const matrix<float> b = random_matrix(6, 3);
 
-    metal::tensor ta(dev, a), tb(dev, b), tc(dev, 4, 3);
+    metal::tensor<float> ta(dev, a), tb(dev, b), tc(dev, 4, 3);
 
-    metal::stream s(dev);
+    metal::stream<float> s(dev);
 
     s.multiply(ta, tb, tc);
     s.wait();
@@ -231,7 +231,7 @@ static void the_multiplies(std::shared_ptr<metal::device> dev) {
     // a^T * b, without materialising the transpose.
     const matrix<float> at = random_matrix(6, 4);
 
-    metal::tensor tat(dev, at), tc2(dev, 4, 3);
+    metal::tensor<float> tat(dev, at), tc2(dev, 4, 3);
 
     s.multiply_tn(tat, tb, tc2);
     s.wait();
@@ -242,7 +242,7 @@ static void the_multiplies(std::shared_ptr<metal::device> dev) {
     // a * b^T.
     const matrix<float> bt = random_matrix(3, 6);
 
-    metal::tensor tbt(dev, bt), tc3(dev, 4, 3);
+    metal::tensor<float> tbt(dev, bt), tc3(dev, 4, 3);
 
     s.multiply_nt(ta, tbt, tc3);
     s.wait();
@@ -251,7 +251,7 @@ static void the_multiplies(std::shared_ptr<metal::device> dev) {
        std::to_string(worst(a * bt.transpose(), tc3.read())));
 
     // beta, which is what makes an accumulate possible.
-    metal::tensor acc(dev, a * b);
+    metal::tensor<float> acc(dev, a * b);
 
     s.multiply(ta, tb, acc, 1.0f, 1.0f);
     s.wait();
@@ -260,7 +260,7 @@ static void the_multiplies(std::shared_ptr<metal::device> dev) {
        std::to_string(worst((a * b) + (a * b), acc.read())));
 
     bool threw = false;
-    try { metal::tensor bad(dev, 9, 9); s.multiply(ta, tb, bad); }
+    try { metal::tensor<float> bad(dev, 9, 9); s.multiply(ta, tb, bad); }
     catch(std::exception&) { threw = true; }
 
     ok("a result of the wrong shape is refused", threw);
@@ -275,9 +275,9 @@ static void many_ops_one_wait(std::shared_ptr<metal::device> dev) {
     const matrix<float> w = random_matrix(6, 4);
     const matrix<float> x = random_matrix(4, 5);
 
-    metal::tensor tw(dev, w), tx(dev, x), tz(dev, 6, 5), ta(dev, 6, 5);
+    metal::tensor<float> tw(dev, w), tx(dev, x), tz(dev, 6, 5), ta(dev, 6, 5);
 
-    metal::stream s(dev);
+    metal::stream<float> s(dev);
 
     s.multiply(tw, tx, tz);
     s.activate(metal::activation::relu, tz, ta);
@@ -289,7 +289,7 @@ static void many_ops_one_wait(std::shared_ptr<metal::device> dev) {
     ok("and afterwards nothing is pending", s.pending() == 0,
        std::to_string(s.pending()));
 
-    const matrix<float> want = ai::activate(ai::activation::relu, w * x);
+    const matrix<float> want = ai::activate_matrix(ai::activation::relu, w * x);
 
     ok("the layer is right", worst(want, ta.read()) < 1e-5,
        std::to_string(worst(want, ta.read())));
@@ -298,7 +298,7 @@ static void many_ops_one_wait(std::shared_ptr<metal::device> dev) {
     // elementwise kernels into a compute encoder, so the stream has to close
     // and reopen one around the other.  Doing it several times over is the
     // case that would break if it did not.
-    metal::tensor t2(dev, 6, 5), t3(dev, 6, 5);
+    metal::tensor<float> t2(dev, 6, 5), t3(dev, 6, 5);
 
     s.multiply(tw, tx, tz);
     s.activate(metal::activation::sigmoid, tz, t2);
@@ -308,7 +308,7 @@ static void many_ops_one_wait(std::shared_ptr<metal::device> dev) {
 
     matrix<float> expect(6, 5);
     const matrix<float> wx = w * x;
-    const matrix<float> sig = ai::activate(ai::activation::sigmoid, wx);
+    const matrix<float> sig = ai::activate_matrix(ai::activation::sigmoid, wx);
 
     for(uint r = 0; r < 6; r++)
         for(uint c = 0; c < 5; c++)


### PR DESCRIPTION
# An element-typed backend interface

Groundwork for putting `NeuralNetwork` on the GPU, which is the next branch.
This lands the interface and both implementations, tested against each other,
so the network is wired to something already proven rather than to something
being invented underneath it.

## Why an interface rather than a second network

`jlib/cuda/neural.hh` is a 399-line fork of the network with the multiplies
routed through cuBLAS. It carries **three bugs that have since been fixed in
the original** -- fan-out initialisation, backpropagation through
already-updated weights, and a gradient that is not a mean -- and nobody
noticed, because it does not build without CUDA (#138).

A second fork for Metal would have made a third copy and a second wrong one. So
the training step exists once and the *device* is the parameter.

## Templated on the element type, not tagged with a dtype

The first draft had `float` baked into every signature with a runtime dtype
enum planned for later. Templating is better and is what landed:

```cpp
template<typename T> class backend;              // ai
template<typename T> class host_backend;         // ai, the reference
template<typename T> class backend;              // metal, T in {float, _Float16}
```

No "not implemented" stubs, no dispatch, and the type is checked where the
mistake would be made. Four things were verified before committing to it:

- **`math::matrix<_Float16>` works**, on Apple clang arm64 *and* gcc 13
  x86_64 -- multiply, hadamard and add, with `sizeof` 2. That was the risk
  that would have sunk the whole approach.
- **MSL has `half` and `bfloat`**, and MPS accepts an fp16 matrix descriptor
  and builds an fp16 `MPSMatrixMultiplication`.
- **MSL has templates and `[[host_name]]`**, so one kernel source serves both
  types and the host looks up `k_activate_f32` or `k_activate_f16`. Five
  kernels, not ten.
- **Mixed precision is not the interface's problem.** MPS's fp16 GEMM
  accumulates in fp32 internally and returns fp16, so accumulation precision is
  the kernel's business. That was my main objection to a single `T` and it does
  not survive contact with the API.

Objective-C++ cannot be a template header, so `metal::tensor`, `stream` and
`backend` are defined in the `.mm` and explicitly instantiated. Adding bfloat
is a third instantiation and a third kernel name.

`metal::tensor<double>` fails on a `static_assert` that says Metal has no
double and there is no fp64 path to add, rather than a page of template errors.

## What is deliberately outside this

**Quantisation.** int4/int8 weights carry per-block scales and zero points and
need a dequant-fused GEMM; that is a different kind of tensor, not a different
`T`, and `backend<int4>` should not be made to mean anything. It will need new
operations whenever it arrives, so this is where the boundary is rather than a
limitation of the design.

**fp16 for training.** It is exercised here because the interface carries it,
but gradients underflow in fp16 -- training in it needs loss scaling and an
fp32 master copy of the weights, neither of which exists. fp16 is for
inference.

## Tests

`tests/ai_backend_test.cc` runs one sequence -- multiply, activate, subtract,
slope, hadamard, multiply_nt, add_scaled, which is every operation the
interface has -- through every available backend in both element types, and
compares:

```
  float      Apple M5 agrees with host: worst 0.000000  (tol 1e-5)
  _Float16   Apple M5 agrees with host: worst 0.000244  (tol 2e-2)
```

0.000244 is about one ULP for fp16 at that magnitude. The tolerance is loose on
purpose: it is there to catch a wrong *operation*, not to measure rounding, and
a transposed multiply moves it by whole numbers.

It also checks that a tensor from one backend handed to another is refused.
The two are the same static type at the call site, so nothing but a runtime
`dynamic_cast` stands between that and reading a GPU buffer as host memory.

**What a green run does not establish**, in the file: that either backend is
right, only that they agree -- two implementations of the same
misunderstanding would pass. `metal_tensor_test` compares the GPU against
hand-written CPU loops, which is the other half.

## Also

`metal_tensor_test` updated for the templates and still green.

The `jlib/metal` library now links `libjai`, which is the right direction:
jlib/ai knows nothing about Metal, so a machine without it builds the neural
library unchanged.

## Numbers

macOS: 64 pass, 4 skip, 0 fail. Linux container: 66 pass, 1 skip, 0 fail, where
the backend test runs host-only for both element types.
