### PR TITLE
Add a pre-norm transformer block with multi-head attention and a SwiGLU feed-forward, plus the silu activation

### DIFF
--- a/jlib/ai/Makefile.am
+++ b/jlib/ai/Makefile.am
@@ -9,4 +9,4 @@ libjai_la_LIBADD = $(top_builddir)/jlib/util/libjutil.la \
 
 libjaiincludedir = $(includedir)/jlib-1.2/jlib/ai
 libjaiinclude_HEADERS = environment.hh agent.hh percept.hh action.hh vacuum.hh \
-                        neural.hh backend.hh attention.hh
+                        neural.hh backend.hh attention.hh transformer.hh

--- a/jlib/ai/backend.hh
+++ b/jlib/ai/backend.hh
@@ -42,7 +42,24 @@ namespace ai {
  *   relu         s > 0 ? 1 : 0
  *   leaky_relu   s > 0 ? 1 : LEAK
  */
-enum class activation { sigmoid, tanh, relu, leaky_relu };
+enum class activation { sigmoid, tanh, relu, leaky_relu, silu };
+
+/**
+ * Whether f'(x) can be recovered from f(x), which is what slope() is given.
+ *
+ * False for silu alone, and not as an oversight: silu(x) = x * sigmoid(x) has
+ * a minimum of about -0.278 near x = -1.278 and rises on both sides of it, so
+ * it is not injective.  An output in (-0.278, 0) came from one of two inputs
+ * with two different slopes, and nothing in the output says which.  Every other
+ * activation here is monotonic, which is the property slope() quietly rests on.
+ *
+ * So silu is a forward-only activation until slope() is given the layer's input
+ * instead of its output.  That is a change to every caller, and inference does
+ * not need it -- see #TODO in the branch notes.
+ */
+inline bool slope_from_output(activation a) {
+    return a != activation::silu;
+}
 
 /**
  * What a backend throws.
@@ -294,6 +311,9 @@ math::matrix<T> activate_matrix(activation a, const math::matrix<T>& in) {
             case activation::tanh:       out(r,c) = T(std::tanh(x));                 break;
             case activation::relu:       out(r,c) = T((x > 0) ? x : C(0));           break;
             case activation::leaky_relu: out(r,c) = T((x > 0) ? x : C(LEAK) * x);    break;
+            // x * sigmoid(x).  Smooth, non-monotonic, and what a modern
+            // feed-forward gates with -- see swiglu in transformer.hh.
+            case activation::silu:       out(r,c) = T(x / (C(1) + std::exp(-x))); break;
             }
         }
     }
@@ -304,6 +324,12 @@ math::matrix<T> activate_matrix(activation a, const math::matrix<T>& in) {
 template<typename T>
 math::matrix<T> slope_matrix(activation a, const math::matrix<T>& out) {
     typedef typename compute_in<T>::type C;
+
+    // Before the loop, not inside it: there is no per-element answer to give.
+    if(!slope_from_output(a))
+        throw backend_error("slope: this activation is not invertible from its "
+                            "output, so its derivative cannot be recovered from "
+                            "one -- it is forward-only");
 
     math::matrix<T> d(out.M, out.N);
 
@@ -316,6 +342,7 @@ math::matrix<T> slope_matrix(activation a, const math::matrix<T>& out) {
             case activation::tanh:       d(r,c) = T(C(1) - s * s);        break;
             case activation::relu:       d(r,c) = T((s > 0) ? C(1) : C(0)); break;
             case activation::leaky_relu: d(r,c) = T((s > 0) ? C(1) : C(LEAK)); break;
+            case activation::silu:       break;   // refused above
             }
         }
     }

--- a/jlib/ai/transformer.hh
+++ b/jlib/ai/transformer.hh
@@ -1,0 +1,244 @@
+/* -*- mode: C++ c-basic-offset: 4  -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+#ifndef JLIB_AI_TRANSFORMER_HH
+#define JLIB_AI_TRANSFORMER_HH
+
+#include <jlib/ai/attention.hh>
+#include <jlib/ai/backend.hh>
+
+#include <vector>
+
+namespace jlib {
+namespace ai {
+
+/**
+ * One pre-norm transformer block: attention, then a gated feed-forward, each
+ * around a residual.
+ *
+ *   h = x + attention(rms_norm(x))
+ *   y = h + swiglu(rms_norm(h))
+ *
+ * Pre-norm -- normalise the branch input, not the sum -- because it is what
+ * lets a deep stack train at all: the residual path from input to output stays
+ * an unmodified sum, so a gradient reaches the bottom without passing through
+ * any normalisation. Post-norm was the original and needs a warmup schedule to
+ * survive depth.
+ *
+ * ### Heads are weights, not slices
+ *
+ * The usual formulation projects to a full (d_model x T) Q, then slices it into
+ * heads. Here each head owns its own (d_head x d_model) projection, so
+ * `wq(h) * x` produces that head's Q directly and nothing is ever sliced. The
+ * two are the same arithmetic -- a slice of (W x) is (a slice of W) x -- and
+ * this way needs no sub-tensor views, which no backend here has.
+ *
+ * The output projection is split the same way: `wo(h)` is (d_model x d_head),
+ * and the heads are summed by accumulating into one output with the GEMM's
+ * beta, rather than concatenated and multiplied once. Again the same
+ * arithmetic, and again no concatenation op is needed.
+ *
+ * The cost is one GEMM dispatch per head instead of one batched call. That is
+ * a performance question; see the notes on the branch.
+ *
+ * ### Scratch and aliasing
+ *
+ * reserve() sizes every intermediate for one sequence length, and forward()
+ * requires exactly that length. Two of the feed-forward steps run in place --
+ * activate and hadamard both write element i from element i and nothing else,
+ * so aliasing input and output is safe for them and only for them.
+ *
+ * The per-head scratch is reused across heads. That is safe because a compute
+ * encoder dispatches serially, which is what the whole stream design already
+ * rests on; it is not safe to make the dispatch concurrent without giving each
+ * head its own.
+ */
+template<typename T>
+class block {
+public:
+    typedef typename backend<T>::tensor_ptr tensor_ptr;
+
+    /**
+     * @param heads must divide d_model
+     * @param d_ff  the feed-forward width, conventionally a few times d_model
+     */
+    block(backend<T>& b, unsigned int d_model, unsigned int heads,
+          unsigned int d_ff);
+
+    unsigned int d_model() const { return m_d_model; }
+    unsigned int heads() const { return m_heads; }
+    unsigned int d_head() const { return m_d_head; }
+    unsigned int d_ff() const { return m_d_ff; }
+
+    /** (d_head x d_model), one per head. */
+    tensor_ptr& wq(unsigned int h) { return m_wq[h]; }
+    tensor_ptr& wk(unsigned int h) { return m_wk[h]; }
+    tensor_ptr& wv(unsigned int h) { return m_wv[h]; }
+
+    /** (d_model x d_head), one per head; the heads are summed through these. */
+    tensor_ptr& wo(unsigned int h) { return m_wo[h]; }
+
+    /**
+     * The feed-forward's three matrices, named for their roles.
+     *
+     * Gate and up are both (d_ff x d_model) and down is (d_model x d_ff), and
+     * the only thing that distinguishes gate from up is that **silu is applied
+     * to the gate**. That is a convention, not a property: swap them and the
+     * result is a different but equally self-consistent network, which no test
+     * here can tell from this one -- verified by mutation. It is only pinned by
+     * a real model's weights, where the tensors arrive named ffn_gate, ffn_up
+     * and ffn_down.
+     *
+     * So they are named rather than numbered. A loader that has to map
+     * "ffn_gate" onto w1() can get it wrong silently; onto w_gate() it cannot.
+     */
+    tensor_ptr& w_gate() { return m_gate; }
+    tensor_ptr& w_up() { return m_up; }
+    tensor_ptr& w_down() { return m_down; }
+
+    /** (d_model x 1) each: the learned RMS norm scales. */
+    tensor_ptr& attn_norm() { return m_attn_norm; }
+    tensor_ptr& ffn_norm() { return m_ffn_norm; }
+
+    /** Size every intermediate for a sequence of this length. */
+    void reserve(unsigned int seq);
+
+    /** out = block(x), with x and out both (d_model x seq). */
+    void forward(const tensor_ptr& x, tensor_ptr& out, bool causal = true);
+
+private:
+    backend<T>& m_b;
+
+    unsigned int m_d_model;
+    unsigned int m_heads;
+    unsigned int m_d_head;
+    unsigned int m_d_ff;
+    unsigned int m_seq = 0;
+
+    std::vector<tensor_ptr> m_wq, m_wk, m_wv, m_wo;
+    tensor_ptr m_gate, m_down, m_up;
+    tensor_ptr m_attn_norm, m_ffn_norm;
+
+    tensor_ptr m_norm, m_q, m_k, m_v, m_scores, m_probs, m_head, m_attn;
+    tensor_ptr m_h1, m_h3, m_ffn;
+};
+
+template<typename T>
+block<T>::block(backend<T>& b, unsigned int d_model, unsigned int heads,
+                unsigned int d_ff)
+    : m_b(b),
+      m_d_model(d_model),
+      m_heads(heads),
+      m_d_head(heads ? d_model / heads : 0),
+      m_d_ff(d_ff)
+{
+    if(heads == 0 || d_model == 0 || d_ff == 0)
+        throw backend_error("block: every dimension must be non-zero");
+
+    if(d_model % heads)
+        throw backend_error("block: heads must divide d_model");
+
+    for(unsigned int h = 0; h < heads; h++) {
+        m_wq.push_back(b.make(m_d_head, d_model));
+        m_wk.push_back(b.make(m_d_head, d_model));
+        m_wv.push_back(b.make(m_d_head, d_model));
+        m_wo.push_back(b.make(d_model, m_d_head));
+    }
+
+    m_gate = b.make(d_ff, d_model);
+    m_up = b.make(d_ff, d_model);
+    m_down = b.make(d_model, d_ff);
+
+    m_attn_norm = b.make(d_model, 1);
+    m_ffn_norm = b.make(d_model, 1);
+}
+
+template<typename T>
+void block<T>::reserve(unsigned int seq) {
+    if(seq == 0)
+        throw backend_error("block: a sequence of no positions");
+
+    m_seq = seq;
+
+    m_norm   = m_b.make(m_d_model, seq);
+    m_q      = m_b.make(m_d_head, seq);
+    m_k      = m_b.make(m_d_head, seq);
+    m_v      = m_b.make(m_d_head, seq);
+    m_scores = m_b.make(seq, seq);
+    m_probs  = m_b.make(seq, seq);
+    m_head   = m_b.make(m_d_head, seq);
+    m_attn   = m_b.make(m_d_model, seq);
+    m_h1     = m_b.make(m_d_ff, seq);
+    m_h3     = m_b.make(m_d_ff, seq);
+    m_ffn    = m_b.make(m_d_model, seq);
+}
+
+template<typename T>
+void block<T>::forward(const tensor_ptr& x, tensor_ptr& out, bool causal) {
+    if(m_seq == 0)
+        throw backend_error("block: forward before reserve");
+
+    if(x->rows() != m_d_model || x->cols() != m_seq)
+        throw backend_error("block: input is not d_model x the reserved length");
+
+    if(out->rows() != m_d_model || out->cols() != m_seq)
+        throw backend_error("block: output is not d_model x the reserved length");
+
+    // --- attention, around a residual ---
+
+    m_b.rms_norm(x, m_attn_norm, m_norm);
+
+    for(unsigned int h = 0; h < m_heads; h++) {
+        m_b.multiply(m_wq[h], m_norm, m_q);
+        m_b.multiply(m_wk[h], m_norm, m_k);
+        m_b.multiply(m_wv[h], m_norm, m_v);
+
+        attention(m_b, m_q, m_k, m_v, m_scores, m_probs, m_head, causal);
+
+        // beta 0 for the first head and 1 for the rest, which sums the heads
+        // in place of concatenating them and projecting once.
+        m_b.multiply(m_wo[h], m_head, m_attn, T(1), h ? T(1) : T(0));
+    }
+
+    m_b.assign(x, out);
+    m_b.add_scaled(T(1), m_attn, out);
+
+    // --- gated feed-forward, around a second residual ---
+
+    m_b.rms_norm(out, m_ffn_norm, m_norm);
+
+    m_b.multiply(m_gate, m_norm, m_h1);
+    m_b.multiply(m_up, m_norm, m_h3);
+
+    // Both in place; see the note on aliasing above.  silu on the gate and not
+    // on the up projection, which is the whole of what makes this SwiGLU --
+    // and is a convention rather than something the arithmetic forces.
+    m_b.activate(activation::silu, m_h1, m_h1);
+    m_b.hadamard(m_h1, m_h3, m_h1);
+
+    m_b.multiply(m_down, m_h1, m_ffn);
+
+    m_b.add_scaled(T(1), m_ffn, out);
+}
+
+}
+}
+
+#endif // JLIB_AI_TRANSFORMER_HH

