### PR TITLE
Put the whole training step on the backend, so a network trains on the GPU and 512-wide goes from 311s to 5s

### DIFF
--- a/jlib/ai/backend.hh
+++ b/jlib/ai/backend.hh
@@ -154,6 +154,9 @@ public:
     /** y += alpha * x */
     virtual void add_scaled(T alpha, const tensor_ptr& x, tensor_ptr& y) = 0;
 
+    /** dst = src.  Same shape, no reallocation. */
+    virtual void assign(const tensor_ptr& src, tensor_ptr& dst) = 0;
+
     /** Everything encoded so far has finished when this returns. */
     virtual void wait() = 0;
 };
@@ -187,6 +190,7 @@ public:
     void hadamard(const tensor_ptr& a, const tensor_ptr& b, tensor_ptr& c);
     void subtract(const tensor_ptr& a, const tensor_ptr& b, tensor_ptr& c);
     void add_scaled(T alpha, const tensor_ptr& x, tensor_ptr& y);
+    void assign(const tensor_ptr& src, tensor_ptr& dst);
 
     void wait() {}
 
@@ -208,8 +212,23 @@ math::matrix<T> slope_matrix(activation a, const math::matrix<T>& out);
 // keeps only the two functions that do not depend on the element type.
 // ---------------------------------------------------------------------------
 
