### PR TITLE
Add softmax and RMS norm to ai::backend and Metal: the first reductions, with the max-subtraction mutation-checked

### DIFF
--- a/jlib/ai/backend.hh
+++ b/jlib/ai/backend.hh
@@ -24,6 +24,7 @@
 
 #include <cmath>
 #include <memory>
+#include <limits>
 #include <sstream>
 #include <string>
 
@@ -157,6 +158,34 @@ public:
     /** dst = src.  Same shape, no reallocation. */
     virtual void assign(const tensor_ptr& src, tensor_ptr& dst) = 0;
 
+    /**
+     * Softmax down each column.
+     *
+     * A column is a sample -- matrices here are (features x batch) -- so this
+     * reduces over features and leaves each column summing to one.
+     *
+     * The maximum is subtracted first.  exp() of a score of 90 overflows a
+     * float and every score in that column becomes nan; subtracting the
+     * column's own maximum shifts the largest exponent to zero, which changes
+     * nothing about the result and everything about whether it exists.  In
+     * fp16 the ceiling is 65504, which arrives at a score of about 11.
+     */
+    virtual void softmax(const tensor_ptr& in, tensor_ptr& out) = 0;
+
+    /**
+     * Root-mean-square normalisation down each column, scaled per feature.
+     *
+     * out[r,c] = in[r,c] / sqrt(mean(in[:,c]^2) + eps) * weight[r]
+     *
+     * What a transformer uses in place of layer normalisation: no mean
+     * subtraction and no bias, which makes it cheaper and, in practice, no
+     * worse.  weight is one column of `rows` entries -- the learned scale --
+     * and is taken as an argument rather than applied afterwards because
+     * there is no broadcast operation to apply it with.
+     */
+    virtual void rms_norm(const tensor_ptr& in, const tensor_ptr& weight,
+                          tensor_ptr& out, float eps = 1e-5f) = 0;
+
     /** Everything encoded so far has finished when this returns. */
     virtual void wait() = 0;
 };
@@ -191,6 +220,9 @@ public:
     void subtract(const tensor_ptr& a, const tensor_ptr& b, tensor_ptr& c);
     void add_scaled(T alpha, const tensor_ptr& x, tensor_ptr& y);
     void assign(const tensor_ptr& src, tensor_ptr& dst);
+    void softmax(const tensor_ptr& in, tensor_ptr& out);
+    void rms_norm(const tensor_ptr& in, const tensor_ptr& weight,
+                  tensor_ptr& out, float eps = 1e-5f);
 
     void wait() {}
 
@@ -395,6 +427,71 @@ void host_backend<T>::add_scaled(T alpha, const tensor_ptr& x, tensor_ptr& y) {
 template<typename T>
 void host_backend<T>::assign(const tensor_ptr& src, tensor_ptr& dst) {
     at(dst) = at(src);
+}
+
+template<typename T>
+void host_backend<T>::softmax(const tensor_ptr& in, tensor_ptr& out) {
+    const math::matrix<T>& x = at(in);
+    math::matrix<T>& y = at(out);
+
+    if(x.M != y.M || x.N != y.N)
+        throw backend_error("softmax: shapes differ");
+
+    // In double regardless of T.  This is the reference the GPU is checked
+    // against, so it should be the more accurate of the two rather than
+    // matching its rounding.
+    //
+    // Which moves the overflow this guards against but does not remove it:
+    // exp() in double survives to about 709 rather than 88, so the
+    // max-subtraction is still load-bearing here and is still tested.
+    for(uint c = 0; c < x.N; c++) {
+        double m = -std::numeric_limits<double>::infinity();
+
+        for(uint r = 0; r < x.M; r++)
+            m = std::max(m, double(x(r,c)));
+
+        double sum = 0;
+
+        for(uint r = 0; r < x.M; r++) {
+            const double e = std::exp(double(x(r,c)) - m);
+
+            y(r,c) = T(e);
+            sum += e;
+        }
+
+        // A column of all -inf would divide by zero.  Cannot arise from a
+        // finite input, since subtracting the maximum leaves at least one
+        // exponent at zero and so at least one term at one.
+        for(uint r = 0; r < x.M; r++)
+            y(r,c) = T(double(y(r,c)) / sum);
+    }
+}
+
+template<typename T>
+void host_backend<T>::rms_norm(const tensor_ptr& in, const tensor_ptr& weight,
+                               tensor_ptr& out, float eps)
+{
+    const math::matrix<T>& x = at(in);
+    const math::matrix<T>& w = at(weight);
+    math::matrix<T>& y = at(out);
+
+    if(x.M != y.M || x.N != y.N)
+        throw backend_error("rms_norm: shapes differ");
+
+    if(w.M != x.M || w.N != 1)
+        throw backend_error("rms_norm: the weight must be one column of rows entries");
+
+    for(uint c = 0; c < x.N; c++) {
+        double ss = 0;
+
+        for(uint r = 0; r < x.M; r++)
+            ss += double(x(r,c)) * double(x(r,c));
+
+        const double inv = 1.0 / std::sqrt(ss / double(x.M) + double(eps));
+
+        for(uint r = 0; r < x.M; r++)
+            y(r,c) = T(double(x(r,c)) * inv * double(w(r,0)));
+    }
 }
 
 }