--- a/jlib/metal/backend.mm
+++ b/jlib/metal/backend.mm
@@ -121,6 +121,14 @@ template<typename T>
 void backend<T>::slope(ai::activation kind, const tensor_ptr& out_of_layer,
                        tensor_ptr& out)
 {
+    // Here rather than in the kernel, which has no way to refuse: a compute
+    // kernel cannot throw, and returning a plausible wrong number is how a
+    // forward-only activation would silently train.
+    if(!ai::slope_from_output(kind))
+        throw ai::backend_error("slope: this activation is not invertible from "
+                                "its output, so its derivative cannot be "
+                                "recovered from one -- it is forward-only");
+
     m_stream->slope(as_metal(kind), at<T>(out_of_layer), at<T>(out));
 }
 

--- a/jlib/metal/tensor.hh
+++ b/jlib/metal/tensor.hh
@@ -41,7 +41,9 @@ namespace metal {
  * networks.  Four enumerators is a cheap duplication and the values are
  * asserted equal in the test.
  */
-enum class activation { sigmoid, tanh, relu, leaky_relu };
+// Order matters: metal::backend casts ai::activation straight across, so these
+// two enumerations have to stay in the same order as well as agree by name.
+enum class activation { sigmoid, tanh, relu, leaky_relu, silu };
 
 /** The slope a leaky ReLU keeps below zero.  Matches ai::LEAK. */
 inline constexpr float LEAK = 0.01f;

--- a/jlib/metal/tensor.mm
+++ b/jlib/metal/tensor.mm
@@ -59,7 +59,10 @@ inline float apply(uint kind, float x) {
     case 0: return 1.0f / (1.0f + exp(-x));
     case 1: return tanh(x);
     case 2: return (x > 0.0f) ? x : 0.0f;
-    default: return (x > 0.0f) ? x : LEAK * x;
+    case 3: return (x > 0.0f) ? x : LEAK * x;
+    // silu.  Kept off default so that adding another kind cannot silently
+    // arrive here as a leaky relu.
+    default: return x / (1.0f + exp(-x));
     }
 }
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -61,6 +61,7 @@ TESTS = \
 	math_dump_test \
 	ai_neural_test \
 	ai_backend_test \
