### PR TITLE
Add causal masking and scaled dot-product attention, built from primitives so one implementation runs on any backend

### DIFF
--- a/jlib/ai/Makefile.am
+++ b/jlib/ai/Makefile.am
@@ -9,4 +9,4 @@ libjai_la_LIBADD = $(top_builddir)/jlib/util/libjutil.la \
 
 libjaiincludedir = $(includedir)/jlib-1.2/jlib/ai
 libjaiinclude_HEADERS = environment.hh agent.hh percept.hh action.hh vacuum.hh \
-                        neural.hh backend.hh
+                        neural.hh backend.hh attention.hh

--- a/jlib/ai/attention.hh
+++ b/jlib/ai/attention.hh
@@ -1,0 +1,122 @@
+/* -*- mode: C++ c-basic-offset: 4  -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+#ifndef JLIB_AI_ATTENTION_HH
+#define JLIB_AI_ATTENTION_HH
+
+#include <jlib/ai/backend.hh>
+
+#include <cmath>
+
+namespace jlib {
+namespace ai {
+
+/**
+ * Scaled dot-product attention for one head.
+ *
+ * out = V . softmax(mask(K^T Q / sqrt(d)))
+ *
+ * **Not a virtual on backend.** Every step is already a primitive, so this is
+ * one implementation that runs wherever the backend runs, rather than one per
+ * backend to keep in agreement. A fused kernel would be faster -- that is what
+ * FlashAttention is -- and would be a backend method when somebody measures a
+ * reason for it.
+ *
+ * ### Shapes, and why they are the transpose of the usual drawing
+ *
+ * A column is a sample everywhere in this library, so here a column is a
+ * *position*: q, k and v are (d x sequence), not (sequence x d).
+ *
+ *   q       (d x Tq)     one column per query position
+ *   k       (d x Tk)     one column per key position
+ *   v       (dv x Tk)    one column per key position, and dv need not equal d
+ *   scores  (Tk x Tq)    scratch: row is the key, column the query
+ *   probs   (Tk x Tq)    scratch: each column sums to one
+ *   out     (dv x Tq)
+ *
+ * That falls out of softmax reducing down a column: a column has to be one
+ * query's distribution over keys, so the key index goes on the rows, and
+ * scores = K^T Q rather than Q K^T. It is worth stating plainly because every
+ * paper draws it the other way, and because it is what decides which triangle
+ * causal_mask clears.
+ *
+ * The consequence is that no transpose and no batched GEMM are needed:
+ * multiply_tn already computes K^T Q, and 1/sqrt(d) rides along as its alpha.
+ * Heads are separate tensors and a separate call each, which costs one GEMM
+ * dispatch per head; batching them is a performance question, not a
+ * correctness one.
+ *
+ * ### scratch
+ *
+ * scores and probs are the caller's, not allocated here. A transformer reuses
+ * them across every layer and every step, and allocating a (Tk x Tq) tensor
+ * per call would dominate. They must not alias each other or any input; that
+ * is unchecked and untested.
+ *
+ * @param causal whether a query may see keys that come after it
+ */
+template<typename T>
+void attention(backend<T>& b,
+               const typename backend<T>::tensor_ptr& q,
+               const typename backend<T>::tensor_ptr& k,
+               const typename backend<T>::tensor_ptr& v,
+               typename backend<T>::tensor_ptr& scores,
+               typename backend<T>::tensor_ptr& probs,
+               typename backend<T>::tensor_ptr& out,
+               bool causal = true)
+{
+    const unsigned int d  = q->rows();
+    const unsigned int tq = q->cols();
+    const unsigned int tk = k->cols();
+    const unsigned int dv = v->rows();
+
+    if(k->rows() != d)
+        throw backend_error("attention: q and k must have the same depth");
+
+    if(v->cols() != tk)
+        throw backend_error("attention: v must have one column per key");
+
+    if(scores->rows() != tk || scores->cols() != tq ||
+       probs->rows() != tk || probs->cols() != tq)
+        throw backend_error("attention: scratch must be keys x queries");
+
+    if(out->rows() != dv || out->cols() != tq)
+        throw backend_error("attention: out must be v's depth x queries");
+
+    // The scale rides along as the GEMM's alpha rather than as a pass of its
+    // own.  1/sqrt(d) keeps the dot products from growing with depth, which is
+    // what would otherwise drive softmax into the flat region where every
+    // gradient is zero.
+    b.multiply_tn(k, q, scores, T(1.0f / std::sqrt(float(d))), T(0));
+
+    if(causal)
+        b.causal_mask(scores);
+
+    b.softmax(scores, probs);
+
+    // out[:,i] = sum_j probs[j,i] * v[:,j] -- a plain multiply, because probs
+    // already has the key index on the rows.
+    b.multiply(v, probs, out);
+}
+
+}
+}
+
+#endif // JLIB_AI_ATTENTION_HH

