### PR TITLE
Fix math::tensor multilinear ops

### DIFF
--- a/jlib/math/buffer.hh
+++ b/jlib/math/buffer.hh
@@ -156,7 +156,14 @@ template<typename T>
 inline
 buffer<T>::buffer(buffer<T> b, unsigned int o, unsigned int s)
     : mbuf(b.mbuf),
-      moff(o),
+      // b.moff + o, not o.  The offset is into the shared array, so a view of
+      // a view has to compose them; taking o alone silently rebased the second
+      // view onto the start of the array.  Nothing caught it because nothing
+      // indexed two levels deep: tensor::operator[] slices one axis per call,
+      // so t[i][j] is a view of a view, and both the 1999 tensor_test and
+      // math_value_test's slice check use index 0 at the outer level, where
+      // b.moff is 0 and the two agree.
+      moff(b.moff + o),
       msize(s)
 {
 }

--- a/jlib/math/tensor.hh
+++ b/jlib/math/tensor.hh
@@ -23,6 +23,7 @@
 
 
 #include <jlib/math/buffer.hh>
+#include <array>
 #include <cstdarg>
 
 
@@ -66,10 +67,36 @@ public:
     tensor(buffer<unsigned int> m);
     tensor(buffer<unsigned int> m, buffer<T> d);
 
+    /**
+     * Slice the first axis: a view, sharing storage with this tensor.
+     *
+     * The const overload returns a const tensor, so `t[i][j] = x` on a const
+     * tensor does not compile.  The constness is shallow, as it is for any
+     * handle type -- copying the result into a non-const tensor shares the same
+     * storage and can write through it.  Blocking that needs a distinct const
+     * view type; see #143.
+     */
     tensor<T> operator[](unsigned int i);
+    const tensor<T> operator[](unsigned int i) const;
 
-    // take ith slice.  in a rank 2 tensor, a slice is a column vector
-    tensor<T> operator()(unsigned int i);
+    /**
+     * Element access by a full index: t(i, j, k) on a rank 3 tensor.
+     *
+     * The same meaning operator() has on matrix, which is m(r, c) -- and no
+     * longer the meaning it had here, where it was a byte-for-byte copy of
+     * operator[] under a comment claiming it returned a column.  Nothing called
+     * it, so nothing changes behaviour; what changes is that the two classes in
+     * this directory now agree about what the operator is for.
+     *
+     * Throws mismatch if the number of indices is not the rank.  Individual
+     * indices are not bounds-checked, matching matrix, which keeps the branch
+     * out of element access.
+     */
+    template<typename... Args>
+    T& operator()(Args... args);
+
+    template<typename... Args>
+    const T& operator()(Args... args) const;
 
     operator T&();
     operator const T&() const;
@@ -81,6 +108,9 @@ public:
     
 private:
     unsigned int mmult(unsigned int o);
+
+    template<typename... Args>
+    unsigned int flat(Args... args) const;
 
     buffer<unsigned int> meta;
     buffer<T> data;