+	ai_transformer_test \
 	math_object_test \
 	tensor_test \
 \
@@ -308,6 +309,10 @@ metal_gemm_test_LDADD   = $(top_builddir)/jlib/metal/libjmetal.la $(METAL_LIBS)
 
 metal_tensor_test_SOURCES = metal_tensor_test.cc
 metal_tensor_test_LDADD   = $(top_builddir)/jlib/metal/libjmetal.la $(JUTIL_LA) $(JSYS_LA) $(METAL_LIBS)
+
+ai_transformer_test_SOURCES  = ai_transformer_test.cc
+ai_transformer_test_CPPFLAGS = $(AM_CPPFLAGS) $(METAL_CPPFLAGS)
+ai_transformer_test_LDADD    = $(JAI_LA) $(JUTIL_LA) $(JSYS_LA) $(METAL_LA)
 
 ai_backend_test_SOURCES  = ai_backend_test.cc
 ai_backend_test_CPPFLAGS = $(AM_CPPFLAGS) $(METAL_CPPFLAGS)

--- a/tests/ai_transformer_test.cc
+++ b/tests/ai_transformer_test.cc
@@ -1,0 +1,546 @@
+/* -*- mode: C++ c-basic-offset: 4 -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+#include <jlib/ai/transformer.hh>
+
+#ifdef HAVE_METAL
+#include <jlib/metal/backend.hh>
+#endif
+
+#include <cmath>
+#include <iostream>
+#include <memory>
+#include <random>
+#include <string>
+#include <vector>
+
+namespace ai = jlib::ai;
+
+using jlib::math::matrix;
+
+static int failures = 0;
+
+static void ok(const std::string& what, bool good, const std::string& detail = "") {
+    if(!good) ++failures;
+    std::cout << (good ? "  ok   " : "  FAIL ") << what;
+    if(!detail.empty()) std::cout << ": " << detail;
+    std::cout << "\n";
+}
+
+template<typename T>
+static matrix<T> random_matrix(uint m, uint n, std::mt19937& gen, float scale = 1.0f) {
+    std::uniform_real_distribution<float> d(-scale, scale);
+
+    matrix<T> a(m, n);
+
+    for(uint r = 0; r < m; r++)
+        for(uint c = 0; c < n; c++)
+            a(r, c) = T(d(gen));
+
+    return a;
+}
+
+template<typename T>
+static double worst(const matrix<T>& a, const matrix<T>& b) {
+    double w = 0;
+
+    for(uint r = 0; r < a.M; r++)
+        for(uint c = 0; c < a.N; c++)
+            w = std::max(w, std::fabs(double(float(a(r,c))) - double(float(b(r,c)))));
+
+    return w;
+}
+
+static const unsigned int D = 8;
+static const unsigned int H = 2;
+static const unsigned int F = 16;
+static const unsigned int N = 5;
+
+/** Every weight in a block, so two backends can be given the same one. */
+template<typename T>
+struct weights {
+    std::vector<matrix<T> > wq, wk, wv, wo;
+    matrix<T> w1, w3, w2, an, fn;
+
+    weights(std::mt19937& gen)
+        : w1(F, D), w3(F, D), w2(D, F), an(D, 1), fn(D, 1)
+    {
+        for(unsigned int h = 0; h < H; h++) {
+            wq.push_back(random_matrix<T>(D / H, D, gen, 0.5f));
+            wk.push_back(random_matrix<T>(D / H, D, gen, 0.5f));
+            wv.push_back(random_matrix<T>(D / H, D, gen, 0.5f));
+            wo.push_back(random_matrix<T>(D, D / H, gen, 0.5f));
+        }
+
+        w1 = random_matrix<T>(F, D, gen, 0.5f);
+        w3 = random_matrix<T>(F, D, gen, 0.5f);
+        w2 = random_matrix<T>(D, F, gen, 0.5f);
+
+        for(unsigned int r = 0; r < D; r++) { an(r,0) = T(1.0f); fn(r,0) = T(1.0f); }
+    }
+};
+
+template<typename T>
+static void load(ai::block<T>& blk, const weights<T>& w) {
+    for(unsigned int h = 0; h < H; h++) {
+        blk.wq(h)->write(w.wq[h]);
+        blk.wk(h)->write(w.wk[h]);
+        blk.wv(h)->write(w.wv[h]);
+        blk.wo(h)->write(w.wo[h]);
+    }
+
+    blk.w_gate()->write(w.w1);
+    blk.w_up()->write(w.w3);
+    blk.w_down()->write(w.w2);
+    blk.attn_norm()->write(w.an);
+    blk.ffn_norm()->write(w.fn);
+}
+
+template<typename T>
+static matrix<T> run(ai::backend<T>& b, const weights<T>& w, const matrix<T>& x,
+                     bool causal = true)
+{
+    ai::block<T> blk(b, D, H, F);
+
+    load(blk, w);
+    blk.reserve(N);
+
+    typename ai::backend<T>::tensor_ptr tx = b.make(x);
+    typename ai::backend<T>::tensor_ptr out = b.make(D, N);
+
+    blk.forward(tx, out, causal);
+    b.wait();
+
+    return out->read();
+}
+
+/**
+ * With both output projections zeroed, the block is the identity.
+ *
+ * Exactly the identity, not nearly: out = x + Wo(...) + W2(...), and both
+ * terms are a multiply by a zero matrix.  Everything else still runs -- the
+ * norms, the attention, the whole feed-forward -- so this says the residual
+ * path is a clean sum and nothing leaks into it.
+ */
+template<typename T>
+static void a_zeroed_block_is_the_identity(const char* name,
+                                           std::vector<ai::backend<T>*>& backends)
+{
+    std::cout << "\na zeroed block is the identity, " << name << ":\n";
+
+    std::mt19937 gen(3);
+
+    weights<T> w(gen);
+
+    for(unsigned int h = 0; h < H; h++)
+        for(unsigned int r = 0; r < D; r++)
+            for(unsigned int c = 0; c < D / H; c++)
+                w.wo[h](r,c) = T(0.0f);
+
+    for(unsigned int r = 0; r < D; r++)
+        for(unsigned int c = 0; c < F; c++)
+            w.w2(r,c) = T(0.0f);
+
+    const matrix<T> x = random_matrix<T>(D, N, gen);
+
+    for(ai::backend<T>* b : backends) {
+        const matrix<T> got = run(*b, w, x);
+
+        ok(std::string("  ") + b->name() + ": out is bit-identical to x",
+           worst(got, x) == 0.0, std::to_string(worst(got, x)));
+    }
+}
+
+/**
+ * The whole block looks only backwards.
+ *
+ * Attention is masked, and everything else -- both norms and the entire
+ * feed-forward -- is position-wise, so a change at the last position must not
+ * reach any earlier output at all.  Bit-identical again, for the same reason
+ * it was in the attention test: a masked score contributes exactly zero.
+ *
+ * This is the assertion that covers the assembly rather than the parts.
+ */
+template<typename T>
+static void the_block_looks_only_backwards(const char* name,
+                                           std::vector<ai::backend<T>*>& backends)
+{
+    std::cout << "\nthe block looks only backwards, " << name << ":\n";
+
+    std::mt19937 gen(11);
+
+    const weights<T> w(gen);
+
+    const matrix<T> x = random_matrix<T>(D, N, gen);
+
+    matrix<T> x2 = x;
+
+    for(unsigned int r = 0; r < D; r++)
+        x2(r, N - 1) = T(float(x2(r, N - 1)) + 2.0f);
+
+    for(ai::backend<T>* b : backends) {
+        const matrix<T> base = run(*b, w, x,  true);
+        const matrix<T> pert = run(*b, w, x2, true);
+
+        bool same = true;
+
+        for(unsigned int c = 0; c + 1 < N; c++)
+            for(unsigned int r = 0; r < D; r++)
+                if(float(base(r,c)) != float(pert(r,c))) same = false;
+
+        ok(std::string("  ") + b->name() +
+           ": a change at the last position leaves every earlier one alone", same);
+
+        // The control, as in the attention test: without the mask it must
+        // reach backwards, or the assertion above is passing on its own.
+        const matrix<T> ob = run(*b, w, x,  false);
+        const matrix<T> op = run(*b, w, x2, false);
+
+        bool moved = false;
+
+        for(unsigned int c = 0; c + 1 < N; c++)
+            for(unsigned int r = 0; r < D; r++)
+                if(float(ob(r,c)) != float(op(r,c))) moved = true;
+
+        ok(std::string("  ") + b->name() + ": and uncausal it does not", moved);
+    }
+}
+
+/**
+ * Heads are separate, and each is routed through its own output projection.
+ *
+ * With head 1's output projection zeroed, head 1's query projection cannot
+ * reach the output -- and head 0's still must, or the test would pass on a
+ * block that ignored its input entirely.
+ */
+template<typename T>
+static void heads_are_routed_separately(const char* name,
+                                        std::vector<ai::backend<T>*>& backends)
+{
+    std::cout << "\nheads are routed separately, " << name << ":\n";
+
+    std::mt19937 gen(23);
+
+    weights<T> w(gen);
+
+    for(unsigned int r = 0; r < D; r++)
+        for(unsigned int c = 0; c < D / H; c++)
+            w.wo[1](r,c) = T(0.0f);
+
+    const matrix<T> x = random_matrix<T>(D, N, gen);
+
+    weights<T> bumped_1 = w;
+    weights<T> bumped_0 = w;
+
+    for(unsigned int r = 0; r < D / H; r++)
+        for(unsigned int c = 0; c < D; c++) {
+            bumped_1.wq[1](r,c) = T(float(bumped_1.wq[1](r,c)) + 1.0f);
+            bumped_0.wq[0](r,c) = T(float(bumped_0.wq[0](r,c)) + 1.0f);
+        }
+
+    for(ai::backend<T>* b : backends) {
+        const matrix<T> base = run(*b, w, x);
+
+        ok(std::string("  ") + b->name() +
+           ": a silenced head's query projection cannot reach the output",
+           worst(base, run(*b, bumped_1, x)) == 0.0);
+
+        ok(std::string("  ") + b->name() + ": while a live head's still does",
+           worst(base, run(*b, bumped_0, x)) > 0.0);
+    }
+}
+
+/**
+ * The heads are summed, not overwritten.
+ *
+ * Give both heads identical weights.  Then routing everything through head 0
+ * and splitting it evenly between the two must give the same answer, since
+ * Wo*o == (Wo/2)*o + (Wo/2)*o.  That is the GEMM's beta accumulation, which is
+ * the one part of the head machinery a per-head test cannot see.
+ */
+template<typename T>
+static void the_heads_are_summed(const char* name,
+                                 std::vector<ai::backend<T>*>& backends)
+{
+    std::cout << "\nthe heads are summed, " << name << ":\n";
+
+    std::mt19937 gen(29);
+
+    weights<T> one(gen);
+
+    one.wq[1] = one.wq[0];
+    one.wk[1] = one.wk[0];
+    one.wv[1] = one.wv[0];
+    one.wo[1] = one.wo[0];
+
+    weights<T> split = one;
+
+    for(unsigned int r = 0; r < D; r++)
+        for(unsigned int c = 0; c < D / H; c++) {
+            const float half = float(one.wo[0](r,c)) * 0.5f;
+
+            split.wo[0](r,c) = T(half);
+            split.wo[1](r,c) = T(half);
+        }
+
+    // And the single-head reference: all of it through head 0, none through 1.
+    weights<T> only_0 = one;
+
+    for(unsigned int r = 0; r < D; r++)
+        for(unsigned int c = 0; c < D / H; c++)
+            only_0.wo[1](r,c) = T(0.0f);
+
+    const matrix<T> x = random_matrix<T>(D, N, gen);
+
+    for(ai::backend<T>* b : backends) {
+        const double d = worst(run(*b, only_0, x), run(*b, split, x));
+
+        ok(std::string("  ") + b->name() +
+           ": one head at full weight equals two at half",
+           d < ((sizeof(T) == 2) ? 5e-3 : 1e-6), std::to_string(d));
+    }
+}
+
+/** silu, and the one thing it cannot do. */
+template<typename T>
+static void silu_is_x_times_sigmoid(const char* name,
+                                    std::vector<ai::backend<T>*>& backends)
+{
+    std::cout << "\nsilu is x times sigmoid, " << name << ":\n";
+
+    std::mt19937 gen(31);
+
+    const matrix<T> x = random_matrix<T>(4, 3, gen, 4.0f);
+
+    for(ai::backend<T>* b : backends) {
+        typename ai::backend<T>::tensor_ptr tx = b->make(x);
+        typename ai::backend<T>::tensor_ptr ty = b->make(4, 3);
+
+        b->activate(ai::activation::silu, tx, ty);
+        b->wait();
+
+        const matrix<T> got = ty->read();
+
+        double furthest = 0;
+
+        for(unsigned int r = 0; r < 4; r++)
+            for(unsigned int c = 0; c < 3; c++) {
+                const double v = double(float(x(r,c)));
+                const double want = v / (1.0 + std::exp(-v));
+
+                furthest = std::max(furthest, std::fabs(want - double(float(got(r,c)))));
+            }
+
+        ok(std::string("  ") + b->name() + ": matches x / (1 + exp(-x))",
+           furthest < ((sizeof(T) == 2) ? 5e-3 : 1e-6), std::to_string(furthest));
+
+        // silu is not injective -- it dips to about -0.278 near x = -1.278 and
+        // rises on both sides -- so its derivative is not a function of its
+        // output, and slope() has nothing but the output.  Refused rather than
+        // answered wrongly.
+        bool threw = false;
+
+        try { b->slope(ai::activation::silu, ty, tx); b->wait(); }
+        catch(std::exception&) { threw = true; }
+
+        ok(std::string("  ") + b->name() + ": and its slope is refused, not guessed",
+           threw);
+    }
+}
+
+/**
+ * Normalising the *branch input* makes the branch scale-invariant.
+ *
+ * rms_norm divides a column by its own RMS, so rms_norm(c*x) is rms_norm(x) --
+ * which means the attention branch sees the same thing whatever x is scaled
+ * by, while the residual path scales with it.  So block(c*x) - c*x must equal
+ * block(x) - x.
+ *
+ * This is what tells pre-norm from no norm at all.  Every other assertion here
+ * survives replacing rms_norm with a plain copy -- verified by mutation --
+ * because a block without normalisation is still causal, still additive, and
+ * still agrees with itself on both backends.
+ *
+ * The feed-forward is switched off for it, since the second residual's input is
+ * not a clean multiple of the first's and the argument does not carry through.
+ * Not exact: eps sits inside the square root, so rms_norm(c*x) and rms_norm(x)
+ * differ by about eps/2 * (1 - 1/c^2).
+ */
+template<typename T>
+static void the_branch_input_is_normalised(const char* name,
+                                           std::vector<ai::backend<T>*>& backends)
+{
+    std::cout << "\nthe branch input is normalised, " << name << ":\n";
+
+    std::mt19937 gen(41);
+
+    weights<T> w(gen);
+
+    for(unsigned int r = 0; r < D; r++)
+        for(unsigned int c = 0; c < F; c++)
+            w.w2(r,c) = T(0.0f);
+
+    const matrix<T> x = random_matrix<T>(D, N, gen);
+
+    matrix<T> x2 = x;
+
+    for(unsigned int r = 0; r < D; r++)
+        for(unsigned int c = 0; c < N; c++)
+            x2(r,c) = T(float(x(r,c)) * 2.0f);
+
+    for(ai::backend<T>* b : backends) {
+        const matrix<T> a = run(*b, w, x);
+        const matrix<T> d = run(*b, w, x2);
+
+        double furthest = 0;
+
+        for(unsigned int r = 0; r < D; r++)
+            for(unsigned int c = 0; c < N; c++) {
+                const double one = double(float(a(r,c))) - double(float(x(r,c)));
+                const double two = double(float(d(r,c))) - double(float(x2(r,c)));
+
+                furthest = std::max(furthest, std::fabs(one - two));
+            }
+
+        ok(std::string("  ") + b->name() +
+           ": doubling the input leaves the attention branch where it was",
+           furthest < ((sizeof(T) == 2) ? 2e-2 : 1e-4), std::to_string(furthest));
+    }
+}
+
+template<typename T>
+static void the_backends_agree(const char* name,
+                               std::vector<ai::backend<T>*>& backends)
+{
+    std::cout << "\nthe backends agree, " << name << ":\n";
+
+    std::mt19937 gen(37);
+
+    const weights<T> w(gen);
+    const matrix<T> x = random_matrix<T>(D, N, gen);
+
+    std::vector<matrix<T> > got;
+
+    for(ai::backend<T>* b : backends) got.push_back(run(*b, w, x));
+
+    for(std::size_t i = 1; i < backends.size(); i++)
+        ok(std::string("  ") + backends[i]->name() + " agrees with host",
+           worst(got[0], got[i]) < ((sizeof(T) == 2) ? 5e-2 : 1e-4),
+           std::to_string(worst(got[0], got[i])));
+}
+
+template<typename T>
+static void the_shapes_are_checked(const char* name, ai::backend<T>& b) {
+    std::cout << "\nthe shapes are checked, " << name << ":\n";
+
+    bool threw = false;
+    try { ai::block<T> bad(b, 8, 3, 16); }
+    catch(std::exception&) { threw = true; }
+
+    ok("  heads must divide d_model", threw);
+
+    ai::block<T> blk(b, D, H, F);
+
+    typename ai::backend<T>::tensor_ptr x = b.make(D, N);
+    typename ai::backend<T>::tensor_ptr out = b.make(D, N);
+
+    threw = false;
+    try { blk.forward(x, out); }
+    catch(std::exception&) { threw = true; }
+
+    ok("  forward before reserve is refused", threw);
+
+    blk.reserve(N);
+
+    typename ai::backend<T>::tensor_ptr wrong = b.make(D, N + 1);
+
+    threw = false;
+    try { blk.forward(wrong, out); }
+    catch(std::exception&) { threw = true; }
+
+    ok("  and a sequence of the wrong length is too", threw);
+}
+
+template<typename T>
+static void everything(const char* name, std::vector<ai::backend<T>*>& b) {
+    a_zeroed_block_is_the_identity<T>(name, b);
+    the_block_looks_only_backwards<T>(name, b);
+    heads_are_routed_separately<T>(name, b);
+    the_heads_are_summed<T>(name, b);
+    the_branch_input_is_normalised<T>(name, b);
+    silu_is_x_times_sigmoid<T>(name, b);
+    the_backends_agree<T>(name, b);
+    the_shapes_are_checked<T>(name, *b[0]);
+}
+
+int main() {
+    std::cout << std::unitbuf;
+
+    {
+        ai::host_backend<float> h;
+        std::vector<ai::backend<float>*> b{ &h };
+
+#ifdef HAVE_METAL
+        std::shared_ptr<jlib::metal::backend<float> > g;
+        try { g.reset(new jlib::metal::backend<float>); b.push_back(g.get()); }
+        catch(std::exception& e) { std::cout << "  (no Metal device: " << e.what() << ")\n"; }
+#endif
+        everything<float>("float", b);
+    }
+
+    {
+        ai::host_backend<_Float16> h;
+        std::vector<ai::backend<_Float16>*> b{ &h };
+
+#ifdef HAVE_METAL
+        std::shared_ptr<jlib::metal::backend<_Float16> > g;
+        try { g.reset(new jlib::metal::backend<_Float16>); b.push_back(g.get()); }
+        catch(std::exception&) {}
+#endif
+        everything<_Float16>("_Float16", b);
+    }
+
+    // What a green run does not establish.
+    //
+    // That the block is a *correct* transformer block, only that it is a
+    // self-consistent one.  Nothing here compares against a reference
+    // implementation, because there is no loader yet and so no real weights to
+    // compare with.
+    //
+    // Specifically and by measurement: swapping silu onto the up projection
+    // instead of the gate fails nothing here.  Which of the two is the gate is
+    // a convention that only a real model's weights can settle, which is why
+    // they are called w_gate() and w_up() rather than w1() and w3() -- the
+    // interface states it because the tests cannot check it.
+    //
+    // Not position.  There is no positional encoding at all, so this block is
+    // permutation-equivariant apart from the causal mask -- reorder the input
+    // columns and the outputs reorder with them.  RoPE is its own branch.
+    //
+    // Not a stack.  One block is tested; nothing checks that N of them compose,
+    // and pre-norm exists precisely for what happens at depth.
+    //
+    // Not training.  forward() only, and silu deliberately refuses to give a
+    // slope, so this block cannot currently be backpropagated through.
+    std::cout << "\n" << (failures ? "FAILED" : "PASSED") << ": " << failures
+              << " failure(s)\n";
+
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
# A transformer block

`ai::attention()` had no caller, and its own write-up said so: *"nothing tests
that a caller splits heads correctly, because there is no caller yet"*. This is
the caller.

```
h = x + attention(rms_norm(x))
y = h + swiglu(rms_norm(h))
```

Pre-norm — normalise the branch input, not the sum — so the residual path from
input to output stays an unmodified sum and a gradient reaches the bottom
without passing through any normalisation. Post-norm was the original and needs
a warmup schedule to survive depth.

## Heads are weights, not slices

The usual formulation projects to a full `(d_model × T)` Q and slices it per
head. Here each head owns its own `(d_head × d_model)` projection, so
`wq(h) * x` **is** that head's Q and nothing is ever sliced. The output side is
split the same way: `wo(h)` is `(d_model × d_head)`, and the heads are summed by
accumulating into one output through the GEMM's `beta` rather than concatenated
and projected once.

Both are the same arithmetic — a slice of `Wx` is `(a slice of W)x` — and this
way needs no sub-tensor views and no concatenation op, neither of which any
backend here has. It continues the pattern the attention branch found: the
layout choice removes the primitive rather than requiring it.

The cost is one GEMM dispatch per head instead of one batched call. Performance,
not correctness.

## silu, and the thing it cannot do

SwiGLU needs `silu(x) = x·sigmoid(x)`, so it joins the `activation` enum. But
`slope()` takes *the layer's own output* and returns f'(x) from it, and that
only works because every activation there was monotonic. **silu is not**: it
dips to about -0.278 near x = -1.278 and rises on both sides, so an output in
(-0.278, 0) came from one of two inputs with two different slopes, and nothing
in the output says which.

So `slope_from_output(activation)` is now a named predicate, and silu is refused
rather than answered wrongly — on the host inside `slope_matrix`, and on Metal
in `backend::slope` **before dispatch**, because a compute kernel cannot throw
and returning a plausible number is how a forward-only activation would silently
train. silu is inference-only until `slope()` is given the layer's input instead
of its output, which is a change to every caller and is not needed yet.

## Tests

`tests/ai_transformer_test.cc`, both element types, both backends. Host and
Metal agree to `0.000000` on the whole block in float.

- **A zeroed block is the identity** — with both output projections zeroed, the
  output is *bit-identical* to the input. Everything still runs, so this says
  the residual path is a clean sum that nothing leaks into.
- **The block looks only backwards** — a change at the last position leaves
  every earlier output bit-identical, because attention is masked and both
  norms and the whole feed-forward are position-wise. With the uncausal control.
- **Heads are routed separately** — silencing head 1's output projection makes
  head 1's *query* projection unable to reach the output, while head 0's still
  can.
- **The heads are summed, not overwritten** — with both heads given identical
  weights, all of it through head 0 equals half through each. That is the `beta`
  accumulation, which per-head assertions cannot see.
- **The branch input is normalised** — see below.
- **silu matches x/(1+exp(-x))**, and its slope is refused rather than guessed.

### Mutation results

| mutation | caught |
| --- | --- |
| drop the attention residual | yes — 4 failures |
| overwrite heads instead of accumulating | yes — 8 failures |
| skip the pre-norm entirely | no → **now yes**, 4 failures |
| apply silu to the up projection instead of the gate | **no, and cannot be** |

**The pre-norm miss was fixable.** Replacing `rms_norm` with a plain copy failed
nothing: a block without normalisation is still causal, still additive, and
still agrees with itself on both backends. But normalising the *branch input*
makes that branch scale-invariant — `rms_norm(c·x)` is `rms_norm(x)` — so
`block(c·x) - c·x` must equal `block(x) - x`. With the feed-forward switched off
(the second residual's input is not a clean multiple of the first's, so the
argument does not carry through) that is a real property, and it now catches the
mutation. Not exact: `eps` sits inside the square root, so the two differ by
about `eps/2 · (1 - 1/c²)`, measured at 1.2e-5 in float against a 1e-4 bound.

**The gate miss is not fixable by a test.** Swapping silu onto the up projection
gives a different but equally self-consistent network. Which of the two is the
gate is a *convention*, settled only by a real model's weights, where the
tensors arrive named `ffn_gate`, `ffn_up` and `ffn_down`.

So the accessors are named rather than numbered: `w_gate()`, `w_up()`,
`w_down()` instead of `w1()`, `w3()`, `w2()`. A loader mapping `"ffn_gate"` onto
`w1()` can get it wrong in silence; onto `w_gate()` it cannot. The interface
states what the tests cannot check.

## One build-system note

Adding a program to `tests/Makefile.am` needs `./autogen.sh` and then
`./config.status` in the build directory. Without them the target is absent from
the generated Makefile and **make falls back to its built-in implicit rule** —
which compiled the test with no `-I` and no `LDADD` and failed on a missing
header, several steps away from the actual cause.

## Verification

- macOS `make check`: 69 tests (was 68), 65 pass, 4 skip, 0 fail.
- Container `make check`: no Metal there, so the host path stands on its own.

## What this does not establish

**That this is a correct transformer block, only a self-consistent one.**
Nothing here compares against a reference implementation, because there is no
loader yet and so no real weights to compare with. The gate mutation above is
the concrete instance: it passes everything.

**Nothing about position.** There is no positional encoding, so apart from the
causal mask this block is permutation-equivariant — reorder the input columns
and the outputs reorder with them. RoPE is its own branch.

**Nothing about depth.** One block is tested; nothing checks that N of them
compose, and pre-norm exists precisely for what happens at depth.

**Not training.** `forward()` only, and silu deliberately refuses to give a
slope, so this block cannot currently be backpropagated through.

**Not memory or speed.** One GEMM dispatch per head, a full `(T × T)` score
matrix, no KV cache: the quadratic-memory form, correct and not what an LLM at
length runs.