--- a/jlib/metal/backend.hh
+++ b/jlib/metal/backend.hh
@@ -68,6 +68,9 @@ public:
     void subtract(const tensor_ptr& a, const tensor_ptr& b, tensor_ptr& c);
     void add_scaled(T alpha, const tensor_ptr& x, tensor_ptr& y);
     void assign(const tensor_ptr& src, tensor_ptr& dst);
+    void softmax(const tensor_ptr& in, tensor_ptr& out);
+    void rms_norm(const tensor_ptr& in, const tensor_ptr& weight,
+                  tensor_ptr& out, float eps = 1e-5f);
 
     void wait();
 

--- a/jlib/metal/backend.mm
+++ b/jlib/metal/backend.mm
@@ -148,6 +148,18 @@ void backend<T>::assign(const tensor_ptr& src, tensor_ptr& dst) {
 }
 
 template<typename T>
+void backend<T>::softmax(const tensor_ptr& in, tensor_ptr& out) {
+    m_stream->softmax(at<T>(in), at<T>(out));
+}
+
+template<typename T>
+void backend<T>::rms_norm(const tensor_ptr& in, const tensor_ptr& weight,
+                          tensor_ptr& out, float eps)
+{
+    m_stream->rms_norm(at<T>(in), at<T>(weight), at<T>(out), eps);
+}
+
+template<typename T>
 void backend<T>::wait() {
     m_stream->wait();
 }

--- a/jlib/metal/tensor.hh
+++ b/jlib/metal/tensor.hh
@@ -183,6 +183,13 @@ public:
     /** y += alpha * x. */
     void add_scaled(float alpha, const tensor<T>& x, tensor<T>& y);
 
+    /** Softmax down each column, with the column's maximum subtracted. */
+    void softmax(const tensor<T>& in, tensor<T>& out);
+
+    /** RMS normalisation down each column, scaled by a per-row weight. */
+    void rms_norm(const tensor<T>& in, const tensor<T>& weight, tensor<T>& out,
+                  float eps = 1e-5f);
+
     /** Commit everything encoded so far and block until the GPU is done. */
     void wait();
 

--- a/jlib/metal/tensor.mm
+++ b/jlib/metal/tensor.mm
@@ -128,6 +128,78 @@ kernel void k_add_scaled(device const T* x [[buffer(0)]],
     if(i < n) y[i] = T(float(y[i]) + alpha * float(x[i]));
 }
 