@@ -164,7 +194,7 @@ tensor<T> tensor<T>::operator[](unsigned int i) {
 
 template<typename T>
 inline
-tensor<T> tensor<T>::operator()(unsigned int i) {
+const tensor<T> tensor<T>::operator[](unsigned int i) const {
     if(!meta.size()) {
         if(i)
             throw mismatch();
@@ -179,6 +209,44 @@ tensor<T> tensor<T>::operator()(unsigned int i) {
     buffer<T> subdata(data, i * p, p);
 
     return tensor<T>(submeta, subdata);
+}
+
+template<typename T>
+template<typename... Args>
+inline
+unsigned int tensor<T>::flat(Args... args) const {
+    // std::array rather than a C array because sizeof...(Args) is 0 for a rank
+    // 0 tensor, and a zero-length C array is not a thing.  t() is how you reach
+    // the single element of a scalar.
+    const std::array<unsigned int, sizeof...(Args)> idx =
+        { static_cast<unsigned int>(args)... };
+
+    if(sizeof...(Args) != rank())
+        throw mismatch();
+
+    // Row-major, so the last index is the fastest and each axis multiplies in
+    // as it is passed: ((i0 * d1 + i1) * d2 + i2) ...  Same layout operator[]
+    // slices with, which is what makes the two agree.
+    unsigned int f = 0;
+
+    for(unsigned int i = 0; i < sizeof...(Args); i++)
+        f = f * meta[i] + idx[i];
+
+    return f;
+}
+
+template<typename T>
+template<typename... Args>
+inline
+T& tensor<T>::operator()(Args... args) {
+    return data[flat(args...)];
+}
+
+template<typename T>
+template<typename... Args>
+inline
+const T& tensor<T>::operator()(Args... args) const {
+    return data[flat(args...)];
 }
 
 template<typename T>

--- a/jlib/math/tensor.hh
+++ b/jlib/math/tensor.hh
@@ -45,7 +45,7 @@ template<typename T>
 bool operator==(const tensor<T>& a, const tensor<T>& b);
 
 template<typename T>    
-bool operator!=(const tensor<T>& a, const T& b);
+bool operator!=(const tensor<T>& a, const tensor<T>& b);
 
 template<typename T>
 class tensor {
@@ -58,6 +58,9 @@ public:
 
     template<typename U>
     friend tensor<U> operator^(const tensor<U>& a, const tensor<U>& b);
+
+    template<typename U>
+    friend bool operator==(const tensor<U>& a, const tensor<U>& b);
 
     explicit tensor(unsigned int r, ...);
     tensor(buffer<unsigned int> m);
@@ -214,73 +217,140 @@ tensor<T>& tensor<T>::operator=(const T& t) {
 }
 
 
+/**
+ * Inner product: contract a's last axis against b's first.
+ *
+ * The result has rank a.rank() + b.rank() - 2, and its shape is a's axes
+ * without the last followed by b's without the first.  Contracting the last
+ * against the first is the pairing that makes rank 2 ^ rank 2 the matrix
+ * product, which is why the rank-2 special case this replaces had already
+ * chosen it; the general case here is that one generalised, not a second
+ * convention beside it.  Rank 1 ^ rank 1 is therefore rank 0 -- the dot
+ * product, delivered as a scalar.
+ */
 template<typename T>    
 inline
 tensor<T> operator^(const tensor<T>& a, const tensor<T>& b) {
-    if(a.rank() == 2 && b.rank() == 2) {
-        if(a.size(1) != b.size(0))
-            throw typename tensor<T>::mismatch();
+    // Both operands need an axis to contract.  Without this the rank
+    // arithmetic below underflows -- a.rank() + b.rank() - 2 is unsigned -- and
+    // asks for a shape of four billion axes.
+    if(a.rank() < 1 || b.rank() < 1)
+        throw typename tensor<T>::mismatch();
 
-        // inner product of two matricies is a matrix with as many rows as the first and columns as the second
-        tensor<T> ret(2, a.size(0), b.size(1));
+    const unsigned int k = a.meta[a.rank() - 1];
 
-        for(unsigned int j = 0; j < b.size(1); j++) {
-            for(unsigned int i = 0; i < a.size(0); i++) {
-                ret[i][j] = 0;
-                for(unsigned int k = 0; k < a.size(1); k++) {
-                    ret[i][j] += (a[i][k] * b[k][j]);
-                }
-            }
-        }
+    if(k != b.meta[0])
+        throw typename tensor<T>::mismatch();
 
-        return ret;
-    } else {
-        throw typename tensor<T>::not_implemented();
+    buffer<unsigned int> meta(a.rank() + b.rank() - 2);
 
-        // inner product is a tensor with rank equal to sum of args' ranks - 2
-        buffer<unsigned int> meta(a.rank() + b.rank() - 2);
-        buffer<T> data;   // was data(), which declares a function
-        tensor<T> ret(meta, data);
-    
-        return ret;
+    // m and n are multiplied out here rather than divided out of the totals,
+    // which costs nothing and means an axis of length zero yields an empty
+    // result instead of dividing by k.
+    unsigned int m = 1;
+    unsigned int n = 1;
+
+    for(unsigned int i = 0; i + 1 < a.rank(); i++) {
+        meta[i] = a.meta[i];
+        m *= a.meta[i];
     }
-}
 
-
-template<typename T>    
-inline
-tensor<T> operator*(const tensor<T>& a, const tensor<T>& b) {
-    // outer product is a tensor with rank equal to sum of args' ranks
-    buffer<unsigned int> meta(a.rank() + b.rank());
-    buffer<T> data(a.meta.product() * b.meta.product());
-    tensor<T> ret(meta, data);
-
-    if(a.rank() == 1 && b.rank() == 1) {
-        meta[0] = a.size(0);
-        meta[1] = b.size(0);
-
-        for(unsigned int i = 0; i < a.size(); i++) {
-            for(unsigned int j = 0; j < b.size(); j++) {
-                ret[i][j] = (a[i] * b[j]);
-            }
-        }
-
-    } else {
-        throw typename tensor<T>::not_implemented();
+    for(unsigned int i = 1; i < b.rank(); i++) {
+        meta[a.rank() + i - 2] = b.meta[i];
+        n *= b.meta[i];
     }
-    
+
+    tensor<T> ret(meta);
+
+    // The storage is row-major -- operator[] slices the first axis at a stride
+    // of the remaining axes' product -- so a is *already* laid out as an m x k
+    // matrix and b as a k x n one.  The axes being contracted are adjacent in
+    // memory by construction, so general contraction is matrix multiply over
+    // the flattened views: no gather, no strides to carry, and no special case
+    // for rank 2, which now falls out of this rather than sitting beside it.
+    for(unsigned int i = 0; i < m; i++) {
+        for(unsigned int j = 0; j < n; j++) {
+            T sum = T();
+
+            for(unsigned int p = 0; p < k; p++)
+                sum += (a.data[i * k + p] * b.data[p * n + j]);
+
+            ret.data[i * n + j] = sum;
+        }
+    }
+
     return ret;
 }
 
+
+/**
+ * Outer product: every element of a against every element of b.
+ *
+ * The result has rank a.rank() + b.rank() and its shape is the two shapes
+ * concatenated.  Rank 0 is not an error but the scaling case -- concatenating
+ * an empty shape gives back the other one, so a scalar times a tensor is that
+ * tensor scaled.
+ */
+template<typename T>    
+inline
+tensor<T> operator*(const tensor<T>& a, const tensor<T>& b) {
+    buffer<unsigned int> meta(a.rank() + b.rank());
+
+    for(unsigned int i = 0; i < a.rank(); i++)
+        meta[i] = a.meta[i];
+
+    for(unsigned int i = 0; i < b.rank(); i++)
+        meta[a.rank() + i] = b.meta[i];
+
+    // Filled before the tensor is built, not after.  The version this replaces
+    // constructed ret from an unfilled meta and wrote the shape in afterwards,
+    // which reached ret at all only because buffer is a shared handle rather
+    // than a value -- right by accident of the ownership model.
+    tensor<T> ret(meta);
+
+    const unsigned int m = a.meta.product();
+    const unsigned int n = b.meta.product();
+
+    // Row-major again: concatenating the shapes concatenates the layouts, so
+    // result element (i,j) is at flat i*n + j whatever the two ranks are.
+    for(unsigned int i = 0; i < m; i++)
+        for(unsigned int j = 0; j < n; j++)
+            ret.data[i * n + j] = (a.data[i] * b.data[j]);
+
+    return ret;
+}
+
+/**
+ * Equal shapes and equal elements.
+ *
+ * Was `a.rank() == b.rank()`, which made every matrix equal to every other
+ * matrix.  Nothing called it and nothing could have -- operator!= below passed
+ * it a scalar, so neither would compile -- but a test of the products has to
+ * compare two of them, and it cannot be built on that.
+ */
 template<typename T>    
 bool operator==(const tensor<T>& a, const tensor<T>& b) {
-    return (a.rank() == b.rank());
+    if(a.rank() != b.rank())
+        return false;
+
+    for(unsigned int i = 0; i < a.rank(); i++)
+        if(a.size(i) != b.size(i))
+            return false;
+
+    const unsigned int n = a.meta.product();
+
+    for(unsigned int i = 0; i < n; i++)
+        if(!(a.data[i] == b.data[i]))
+            return false;
+
+    return true;
 }
 
 template<typename T>
-bool operator!=(const tensor<T>& a, const T& b) {
+bool operator!=(const tensor<T>& a, const tensor<T>& b) {
     return !(a == b);
 }
+
     
 
 }

--- a/tests/math_value_test.cc
+++ b/tests/math_value_test.cc
@@ -301,6 +301,33 @@ static void buffer_keeps_its_reference_semantics() {
 
     ok("and a tensor slice still writes through to its parent",
        t[0][0] == 5, std::to_string(t[0][0]));
+
+    // Index 0 at the outer level, which is what the assertion above uses, is
+    // the one case where a view of a view cannot tell a composed offset from a
+    // rebased one.  These are the cases that can.
+    buffer<double> whole(4);
+
+    for(unsigned int i = 0; i < 4; i++) whole[i] = double(i);
+
+    buffer<double> tail(whole, 2, 2);
+    buffer<double> last(tail, 1, 1);
+
+    ok("a view of a view composes offsets rather than rebasing",
+       last[0] == 3, std::to_string(last[0]));
+
+    last[0] = 7;
+
+    ok("and writes through both levels to the original",
+       whole[3] == 7, std::to_string(whole[3]));
+
+    t[0][0] = 1;
+    t[1][1] = 2;
+
+    // Before the fix these were the same element, so the second write landed on
+    // the first and both read back as 2.
+    ok("so two tensor elements two levels down do not alias",
+       t[0][0] == 1 && t[1][1] == 2,
+       std::to_string(t[0][0]) + " and " + std::to_string(t[1][1]));
 }
 
 int main() {

--- a/tests/tensor_test.cc
+++ b/tests/tensor_test.cc
@@ -18,40 +18,376 @@
  *
  */
 
+#include <cmath>
 #include <iostream>
-#include <sstream>
 #include <string>
 
 #include <jlib/math/tensor.hh>
-#include <jlib/util/util.hh>
 
 using namespace jlib::math;
 
 typedef double T;
 
-int main(int argc, char** argv) {
-    tensor<T> scalar(0);
-    tensor<T> vector(1, 5);
-    tensor<T> matrix(2, 5, 5);
-    const T VAL = 5.0;
-    T val;
+static int failures = 0;
 
-    scalar = VAL;
-  
-    try {
-        vector = 5.0;
+static void ok(const std::string& what, bool good, const std::string& detail = "") {
+    std::cout << (good ? "  ok   " : "  FAIL ") << what;
 
-        std::cerr << "tensor_test: was able to assign a scalar to a vector!" << std::endl;
-        return 1;
-    } catch(tensor<T>::mismatch&) {}
+    if(!detail.empty()) std::cout << ": " << detail;
 
-    val = scalar;
-    if(val != VAL) {
-        std::cerr << "tensor_test: assigning rank 0 tensor to scalar failed to return assigned value ("<< val << " != " << VAL << ")!" << std::endl;
-        return 1;
-    }
+    std::cout << "\n";
 
-    return 0;
+    if(!good) failures++;
 }
 
- 
+static double g_next = 0;
+
+static void fill_rec(tensor<T> t) {
+    if(t.rank() == 0) {
+        t = g_next;
+        g_next += 1.0;
+
+        return;
+    }
+
+    for(unsigned int i = 0; i < t.size(0); i++)
+        fill_rec(t[i]);
+}
+
+/**
+ * Fill with base, base+1, base+2, ... in row-major order.
+ *
+ * By recursion down operator[], not by a flat loop: operator[] slices the
+ * first axis rather than indexing an element, so `t[i] = x` on anything above
+ * rank 1 is a mismatch.  Recursing also means the fill order is whatever
+ * slicing says it is, rather than an assumption about the layout that the
+ * contraction below is supposed to be testing.
+ */
+static void fill(tensor<T>& t, double base = 1.0) {
+    g_next = base;
+
+    fill_rec(t);
+}
+
+static double at2(tensor<T>& t, unsigned int i, unsigned int j) {
+    return t[i][j];
+}
+
+static void a_scalar_is_rank_zero() {
+    std::cout << "\na scalar is rank zero:\n";
+
+    tensor<T> scalar(0);
+    tensor<T> vector(1, 5u);
+
+    const T VAL = 5.0;
+
+    scalar = VAL;
+
+    // Both of these are the 1999 test, unchanged in substance.
+    bool threw = false;
+
+    try { vector = 5.0; }
+    catch(tensor<T>::mismatch&) { threw = true; }
+
+    ok("assigning a scalar to a vector is refused", threw);
+
+    const T val = scalar;
+
+    ok("and a rank 0 tensor round-trips a scalar", val == VAL,
+       std::to_string(val));
+}
+
+static void contraction_is_matrix_multiply_at_rank_two() {
+    std::cout << "\ncontraction is matrix multiply at rank two:\n";
+
+    tensor<T> a(2, 3u, 4u);
+    tensor<T> b(2, 4u, 5u);
+
+    fill(a);
+    fill(b, 0.5);
+
+    tensor<T> c = a ^ b;
+
+    ok("the result is rank 2", c.rank() == 2, std::to_string(c.rank()));
+    ok("with as many rows as the first and columns as the second",
+       c.rank() == 2 && c.size(0) == 3 && c.size(1) == 5);
+
+    // An independent triple loop, written here rather than reused from the
+    // header, because a header that checks itself proves nothing.
+    double furthest = 0;
+
+    for(unsigned int i = 0; i < 3; i++) {
+        for(unsigned int j = 0; j < 5; j++) {
+            double sum = 0;
+
+            for(unsigned int k = 0; k < 4; k++)
+                sum += at2(a, i, k) * at2(b, k, j);
+
+            furthest = std::max(furthest, std::fabs(sum - at2(c, i, j)));
+        }
+    }
+
+    ok("and every element matches a hand-written triple loop", furthest == 0,
+       std::to_string(furthest));
+
+    // The identity is the cheapest check that the flattening is the right way
+    // round: a transposed layout would still have the right shape here and the
+    // wrong numbers.
+    tensor<T> id(2, 4u, 4u);
+
+    for(unsigned int i = 0; i < 4; i++) id[i][i] = 1.0;
+
+    tensor<T> same = a ^ id;
+
+    ok("contracting with the identity returns the original", same == a);
+}
+
+static void contraction_generalises_past_rank_two() {
+    std::cout << "\ncontraction generalises past rank two:\n";
+
+    tensor<T> a(3, 2u, 3u, 4u);
+    tensor<T> b(2, 4u, 5u);
+
+    fill(a);
+    fill(b, 0.25);
+
+    tensor<T> c = a ^ b;
+
+    // rank 3 + rank 2 - 2 = rank 3, shaped (2,3,5): a's axes without its last,
+    // then b's without its first.  This is the case that threw until now.
+    ok("rank 3 ^ rank 2 is rank 3", c.rank() == 3, std::to_string(c.rank()));
+    ok("shaped (2,3,5)",
+       c.rank() == 3 && c.size(0) == 2 && c.size(1) == 3 && c.size(2) == 5);
+
+    // Every (i, :, :) slice of the result must be that slice of a times b, and
+    // slicing is independent of the contraction code.
+    double furthest = 0;
+
+    for(unsigned int i = 0; i < 2; i++) {
+        tensor<T> ai = a[i];
+        tensor<T> ci = c[i];
+        tensor<T> want = ai ^ b;
+
+        for(unsigned int r = 0; r < 3; r++)
+            for(unsigned int s = 0; s < 5; s++)
+                furthest = std::max(furthest,
+                                    std::fabs(at2(ci, r, s) - at2(want, r, s)));
+    }
+
+    ok("and each slice of it is that slice of a contracted with b",
+       furthest == 0, std::to_string(furthest));
+
+    tensor<T> u(1, 4u);
+    tensor<T> v(1, 4u);
+
+    fill(u);
+    fill(v, 2.0);
+
+    tensor<T> dot = u ^ v;
+
+    double want = 0;
+    for(unsigned int i = 0; i < 4; i++) want += (1.0 + i) * (2.0 + i);
+
+    ok("rank 1 ^ rank 1 is rank 0", dot.rank() == 0, std::to_string(dot.rank()));
+    ok("holding the dot product", double(T(dot)) == want,
+       std::to_string(double(T(dot))) + " vs " + std::to_string(want));
+}
+
+static void contraction_is_associative() {
+    std::cout << "\ncontraction is associative:\n";
+
+    tensor<T> a(2, 2u, 3u);
+    tensor<T> b(2, 3u, 4u);
+    tensor<T> c(2, 4u, 2u);
+
+    fill(a, 0.5);
+    fill(b, 1.5);
+    fill(c, 0.25);
+
+    // (ab)c == a(bc).  A property of the operation rather than of any one
+    // result, so it does not need a second implementation to check against --
+    // and it exercises the shape bookkeeping in both orders.
+    tensor<T> left = (a ^ b) ^ c;
+    tensor<T> right = a ^ (b ^ c);
+
+    double furthest = 0;
+
+    for(unsigned int i = 0; i < 2; i++)
+        for(unsigned int j = 0; j < 2; j++)
+            furthest = std::max(furthest,
+                                std::fabs(at2(left, i, j) - at2(right, i, j)));
+
+    // Exactly equal is too much to ask of floating point in general; these
+    // values are small and dyadic, so it happens to hold, and asking for it
+    // catches an association error that a loose bound would let through.
+    ok("(a^b)^c equals a^(b^c)", furthest == 0, std::to_string(furthest));
+}
+
+static void the_outer_product_concatenates_shapes() {
+    std::cout << "\nthe outer product concatenates shapes:\n";
+
+    tensor<T> a(2, 2u, 3u);
+    tensor<T> b(2, 4u, 5u);
+
+    fill(a);
+    fill(b, 0.5);
+
+    tensor<T> c = a * b;
+
+    ok("rank 2 * rank 2 is rank 4", c.rank() == 4, std::to_string(c.rank()));
+    ok("shaped (2,3,4,5)",
+       c.rank() == 4 && c.size(0) == 2 && c.size(1) == 3 &&
+       c.size(2) == 4 && c.size(3) == 5);
+
+    double furthest = 0;
+
+    for(unsigned int i = 0; i < 2; i++)
+        for(unsigned int j = 0; j < 3; j++)
+            for(unsigned int k = 0; k < 4; k++)
+                for(unsigned int l = 0; l < 5; l++) {
+                    const double got = c[i][j][k][l];
+
+                    furthest = std::max(furthest,
+                                        std::fabs(got - at2(a, i, j) * at2(b, k, l)));
+                }
+
+    ok("and every element is the product of its two sources", furthest == 0,
+       std::to_string(furthest));
+
+    // Rank 0 is the scaling case, not an error: an empty shape concatenated
+    // with a shape is that shape.
+    tensor<T> s(0);
+    s = 3.0;
+
+    tensor<T> scaled = s * a;
+
+    ok("a rank 0 operand leaves the rank alone", scaled.rank() == 2,
+       std::to_string(scaled.rank()));
+
+    double worst = 0;
+
+    for(unsigned int i = 0; i < 2; i++)
+        for(unsigned int j = 0; j < 3; j++)
+            worst = std::max(worst, std::fabs(at2(scaled, i, j) - 3.0 * at2(a, i, j)));
+
+    ok("and scales every element", worst == 0, std::to_string(worst));
+}
+
+static void the_two_products_agree_where_they_meet() {
+    std::cout << "\nthe two products agree where they meet:\n";
+
+    // (u (x) v) . w == u (v . w).  The one identity that constrains both
+    // operators at once, so a consistent misunderstanding of the layout in
+    // both would have to survive it.
+    tensor<T> u(1, 3u);
+    tensor<T> v(1, 4u);
+    tensor<T> w(1, 4u);
+
+    fill(u, 1.0);
+    fill(v, 0.5);
+    fill(w, 2.0);
+
+    tensor<T> lhs = (u * v) ^ w;
+
+    double vw = 0;
+    for(unsigned int i = 0; i < 4; i++) vw += (0.5 + i) * (2.0 + i);
+
+    ok("(u * v) ^ w is rank 1", lhs.rank() == 1, std::to_string(lhs.rank()));
+
+    double furthest = 0;
+
+    for(unsigned int i = 0; i < 3; i++)
+        furthest = std::max(furthest, std::fabs(double(lhs[i]) - (1.0 + i) * vw));
+
+    ok("and equals u scaled by v.w", furthest == 0, std::to_string(furthest));
+}
+
+static void a_bad_contraction_is_refused() {
+    std::cout << "\na bad contraction is refused:\n";
+
+    tensor<T> a(2, 3u, 4u);
+    tensor<T> b(2, 5u, 6u);
+    tensor<T> s(0);
+
+    bool threw = false;
+    try { tensor<T> c = a ^ b; }
+    catch(tensor<T>::mismatch&) { threw = true; }
+
+    ok("axes of different lengths do not contract", threw);
+
+    // Not a mismatch that shows up as a wrong answer: rank() - 2 is unsigned,
+    // so without the guard this asks for a shape of four billion axes.
+    threw = false;
+    try { tensor<T> c = s ^ a; }
+    catch(tensor<T>::mismatch&) { threw = true; }
+
+    ok("and a rank 0 operand has no axis to contract", threw);
+
+    threw = false;
+    try { tensor<T> c = a ^ s; }
+    catch(tensor<T>::mismatch&) { threw = true; }
+
+    ok("in either position", threw);
+}
+
+static void equality_compares_shape_and_elements() {
+    std::cout << "\nequality compares shape and elements:\n";
+
+    tensor<T> a(2, 2u, 3u);
+    tensor<T> b(2, 2u, 3u);
+    tensor<T> c(2, 3u, 2u);
+
+    fill(a);
+    fill(b);
+    fill(c);
+
+    ok("equal shapes and equal elements are equal", a == b);
+
+    b[1][2] = 99.0;
+
+    // The version this replaces returned true here, and for a == c: it compared
+    // ranks and nothing else.
+    ok("one differing element is not equal", a != b);
+    ok("and the same elements in a different shape are not equal", a != c);
+}
+
+int main() {
+    a_scalar_is_rank_zero();
+    contraction_is_matrix_multiply_at_rank_two();
+    contraction_generalises_past_rank_two();
+    contraction_is_associative();
+    the_outer_product_concatenates_shapes();
+    the_two_products_agree_where_they_meet();
+    a_bad_contraction_is_refused();
+    equality_compares_shape_and_elements();
+
+    // What a green run does not establish.
+    //
+    // That these are tensors in the physics sense.  There is no metric, no dual
+    // space, and no distinction between an upper and a lower index, so nothing
+    // here transforms under a change of basis -- which is the property that
+    // defines the word elsewhere.  These are multiway arrays with a contraction
+    // and an outer product, which is what the numerical multilinear algebra
+    // literature means by the term and all that is claimed.
+    //
+    // Nothing about performance.  Contraction is a naive triple loop over the
+    // flattened views, with no blocking and no vectorisation, and it is not
+    // what math::matrix or the Metal backend use.
+    //
+    // That the rank-0 guard in operator^ is what makes the two assertions in
+    // "a bad contraction is refused" pass.  Removing it leaves them green:
+    // a.rank() - 1 underflows to 4294967295, the read off the end of an empty
+    // shape returns garbage, and the garbage fails the very next shape check --
+    // which throws the same mismatch the test is looking for.  Under
+    // -fsanitize=address the unguarded version faults instead, which is the
+    // only way seen so far to tell the two apart.  The guard is load-bearing;
+    // this test is not what establishes it.
+    //
+    // And only one contraction convention: a's last axis against b's first.
+    // Contracting an arbitrary pair of axes, which is what einsum does and what
+    // a real tensor library needs, is not here.
+    std::cout << "\n" << (failures ? "FAILED" : "PASSED") << ": " << failures
+              << " failure(s)\n";
+
+    return failures ? 1 : 0;
+}

--- a/tests/tensor_test.cc
+++ b/tests/tensor_test.cc
@@ -73,6 +73,54 @@ static double at2(tensor<T>& t, unsigned int i, unsigned int j) {
     return t[i][j];
 }
 
+/**
+ * Writing through a const tensor must not compile.
+ *
+ * Asserted in both directions: a concept that is false because of a typo rather
+ * than because of constness would pass the half that matters and prove nothing.
+ */
+template<typename U>
+concept assignable_through = requires(U& t) { t[0][0] = 1.0; };
+
+static_assert(assignable_through<tensor<T> >,
+              "a non-const tensor should be writable through operator[]");
+static_assert(!assignable_through<const tensor<T> >,
+              "a const tensor should not be");
+
+static void the_accessors_agree(tensor<T>& t) {
+    std::cout << "\nthe accessors agree:\n";
+
+    const tensor<T>& ct = t;
+
+    double furthest = 0;
+
+    for(unsigned int i = 0; i < t.size(0); i++)
+        for(unsigned int j = 0; j < t.size(1); j++) {
+            // t(i,j) walks strides; t[i][j] builds two views and slices.  They
+            // share no code, so agreeing is worth something.
+            furthest = std::max(furthest, std::fabs(t(i, j) - at2(t, i, j)));
+
+            // And the const overloads reach the same elements, which is the
+            // whole point of adding them: this line did not compile before.
+            furthest = std::max(furthest, std::fabs(ct(i, j) - double(ct[i][j])));
+        }
+
+    ok("operator(i,j), operator[i][j] and their const forms all agree",
+       furthest == 0, std::to_string(furthest));
+
+    tensor<T> scalar(0);
+    scalar = 7.0;
+
+    ok("and operator() with no indices reaches a rank 0 element",
+       scalar() == 7.0, std::to_string(scalar()));
+
+    bool threw = false;
+    try { t(0u); }
+    catch(tensor<T>::mismatch&) { threw = true; }
+
+    ok("while the wrong number of indices is a mismatch", threw);
+}
+
 static void a_scalar_is_rank_zero() {
     std::cout << "\na scalar is rank zero:\n";
 
@@ -361,6 +409,12 @@ int main() {
     a_bad_contraction_is_refused();
     equality_compares_shape_and_elements();
 
+    {
+        tensor<T> t(2, 3u, 4u);
+        fill(t);
+        the_accessors_agree(t);
+    }
+
     // What a green run does not establish.
     //
     // That these are tensors in the physics sense.  There is no metric, no dual
@@ -382,6 +436,12 @@ int main() {
     // -fsanitize=address the unguarded version faults instead, which is the
     // only way seen so far to tell the two apart.  The guard is load-bearing;
     // this test is not what establishes it.
+    //
+    // That a const tensor is deeply const.  operator[] const returns a const
+    // tensor, which blocks `ct[i][j] = x` -- the static_assert above is what
+    // checks that -- but the result still shares storage, so copying it into a
+    // non-const tensor writes through.  The constness is shallow, as it is for
+    // any handle type.  See #143.
     //
     // And only one contraction convention: a's last axis against b's first.
     // Contracting an arbitrary pair of axes, which is what einsum does and what


### PR DESCRIPTION
# Finish the multilinear half of `math::tensor`

`math::tensor` has had the shape of a tensor library since 1999 — `rank()`, an
outer product on `*`, a contraction on `^`, and comments carrying the correct
rank arithmetic. What it did not have was either product.

## What was actually there

Both operators implemented one degenerate case and threw `not_implemented` for
everything else: `^` handled rank 2 ⊗ rank 2, which is matrix multiply, and `*`
handled rank 1 ⊗ rank 1. In `^` the general implementation was sketched in dead
code *after* the throw — a `meta` buffer of the right size and nothing that
fills it.

The stronger finding is that **neither of the two implemented paths compiled.**
They are templates, and `tests/tensor_test.cc` — 57 lines from 1999 — never
called either one, so nothing ever instantiated them and nothing ever
type-checked them. Instantiating them by hand gives four errors: `a[i]` needs a
non-const `operator[]` on a `const tensor&`, and `a.size()` is called with no
argument when it requires an axis index. So the file had no working product at
all, at any rank.

## Both products are flat loops, because the storage is row-major

`operator[]` slices the first axis at a stride of the remaining axes' product,
which makes the layout row-major. That single fact collapses both operations:

- **Outer product** — the result's shape is the two shapes concatenated, and in
  row-major, concatenating shapes concatenates layouts. So result element
  `(i,j)` is at flat `i*n + j` whatever the two ranks are. One double loop over
  the flattened operands, no shape-walking at all.
- **Contraction** — contracting `a`'s last axis against `b`'s first, `a` is
  *already* laid out as an `m × k` matrix and `b` as a `k × n` one: the axes
  being contracted are adjacent in memory by construction. General contraction
  is therefore matrix multiply over the flattened views, with no gather and no
  strides to carry.

The rank-2 case now falls out of the general one rather than sitting beside it,
so the special case is deleted rather than kept.

Two details worth naming. `m` and `n` are multiplied out from the shapes rather
than divided out of the totals — same cost, and an axis of length zero yields an
empty result instead of dividing by `k`. And the rank guard on `^` is not
decorative: `a.rank() + b.rank() - 2` is unsigned, so a rank-0 operand underflows
it.

`operator*` also stops filling `meta` *after* building the tensor from it. The
old code did, and reached the result at all only because `buffer` is a shared
handle rather than a value — correct by accident of the ownership model.

## The bug underneath

Making the products work meant writing a test that reads results back, and the
first run showed `a[0]` and `a[1]` returning the same elements.

The cause was not in the new code. `buffer`'s view constructor is

```cpp
buffer(buffer<T> b, unsigned int o, unsigned int s)
    : mbuf(b.mbuf), moff(o), msize(s) {}
```

`moff(o)`, not `moff(b.moff + o)` — a view of a view **rebases onto the start of
the array** instead of composing offsets. `tensor::operator[]` slices one axis
per call, so `t[i][j]` is exactly a view of a view: every row of a rank-2 tensor
aliased row 0.

Nothing had ever caught it, and the reason is precise. The two tests that touch
slicing both use index 0 at the outer level — the 1999 `tensor_test` never
indexes at all, and `math_value_test`'s slice assertion is `t[0][0] = 5`. At
outer index 0, `b.moff` is 0 and the broken form and the correct one agree.
Writing through to the parent still worked, so the test that existed to check
reference semantics passed while the offsets were wrong.

The regression assertions go in `math_value_test`, beside the one that missed
it: a two-level view reads and writes the right element, and two tensor elements
two levels down do not alias.

`operator==` is also fixed. It was `a.rank() == b.rank()`, which made every
matrix equal to every other matrix; `operator!=` took a *scalar* and passed it
there, so neither would have compiled either. A test of the products has to
compare two of them, and it cannot be built on that.

## The element accessors, which were in the way

Finishing the products made two interface problems concrete rather than
theoretical, because a test that reads results back runs into both.

**`operator()` was a byte-for-byte copy of `operator[]`**, under a comment
claiming it returned a column vector when it returned a row. The argument for
removing it is not that it duplicated `operator[]` — it is that `matrix`, in the
same directory, spells element access `m(r, c)`. So `tensor::operator()` meant
something different from what the operator means in the sibling class. It is now
multi-index element access: `t(i, j, k)`, with the flat index walked from the
same row-major strides `operator[]` slices with. Nothing called the old one, so
nothing changes behaviour. Indices are not bounds-checked, matching `matrix`,
which deliberately keeps the branch out of element access; the wrong *number* of
indices throws `mismatch`. `t()` reaches the element of a rank 0 tensor, which is
why the index list is a `std::array` — `sizeof...(Args)` is 0 there, and a
zero-length C array is not a thing.

**`operator[]` had no const overload**, so nothing could be read out of a
`const tensor&` at all. It now has one, returning `const tensor<T>` so that
`ct[i][j] = x` does not compile.

That constness is shallow, and the branch says so rather than implying more: the
const overload still returns a tensor sharing the parent's storage, so copying it
into a non-const tensor writes through. That is ordinary handle behaviour —
`const` binds to the handle, not the pointee — and fixing it needs a distinct
const view type. #143 is retitled to be about exactly that, with the
`operator()` half closed out.

## Tests

`tests/tensor_test.cc` rewritten in house style, keeping the 1999 assertions
(a scalar will not assign to a vector; a rank-0 tensor round-trips a scalar).
Added: rank-2 contraction against a hand-written triple loop and against the
identity; rank 3 ^ rank 2 checked slice-by-slice, where slicing is independent
of the contraction code; rank 1 ^ rank 1 as the dot product; associativity
`(a^b)^c == a^(b^c)`, which is a property of the operation and needs no second
implementation; outer product shape and elements; rank 0 as the scaling case;
and the one identity that constrains both operators at once,
`(u ⊗ v) · w == u (v · w)`.

The new accessors are cross-checked against each other: `t(i,j)` walks strides
and `t[i][j]` builds two views and slices, sharing no code, so their agreeing is
worth something. That the const forms reach the same elements is checked in the
same loop — a line that did not compile before this branch.

That writing through a const tensor fails to compile is a `static_assert` on a
concept, asserted **in both directions**. A concept that came out false because
of a typo rather than because of constness would pass the half that matters and
prove nothing, so the non-const case is the control.

The test's `fill` recurses through `operator[]` rather than looping flat —
partly because it has to, since `t[i] = x` above rank 1 is a mismatch, and
partly so the fill order is whatever slicing says it is rather than an
assumption about the layout the contraction is supposed to be testing.

### Mutation results

| mutation | caught |
| --- | --- |
| transpose `b`'s read in the contraction | yes — 3 failures |
| transpose the outer product's write | yes — 3 failures |
| remove the rank-0 guard from `^` | **no** |

The third is worth recording. Removing the guard leaves the suite green:
`a.rank() - 1` underflows to 4294967295, the read off the end of an empty shape
returns garbage, and the garbage fails the very next shape check — which throws
the same `mismatch` the test is looking for. Under `-fsanitize=address` the
unguarded version faults instead. So the guard is load-bearing and this test is
not what establishes it, which is now written in the test.

## Verification

- macOS `make check`: 68 tests, 64 pass, 4 skip, 0 fail.
- Container `make check`: 67 tests, 66 pass, 1 skip, 0 fail.

The `buffer` fix has reach — `matrix`, `vertex`, `object` and the plots all sit
on it — so both suites passing matters more here than a nine-line diff to
`buffer.hh` suggests.

## What this does not establish

**That these are tensors in the physics sense.** There is no metric, no dual
space, and no distinction between an upper and a lower index, so nothing here
transforms under a change of basis — which is the property that defines the word
elsewhere. These are multiway arrays with a contraction and an outer product,
which is what the numerical multilinear algebra literature means by the term and
all that is claimed. Index variance would be a separate piece of work, and a
type-system one: variance is a compile-time property of each slot.

**Nothing about performance.** Contraction is a naive triple loop with no
blocking and no vectorisation. It is not what `math::matrix` or the Metal
backend use, and nothing in the library depends on `math::tensor` at all.

**Only one contraction convention** — `a`'s last axis against `b`'s first, which
is the pairing that makes rank 2 ^ rank 2 the matrix product. Contracting an
arbitrary pair of axes, which is what `einsum` does and what a general tensor
library needs, is not here.

**That a const tensor is deeply const** — see above. The `static_assert` checks
that `ct[i][j] = x` is rejected; it cannot check that no route around it exists,
and one does.

The products and `operator==` still reach the private `data` buffer through
friendship rather than going through the new const accessors. That is
deliberate: the flat loops are the whole point of the row-major argument, and
routing them through `operator[]` would allocate two buffer views per element.

## Follow-ups filed

**#143** — const on a tensor is shallow, because slices share storage. Retitled
from the two gaps this branch found; the `operator()` half is closed out here.
Fixing the rest needs a distinct const view type, worth doing only if something
starts relying on const to mean read-only.

**#144** — the operators want to be hidden friends, and `operator!=` can go
entirely, since C++20 rewrites `a != b` to `!(a == b)` when no `operator!=` is
visible. That rewriting was verified against a minimal case rather than assumed.
The issue also records *why* the textbook argument for free binary operators
does not apply to this code: it is about implicit conversions on the left
operand, and these are function templates, where deduction runs before
conversions and never considers user-defined ones. Free versus member is
conversion-neutral for a class template — so the question should be settled on
bookkeeping, and it is written down that way to stop it being re-litigated from
a rule that does not reach it.