--- a/jlib/ai/backend.hh
+++ b/jlib/ai/backend.hh
@@ -173,6 +173,24 @@ public:
     virtual void softmax(const tensor_ptr& in, tensor_ptr& out) = 0;
 
     /**
+     * Set everything strictly below the diagonal to -infinity, in place.
+     *
+     * For causal attention, where a query may not see a key that comes after
+     * it.  Strictly *below* the diagonal, which is the transpose of how this
+     * is usually drawn: softmax here reduces down a column, so a column has to
+     * be one query's distribution over keys, which puts the key index on the
+     * rows.  A query at i must not see a key at j > i, and j > i is row >
+     * column.  See attention.hh, which is the only caller and says the same
+     * thing from the other end.
+     *
+     * -infinity rather than a large negative number, because softmax subtracts
+     * the column maximum and exp(-inf - m) is exactly zero for finite m.  A
+     * fully masked column would give nan; this mask cannot produce one, since
+     * element (c,c) is always kept.
+     */
+    virtual void causal_mask(tensor_ptr& s) = 0;
+
+    /**
      * Root-mean-square normalisation down each column, scaled per feature.
      *
      * out[r,c] = in[r,c] / sqrt(mean(in[:,c]^2) + eps) * weight[r]
@@ -221,6 +239,7 @@ public:
     void add_scaled(T alpha, const tensor_ptr& x, tensor_ptr& y);
     void assign(const tensor_ptr& src, tensor_ptr& dst);
     void softmax(const tensor_ptr& in, tensor_ptr& out);
+    void causal_mask(tensor_ptr& s);
     void rms_norm(const tensor_ptr& in, const tensor_ptr& weight,
                   tensor_ptr& out, float eps = 1e-5f);
 
@@ -465,6 +484,20 @@ void host_backend<T>::softmax(const tensor_ptr& in, tensor_ptr& out) {
         for(uint r = 0; r < x.M; r++)
             y(r,c) = T(double(y(r,c)) / sum);
     }
+}
+
+template<typename T>
+void host_backend<T>::causal_mask(tensor_ptr& s) {
+    math::matrix<T>& x = at(s);
+
+    // Through float, not std::numeric_limits<T>: _Float16 is a compiler
+    // extension and numeric_limits is not specialised for it.  Converting a
+    // float infinity to half gives a half infinity.
+    const T neg_inf = T(-std::numeric_limits<float>::infinity());
+
+    for(uint c = 0; c < x.N; c++)
+        for(uint r = c + 1; r < x.M; r++)
+            x(r,c) = neg_inf;
 }
 
 template<typename T>

--- a/jlib/metal/backend.hh
+++ b/jlib/metal/backend.hh
@@ -69,6 +69,7 @@ public:
     void add_scaled(T alpha, const tensor_ptr& x, tensor_ptr& y);
     void assign(const tensor_ptr& src, tensor_ptr& dst);
     void softmax(const tensor_ptr& in, tensor_ptr& out);
+    void causal_mask(tensor_ptr& s);
     void rms_norm(const tensor_ptr& in, const tensor_ptr& weight,
                   tensor_ptr& out, float eps = 1e-5f);
 

--- a/jlib/metal/backend.mm
+++ b/jlib/metal/backend.mm
@@ -153,6 +153,11 @@ void backend<T>::softmax(const tensor_ptr& in, tensor_ptr& out) {
 }
 
 template<typename T>
+void backend<T>::causal_mask(tensor_ptr& s) {
+    m_stream->causal_mask(at<T>(s));
+}
+
+template<typename T>
 void backend<T>::rms_norm(const tensor_ptr& in, const tensor_ptr& weight,
                           tensor_ptr& out, float eps)
 {

--- a/jlib/metal/tensor.hh
+++ b/jlib/metal/tensor.hh
@@ -186,6 +186,9 @@ public:
     /** Softmax down each column, with the column's maximum subtracted. */
     void softmax(const tensor<T>& in, tensor<T>& out);
 