+// The reductions.  One thread per *column*, looping down the rows.
+//
+// Parallel across columns and serial within one, which is the right shape for
+// what this is for: a batch or a set of attention heads gives many columns,
+// and the feature dimension is what a column is.  A threadgroup reduction per
+// column would beat it when there are few very tall columns; that is a
+// measurement nobody has taken, and this is the version that is obviously
+// correct.
+
+template<typename T>
+kernel void k_softmax(device const T* in [[buffer(0)]],
+                      device T* out [[buffer(1)]],
+                      constant uint& rows [[buffer(2)]],
+                      constant uint& cols [[buffer(3)]],
+                      uint c [[thread_position_in_grid]])
+{
+    if(c >= cols) return;
+
+    // Column-major, so a column is contiguous.
+    device const T* x = in + (ulong)c * rows;
+    device T* y = out + (ulong)c * rows;
+
+    // The maximum first.  exp() of a large score overflows and takes the whole
+    // column to nan with it; subtracting the column's own maximum puts the
+    // largest exponent at zero and changes nothing else.
+    float m = -INFINITY;
+
+    for(uint r = 0; r < rows; r++)
+        m = max(m, float(x[r]));
+
+    float sum = 0.0f;
+
+    for(uint r = 0; r < rows; r++) {
+        const float e = exp(float(x[r]) - m);
+
+        y[r] = T(e);
+        sum += e;
+    }
+
+    for(uint r = 0; r < rows; r++)
+        y[r] = T(float(y[r]) / sum);
+}
+
+template<typename T>
+kernel void k_rms_norm(device const T* in [[buffer(0)]],
+                       device const T* w [[buffer(1)]],
+                       device T* out [[buffer(2)]],
+                       constant uint& rows [[buffer(3)]],
+                       constant uint& cols [[buffer(4)]],
+                       constant float& eps [[buffer(5)]],
+                       uint c [[thread_position_in_grid]])
+{
+    if(c >= cols) return;
+
+    device const T* x = in + (ulong)c * rows;
+    device T* y = out + (ulong)c * rows;
+
+    // Accumulated in float even when T is half: a sum of squares over a few
+    // thousand features overflows fp16 long before the values themselves do.
+    float ss = 0.0f;
+
+    for(uint r = 0; r < rows; r++) {
+        const float v = float(x[r]);
+        ss += v * v;
+    }
+
+    const float inv = rsqrt(ss / float(rows) + eps);
+
+    for(uint r = 0; r < rows; r++)
+        y[r] = T(float(x[r]) * inv * float(w[r]));
+}
+
 #define INSTANTIATE(NAME, T, SUFFIX)                                        \
     template [[host_name(#NAME SUFFIX)]] kernel void NAME<T>
 
@@ -151,6 +223,16 @@ INSTANTIATE(k_add_scaled, float, "_f32")(device const float*, device float*,
                                          constant float&, constant uint&, uint);
 INSTANTIATE(k_add_scaled, half, "_f16")(device const half*, device half*,
                                         constant float&, constant uint&, uint);
+INSTANTIATE(k_softmax, float, "_f32")(device const float*, device float*,
+                                      constant uint&, constant uint&, uint);
+INSTANTIATE(k_softmax, half, "_f16")(device const half*, device half*,
+                                     constant uint&, constant uint&, uint);
+INSTANTIATE(k_rms_norm, float, "_f32")(device const float*, device const float*,
+                                       device float*, constant uint&,
+                                       constant uint&, constant float&, uint);
+INSTANTIATE(k_rms_norm, half, "_f16")(device const half*, device const half*,
+                                      device half*, constant uint&,
+                                      constant uint&, constant float&, uint);
 )METAL";
 
 /** The per-type details: what MPS calls it, and what the kernels are named. */
@@ -254,6 +336,8 @@ struct stream<T>::impl {
     id<MTLComputePipelineState> hadamard = nil;
     id<MTLComputePipelineState> subtract = nil;
     id<MTLComputePipelineState> add_scaled = nil;
+    id<MTLComputePipelineState> softmax = nil;
+    id<MTLComputePipelineState> rms_norm = nil;
 
     unsigned int pending = 0;
 };
@@ -266,6 +350,8 @@ struct pipelines {
     id<MTLComputePipelineState> hadamard = nil;
     id<MTLComputePipelineState> subtract = nil;
     id<MTLComputePipelineState> add_scaled = nil;
+    id<MTLComputePipelineState> softmax = nil;
+    id<MTLComputePipelineState> rms_norm = nil;
 };
 
 /**
@@ -315,6 +401,8 @@ pipelines& compiled(id<MTLDevice> gpu) {
         { "k_hadamard",   &p.hadamard },
         { "k_subtract",   &p.subtract },
         { "k_add_scaled", &p.add_scaled },
+        { "k_softmax",    &p.softmax },
+        { "k_rms_norm",   &p.rms_norm },
     };
 
     for(auto& w : wanted) {
@@ -376,6 +464,8 @@ stream<T>::stream(std::shared_ptr<device> d)
     m_impl->hadamard = p.hadamard;
     m_impl->subtract = p.subtract;
     m_impl->add_scaled = p.add_scaled;
+    m_impl->softmax = p.softmax;
+    m_impl->rms_norm = p.rms_norm;
 }
 
 template<typename T>
@@ -511,6 +601,54 @@ void stream<T>::add_scaled(float alpha, const tensor<T>& x, tensor<T>& y) {
     [m_impl->enc setBytes:&n length:sizeof(n) atIndex:3];
 
     dispatch(m_impl->enc, m_impl->add_scaled, n);
+
+    m_impl->pending++;
+}
+
+template<typename T>
+void stream<T>::softmax(const tensor<T>& in, tensor<T>& out) {
+    same_shape(in, out, "softmax");
+
+    open();
+
+    const unsigned int rows = in.rows();
+    const unsigned int cols = in.cols();
+
+    [m_impl->enc setComputePipelineState:m_impl->softmax];
+    [m_impl->enc setBuffer:in.m_impl->buf offset:0 atIndex:0];
+    [m_impl->enc setBuffer:out.m_impl->buf offset:0 atIndex:1];
+    [m_impl->enc setBytes:&rows length:sizeof(rows) atIndex:2];
+    [m_impl->enc setBytes:&cols length:sizeof(cols) atIndex:3];
+
+    // One thread per column, not per element.
+    dispatch(m_impl->enc, m_impl->softmax, cols);
+
+    m_impl->pending++;
+}
+
+template<typename T>
+void stream<T>::rms_norm(const tensor<T>& in, const tensor<T>& weight,
+                         tensor<T>& out, float eps)
+{
+    same_shape(in, out, "rms_norm");
+
+    if(weight.rows() != in.rows() || weight.cols() != 1)
+        throw ai::backend_error("rms_norm: the weight must be one column of rows entries");
+
+    open();
+
+    const unsigned int rows = in.rows();
+    const unsigned int cols = in.cols();
+
+    [m_impl->enc setComputePipelineState:m_impl->rms_norm];
+    [m_impl->enc setBuffer:in.m_impl->buf offset:0 atIndex:0];
+    [m_impl->enc setBuffer:weight.m_impl->buf offset:0 atIndex:1];
+    [m_impl->enc setBuffer:out.m_impl->buf offset:0 atIndex:2];
+    [m_impl->enc setBytes:&rows length:sizeof(rows) atIndex:3];
+    [m_impl->enc setBytes:&cols length:sizeof(cols) atIndex:4];
+    [m_impl->enc setBytes:&eps length:sizeof(eps) atIndex:5];
+
+    dispatch(m_impl->enc, m_impl->rms_norm, cols);
 
     m_impl->pending++;
 }

--- a/tests/ai_backend_test.cc
+++ b/tests/ai_backend_test.cc
@@ -151,6 +151,144 @@ static void one_type(const char* name, std::vector<ai::backend<T>*>& backends) {
     }
 }
 
+/** Softmax and RMS norm, which are the first operations that reduce. */
+template<typename T>
+static void the_reductions(const char* name, std::vector<ai::backend<T>*>& backends) {
+    std::cout << "\nreductions, " << name << ":\n";
+
+    std::mt19937 gen(31);
+
+    // Rectangular, and taller than it is wide, because these reduce down a
+    // column: a square would let a rows/cols mix-up produce a plausible answer.
+    const matrix<T> x = random_matrix<T>(7, 4, gen);
+
+    matrix<T> w(7, 1);
+    for(uint r = 0; r < 7; r++) w(r,0) = T(0.5f + 0.1f * r);
+
+    std::vector<matrix<T> > soft, rms;
+
+    for(ai::backend<T>* b : backends) {
+        typename ai::backend<T>::tensor_ptr tx = b->make(x);
+        typename ai::backend<T>::tensor_ptr tw = b->make(w);
+        typename ai::backend<T>::tensor_ptr ts = b->make(7, 4);
+        typename ai::backend<T>::tensor_ptr tr = b->make(7, 4);
+
+        b->softmax(tx, ts);
+        b->rms_norm(tx, tw, tr, 1e-5f);
+        b->wait();
+
+        soft.push_back(ts->read());
+        rms.push_back(tr->read());
+    }
+
+    // Each column sums to one, which is the defining property and does not
+    // need a second implementation to check.
+    for(std::size_t i = 0; i < backends.size(); i++) {
+        double furthest = 0;
+
+        for(uint c = 0; c < 4; c++) {
+            double sum = 0;
+
+            for(uint r = 0; r < 7; r++) sum += double(float(soft[i](r,c)));
+
+            furthest = std::max(furthest, std::fabs(sum - 1.0));
+        }
+
+        ok(std::string("  ") + backends[i]->name() + ": every softmax column sums to one",
+           furthest < ((sizeof(T) == 2) ? 5e-3 : 1e-6),
+           "furthest from 1 was " + std::to_string(furthest));
+    }
+
+    // And RMS norm leaves each column with unit root-mean-square, once the
+    // per-feature weight is divided back out.
+    for(std::size_t i = 0; i < backends.size(); i++) {
+        double furthest = 0;
+
+        for(uint c = 0; c < 4; c++) {
+            double ss = 0;
+
+            for(uint r = 0; r < 7; r++) {
+                const double v = double(float(rms[i](r,c))) / double(float(w(r,0)));
+                ss += v * v;
+            }
+
+            furthest = std::max(furthest, std::fabs(std::sqrt(ss / 7.0) - 1.0));
+        }
+
+        // Just *under* one, not exactly one, and deliberately: eps sits in the
+        // denominator, so the result is scaled by 1/sqrt(1 + eps/ms).  For
+        // values in [-1,1] that is about 1.4e-5 low, which is what this
+        // measures -- the first version of this assertion used 1e-5 and caught
+        // eps rather than a bug.  A real error here is of order one.
+        ok(std::string("  ") + backends[i]->name() + ": rms_norm leaves unit RMS",
+           furthest < ((sizeof(T) == 2) ? 5e-3 : 1e-3),
+           "furthest from 1 was " + std::to_string(furthest));
+    }
+
+    for(std::size_t i = 1; i < backends.size(); i++) {
+        const double tol = (sizeof(T) == 2) ? 2e-2 : 1e-5;
+
+        ok(std::string("  ") + backends[i]->name() + " agrees on softmax",
+           worst(soft[0], soft[i]) < tol, std::to_string(worst(soft[0], soft[i])));
+
+        ok(std::string("  ") + backends[i]->name() + " agrees on rms_norm",
+           worst(rms[0], rms[i]) < tol, std::to_string(worst(rms[0], rms[i])));
+    }
+}
+
+/** The reason softmax subtracts the column maximum. */
+template<typename T>
+static void softmax_survives_a_large_score(const char* name,
+                                           std::vector<ai::backend<T>*>& backends)
+{
+    std::cout << "\nsoftmax survives a large score, " << name << ":\n";
+
+    // 800, not 90.  exp(90) overflows a float and this test was written with
+    // that in mind -- but the host reference accumulates in double, where
+    // exp(90) is about 1.2e39 and perfectly finite, so removing the
+    // max-subtraction from the host failed to fail.  exp(800) overflows every
+    // type involved, so one value covers both backends.
+    //
+    // The input itself stays representable: 800 fits in fp16, whose ceiling is
+    // 65504.  It is exp() that cannot survive it.
+    const float big = 800.0f;
+
+    matrix<T> x(3, 2);
+    x(0,0) = T(big);   x(0,1) = T(0.0f);
+    x(1,0) = T(0.0f);  x(1,1) = T(big);
+    x(2,0) = T(-big);  x(2,1) = T(0.0f);
+
+    for(ai::backend<T>* b : backends) {
+        typename ai::backend<T>::tensor_ptr tx = b->make(x);
+        typename ai::backend<T>::tensor_ptr ts = b->make(3, 2);
+
+        b->softmax(tx, ts);
+        b->wait();
+
+        const matrix<T> got = ts->read();
+
+        bool finite = true;
+        double sum0 = 0;
+
+        for(uint r = 0; r < 3; r++) {
+            for(uint c = 0; c < 2; c++)
+                if(!std::isfinite(float(got(r,c)))) finite = false;
+
+            sum0 += double(float(got(r,0)));
+        }
+
+        ok(std::string("  ") + b->name() + ": no nan or inf", finite);
+
+        ok(std::string("  ") + b->name() + ": and the column still sums to one",
+           std::fabs(sum0 - 1.0) < ((sizeof(T) == 2) ? 5e-3 : 1e-6),
+           std::to_string(sum0));
+
+        // The largest score should take essentially all of the mass.
+        ok(std::string("  ") + b->name() + ": with the mass on the largest score",
+           double(float(got(0,0))) > 0.99, std::to_string(float(got(0,0))));
+    }
+}
+
 static void a_tensor_from_the_wrong_backend_is_refused() {
     std::cout << "\na tensor from the wrong backend is refused:\n";
 
@@ -197,8 +335,12 @@ int main() {
         try { g.reset(new jlib::metal::backend<float>); b.push_back(g.get()); }
         catch(std::exception& e) { std::cout << "  (no Metal device: " << e.what() << ")\n"; }
         one_type<float>("float", b);
+        the_reductions<float>("float", b);
+        softmax_survives_a_large_score<float>("float", b);
 #else
         one_type<float>("float", b);
+        the_reductions<float>("float", b);
+        softmax_survives_a_large_score<float>("float", b);
 #endif
     }
 
@@ -212,6 +354,8 @@ int main() {
         catch(std::exception&) {}
 #endif
         one_type<_Float16>("_Float16", b);
+        the_reductions<_Float16>("_Float16", b);
+        softmax_survives_a_large_score<_Float16>("_Float16", b);
     }
 
     a_tensor_from_the_wrong_backend_is_refused();
@@ -230,6 +374,14 @@ int main() {
     // which exists.  fp16 is for inference.
     //
     // Not double, which Metal has no type for and cannot be given one.
+    //
+    // The agreement assertions above would not, on their own, have caught a
+    // missing max-subtraction: at the magnitudes random_matrix produces, both
+    // backends give the same answer with or without it.  That is what
+    // softmax_survives_a_large_score is for, and it was checked by deleting the
+    // subtraction from each backend in turn and confirming each deletion fails
+    // the test.  No other assertion here has been mutation-checked, so the rest
+    // carry only the usual claim: they pass.
     std::cout << "\n" << (failures ? "FAILED" : "PASSED") << ": " << failures
               << " failure(s)\n";
 


### PR DESCRIPTION
# Reductions: softmax and RMS norm

Every kernel in `ai::backend` until now was elementwise or a GEMM. Both of
those are embarrassingly parallel per output element; neither needs a thread to
look at more than its own inputs. Softmax and RMS norm are the first operations
that **reduce** — each output depends on every entry in its column — and a
transformer cannot be built without them. They are the missing primitive class,
which is why they are this branch.

## What they are

Both reduce down a **column**, because a column is a sample here: matrices are
(features × batch), so reducing over features is reducing over the thing a
sample is made of.

- **`softmax(in, out)`** — exponentiate and normalise, so each column sums to
  one.
- **`rms_norm(in, weight, out, eps)`** —
  `out[r,c] = in[r,c] / sqrt(mean(in[:,c]^2) + eps) * weight[r]`. What a
  transformer uses in place of layer normalisation: no mean subtraction and no
  bias. `weight` is a column of `rows` entries, the learned per-feature scale,
  and is an *argument* rather than something applied afterwards because there
  is no broadcast operation to apply it with.

Both land in three places, as every operation here does: the pure-virtual
interface in `ai::backend<T>`, the reference implementation in
`host_backend<T>`, and a templated MSL kernel in `metal::tensor.mm` reached
through `metal::stream<T>` and `metal::backend<T>`. One thread per column, which
suits the shapes an LLM produces — many columns, and a reduction length equal to
the model dimension.

## The max-subtraction, and proving it is load-bearing

`exp()` of a large score overflows, the column's sum becomes `inf`, and every
entry becomes `inf/inf` — `nan`. Subtracting the column's own maximum first
shifts the largest exponent to zero. It changes nothing about the result and
everything about whether the result exists. The thresholds differ per type:
about 88 for float, about 11 for fp16 (whose ceiling is 65504), about 709 for
double.

The interesting part is that **the ordinary assertions would never have caught
its absence.** At the magnitudes `random_matrix` produces, softmax gives exactly
the same answer with or without the subtraction, on both backends. A
correctness-by-agreement test is blind to it.

So `softmax_survives_a_large_score` exists to hold that one line down, and it
was verified by deleting the subtraction from each backend in turn:

| mutation | result |
| --- | --- |
| removed from the Metal kernel | GPU columns go `nan` — **caught** |
| removed from the host reference | **not caught**, first attempt |

The second result is the useful one. The host reference accumulates in `double`
regardless of `T` — deliberately, since it is what the GPU is checked against
and should be the more accurate of the two rather than matching its rounding —
and the test used a score of 90, chosen for float's threshold. `exp(90)` in
double is about 1.2e39, perfectly finite. The assertion was protecting the GPU
path only, and passing looked identical either way.

Raising the score to **800**, which overflows every type involved, makes one
value cover both. Re-run: both mutations now fail the test. The input stays
representable — 800 fits comfortably in fp16 — it is `exp()` that cannot
survive it.

Two things came out of that worth keeping. Computing the reference in a wider
type moves an overflow guard's threshold without removing the need for it, and
that is now written at the point of use. And a "does not establish" note is only
worth what it has been checked against: the test's closing comment now says
which assertion was mutation-checked and that no other one was.

## Also a corrected tolerance of my own

The first version of the `rms_norm` unit-RMS assertion used a bound of 1e-5 and
failed. The cause was not the kernel: `eps` sits in the denominator, so the
result is scaled by `1/sqrt(1 + eps/ms)` — for values in [-1,1] about 1.4e-5
low, by design. The assertion was measuring `eps`. A real error in this
operation is of order one, not of order `eps`, so the bound is now 1e-3 and the
comment says why, including that it caught the author before it caught a bug.

## Test shapes

The reduction test uses a **7×4** matrix, rectangular and taller than it is
wide, on purpose: a square matrix lets a rows/cols transposition produce a
plausible-looking answer. Assertions are the defining properties where one
exists — each softmax column sums to one; RMS norm leaves unit root-mean-square
once the per-feature weight is divided back out — plus host-versus-GPU
agreement, in both `float` and `_Float16`.

## Verification

- macOS `make check`: 68 tests, 64 pass, 4 skip, 0 fail.
- Container `make check`: 67 tests, 66 pass, 1 skip, 0 fail. No Metal there, so
  the host reductions are what is exercised — which is the half of the argument
  that has to hold on both platforms.

## What this does not establish

That either implementation is *right*, only that they agree and that each
satisfies the defining property of the operation it claims to be. Two
implementations of the same misunderstanding still pass.

Nothing about performance: one thread per column is the obvious mapping, not a
measured one, and a reduction long enough to want threadgroup cooperation would
want a different kernel. Nothing here is large enough to say so yet.

And not fp16's suitability for training — it is exercised because the interface
carries it. Gradients underflow in fp16, and training needs loss scaling and an
fp32 master copy of the weights, neither of which exists. fp16 is for inference,
which is where this arc is going.