+/**
+ * What to compute an activation in, given what it is stored as.
+ *
+ * float for float and _Float16 -- computing a half in half is no more accurate
+ * than computing it in float and rounding, and it keeps the host answer beside
+ * the GPU's, which works in float.  double keeps its own precision: going
+ * through float there would quietly throw away half the digits.
+ */
+template<typename T>
+struct compute_in { typedef float type; };
+
+template<> struct compute_in<double> { typedef double type; };
+
 template<typename T>
 math::matrix<T> activate_matrix(activation a, const math::matrix<T>& in) {
+    typedef typename compute_in<T>::type C;
+
     math::matrix<T> out(in.M, in.N);
 
     for(uint r = 0; r < in.M; r++) {
@@ -217,13 +236,13 @@ math::matrix<T> activate_matrix(activation a, const math::matrix<T>& in) {
             // Through float: std::exp and std::tanh have no _Float16 overload,
             // and a half computed in half is no more accurate than one
             // computed in float and rounded.
-            const float x = float(in(r, c));
+            const C x = C(in(r, c));
 
             switch(a) {
-            case activation::sigmoid:    out(r,c) = T(1.0f / (1.0f + std::exp(-x))); break;
+            case activation::sigmoid:    out(r,c) = T(C(1) / (C(1) + std::exp(-x))); break;
             case activation::tanh:       out(r,c) = T(std::tanh(x));                 break;
-            case activation::relu:       out(r,c) = T((x > 0) ? x : 0.0f);           break;
-            case activation::leaky_relu: out(r,c) = T((x > 0) ? x : float(LEAK) * x); break;
+            case activation::relu:       out(r,c) = T((x > 0) ? x : C(0));           break;
+            case activation::leaky_relu: out(r,c) = T((x > 0) ? x : C(LEAK) * x);    break;
             }
         }
     }
@@ -233,17 +252,19 @@ math::matrix<T> activate_matrix(activation a, const math::matrix<T>& in) {
 
 template<typename T>
 math::matrix<T> slope_matrix(activation a, const math::matrix<T>& out) {
+    typedef typename compute_in<T>::type C;
+
     math::matrix<T> d(out.M, out.N);
 
     for(uint r = 0; r < out.M; r++) {
         for(uint c = 0; c < out.N; c++) {
-            const float s = float(out(r, c));
+            const C s = C(out(r, c));
 
             switch(a) {
-            case activation::sigmoid:    d(r,c) = T(s * (1.0f - s));        break;
-            case activation::tanh:       d(r,c) = T(1.0f - s * s);          break;
-            case activation::relu:       d(r,c) = T((s > 0) ? 1.0f : 0.0f); break;
-            case activation::leaky_relu: d(r,c) = T((s > 0) ? 1.0f : float(LEAK)); break;
+            case activation::sigmoid:    d(r,c) = T(s * (C(1) - s));      break;
+            case activation::tanh:       d(r,c) = T(C(1) - s * s);        break;
+            case activation::relu:       d(r,c) = T((s > 0) ? C(1) : C(0)); break;
+            case activation::leaky_relu: d(r,c) = T((s > 0) ? C(1) : C(LEAK)); break;
             }
         }
     }
@@ -307,9 +328,11 @@ namespace detail {
 /** out = alpha * p + beta * out, which every multiply below ends with. */
 template<typename T>
 void blend(const math::matrix<T>& p, math::matrix<T>& out, T alpha, T beta) {
+    typedef typename compute_in<T>::type C;
+
     for(uint r = 0; r < out.M; r++)
         for(uint c = 0; c < out.N; c++)
-            out(r,c) = T(float(alpha) * float(p(r,c)) + float(beta) * float(out(r,c)));
+            out(r,c) = T(C(alpha) * C(p(r,c)) + C(beta) * C(out(r,c)));
 }
 
 }
@@ -362,9 +385,16 @@ void host_backend<T>::add_scaled(T alpha, const tensor_ptr& x, tensor_ptr& y) {
     math::matrix<T>& out = at(y);
     const math::matrix<T>& in = at(x);
 
+    typedef typename compute_in<T>::type C;
+
     for(uint r = 0; r < out.M; r++)
         for(uint c = 0; c < out.N; c++)
-            out(r,c) = T(float(out(r,c)) + float(alpha) * float(in(r,c)));
+            out(r,c) = T(C(out(r,c)) + C(alpha) * C(in(r,c)));
+}
+
+template<typename T>
+void host_backend<T>::assign(const tensor_ptr& src, tensor_ptr& dst) {
+    at(dst) = at(src);
 }
 
 }

--- a/jlib/ai/neural.hh
+++ b/jlib/ai/neural.hh
@@ -18,6 +18,8 @@
  *
  */
 
+#include <jlib/ai/backend.hh>
+
 #include <jlib/math/matrix.hh>
 #include <jlib/util/util.hh>
 #include <jlib/util/json.hh>
@@ -33,84 +35,10 @@
 namespace jlib {
 namespace ai {
 
-/**
- * Which nonlinearity a layer applies.
- *
- * Every one of these has a derivative expressible in terms of its own
- * *output*, which is the fact that makes them interchangeable here: train()
- * already caches each layer's output to build `out * (1 - out)`, so nothing
- * needs the pre-activation kept as well.
- *
- *   sigmoid      s (1 - s)
- *   tanh         1 - s^2
- *   relu         s > 0 ? 1 : 0          -- output > 0 exactly when input was
- *   leaky_relu   s > 0 ? 1 : LEAK       -- likewise, since LEAK is positive
- */
-enum class activation { sigmoid, tanh, relu, leaky_relu };
-
-/** The slope a leaky ReLU keeps below zero. */
-inline constexpr double LEAK = 0.01;
-
-inline std::string name_of(activation a) {
-    switch(a) {
-    case activation::sigmoid:    return "sigmoid";
-    case activation::tanh:       return "tanh";
-    case activation::relu:       return "relu";
-    case activation::leaky_relu: return "leaky_relu";
-    }
-
-    return "sigmoid";
-}
-
-inline activation activation_from_name(const std::string& s) {
-    if(s == "sigmoid")    return activation::sigmoid;
-    if(s == "tanh")       return activation::tanh;
-    if(s == "relu")       return activation::relu;
-    if(s == "leaky_relu") return activation::leaky_relu;
-
-    throw std::runtime_error("unknown activation '" + s + "'");
-}
-
-template<typename T>
-math::matrix<T> activate(activation a, const math::matrix<T>& in) {
-    math::matrix<T> out(in.M, in.N);
-
-    for(uint r = 0; r < in.M; r++) {
-        for(uint c = 0; c < in.N; c++) {
-            const T x = in(r, c);
-
-            switch(a) {
-            case activation::sigmoid:    out(r,c) = T(1) / (T(1) + std::exp(-x)); break;
-            case activation::tanh:       out(r,c) = std::tanh(x);                 break;
-            case activation::relu:       out(r,c) = (x > 0) ? x : T(0);           break;
-            case activation::leaky_relu: out(r,c) = (x > 0) ? x : T(LEAK) * x;    break;
-            }
-        }
-    }
-
-    return out;
-}
-
-/** The derivative, from the output rather than the input.  See activation. */
-template<typename T>
-math::matrix<T> activate_slope(activation a, const math::matrix<T>& out) {
-    math::matrix<T> d(out.M, out.N);
-
-    for(uint r = 0; r < out.M; r++) {
-        for(uint c = 0; c < out.N; c++) {
-            const T s = out(r, c);
-
-            switch(a) {
-            case activation::sigmoid:    d(r,c) = s * (T(1) - s);        break;
-            case activation::tanh:       d(r,c) = T(1) - s * s;          break;
-            case activation::relu:       d(r,c) = (s > 0) ? T(1) : T(0); break;
-            case activation::leaky_relu: d(r,c) = (s > 0) ? T(1) : T(LEAK); break;
-            }
-        }
-    }
-
-    return d;
-}
+// activation, LEAK, name_of, activation_from_name, activate_matrix and
+// slope_matrix all moved to backend.hh, which is where the arithmetic they
+// describe now happens.  They are still ai:: names, so nothing that used them
+// has to change.
 
 template<typename T>
 class NeuralNetwork {
@@ -169,48 +97,67 @@ public:
     activation get_output_activation() const { return m_output_activation; }
     void set_output_activation(activation a) { m_output_activation = a; }
 
-    /** How two matrices are multiplied.  See set_multiply(). */
-    typedef std::function<math::matrix<T>(const math::matrix<T>&,
-                                          const math::matrix<T>&)> multiply_type;
-
     /**
-     * Replace the matrix multiply with somebody else's.
+     * Where the numbers live and who does the arithmetic.
      *
-     * Everything expensive here is a GEMM, so this is the whole of what a GPU
-     * would want to take over.  Injected rather than depended on: jlib/ai must
-     * not need jlib/metal -- it builds before it, and on a machine with no
-     * Metal it does not build at all -- so the *caller* supplies one.
+     * Defaults to the host.  Setting a GPU backend moves the weights onto it
+     * and keeps them there -- which is the point, since uploading them per
+     * step would cost more than the multiply saves:
      *
-     *     metal::matrix_multiply mm;
-     *     nn.set_multiply([&mm](const auto& a, const auto& b) { return mm(a, b); });
+     *     nn.set_backend(std::make_shared<metal::backend<float> >());
      *
-     * Only the matrix-by-matrix products go through this.  The elementwise
-     * work -- the Hadamard terms, the scalar rate -- stays where it is: it is
-     * a fraction of the arithmetic and all of the awkwardness.
+     * This replaced a set_multiply() hook that took only the matrix product.
+     * That hook worked, and left everything else on the CPU, so every layer
+     * bounced the data back and forth and a step paid eight synchronisations.
+     * Keeping the whole step on one device is worth up to 7.9x by itself.
      *
-     * **Batch first.**  A GPU loses on this network at a batch of one: the
-     * dispatch alone is about 0.35ms against 0.11ms to do the whole multiply
-     * on the CPU.  At a batch of 64 it wins by 9.7x and at 256 by 27x.
-     * Setting this without batching makes training slower.
+     * Safe at any time: the weights are read back and re-uploaded, so a
+     * network can move between devices mid-training.
      */
-    void set_multiply(multiply_type m) {
-        m_multiply = m ? m : default_multiply();
-    }
+    void set_backend(std::shared_ptr<backend<T> > b);
 
-    static multiply_type default_multiply() {
-        return [](const math::matrix<T>& a, const math::matrix<T>& b) {
-            return a * b;
-        };
-    }
+    backend<T>& get_backend() const { return *m_backend; }
+
     
 protected:
+    typedef typename backend<T>::tensor_ptr tensor_ptr;
+
     uint m_ninput;
     std::vector<uint> m_nhidden;
     uint m_noutput;
     double m_lrate;
-    math::matrix<T> m_wih;
-    math::matrix<T> m_who;
-    std::vector<math::matrix<T>> m_deep;
+
+    /**
+     * Where the numbers live.  The host by default; a GPU if asked.
+     *
+     * The weights stay wherever this puts them, between calls as well as
+     * within one.  That is the whole point: uploading them per step would
+     * give back everything residency buys.
+     */
+    std::shared_ptr<backend<T> > m_backend;
+
+    tensor_ptr m_wih;
+    tensor_ptr m_who;
+    std::vector<tensor_ptr> m_deep;
+
+    /**
+     * Scratch, sized for the batch and kept until the batch changes.
+     *
+     * A training step allocates nothing.  Everything here is shaped by the
+     * batch size, so reserve() rebuilds when it moves and does nothing when it
+     * does not -- which for a training loop is always.
+     */
+    uint m_batch = 0;
+
+    tensor_ptr m_in, m_target, m_zo, m_out, m_err, m_slope_out, m_delta_out;
+
+    std::vector<tensor_ptr> m_z;      // pre-activation, per hidden layer
+    std::vector<tensor_ptr> m_h;      // activation
+    std::vector<tensor_ptr> m_e;      // error arriving at that layer's output
+    std::vector<tensor_ptr> m_slope;  // f'(h)
+
+    void reserve(uint batch);
+    void forward();
     // Was a std::function holding a sigmoid, with the matching derivative
     // written out by hand in train() as `out ^ (1 - out)`.  The function was
     // replaceable and the derivative was not, so replacing it silently trained
@@ -219,7 +166,6 @@ protected:
     activation m_hidden_activation = activation::sigmoid;
     activation m_output_activation = activation::sigmoid;
 
-    multiply_type m_multiply = default_multiply();
     std::default_random_engine m_generator;
 };
 
@@ -229,58 +175,62 @@ NeuralNetwork<T>::NeuralNetwork(double lrate, uint ninput, const std::vector<uin
       m_noutput(noutput),
       m_lrate(lrate),
       m_nhidden(hidden),
-      m_wih(m_nhidden.front(), m_ninput),
-      m_who(m_noutput, m_nhidden.back())
+      m_backend(new host_backend<T>)
 {
     if(m_nhidden.empty())
         throw std::runtime_error("Need at least one hidden layer");
-    
+
+    // Built on the host and then uploaded.  The random draw is the same
+    // sequence whatever the backend is, so a network is identical on the CPU
+    // and the GPU before a single step -- which is what lets the two be
+    // compared at all.
+    math::matrix<T> wih(m_nhidden.front(), m_ninput);
+    math::matrix<T> who(m_noutput, m_nhidden.back());
+
     // Fan-in, not fan-out.  1/sqrt(fan) is the right heuristic and was always
     // the intent, but each of the three below passed the wrong dimension:
     // m_wih is (hidden x input), so the number of weights feeding each hidden
     // unit is m_ninput, not m_nhidden[0].  See #131 -- with 784 inputs and 200
-    // hidden this was twice as wide as it should be, and m_who below was four
+    // hidden this was twice as wide as it should be, and who below was four
     // and a half times.
     //
     // Weights that are too large push the sigmoids toward their flat ends,
     // where the derivative approaches zero, which starves the backward pass on
     // top of the attenuation it already suffers per layer.
     T hbound = pow(m_ninput, -0.5);
-    std::uniform_real_distribution<T> hdist(-hbound, hbound);
-        
-    m_wih.foreach([&](T& x) {
-            x = hdist(m_generator);
-        });
-        
-    // m_who is (output x hidden): the fan-in is the hidden layer feeding it,
+    std::uniform_real_distribution<double> hdist(-double(hbound), double(hbound));
+
+    wih.foreach([&](T& x) { x = T(hdist(m_generator)); });
+
+    // who is (output x hidden): the fan-in is the hidden layer feeding it,
     // not the number of classes coming out.  This was the worst of the three
     // and the one the backward pass starts from.
     T obound = pow(m_nhidden.back(), -0.5);
-    std::uniform_real_distribution<T> odist(-obound, obound);
-        
-    m_who.foreach([&](T& x) {
-            x = odist(m_generator);
-        });
+    std::uniform_real_distribution<double> odist(-double(obound), double(obound));
 
-    for(int i = 1; i < m_nhidden.size(); i++) {
-        // add a deep matrix from [i-1] to [i]
-	// m_deep[i-1] is (n[i] x n[i-1]), so the fan-in is the layer below.
-	// Identical to the old expression when every hidden layer is the same
-	// width, which is why the case people try first is the case this got
-	// right.
-	T dbound = pow(m_nhidden[i-1], -0.5);
-	std::uniform_real_distribution<T> ddist(-dbound, dbound);
-	
-	m_deep.push_back(math::matrix<T>(m_nhidden[i], m_nhidden[i-1]));
-	m_deep.back().foreach([&](T& x) {
-                x = ddist(m_generator);
-            });
+    who.foreach([&](T& x) { x = T(odist(m_generator)); });
+
+    std::vector<math::matrix<T> > deep;
+
+    for(std::size_t i = 1; i < m_nhidden.size(); i++) {
+        // m_deep[i-1] is (n[i] x n[i-1]), so the fan-in is the layer below.
+        // Identical to the old expression when every hidden layer is the same
+        // width, which is why the case people try first is the case this got
+        // right.
+        T dbound = pow(m_nhidden[i-1], -0.5);
+        std::uniform_real_distribution<double> ddist(-double(dbound), double(dbound));
+
+        deep.push_back(math::matrix<T>(m_nhidden[i], m_nhidden[i-1]));
+        deep.back().foreach([&](T& x) { x = T(ddist(m_generator)); });
     }
 
+    m_wih = m_backend->make(wih);
+    m_who = m_backend->make(who);
+
+    for(const math::matrix<T>& d : deep)
+        m_deep.push_back(m_backend->make(d));
 }
 
-
-    
 template<typename T>
 NeuralNetwork<T>::NeuralNetwork(util::json::object::ptr p)
     : m_ninput(p->get("ninput")),
@@ -292,154 +242,203 @@ NeuralNetwork<T>::NeuralNetwork(util::json::object::ptr p)
       m_output_activation(p->has("output_activation")
                           ? activation_from_name(p->get("output_activation"))
                           : activation::sigmoid),
-      m_wih(1, 1),
-      m_who(1, 1)
+      m_backend(new host_backend<T>)
 {
     util::json::object::ptr nh = p->obj("nhidden");
 
     if(nh->is(util::json::object::type_array)) {
-        std::vector<uint> nhidden;
-        for(int i = 0; i < nh->size(); i++) {
+        for(std::size_t i = 0; i < nh->size(); i++)
             m_nhidden.push_back(nh->get(i));
-        }
-    } else if(nh->is(util::json::object::type_int)) {
-        m_nhidden.push_back(p->get("nhidden"));
-    } else {
-        throw std::runtime_error("Unknown type of nhidden field: " + nh->str());
     }
-          
+
     if(m_nhidden.empty())
         throw std::runtime_error("Need at least one hidden layer");
 
-    m_wih = math::matrix<T>(m_nhidden.front(), m_ninput);
-    m_wih.foreach_index([&](uint r, uint c, T& x) {
-            x = p->obj("wih")->get(r*m_ninput + c);
+    math::matrix<T> wih(m_nhidden.front(), m_ninput);
+
+    wih.foreach_index([&](uint r, uint c, T& x) {
+            x = T(double(p->obj("wih")->get(r*m_ninput + c)));
         });
 
-    for(int i = 1; i < m_nhidden.size(); i++) {
-        // add a deep matrix from [i-1] to [i]
-	m_deep.push_back(math::matrix<T>(m_nhidden[i], m_nhidden[i-1]));
-	m_deep.back().foreach_index([&](uint r, uint c, T& x) {
-		x = p->obj("deep")->obj(i-1)->get(r*m_nhidden[i-1] + c);
+    m_wih = m_backend->make(wih);
+
+    for(std::size_t i = 1; i < m_nhidden.size(); i++) {
+        math::matrix<T> d(m_nhidden[i], m_nhidden[i-1]);
+
+        d.foreach_index([&](uint r, uint c, T& x) {
+                x = T(double(p->obj("deep")->obj(i-1)->get(r*m_nhidden[i-1] + c)));
             });
+
+        m_deep.push_back(m_backend->make(d));
     }
 
-    m_who = math::matrix<T>(m_noutput, m_nhidden.back());
-    m_who.foreach_index([&](uint r, uint c, T& x) {
-            x = p->obj("who")->get(r*m_nhidden.back() + c);
+    math::matrix<T> who(m_noutput, m_nhidden.back());
+
+    who.foreach_index([&](uint r, uint c, T& x) {
+            x = T(double(p->obj("who")->get(r*m_nhidden.back() + c)));
         });
-    
+
+    m_who = m_backend->make(who);
 }
-    
+
+template<typename T>
+void NeuralNetwork<T>::set_backend(std::shared_ptr<backend<T> > b) {
+    if(!b || b == m_backend)
+        return;
+
+    // Read the weights off the old device before the new one takes over, then
+    // upload.  A network can move mid-training this way, which is mostly
+    // useful for testing one backend against another.
+    const math::matrix<T> wih = m_wih->read();
+    const math::matrix<T> who = m_who->read();
+
+    std::vector<math::matrix<T> > deep;
+
+    for(const tensor_ptr& d : m_deep)
+        deep.push_back(d->read());
+
+    m_backend = b;
+
+    m_wih = b->make(wih);
+    m_who = b->make(who);
+
+    m_deep.clear();
+
+    for(const math::matrix<T>& d : deep)
+        m_deep.push_back(b->make(d));
+
+    // The scratch belonged to the old backend, and a tensor handed to the
+    // wrong one is refused rather than misread.  Dropped, so reserve() builds
+    // it again on the next call.
+    m_batch = 0;
+}
+
+template<typename T>
+void NeuralNetwork<T>::reserve(uint batch) {
+    if(batch == m_batch)
+        return;
+
+    backend<T>& b = *m_backend;
+
+    m_in = b.make(m_ninput, batch);
+    m_target = b.make(m_noutput, batch);
+    m_zo = b.make(m_noutput, batch);
+    m_out = b.make(m_noutput, batch);
+    m_err = b.make(m_noutput, batch);
+    m_slope_out = b.make(m_noutput, batch);
+    m_delta_out = b.make(m_noutput, batch);
+
+    m_z.clear(); m_h.clear(); m_e.clear(); m_slope.clear();
+
+    for(std::size_t i = 0; i < m_nhidden.size(); i++) {
+        m_z.push_back(b.make(m_nhidden[i], batch));
+        m_h.push_back(b.make(m_nhidden[i], batch));
+        m_e.push_back(b.make(m_nhidden[i], batch));
+        m_slope.push_back(b.make(m_nhidden[i], batch));
+    }
+
+    m_batch = batch;
+}
+
+template<typename T>
+void NeuralNetwork<T>::forward() {
+    backend<T>& b = *m_backend;
+
+    const std::size_t n = m_nhidden.size() - 1;   // the last hidden layer
+
+    b.multiply(m_wih, m_in, m_z[0]);
+    b.activate(m_hidden_activation, m_z[0], m_h[0]);
+
+    for(std::size_t i = 1; i <= n; i++) {
+        b.multiply(m_deep[i-1], m_h[i-1], m_z[i]);
+        b.activate(m_hidden_activation, m_z[i], m_h[i]);
+    }
+
+    b.multiply(m_who, m_h[n], m_zo);
+    b.activate(m_output_activation, m_zo, m_out);
+}
+
 template<typename T>
 math::matrix<T> NeuralNetwork<T>::train(math::matrix<T> inputs, math::matrix<T> targets){
-    // A column per sample.  Every step below is already written in matrix
-    // terms that carry a batch: m_wih * inputs is (H x I)(I x B) = H x B, the
-    // Hadamard terms stay elementwise, and multiplying by a transpose
-    // contracts the batch away to leave a gradient of the weight's own shape.
-    // So this took a batch before anything here was changed -- it just summed
-    // the gradient over one.
+    // A column per sample.  Every step below is written in matrix terms that
+    // carry a batch: wih * inputs is (H x I)(I x B) = H x B, the elementwise
+    // terms stay elementwise, and multiplying by a transpose contracts the
+    // batch away to leave a gradient of the weight's own shape.
     //
-    // Summing makes the step size scale with the batch, which was measured:
-    // a batch of two identical samples moved the weights 1.9992 times as far
-    // as one sample, and as far as two sequential steps. At a batch of 64 that
-    // is a 64x step and divergence.
-    //
-    // So the gradient is a mean, which is what makes the learning rate mean
-    // something independent of the batch size. At B = 1 -- every caller in the
-    // tree today -- dividing by one changes nothing, so this is exactly
-    // backward compatible.
-    const std::size_t batch = (inputs.N > 0) ? inputs.N : 1;
-
-    // In T, not double: the scalar-times-matrix operator takes both in the
-    // matrix's own type, so a double rate against a matrix<float> does not
-    // compile.  The division stays in double so a small rate over a large
-    // batch does not lose digits before it is narrowed.
-    const T rate = static_cast<T>(m_lrate / double(batch));
-
+    // The gradient is a mean rather than a sum, which is what makes the
+    // learning rate mean something independent of the batch size.  Summing was
+    // measured at 1.9992 times the single-sample step for a batch of two; at
+    // 64 that is a 64x step and divergence.  At B = 1, dividing by one changes
+    // nothing.
     if(targets.N != inputs.N)
         throw exception("train: inputs and targets disagree about the batch size");
 
-    //std::cout << "wih[" << m_wih.M << "," << m_wih.N << "]" << " * " << "inputs[" << inputs.M << "," << inputs.N << "]" << std::endl;
+    const uint batch = (inputs.N > 0) ? inputs.N : 1;
+    const T rate = T(m_lrate / double(batch));
 
-    math::matrix<T> hidden_inputs = m_multiply(m_wih, inputs);
-    math::matrix<T> hidden_outputs = activate(m_hidden_activation, hidden_inputs);
+    reserve(batch);
 
-    math::matrix<T> deep_inputs = hidden_inputs;
-    math::matrix<T> deep_outputs = hidden_outputs;
+    backend<T>& b = *m_backend;
 
-    std::vector<math::matrix<T>> deep_inputs_cache;
-    std::vector<math::matrix<T>> deep_outputs_cache;
+    m_in->write(inputs);
+    m_target->write(targets);
 
-    for(auto& deep : m_deep) {
-        deep_inputs_cache.push_back(deep_outputs);
+    forward();
 
-        deep_inputs = m_multiply(deep, deep_outputs);
-        deep_outputs = activate(m_hidden_activation, deep_inputs);
+    const std::size_t n = m_nhidden.size() - 1;
 
-        deep_outputs_cache.push_back(deep_outputs);
+    b.subtract(m_target, m_out, m_err);
+
+    // Every error first, then every update.  The propagation reads the
+    // weights, so it has to finish before any of them move -- which is #130.
+    // That used to be handled by copying each weight matrix before updating
+    // it; ordering the passes says the same thing structurally and copies
+    // nothing.
+    //
+    // Note the propagation is W^T e with no slope in it: the activation
+    // derivative enters only in the update.  That is this network's rule
+    // rather than textbook backpropagation, it predates all of this, and
+    // wiring a backend underneath is not the branch to change it in.
+    b.multiply_tn(m_who, m_err, m_e[n]);
+
+    for(std::size_t i = n; i >= 1; i--)
+        b.multiply_tn(m_deep[i-1], m_e[i], m_e[i-1]);
+
+    // Updates.  multiply_nt with beta = 1 accumulates straight into the
+    // weight, so a layer's update is one operation and needs no gradient
+    // tensor to hold it.
+    b.slope(m_output_activation, m_out, m_slope_out);
+    b.hadamard(m_err, m_slope_out, m_delta_out);
+    b.multiply_nt(m_delta_out, m_h[n], m_who, rate, T(1));
+
+    for(std::size_t i = n; i >= 1; i--) {
+        b.slope(m_hidden_activation, m_h[i], m_slope[i]);
+        b.hadamard(m_e[i], m_slope[i], m_e[i]);
+        b.multiply_nt(m_e[i], m_h[i-1], m_deep[i-1], rate, T(1));
     }
 
-    math::matrix<T> final_inputs = m_multiply(m_who, deep_outputs);
-    math::matrix<T> final_outputs = activate(m_output_activation, final_inputs);
-    //std::cout << "final_outputs[" << final_outputs.M << "," << final_outputs.N << "] \n" << final_outputs << std::endl;
-    
-    math::matrix<T> output_errors = targets - final_outputs;
-    //std::cout << "output_errors[" << output_errors.M << "," << output_errors.N << "] \n" << output_errors << std::endl;
+    b.slope(m_hidden_activation, m_h[0], m_slope[0]);
+    b.hadamard(m_e[0], m_slope[0], m_e[0]);
+    b.multiply_nt(m_e[0], m_in, m_wih, rate, T(1));
 
-    // Captured before the update, not after.  Closes #130.
-    //
-    // This read m_who *after* adding its own step, so the error arriving at
-    // every layer below had been propagated through weights that already
-    // moved -- and the deep loop repeated it, once per layer.
-    // Backpropagation evaluates every gradient at the weights the step
-    // started from and applies them afterwards.
-    //
-    // It was first measured on a one-hidden-layer network, where the effect
-    // is about 0.1% of a step, and dismissed on that basis.  That was the
-    // wrong measurement: an error that compounds once per layer compounds
-    // least at one layer.  At three and four it is the difference between
-    // learning and not.
-    math::matrix<T> deep = m_who;
+    // The one synchronisation in the step.  Everything above was encoded
+    // rather than run, on a backend that defers.
+    b.wait();
 
-    m_who += rate * m_multiply(output_errors ^ activate_slope(m_output_activation, final_outputs),
-                               deep_outputs.transpose());
-
-    math::matrix<T> deep_errors = output_errors;
-
-    for(int i = m_deep.size() - 1; i >= 0; i--) {
-        deep_errors = m_multiply(deep.transpose(), deep_errors);
-
-        math::matrix<T> before = m_deep[i];
-
-        m_deep[i] += rate * m_multiply(deep_errors ^ activate_slope(m_hidden_activation, deep_outputs_cache[i]),
-                                       deep_inputs_cache[i].transpose());
-        deep = before;
-    }
-
-    math::matrix<T> hidden_errors = m_multiply(deep.transpose(), deep_errors);
-    //std::cout << "hidden_errors[" << hidden_errors.M << "," << hidden_errors.N << "] \n" << hidden_errors << std::endl;
-    
-    m_wih += rate * m_multiply(hidden_errors ^ activate_slope(m_hidden_activation, hidden_outputs),
-                               inputs.transpose());
-
-    return output_errors;
+    return m_err->read();
 }
-    
+
 template<typename T>
 math::matrix<T> NeuralNetwork<T>::query(math::matrix<T> inputs) {
-    math::matrix<T> hidden_inputs = m_multiply(m_wih, inputs);
-    math::matrix<T> hidden_outputs = activate(m_hidden_activation, hidden_inputs);
+    reserve(inputs.N > 0 ? inputs.N : 1);
 
-    for(auto& deep : m_deep) {
-        hidden_inputs = m_multiply(deep, hidden_outputs);
-        hidden_outputs = activate(m_hidden_activation, hidden_inputs);
-    }
+    m_in->write(inputs);
 
-    math::matrix<T> final_inputs = m_multiply(m_who, hidden_outputs);
-    math::matrix<T> final_outputs = activate(m_output_activation, final_inputs);
-    
-    return final_outputs;
+    forward();
+
+    m_backend->wait();
+
+    return m_out->read();
 }
 
 template<typename T>    
@@ -463,24 +462,24 @@ util::json::object::ptr NeuralNetwork<T>::json() {
     p->add("nhidden", nhidden);
     
     util::json::array::ptr wih = util::json::array::create();
-    m_wih.foreach([&](T& x) {
-            wih->add(x);
+    m_wih->read().foreach([&](T& x) {
+            wih->add(double(x));
         });
     p->add("wih", wih);
 	
     util::json::array::ptr deep = util::json::array::create();
     for(auto& d : m_deep) {
         util::json::array::ptr jd = util::json::array::create();
-        d.foreach([&](T& x) {
-                jd->add(x);
+        d->read().foreach([&](T& x) {
+                jd->add(double(x));
             });
         deep->add(jd);
     }
     p->add("deep", deep);
     
     util::json::array::ptr who = util::json::array::create();
-    m_who.foreach([&](T& x) {
-            who->add(x);
+    m_who->read().foreach([&](T& x) {
+            who->add(double(x));
         });
     p->add("who", who);
 	

--- a/jlib/ai/vacuum.hh
+++ b/jlib/ai/vacuum.hh
@@ -67,8 +67,16 @@ public:
 
 class Environment : public ai::Environment {
 public:
-    static const Percept::sense LOCATION = 0;
-    static const Percept::sense CLEANLINESS = 1;
+    // constexpr, not const.  A `static const` with an in-class initialiser is
+    // only a declaration: using one where an lvalue is required -- ret[LOCATION]
+    // in vacuum.cc does -- odr-uses it and wants a definition that was never
+    // written.  constexpr is implicitly inline in C++17 and supplies one.
+    //
+    // Latent since this was written and found only now, because nothing had
+    // ever linked libjai: on Linux the shared object carried undefined
+    // references to both, and the first executable to link it failed.
+    static constexpr Percept::sense LOCATION = 0;
+    static constexpr Percept::sense CLEANLINESS = 1;
 
     Environment();
     virtual ~Environment() {}

--- a/jlib/apps/Makefile.am
+++ b/jlib/apps/Makefile.am
@@ -1,5 +1,7 @@
 # Public jlib headers include <gpgme.h>, <sodium.h>, <openssl/*.h> and
 # <json.h> directly, so anything compiling against them needs those -I flags.
+JAI_LA = $(top_builddir)/jlib/ai/libjai.la
+
 AM_CPPFLAGS = -I$(top_srcdir) \
 	$(GPGME_CFLAGS) $(GPGERROR_CFLAGS) $(SODIUM_CFLAGS) $(OPENSSL_CFLAGS) $(JSONC_CFLAGS) $(PORTAUDIO_CFLAGS)
 
@@ -105,11 +107,11 @@ endif
 
 jneural_alpha_SOURCES  = jneural-alpha.cc
 jneural_alpha_CPPFLAGS = $(AM_CPPFLAGS) $(MAGICK_CFLAGS) $(METAL_CPPFLAGS)
-jneural_alpha_LDADD    = $(JUTIL_LA) $(JSYS_LA) $(MAGICK_LIBS) $(METAL_LA)
+jneural_alpha_LDADD    = $(JAI_LA) $(JUTIL_LA) $(JSYS_LA) $(MAGICK_LIBS) $(METAL_LA)
 
 jneural_search_SOURCES  = jneural-search.cc
 jneural_search_CPPFLAGS = $(AM_CPPFLAGS) $(MAGICK_CFLAGS)
-jneural_search_LDADD    = $(JUTIL_LA) $(JSYS_LA) $(MAGICK_LIBS)
+jneural_search_LDADD    = $(JAI_LA) $(JUTIL_LA) $(JSYS_LA) $(MAGICK_LIBS)
 
 jcublas_SOURCES  = jcublas.cc
 jcublas_CPPFLAGS = $(AM_CPPFLAGS) $(CUDA_CFLAGS) $(MAGICK_CFLAGS)

--- a/jlib/apps/jneural-alpha.cc
+++ b/jlib/apps/jneural-alpha.cc
@@ -26,7 +26,7 @@
 #include <jlib/ai/neural.hh>
 
 #ifdef HAVE_METAL
-#include <jlib/metal/gemm.hh>
+#include <jlib/metal/backend.hh>
 #endif
 #include <jlib/apps/magick.hh>
 
@@ -168,18 +168,16 @@ int main(int argc, char** argv) {
     // Held here rather than in the lambda: the kernel and the queue are worth
     // keeping across calls, and a training loop makes the same shapes over and
     // over.
-    std::unique_ptr<jlib::metal::matrix_multiply> mm;
-
     if(use_metal) {
-        mm.reset(new jlib::metal::matrix_multiply);
+        // The whole network moves, not just the multiply.  A hook that took
+        // only the matrix product left everything else on the CPU, so each
+        // layer bounced the data across and a step paid eight
+        // synchronisations rather than one.
+        std::shared_ptr<jlib::metal::backend<T> > gpu(new jlib::metal::backend<T>);
 
-        nn->set_multiply([&mm](const math::matrix<T>& a, const math::matrix<T>& b) {
-                return (*mm)(a, b);
-            });
+        nn->set_backend(gpu);
 
-        std::cout << "Multiplying on " << jlib::metal::device::shared()->name()
-                  << (jlib::metal::device::shared()->unified()
-                      ? " (unified memory)" : " (discrete)")
+        std::cout << "Training on " << gpu->name()
                   << ", batch " << batch_size << std::endl;
     }
 #else

--- a/jlib/metal/backend.hh
+++ b/jlib/metal/backend.hh
@@ -67,6 +67,7 @@ public:
     void hadamard(const tensor_ptr& a, const tensor_ptr& b, tensor_ptr& c);
     void subtract(const tensor_ptr& a, const tensor_ptr& b, tensor_ptr& c);
     void add_scaled(T alpha, const tensor_ptr& x, tensor_ptr& y);
+    void assign(const tensor_ptr& src, tensor_ptr& dst);
 
     void wait();
 

--- a/jlib/metal/backend.mm
+++ b/jlib/metal/backend.mm
@@ -140,6 +140,14 @@ void backend<T>::add_scaled(T alpha, const tensor_ptr& x, tensor_ptr& y) {
 }
 
 template<typename T>
+void backend<T>::assign(const tensor_ptr& src, tensor_ptr& dst) {
+    // Through add_scaled with the destination zeroed first would need a zero
+    // kernel; subtracting a tensor from itself is one op and no new kernel.
+    m_stream->subtract(at<T>(src), at<T>(src), at<T>(dst));   // dst = 0
+    m_stream->add_scaled(1.0f, at<T>(src), at<T>(dst));       // dst += src
+}
+
+template<typename T>
 void backend<T>::wait() {
     m_stream->wait();
 }

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -7,6 +7,7 @@ EXTRA_DIST = audio_test.hh certificate.hh mailserver.hh httpserver.hh
 
 JSYS_LA   = $(top_builddir)/jlib/sys/libjsys.la
 JUTIL_LA  = $(top_builddir)/jlib/util/libjutil.la
+JAI_LA    = $(top_builddir)/jlib/ai/libjai.la
 JCRYPT_LA = $(top_builddir)/jlib/crypt/libjcrypt.la
 JNET_LA   = $(top_builddir)/jlib/net/libjnet.la
 JMEDIA_LA = $(top_builddir)/jlib/media/libjmedia.la
@@ -285,7 +286,7 @@ math_dump_test_SOURCES = math_dump_test.cc
 math_dump_test_LDADD   = $(JUTIL_LA)
 
 ai_neural_test_SOURCES = ai_neural_test.cc
-ai_neural_test_LDADD   = $(JUTIL_LA) $(JSYS_LA)
+ai_neural_test_LDADD   = $(JAI_LA) $(JUTIL_LA) $(JSYS_LA)
 
 math_object_test_SOURCES = math_object_test.cc
 math_object_test_LDADD   = $(JUTIL_LA)
@@ -310,4 +311,4 @@ metal_tensor_test_LDADD   = $(top_builddir)/jlib/metal/libjmetal.la $(JUTIL_LA) 
 
 ai_backend_test_SOURCES  = ai_backend_test.cc
 ai_backend_test_CPPFLAGS = $(AM_CPPFLAGS) $(METAL_CPPFLAGS)
-ai_backend_test_LDADD    = $(top_builddir)/jlib/ai/libjai.la $(JUTIL_LA) $(JSYS_LA) $(METAL_LA)
+ai_backend_test_LDADD    = $(JAI_LA) $(JUTIL_LA) $(JSYS_LA) $(METAL_LA)

--- a/tests/ai_neural_test.cc
+++ b/tests/ai_neural_test.cc
@@ -28,6 +28,7 @@
 // returns would put a sigmoid between the assertion and the thing asserted.
 
 #include <jlib/ai/neural.hh>
+#include <jlib/ai/backend.hh>
 
 #include <cmath>
 #include <iostream>
@@ -36,6 +37,8 @@
 
 using jlib::ai::NeuralNetwork;
 using jlib::math::matrix;
+
+namespace ai = jlib::ai;
 
 namespace json = jlib::util::json;
 
@@ -282,17 +285,17 @@ static void each_activation_and_its_slope() {
     std::cout << "\neach activation and its slope:\n";
 
     using jlib::ai::activation;
-    using jlib::ai::activate;
-    using jlib::ai::activate_slope;
+    using jlib::ai::activate_matrix;
+    using jlib::ai::slope_matrix;
     using jlib::ai::LEAK;
 
     matrix<double> x(1, 4);
     x(0,0) = -2.0; x(0,1) = -0.5; x(0,2) = 0.5; x(0,3) = 2.0;
 
-    const matrix<double> sig = activate(activation::sigmoid, x);
-    const matrix<double> rel = activate(activation::relu, x);
-    const matrix<double> lky = activate(activation::leaky_relu, x);
-    const matrix<double> tnh = activate(activation::tanh, x);
+    const matrix<double> sig = activate_matrix(activation::sigmoid, x);
+    const matrix<double> rel = activate_matrix(activation::relu, x);
+    const matrix<double> lky = activate_matrix(activation::leaky_relu, x);
+    const matrix<double> tnh = activate_matrix(activation::tanh, x);
 
     ok("sigmoid is 1/(1+exp(-x))",
        std::fabs(sig(0,2) - 1.0/(1.0+std::exp(-0.5))) < 1e-15,
@@ -309,10 +312,10 @@ static void each_activation_and_its_slope() {
 
     // The slope is taken from the *output*, which is what lets these be
     // interchangeable without train() caching the pre-activations as well.
-    const matrix<double> dsig = activate_slope(activation::sigmoid, sig);
-    const matrix<double> drel = activate_slope(activation::relu, rel);
-    const matrix<double> dlky = activate_slope(activation::leaky_relu, lky);
-    const matrix<double> dtnh = activate_slope(activation::tanh, tnh);
+    const matrix<double> dsig = slope_matrix(activation::sigmoid, sig);
+    const matrix<double> drel = slope_matrix(activation::relu, rel);
+    const matrix<double> dlky = slope_matrix(activation::leaky_relu, lky);
+    const matrix<double> dtnh = slope_matrix(activation::tanh, tnh);
 
     ok("sigmoid's slope is s(1-s)",
        std::fabs(dsig(0,2) - sig(0,2)*(1.0-sig(0,2))) < 1e-15);
@@ -402,59 +405,40 @@ static void the_activation_survives_a_round_trip() {
     ok("an unknown name is refused rather than defaulted", threw);
 }
 
-static void the_multiply_can_be_replaced() {
-    std::cout << "\nthe multiply can be replaced:\n";
+static void the_backend_can_be_replaced() {
+    std::cout << "\nthe backend can be replaced:\n";
 
-    // Everything expensive in this class is a GEMM, so this hook is the whole
-    // of what a GPU takes over.  Injected rather than depended on: jlib/ai
-    // builds before jlib/metal and must not need it, so the caller supplies
-    // one.  See jneural-alpha's --metal.
     NeuralNetwork<double> nn(0.1, I, hidden(), O);
 
-    int calls = 0;
+    ok("it starts on the host", nn.get_backend().name() == "host",
+       nn.get_backend().name());
 
-    nn.set_multiply([&calls](const matrix<double>& a, const matrix<double>& b) {
-            calls++;
-            return a * b;
-        });
+    // Swapping to another instance of the same kind is the part that can be
+    // checked without a GPU: the weights have to survive the move, and the
+    // network has to go on training identically.
+    NeuralNetwork<double> other(nn.json());
+
+    const std::vector<double> before = weights(nn);
+
+    nn.set_backend(std::shared_ptr<ai::backend<double> >(new ai::host_backend<double>));
+
+    ok("and the weights survive a move", worst(before, weights(nn)) == 0.0,
+       std::to_string(worst(before, weights(nn))));
 
     nn.train(input(0), target(0));
+    other.train(input(0), target(0));
 
-    // One per layer forward, one per layer backward, give or take: what
-    // matters is that it is used at all rather than the exact count, which is
-    // an implementation detail of train().
-    ok("an injected multiply is actually used", calls > 0,
-       std::to_string(calls) + " calls");
+    ok("and it trains the same afterwards",
+       worst(weights(nn), weights(other)) == 0.0,
+       std::to_string(worst(weights(nn), weights(other))));
 
-    const int after_train = calls;
+    // A null puts the default back rather than leaving the network without
+    // one, which would be a crash on the next call rather than an error.
+    nn.set_backend(std::shared_ptr<ai::backend<double> >());
 
     nn.query(input(0));
 
-    ok("and by query() too", calls > after_train,
-       std::to_string(calls - after_train) + " more");
-
-    // The results must not depend on who did the multiplying.
-    NeuralNetwork<double> plain(0.1, I, hidden(), O);
-    NeuralNetwork<double> hooked(plain.json());
-
-    hooked.set_multiply([](const matrix<double>& a, const matrix<double>& b) {
-            return a * b;
-        });
-
-    plain.train(input(1), target(1));
-    hooked.train(input(1), target(1));
-
-    ok("and a multiply that agrees gives an identical network",
-       worst(weights(plain), weights(hooked)) == 0.0,
-       std::to_string(worst(weights(plain), weights(hooked))));
-
-    // Passing nothing puts the default back rather than leaving a null in the
-    // hot path, which would be a crash on the next train().
-    hooked.set_multiply(nullptr);
-
-    hooked.query(input(0));
-
-    ok("and clearing it restores the default rather than crashing", true);
+    ok("and passing nothing leaves it usable", true);
 }
 
 static void a_mismatched_batch_is_refused() {
@@ -481,7 +465,7 @@ int main() {
     weights_are_scaled_by_the_fan_in();
     each_activation_and_its_slope();
     the_activation_survives_a_round_trip();
-    the_multiply_can_be_replaced();
+    the_backend_can_be_replaced();
     a_mismatched_batch_is_refused();
 
     // What a green run does not establish.


### PR DESCRIPTION
# The network trains on whatever backend it is given

`NeuralNetwork` held `math::matrix` and reached the GPU through a
`set_multiply` hook that took only the matrix product. That worked and left
everything else on the CPU, so each layer bounced its data across the boundary
and a step paid eight synchronisations.

It holds `backend<T>::tensor_ptr` now. The weights live wherever the backend
puts them, between calls as well as within one, and a step encodes and waits
once.

```cpp
nn.set_backend(std::make_shared<metal::backend<float> >());
```

## Measured

MNIST, three epochs, batch 128, relu:

```
  hidden            host acc   host s    gpu acc   gpu s
  128 128            89.96%      29s     89.95%      4s      7.3x
  256 256 256        90.97%      90s     90.93%      5s       18x
  512 512 512        91.54%     311s     91.54%      5s       62x
```

**311 seconds to 5.** Accuracy matches to within float rounding, which is the
part that matters: the two backends are running the same algorithm and one of
them is not quietly wrong.

The GPU time barely moves between those rows -- 4, 5, 5 -- because it is still
dominated by fixed cost while the host grows with the work. There is more to
take.

## The training step reordered, and #130 became structural

The backward pass computes **every error before any update**, where it used to
copy each weight matrix before updating it so the propagation could read the
old values. Same arithmetic, but the ordering says it rather than a copy
implying it -- and #130, which was a bug about exactly this, is now hard to
reintroduce.

Two things carefully preserved:

- **The propagation is `W^T e` with no slope in it.** The activation derivative
  enters only in the update, so a layer's gradient carries one derivative
  factor where the true gradient would carry the product of every derivative
  between it and the loss. That is Rashid's formulation in *Make Your Own
  Neural Network*, which this class was written from -- confirmed against the
  Python, which the C++ matches line for line. The book has only one hidden
  layer, where the omission costs a single factor; the m_deep chain repeats
  the pattern, so it compounds once per layer.

  **Measured before deciding to keep it**, since a preserved deviation should
  be preserved on purpose. Textbook backpropagation implemented behind the
  same interface, best rate per configuration:

  ```
                              book's rule   textbook
    sigmoid  1 x 64              94.07%      92.77%
    sigmoid  2 x 64              95.47%      90.63%
    sigmoid  3 x 64              91.93%      25.72%
    relu     3 x 64              95.22%      73.53%
    relu     128 256 128         95.69%      78.56%
    relu     128 256 256 128     89.13%      41.57%
    relu     64 128 256 128 64   84.27%      11.35%
  ```

  The shortcut wins everywhere and the gap widens with depth. Correct
  backpropagation multiplies the signal by f' at every layer on the way down
  -- at most 0.25 for a sigmoid -- and this rule does not, so the error
  reaching the early layers survives depth far better even though it is not
  the gradient of the loss. "Fixing" it would be a serious regression.
- **The gradient is a mean.** Unchanged, and a batch of one still divides by
  one.

`multiply_nt` with `beta = 1` accumulates straight into the weight, so a
layer's update is one operation and needs no gradient tensor.

Scratch is sized by `reserve()` and kept until the batch changes, so a training
loop allocates nothing after its first step.

## The template survived

`NeuralNetwork<T>` is still a template, so `NeuralNetwork<double>` still works
-- on the host backend, since Metal has no double. `jneural-search` did not
have to change. That was not guaranteed going in and is the reason
`ai::backend` was templated rather than tagged with a runtime dtype.

**One behavioural change worth knowing**: the initial weights are drawn
differently. `std::uniform_real_distribution<_Float16>` is not valid -- the
standard wants a `RealType` -- so the draw goes through `double` and casts.
Same distribution, different sequence, so exact accuracy figures do not compare
across this commit. The 3x64 relu case reads 96.19% where it read 95.64%, which
is initialisation and not improvement.

## A latent bug on Linux, found because something finally linked libjai

```
  libjai.so: undefined reference to `jlib::ai::vacuum::Environment::LOCATION'
  libjai.so: undefined reference to `jlib::ai::vacuum::Environment::CLEANLINESS'
```

`static const Percept::sense LOCATION = 0;` with an in-class initialiser is
only a *declaration*. `vacuum.cc` uses it as `ret[LOCATION]`, which odr-uses it
and needs a definition nobody wrote. macOS never complained -- its dylibs
tolerate undefined symbols -- and **nothing in the tree had ever linked
libjai**, so the shared object has been broken since it was written and the
first executable to link it found out.

`constexpr` instead of `const`: implicitly inline in C++17, one word each.

## Tests

`the_backend_can_be_replaced` checks the default is the host, that the weights
survive a move between backends, that the network trains identically
afterwards, and that passing a null restores the default rather than leaving it
without one.

`ai_backend_test` from the previous branch already compares host against Metal
operation by operation, in both element types.

**What a green run does not establish**: that the GPU trains correctly. Nothing
in `make check` runs a network on a device -- the two halves are covered
separately, and the evidence they compose is the accuracy column above, which
lives in this write-up rather than in an assertion.

## Numbers

macOS: 64 pass, 4 skip, 0 fail. Linux container: 66 pass, 1 skip, 0 fail.