+    /** Set everything strictly below the diagonal to -infinity, in place. */
+    void causal_mask(tensor<T>& s);
+
     /** RMS normalisation down each column, scaled by a per-row weight. */
     void rms_norm(const tensor<T>& in, const tensor<T>& weight, tensor<T>& out,
                   float eps = 1e-5f);

--- a/jlib/metal/tensor.mm
+++ b/jlib/metal/tensor.mm
@@ -200,6 +200,35 @@ kernel void k_rms_norm(device const T* in [[buffer(0)]],
         y[r] = T(float(x[r]) * inv * float(w[r]));
 }
 
+/**
+ * Causal masking, in place.
+ *
+ * Row is the key position and column the query position -- the transpose of
+ * how attention is usually drawn -- because softmax here reduces down a column,
+ * so a column has to be one query's distribution over keys.  A query at i may
+ * not see a key at j > i, and j > i is row > column, so what goes is everything
+ * strictly *below* the diagonal.  The usual presentation masks above it; this
+ * is the same mask seen from the other side.
+ *
+ * -infinity rather than a large negative number: softmax subtracts the column
+ * maximum, so exp(-inf - m) is exactly 0 for any finite m.  A column with no
+ * unmasked entry would give -inf - -inf = nan, which causal masking cannot
+ * produce -- element (c,c) is always kept, so every column has at least one.
+ */
+template<typename T>
+kernel void k_causal_mask(device T* s [[buffer(0)]],
+                          constant uint& rows [[buffer(1)]],
+                          constant uint& cols [[buffer(2)]],
+                          uint c [[thread_position_in_grid]])
+{
+    if(c >= cols) return;
+
+    device T* x = s + (ulong)c * rows;
+
+    for(uint r = c + 1; r < rows; r++)
+        x[r] = T(-INFINITY);
+}
+
 #define INSTANTIATE(NAME, T, SUFFIX)                                        \
     template [[host_name(#NAME SUFFIX)]] kernel void NAME<T>
 
@@ -227,6 +256,10 @@ INSTANTIATE(k_softmax, float, "_f32")(device const float*, device float*,
                                       constant uint&, constant uint&, uint);
 INSTANTIATE(k_softmax, half, "_f16")(device const half*, device half*,
                                      constant uint&, constant uint&, uint);
+INSTANTIATE(k_causal_mask, float, "_f32")(device float*, constant uint&,
+                                          constant uint&, uint);
+INSTANTIATE(k_causal_mask, half, "_f16")(device half*, constant uint&,
+                                         constant uint&, uint);
 INSTANTIATE(k_rms_norm, float, "_f32")(device const float*, device const float*,
                                        device float*, constant uint&,
                                        constant uint&, constant float&, uint);
@@ -337,6 +370,7 @@ struct stream<T>::impl {
     id<MTLComputePipelineState> subtract = nil;
     id<MTLComputePipelineState> add_scaled = nil;
     id<MTLComputePipelineState> softmax = nil;
+    id<MTLComputePipelineState> causal_mask = nil;
     id<MTLComputePipelineState> rms_norm = nil;
 
     unsigned int pending = 0;
@@ -351,6 +385,7 @@ struct pipelines {
     id<MTLComputePipelineState> subtract = nil;
     id<MTLComputePipelineState> add_scaled = nil;
     id<MTLComputePipelineState> softmax = nil;
+    id<MTLComputePipelineState> causal_mask = nil;
     id<MTLComputePipelineState> rms_norm = nil;
 };
 
@@ -402,6 +437,7 @@ pipelines& compiled(id<MTLDevice> gpu) {
         { "k_subtract",   &p.subtract },
         { "k_add_scaled", &p.add_scaled },
         { "k_softmax",    &p.softmax },
+        { "k_causal_mask", &p.causal_mask },
         { "k_rms_norm",   &p.rms_norm },
     };
 
@@ -465,6 +501,7 @@ stream<T>::stream(std::shared_ptr<device> d)
     m_impl->subtract = p.subtract;
     m_impl->add_scaled = p.add_scaled;
     m_impl->softmax = p.softmax;
+    m_impl->causal_mask = p.causal_mask;
     m_impl->rms_norm = p.rms_norm;
 }
 
@@ -622,6 +659,23 @@ void stream<T>::softmax(const tensor<T>& in, tensor<T>& out) {
 
     // One thread per column, not per element.
     dispatch(m_impl->enc, m_impl->softmax, cols);
+
+    m_impl->pending++;
+}
+
+template<typename T>
+void stream<T>::causal_mask(tensor<T>& s) {
+    open();
+
+    const unsigned int rows = s.rows();
+    const unsigned int cols = s.cols();
+
+    [m_impl->enc setComputePipelineState:m_impl->causal_mask];
+    [m_impl->enc setBuffer:s.m_impl->buf offset:0 atIndex:0];
+    [m_impl->enc setBytes:&rows length:sizeof(rows) atIndex:1];
+    [m_impl->enc setBytes:&cols length:sizeof(cols) atIndex:2];
+
+    dispatch(m_impl->enc, m_impl->causal_mask, cols);
 
     m_impl->pending++;
 }

--- a/tests/ai_backend_test.cc
+++ b/tests/ai_backend_test.cc
@@ -29,6 +29,7 @@
 // math::matrix, so there is nothing clever in it to be wrong about twice.
 
 #include <jlib/ai/backend.hh>
+#include <jlib/ai/attention.hh>
 
 #ifdef HAVE_METAL
 #include <jlib/metal/backend.hh>
@@ -289,6 +290,249 @@ static void softmax_survives_a_large_score(const char* name,
     }
 }
 
+/** Run one head of attention and bring the result back. */
+template<typename T>
+static matrix<T> run_attention(ai::backend<T>& b, const matrix<T>& q,
+                               const matrix<T>& k, const matrix<T>& v, bool causal)
+{
+    typename ai::backend<T>::tensor_ptr tq = b.make(q);
+    typename ai::backend<T>::tensor_ptr tk = b.make(k);
+    typename ai::backend<T>::tensor_ptr tv = b.make(v);
+
+    typename ai::backend<T>::tensor_ptr sc = b.make(k.N, q.N);
+    typename ai::backend<T>::tensor_ptr pr = b.make(k.N, q.N);
+    typename ai::backend<T>::tensor_ptr out = b.make(v.M, q.N);
+
+    ai::attention(b, tq, tk, tv, sc, pr, out, causal);
+    b.wait();
+
+    return out->read();
+}
+
+/** Attention: the first composite, built from primitives rather than a virtual. */
+template<typename T>
+static void the_attention(const char* name, std::vector<ai::backend<T>*>& backends) {
+    std::cout << "\nattention, " << name << ":\n";
+
+    const unsigned int d = 6;
+    const unsigned int n = 5;
+
+    std::mt19937 gen(101);
+
+    const matrix<T> q = random_matrix<T>(d, n, gen);
+    const matrix<T> k = random_matrix<T>(d, n, gen);
+    const matrix<T> v = random_matrix<T>(d, n, gen);
+
+    std::vector<matrix<T> > got;
+
+    for(ai::backend<T>* b : backends) {
+        typename ai::backend<T>::tensor_ptr tq = b->make(q);
+        typename ai::backend<T>::tensor_ptr tk = b->make(k);
+        typename ai::backend<T>::tensor_ptr tv = b->make(v);
+
+        typename ai::backend<T>::tensor_ptr sc = b->make(n, n);
+        typename ai::backend<T>::tensor_ptr pr = b->make(n, n);
+        typename ai::backend<T>::tensor_ptr out = b->make(d, n);
+
+        ai::attention(*b, tq, tk, tv, sc, pr, out, true);
+        b->wait();
+
+        const matrix<T> p = pr->read();
+
+        double furthest = 0;
+
+        for(unsigned int c = 0; c < n; c++) {
+            double sum = 0;
+
+            for(unsigned int r = 0; r < n; r++) sum += double(float(p(r,c)));
+
+            furthest = std::max(furthest, std::fabs(sum - 1.0));
+        }
+
+        ok(std::string("  ") + b->name() + ": every masked column still sums to one",
+           furthest < ((sizeof(T) == 2) ? 5e-3 : 1e-6), std::to_string(furthest));
+
+        // Strictly below the diagonal, which is where a key later than the
+        // query lives in this layout.  Exactly zero, not merely small:
+        // exp(-inf - m) is 0 for finite m.
+        bool clean = true;
+
+        for(unsigned int c = 0; c < n; c++)
+            for(unsigned int r = c + 1; r < n; r++)
+                if(float(p(r,c)) != 0.0f) clean = false;
+
+        ok(std::string("  ") + b->name() + ": with exactly zero weight on later keys",
+           clean);
+
+        got.push_back(out->read());
+    }
+
+    for(std::size_t i = 1; i < backends.size(); i++)
+        ok(std::string("  ") + backends[i]->name() + " agrees on the output",
+           worst(got[0], got[i]) < ((sizeof(T) == 2) ? 2e-2 : 1e-5),
+           std::to_string(worst(got[0], got[i])));
+}
+
+/**
+ * The property the mask exists for, and the one that catches it upside down.
+ *
+ * A shape check and a sums-to-one check both pass with the triangle inverted.
+ * This does not: change a key and a value at the last position, and every
+ * *earlier* output has to be untouched.
+ */
+template<typename T>
+static void attention_looks_only_backwards(const char* name,
+                                           std::vector<ai::backend<T>*>& backends)
+{
+    std::cout << "\nattention looks only backwards, " << name << ":\n";
+
+    const unsigned int d = 4;
+    const unsigned int n = 6;
+
+    std::mt19937 gen(7);
+
+    const matrix<T> q = random_matrix<T>(d, n, gen);
+    const matrix<T> k = random_matrix<T>(d, n, gen);
+    const matrix<T> v = random_matrix<T>(d, n, gen);
+
+    matrix<T> k2 = k;
+    matrix<T> v2 = v;
+
+    for(unsigned int r = 0; r < d; r++) {
+        k2(r, n - 1) = T(float(k2(r, n - 1)) + 3.0f);
+        v2(r, n - 1) = T(float(v2(r, n - 1)) - 2.5f);
+    }
+
+    for(ai::backend<T>* b : backends) {
+        const matrix<T> base = run_attention(*b, q, k,  v,  true);
+        const matrix<T> pert = run_attention(*b, q, k2, v2, true);
+
+        // Bit-identical, not merely close.  The masked score contributes
+        // exp(-inf) = 0 to the sum and never wins the max, so the arithmetic
+        // for an earlier column is the same arithmetic on the same values.
+        bool same = true;
+
+        for(unsigned int c = 0; c + 1 < n; c++)
+            for(unsigned int r = 0; r < d; r++)
+                if(float(base(r,c)) != float(pert(r,c))) same = false;
+
+        ok(std::string("  ") + b->name() +
+           ": changing the last key and value leaves every earlier output alone",
+           same);
+
+        // The control.  Without the mask the same change must reach backwards,
+        // or the assertion above is passing for some reason of its own.
+        const matrix<T> open_base = run_attention(*b, q, k,  v,  false);
+        const matrix<T> open_pert = run_attention(*b, q, k2, v2, false);
+
+        bool moved = false;
+
+        for(unsigned int c = 0; c + 1 < n; c++)
+            for(unsigned int r = 0; r < d; r++)
+                if(float(open_base(r,c)) != float(open_pert(r,c))) moved = true;
+
+        ok(std::string("  ") + b->name() + ": and without the mask it does not",
+           moved);
+    }
+}
+
+/**
+ * Zero queries make every score zero, so softmax is uniform and the output is
+ * a plain mean -- of the keys a query can see, which under the mask is a
+ * running prefix mean.  An exact expected value that owes nothing to a second
+ * implementation.
+ */
+template<typename T>
+static void flat_scores_average_the_values(const char* name,
+                                           std::vector<ai::backend<T>*>& backends)
+{
+    std::cout << "\nflat scores average the values, " << name << ":\n";
+
+    const unsigned int d = 3;
+    const unsigned int n = 4;
+
+    std::mt19937 gen(19);
+
+    const matrix<T> q(d, n);            // zeros
+    const matrix<T> k = random_matrix<T>(d, n, gen);
+    const matrix<T> v = random_matrix<T>(d, n, gen);
+
+    for(ai::backend<T>* b : backends) {
+        const matrix<T> got = run_attention(*b, q, k, v, true);
+
+        double furthest = 0;
+
+        for(unsigned int c = 0; c < n; c++) {
+            for(unsigned int r = 0; r < d; r++) {
+                double mean = 0;
+
+                for(unsigned int j = 0; j <= c; j++) mean += double(float(v(r,j)));
+
+                mean /= double(c + 1);
+
+                furthest = std::max(furthest, std::fabs(mean - double(float(got(r,c)))));
+            }
+        }
+
+        ok(std::string("  ") + b->name() +
+           ": each output is the mean of the values up to it",
+           furthest < ((sizeof(T) == 2) ? 2e-2 : 1e-5), std::to_string(furthest));
+    }
+}
+
+/**
+ * The 1/sqrt(d) scale, which nothing else here pins down.
+ *
+ * Every other attention assertion survives its removal: the prefix-mean test
+ * uses zero queries, so the scores are zero at any scale, and the host/GPU
+ * comparison drops it on both sides at once.  This is an exact expected value
+ * that the scale changes.
+ *
+ * One query and two keys, chosen so the arithmetic is short.  k_0 is the zero
+ * vector and k_1 is all ones against a query of all ones, so the dot products
+ * are 0 and d.  Scaled by 1/sqrt(d) with d = 4 the scores are 0 and 2, and the
+ * weight on the second key is e^2 / (1 + e^2).  Unscaled they would be 0 and 4,
+ * giving 0.982 instead of 0.881.
+ *
+ * Not causal: with one query at position 0 the mask would hide key 1, which is
+ * the whole experiment.
+ */
+template<typename T>
+static void the_scale_is_applied(const char* name,
+                                 std::vector<ai::backend<T>*>& backends)
+{
+    std::cout << "\nthe scale is applied, " << name << ":\n";
+
+    const unsigned int d = 4;
+
+    matrix<T> q(d, 1);
+    matrix<T> k(d, 2);
+    matrix<T> v(1, 2);
+
+    for(unsigned int r = 0; r < d; r++) {
+        q(r,0) = T(1.0f);
+        k(r,0) = T(0.0f);
+        k(r,1) = T(1.0f);
+    }
+
+    v(0,0) = T(0.0f);
+    v(0,1) = T(1.0f);
+
+    // exp(2) / (1 + exp(2)), which is the weight the scaled score puts on k_1,
+    // and v picks it out because v_0 is 0 and v_1 is 1.
+    const double want = std::exp(2.0) / (1.0 + std::exp(2.0));
+
+    for(ai::backend<T>* b : backends) {
+        const matrix<T> got = run_attention(*b, q, k, v, false);
+
+        const double diff = std::fabs(double(float(got(0,0))) - want);
+
+        ok(std::string("  ") + b->name() + ": the score is divided by sqrt(d)",
+           diff < ((sizeof(T) == 2) ? 5e-3 : 1e-5),
+           std::to_string(double(float(got(0,0)))) + " vs " + std::to_string(want));
+    }
+}
+
 static void a_tensor_from_the_wrong_backend_is_refused() {
     std::cout << "\na tensor from the wrong backend is refused:\n";
 
@@ -337,10 +581,18 @@ int main() {
         one_type<float>("float", b);
         the_reductions<float>("float", b);
         softmax_survives_a_large_score<float>("float", b);
+        the_attention<float>("float", b);
+        attention_looks_only_backwards<float>("float", b);
+        flat_scores_average_the_values<float>("float", b);
+        the_scale_is_applied<float>("float", b);
 #else
         one_type<float>("float", b);
         the_reductions<float>("float", b);
         softmax_survives_a_large_score<float>("float", b);
+        the_attention<float>("float", b);
+        attention_looks_only_backwards<float>("float", b);
+        flat_scores_average_the_values<float>("float", b);
+        the_scale_is_applied<float>("float", b);
 #endif
     }
 
@@ -356,6 +608,10 @@ int main() {
         one_type<_Float16>("_Float16", b);
         the_reductions<_Float16>("_Float16", b);
         softmax_survives_a_large_score<_Float16>("_Float16", b);
+        the_attention<_Float16>("_Float16", b);
+        attention_looks_only_backwards<_Float16>("_Float16", b);
+        flat_scores_average_the_values<_Float16>("_Float16", b);
+        the_scale_is_applied<_Float16>("_Float16", b);
     }
 
     a_tensor_from_the_wrong_backend_is_refused();
@@ -374,6 +630,13 @@ int main() {
     // which exists.  fp16 is for inference.
     //
     // Not double, which Metal has no type for and cannot be given one.
+    //
+    // For attention specifically: that a fused kernel would agree.  This is a
+    // composite of primitives, and the checks below are against the properties
+    // of the operation rather than against a reference implementation, so a
+    // FlashAttention-style kernel would have to be re-verified rather than
+    // assumed.  Nor multi-head anything -- heads here are separate tensors and
+    // separate calls, and nothing tests that a caller splits them correctly.
     //
     // The agreement assertions above would not, on their own, have caught a
     // missing max-subtraction: at the magnitudes random_matrix produces, both


### PR DESCRIPTION
# Attention

The reductions branch called softmax "the missing primitive class blocking any
transformer work". This is what it was blocking: scaled dot-product attention,
with causal masking, running on either backend in either element type.

## It needed one new primitive, not four

The plan for this branch expected a transpose, a batched GEMM and a mask. It
needed the mask. The reason is the layout, and it is worth writing down because
it is the whole design.

**A column is a sample everywhere in this library, and softmax reduces down a
column.** So a column of the score matrix has to be one query's distribution
over keys, which puts the *key* index on the rows:

```
q       (d  x Tq)     one column per query position
k       (d  x Tk)     one column per key position
v       (dv x Tk)
scores  (Tk x Tq)     row is the key, column the query
out     (dv x Tq)
```

That is the transpose of how every paper draws it, and it makes the whole
operation fall out of primitives that already existed:

- `scores = Kᵀ Q` is **`multiply_tn`**, which was already there for backprop,
  and `1/sqrt(d)` rides along as its `alpha` — so the scale is not a pass of its
  own either.
- softmax down columns is the existing op, unchanged.
- `out = V P` is a **plain `multiply`**, because `P` already has the key index
  on the rows.

No transpose op, no batched GEMM, no separate scaling kernel. Heads are separate
tensors and one call each, which costs a GEMM dispatch per head; batching them
is a performance question and not a correctness one.

## `causal_mask`

The one addition: set everything strictly **below** the diagonal to `-infinity`,
in place. Below, not above, for the same transposed reason — a query at `i` must
not see a key at `j > i`, and `j > i` is row > column. Both the backend header
and `attention.hh` say so at the point of use, because it is exactly the kind of
thing that is invisible when wrong.

`-infinity` rather than a large negative number, because softmax subtracts the
column maximum and `exp(-inf - m)` is exactly zero for finite `m`. A fully
masked column would give `nan`; this mask cannot produce one, since element
`(c,c)` is always kept.

## `attention()` is not a virtual

Every step is already a backend primitive, so `ai::attention()` is one function
in a header that runs wherever the backend runs — rather than one implementation
per backend to keep in agreement. A fused kernel would be faster (that is what
FlashAttention is) and would be a backend method when somebody measures a reason
for it.

The scratch matrices are the caller's, not allocated inside: a transformer reuses
them across every layer and every step, and allocating a `(Tk x Tq)` tensor per
call would dominate.

## Tests

Four properties, in `float` and `_Float16`, on host and Metal:

- **Masked columns still sum to one**, and carry **exactly zero** weight on
  later keys — exactly, not approximately, which is what `exp(-inf)` buys.
- **Attention looks only backwards.** Change a key and a value at the last
  position; every earlier output must be **bit-identical**. It is, because a
  masked score contributes exactly 0 to the sum and never wins the max, so the
  arithmetic for an earlier column is the same arithmetic on the same values.
  With a control: without the mask the same change *must* reach backwards, or
  the assertion is passing for a reason of its own.
- **Flat scores average the values.** Zero queries make every score zero, so
  softmax is uniform and each output is the mean of the values the query can
  see — a running prefix mean under the mask. An exact expected value owing
  nothing to a second implementation.
- **The scale is applied** — see below.

Host and Metal agree to `0.000000` on the attention output in float.

### Mutation results

| mutation | caught |
| --- | --- |
| invert the mask triangle, both backends | yes — 8 failures |
| drop the `1/sqrt(d)` scale | **no** |

The second is the useful one. Nothing pinned the scale: the prefix-mean test
uses zero queries, so the scores are zero at any scale, and the host/GPU
comparison drops it on both sides at once. Every assertion survived its removal.

`the_scale_is_applied` fixes that with an exact expected value the scale
changes. One query, two keys, `k_0` the zero vector and `k_1` all ones against a
query of all ones, so the dot products are 0 and `d`. Scaled by `1/sqrt(4)` the
scores are 0 and 2 and the weight on the second key is `e²/(1+e²) = 0.8808`;
unscaled they would be 0 and 4, giving `0.9820`. Re-running the mutation now
gives 4 failures.

It is deliberately not causal: with one query at position 0 the mask would hide
key 1, which is the experiment.

## Verification

- macOS `make check`: 68 tests, 64 pass, 4 skip, 0 fail.
- Container `make check`: 67 tests, 66 pass, 1 skip, 0 fail — no Metal there, so
  that run is the host path standing on its own.

## What this does not establish

**That a fused kernel would agree.** These checks are against the properties of
the operation, not against a reference implementation, so a FlashAttention-style
kernel would have to be re-verified rather than assumed.

**Nothing about multi-head.** Heads here are separate tensors and separate calls.
Nothing tests that a caller splits or recombines them correctly, because there is
no caller yet — that arrives with the transformer block, along with the output
projection that sums the heads back together.

**Nothing about performance.** One GEMM dispatch per head, a `(Tk x Tq)` score
matrix held in full, and no KV cache: this is the quadratic-memory form, which
is correct and is not what an LLM at length runs.

**And not training.** `attention()` is forward only. The backward pass through a
softmax is not here, and nothing in the branch needs it yet.
