### PR TITLE
Add rotary position embedding and wire it into the block, so attention finally depends on where a token sits

### DIFF
--- a/jlib/ai/backend.hh
+++ b/jlib/ai/backend.hh
@@ -62,6 +62,27 @@ inline bool slope_from_output(activation a) {
 }
 
 /**
+ * Which dimensions RoPE pairs up before rotating them.
+ *
+ * Both are in use and they are not compatible: a model trained under one and
+ * run under the other produces fluent nonsense rather than an error.
+ *
+ * - `interleaved` pairs (0,1), (2,3), (4,5)... -- the original RoFormer paper,
+ *   and what ggml calls the normal rope type.
+ * - `split` pairs (j, j + d/2) -- what GPT-NeoX introduced and what the
+ *   HuggingFace Llama implementation uses, with the checkpoint's weights
+ *   permuted at conversion time to match.
+ *
+ * **No test here can tell them apart**, and that is not a gap in the tests:
+ * every property RoPE has -- that it preserves the norm, that it is the
+ * identity at position 0, that the inner product depends only on the relative
+ * position -- holds for both, because both are block-diagonal rotations and
+ * differ only in which coordinates share a block.  It is settled by the model,
+ * so it is a parameter with a name rather than a choice buried in a kernel.
+ */
+enum class rope_layout { interleaved, split };
+
+/**
  * What a backend throws.
  *
  * At namespace scope rather than nested in backend<T>: a nested class of a
@@ -208,6 +229,32 @@ public:
     virtual void causal_mask(tensor_ptr& s) = 0;
 
     /**
+     * Rotary position embedding, in place.
+     *
+     * Rotates each column by an angle that grows with its position, in
+     * `rows/2` independent two-dimensional planes, each turning at its own
+     * rate.  Applied to the queries and the keys after their projections and
+     * before the scores -- never to the values, which carry content rather
+     * than position.
+     *
+     * What it buys is that the *score* between a query and a key comes to
+     * depend on the distance between them rather than on where the pair sits:
+     * rotating by m and by n leaves an inner product that is a function of
+     * n - m alone.  That is the whole idea, and it is what the tests check.
+     *
+     * A column is a position, so column c is at `base_pos + c`.  base_pos is
+     * for decoding one token at a time against a cache, where the single
+     * column being processed is at position n rather than 0.
+     *
+     * @param theta  the frequency base, 10000 by convention
+     * @param layout which dimensions get paired; see rope_layout, and note
+     *               that no test can check this one for you
+     */
+    virtual void rope(tensor_ptr& x, unsigned int base_pos = 0,
+                      float theta = 10000.0f,
+                      rope_layout layout = rope_layout::interleaved) = 0;
+
+    /**
      * Root-mean-square normalisation down each column, scaled per feature.
      *
      * out[r,c] = in[r,c] / sqrt(mean(in[:,c]^2) + eps) * weight[r]
@@ -257,6 +304,8 @@ public:
     void assign(const tensor_ptr& src, tensor_ptr& dst);
     void softmax(const tensor_ptr& in, tensor_ptr& out);
     void causal_mask(tensor_ptr& s);
+    void rope(tensor_ptr& x, unsigned int base_pos = 0, float theta = 10000.0f,
+              rope_layout layout = rope_layout::interleaved);
     void rms_norm(const tensor_ptr& in, const tensor_ptr& weight,
                   tensor_ptr& out, float eps = 1e-5f);
 
@@ -525,6 +574,46 @@ void host_backend<T>::causal_mask(tensor_ptr& s) {
     for(uint c = 0; c < x.N; c++)
         for(uint r = c + 1; r < x.M; r++)
             x(r,c) = neg_inf;
+}
+
+template<typename T>
+void host_backend<T>::rope(tensor_ptr& x, unsigned int base_pos, float theta,
+                           rope_layout layout)
+{
+    math::matrix<T>& m = at(x);
+
+    if(m.M % 2)
+        throw backend_error("rope: rotates in planes, so it needs an even "
+                            "number of rows");
+
+    const uint half = m.M / 2;
+
+    // In double, like softmax and for the same reason: this is the reference
+    // the GPU is checked against.  It matters more here than elsewhere -- the
+    // angle is position * frequency and grows without bound, so cos and sin of
+    // it lose precision at long sequence lengths, and the host should be the
+    // one that loses less.
+    for(uint c = 0; c < m.N; c++) {
+        const double pos = double(base_pos + c);
+
+        for(uint j = 0; j < half; j++) {
+            const uint a = (layout == rope_layout::split) ? j : 2 * j;
+            const uint b = (layout == rope_layout::split) ? j + half : 2 * j + 1;
+
+            const double freq = std::pow(double(theta),
+                                         -2.0 * double(j) / double(m.M));
+            const double angle = pos * freq;
+
+            const double co = std::cos(angle);
+            const double si = std::sin(angle);
+
+            const double xa = double(m(a,c));
+            const double xb = double(m(b,c));
+
+            m(a,c) = T(xa * co - xb * si);
+            m(b,c) = T(xa * si + xb * co);
+        }
+    }
 }
 
 template<typename T>

--- a/jlib/ai/transformer.hh
+++ b/jlib/ai/transformer.hh
@@ -117,11 +117,34 @@ public:
     tensor_ptr& attn_norm() { return m_attn_norm; }
     tensor_ptr& ffn_norm() { return m_ffn_norm; }
 
+    /**
+     * Turn on rotary position embedding for this block's queries and keys.
+     *
+     * Not for the values: they carry what a position says, not which position
+     * said it, and rotating them would make the thing attended *to* depend on
+     * where it sat.
+     *
+     * Off by default, which leaves the block permutation-equivariant apart
+     * from the causal mask -- reorder the input columns and the outputs
+     * reorder with them.  Any real model wants this on.
+     *
+     * @param layout no test can check this for you; see ai::rope_layout
+     */
+    void set_rope(bool on, float theta = 10000.0f,
+                  rope_layout layout = rope_layout::interleaved);
+
     /** Size every intermediate for a sequence of this length. */
     void reserve(unsigned int seq);
 
-    /** out = block(x), with x and out both (d_model x seq). */
-    void forward(const tensor_ptr& x, tensor_ptr& out, bool causal = true);
+    /**
+     * out = block(x), with x and out both (d_model x seq).
+     *
+     * @param base_pos the position of the first column, for decoding against a
+     *                 cache where the columns being processed are not at the
+     *                 start of the sequence
+     */
+    void forward(const tensor_ptr& x, tensor_ptr& out, bool causal = true,
+                 unsigned int base_pos = 0);
 
 private:
     backend<T>& m_b;
@@ -131,6 +154,10 @@ private:
     unsigned int m_d_head;
     unsigned int m_d_ff;
     unsigned int m_seq = 0;
+
+    bool m_rope = false;
+    float m_theta = 10000.0f;
+    rope_layout m_layout = rope_layout::interleaved;
 
     std::vector<tensor_ptr> m_wq, m_wk, m_wv, m_wo;
     tensor_ptr m_gate, m_down, m_up;
@@ -171,6 +198,20 @@ block<T>::block(backend<T>& b, unsigned int d_model, unsigned int heads,
 }
 
 template<typename T>
+void block<T>::set_rope(bool on, float theta, rope_layout layout) {
+    // Here rather than at the first forward(): d_head is fixed at construction,
+    // so this is knowable now, and a shape error is worth having at the point
+    // the caller made the choice.
+    if(on && (m_d_head % 2))
+        throw backend_error("block: rope rotates in planes, so d_model / heads "
+                            "must be even");
+
+    m_rope = on;
+    m_theta = theta;
+    m_layout = layout;
+}
+
+template<typename T>
 void block<T>::reserve(unsigned int seq) {
     if(seq == 0)
         throw backend_error("block: a sequence of no positions");
@@ -191,7 +232,9 @@ void block<T>::reserve(unsigned int seq) {
 }
 
 template<typename T>
-void block<T>::forward(const tensor_ptr& x, tensor_ptr& out, bool causal) {
+void block<T>::forward(const tensor_ptr& x, tensor_ptr& out, bool causal,
+                       unsigned int base_pos)
+{
     if(m_seq == 0)
         throw backend_error("block: forward before reserve");
 
@@ -209,6 +252,12 @@ void block<T>::forward(const tensor_ptr& x, tensor_ptr& out, bool causal) {
         m_b.multiply(m_wq[h], m_norm, m_q);
         m_b.multiply(m_wk[h], m_norm, m_k);
         m_b.multiply(m_wv[h], m_norm, m_v);
+
+        // Queries and keys only.  See set_rope.
+        if(m_rope) {
+            m_b.rope(m_q, base_pos, m_theta, m_layout);
+            m_b.rope(m_k, base_pos, m_theta, m_layout);
+        }
 
         attention(m_b, m_q, m_k, m_v, m_scores, m_probs, m_head, causal);
 

--- a/jlib/metal/backend.hh
+++ b/jlib/metal/backend.hh
@@ -70,6 +70,8 @@ public:
     void assign(const tensor_ptr& src, tensor_ptr& dst);
     void softmax(const tensor_ptr& in, tensor_ptr& out);
     void causal_mask(tensor_ptr& s);
+    void rope(tensor_ptr& x, unsigned int base_pos = 0, float theta = 10000.0f,
+              ai::rope_layout layout = ai::rope_layout::interleaved);
     void rms_norm(const tensor_ptr& in, const tensor_ptr& weight,
                   tensor_ptr& out, float eps = 1e-5f);
 

--- a/jlib/metal/backend.mm
+++ b/jlib/metal/backend.mm
@@ -166,6 +166,13 @@ void backend<T>::causal_mask(tensor_ptr& s) {
 }
 
 template<typename T>
+void backend<T>::rope(tensor_ptr& x, unsigned int base_pos, float theta,
+                      ai::rope_layout layout)
+{
+    m_stream->rope(at<T>(x), base_pos, theta, layout == ai::rope_layout::split);
+}
+
+template<typename T>
 void backend<T>::rms_norm(const tensor_ptr& in, const tensor_ptr& weight,
                           tensor_ptr& out, float eps)
 {

--- a/jlib/metal/tensor.hh
+++ b/jlib/metal/tensor.hh
@@ -191,6 +191,9 @@ public:
     /** Set everything strictly below the diagonal to -infinity, in place. */
     void causal_mask(tensor<T>& s);
 
+    /** Rotary position embedding, in place; see ai::backend::rope. */
+    void rope(tensor<T>& x, unsigned int base_pos, float theta, bool split);
+
     /** RMS normalisation down each column, scaled by a per-row weight. */
     void rms_norm(const tensor<T>& in, const tensor<T>& weight, tensor<T>& out,
                   float eps = 1e-5f);

--- a/jlib/metal/tensor.mm
+++ b/jlib/metal/tensor.mm
@@ -232,6 +232,51 @@ kernel void k_causal_mask(device T* s [[buffer(0)]],
         x[r] = T(-INFINITY);
 }
 
+/**
+ * Rotary position embedding, in place.  One thread per (column, plane).
+ *
+ * The angle is computed in float where the host uses double.  For the sequence
+ * lengths anything here runs at the two agree to well under fp16's resolution;
+ * at tens of thousands of positions the float angle would start to drift, and
+ * the fix then is a precomputed table rather than more precision here.
+ */
+template<typename T>
+kernel void k_rope(device T* x [[buffer(0)]],
+                   constant uint& rows [[buffer(1)]],
+                   constant uint& cols [[buffer(2)]],
+                   constant uint& base_pos [[buffer(3)]],
+                   constant float& theta [[buffer(4)]],
+                   constant uint& split [[buffer(5)]],
+                   uint i [[thread_position_in_grid]])
+{
+    // Not `half`: that is the fp16 type in MSL, and naming a variable after it
+    // fails to compile in a way whose message points at the declaration rather
+    // than at the name.
+    const uint planes = rows / 2;
+
+    if(i >= cols * planes) return;
+
+    const uint c = i / planes;
+    const uint j = i % planes;
+
+    const uint a = split ? j : 2 * j;
+    const uint b = split ? j + planes : 2 * j + 1;
+
+    const float freq = pow(theta, -2.0f * float(j) / float(rows));
+    const float angle = float(base_pos + c) * freq;
+
+    const float co = cos(angle);
+    const float si = sin(angle);
+
+    device T* col = x + (ulong)c * rows;
+
+    const float xa = float(col[a]);
+    const float xb = float(col[b]);
+
+    col[a] = T(xa * co - xb * si);
+    col[b] = T(xa * si + xb * co);
+}
+
 #define INSTANTIATE(NAME, T, SUFFIX)                                        \
     template [[host_name(#NAME SUFFIX)]] kernel void NAME<T>
 
@@ -263,6 +308,12 @@ INSTANTIATE(k_causal_mask, float, "_f32")(device float*, constant uint&,
                                           constant uint&, uint);
 INSTANTIATE(k_causal_mask, half, "_f16")(device half*, constant uint&,
                                          constant uint&, uint);
+INSTANTIATE(k_rope, float, "_f32")(device float*, constant uint&, constant uint&,
+                                   constant uint&, constant float&,
+                                   constant uint&, uint);
+INSTANTIATE(k_rope, half, "_f16")(device half*, constant uint&, constant uint&,
+                                  constant uint&, constant float&,
+                                  constant uint&, uint);
 INSTANTIATE(k_rms_norm, float, "_f32")(device const float*, device const float*,
                                        device float*, constant uint&,
                                        constant uint&, constant float&, uint);
@@ -374,6 +425,7 @@ struct stream<T>::impl {
     id<MTLComputePipelineState> add_scaled = nil;
     id<MTLComputePipelineState> softmax = nil;
     id<MTLComputePipelineState> causal_mask = nil;
+    id<MTLComputePipelineState> rope = nil;
     id<MTLComputePipelineState> rms_norm = nil;
 
     unsigned int pending = 0;
@@ -389,6 +441,7 @@ struct pipelines {
     id<MTLComputePipelineState> add_scaled = nil;
     id<MTLComputePipelineState> softmax = nil;
     id<MTLComputePipelineState> causal_mask = nil;
+    id<MTLComputePipelineState> rope = nil;
     id<MTLComputePipelineState> rms_norm = nil;
 };
 
@@ -441,6 +494,7 @@ pipelines& compiled(id<MTLDevice> gpu) {
         { "k_add_scaled", &p.add_scaled },
         { "k_softmax",    &p.softmax },
         { "k_causal_mask", &p.causal_mask },
+        { "k_rope",       &p.rope },
         { "k_rms_norm",   &p.rms_norm },
     };
 
@@ -505,6 +559,7 @@ stream<T>::stream(std::shared_ptr<device> d)
     m_impl->add_scaled = p.add_scaled;
     m_impl->softmax = p.softmax;
     m_impl->causal_mask = p.causal_mask;
+    m_impl->rope = p.rope;
     m_impl->rms_norm = p.rms_norm;
 }
 
@@ -679,6 +734,35 @@ void stream<T>::causal_mask(tensor<T>& s) {
     [m_impl->enc setBytes:&cols length:sizeof(cols) atIndex:2];
 
     dispatch(m_impl->enc, m_impl->causal_mask, cols);
+
+    m_impl->pending++;
+}
+
+template<typename T>
+void stream<T>::rope(tensor<T>& x, unsigned int base_pos, float theta,
+                     bool split)
+{
+    if(x.rows() % 2)
+        throw typename tensor<T>::exception("rope: rotates in planes, so it "
+                                            "needs an even number of rows");
+
+    open();
+
+    const unsigned int rows = x.rows();
+    const unsigned int cols = x.cols();
+    const unsigned int is_split = split ? 1u : 0u;
+
+    [m_impl->enc setComputePipelineState:m_impl->rope];
+    [m_impl->enc setBuffer:x.m_impl->buf offset:0 atIndex:0];
+    [m_impl->enc setBytes:&rows length:sizeof(rows) atIndex:1];
+    [m_impl->enc setBytes:&cols length:sizeof(cols) atIndex:2];
+    [m_impl->enc setBytes:&base_pos length:sizeof(base_pos) atIndex:3];
+    [m_impl->enc setBytes:&theta length:sizeof(theta) atIndex:4];
+    [m_impl->enc setBytes:&is_split length:sizeof(is_split) atIndex:5];
+
+    // One thread per rotation plane per column, not per column: d_head is
+    // small and the sequence can be long, so this is where the parallelism is.
+    dispatch(m_impl->enc, m_impl->rope, cols * (rows / 2));
 
     m_impl->pending++;
 }

--- a/tests/ai_backend_test.cc
+++ b/tests/ai_backend_test.cc
@@ -533,6 +533,190 @@ static void the_scale_is_applied(const char* name,
     }
 }
 
+/** The inner product of two columns, in double. */
+template<typename T>
+static double dot(const matrix<T>& a, uint ca, const matrix<T>& b, uint cb) {
+    double d = 0;
+
+    for(uint r = 0; r < a.M; r++)
+        d += double(float(a(r,ca))) * double(float(b(r,cb)));
+
+    return d;
+}
+
+/**
+ * RoPE is a rotation, so it preserves length and is the identity at zero.
+ *
+ * Both are exact statements about what the operation *is*, and neither needs a
+ * second implementation to check.
+ */
+template<typename T>
+static void rope_is_a_rotation(const char* name, std::vector<ai::backend<T>*>& backends) {
+    std::cout << "\nrope is a rotation, " << name << ":\n";
+
+    const uint d = 8;
+    const uint n = 4;
+
+    std::mt19937 gen(53);
+
+    const matrix<T> x = random_matrix<T>(d, n, gen);
+
+    for(ai::backend<T>* b : backends) {
+        typename ai::backend<T>::tensor_ptr t = b->make(x);
+
+        b->rope(t, 5);
+        b->wait();
+
+        const matrix<T> got = t->read();
+
+        double furthest = 0;
+
+        for(uint c = 0; c < n; c++)
+            furthest = std::max(furthest,
+                                std::fabs(std::sqrt(dot(got,c,got,c)) -
+                                          std::sqrt(dot(x,c,x,c))));
+
+        ok(std::string("  ") + b->name() + ": every column keeps its length",
+           furthest < ((sizeof(T) == 2) ? 5e-3 : 1e-5), std::to_string(furthest));
+
+        // Position 0 turns through zero radians, so it is exactly the input --
+        // and base_pos 0 means column c is at position c, so only the first
+        // column is untouched.
+        typename ai::backend<T>::tensor_ptr z = b->make(x);
+
+        b->rope(z, 0);
+        b->wait();
+
+        const matrix<T> zero = z->read();
+
+        bool identical = true;
+
+        for(uint r = 0; r < d; r++)
+            if(float(zero(r,0)) != float(x(r,0))) identical = false;
+
+        ok(std::string("  ") + b->name() + ": and position zero is untouched",
+           identical);
+
+        bool moved = false;
+
+        for(uint r = 0; r < d; r++)
+            if(float(zero(r,3)) != float(x(r,3))) moved = true;
+
+        ok(std::string("  ") + b->name() + ": while a later position is not",
+           moved);
+    }
+}
+
+/**
+ * The property RoPE exists for: the score depends only on the distance.
+ *
+ * <RoPE(q, m), RoPE(k, n)> is a function of n - m alone, so shifting both
+ * positions by the same amount must leave every inner product where it was.
+ * This is the one assertion that would fail for almost any other way of mixing
+ * position into a vector, and it is why RoPE is used instead of adding a
+ * positional vector to the input.
+ */
+template<typename T>
+static void rope_makes_the_score_relative(const char* name,
+                                          std::vector<ai::backend<T>*>& backends)
+{
+    std::cout << "\nrope makes the score relative, " << name << ":\n";
+
+    const uint d = 8;
+    const uint n = 3;
+
+    std::mt19937 gen(59);
+
+    const matrix<T> q = random_matrix<T>(d, n, gen);
+    const matrix<T> k = random_matrix<T>(d, n, gen);
+
+    for(ai::backend<T>* b : backends) {
+        std::vector<double> base;
+        double furthest = 0;
+
+        // The same pair of columns, rotated from four different starting
+        // positions.  Every relative offset is the same in each, so every dot
+        // product between them should be too.
+        for(unsigned int shift : { 0u, 1u, 7u, 40u }) {
+            typename ai::backend<T>::tensor_ptr tq = b->make(q);
+            typename ai::backend<T>::tensor_ptr tk = b->make(k);
+
+            b->rope(tq, shift);
+            b->rope(tk, shift);
+            b->wait();
+
+            const matrix<T> rq = tq->read();
+            const matrix<T> rk = tk->read();
+
+            std::vector<double> now;
+
+            for(uint i = 0; i < n; i++)
+                for(uint j = 0; j < n; j++)
+                    now.push_back(dot(rq, i, rk, j));
+
+            if(shift == 0) {
+                base = now;
+                continue;
+            }
+
+            for(std::size_t at = 0; at < now.size(); at++)
+                furthest = std::max(furthest, std::fabs(base[at] - now[at]));
+        }
+
+        ok(std::string("  ") + b->name() +
+           ": shifting both positions leaves every score alone",
+           furthest < ((sizeof(T) == 2) ? 5e-2 : 1e-4), std::to_string(furthest));
+    }
+}
+
+template<typename T>
+static void the_two_rope_layouts_differ(const char* name,
+                                        std::vector<ai::backend<T>*>& backends)
+{
+    std::cout << "\nthe two rope layouts differ, " << name << ":\n";
+
+    std::mt19937 gen(61);
+
+    const matrix<T> x = random_matrix<T>(8, 3, gen);
+
+    for(ai::backend<T>* b : backends) {
+        typename ai::backend<T>::tensor_ptr a = b->make(x);
+        typename ai::backend<T>::tensor_ptr c = b->make(x);
+
+        b->rope(a, 2, 10000.0f, ai::rope_layout::interleaved);
+        b->rope(c, 2, 10000.0f, ai::rope_layout::split);
+        b->wait();
+
+        const matrix<T> ia = a->read();
+        const matrix<T> sp = c->read();
+
+        ok(std::string("  ") + b->name() + ": interleaved is not split",
+           worst(ia, sp) > 1e-3, std::to_string(worst(ia, sp)));
+
+        // And both are rotations, which is what makes them indistinguishable
+        // by any property test.
+        double la = 0, ls = 0;
+
+        for(uint r = 0; r < 8; r++) {
+            la += double(float(ia(r,1))) * double(float(ia(r,1)));
+            ls += double(float(sp(r,1))) * double(float(sp(r,1)));
+        }
+
+        ok(std::string("  ") + b->name() + ": and both preserve the length",
+           std::fabs(std::sqrt(la) - std::sqrt(ls)) < ((sizeof(T) == 2) ? 5e-3 : 1e-5),
+           std::to_string(std::fabs(std::sqrt(la) - std::sqrt(ls))));
+
+        typename ai::backend<T>::tensor_ptr odd = b->make(7, 2);
+
+        bool threw = false;
+        try { b->rope(odd); b->wait(); }
+        catch(std::exception&) { threw = true; }
+
+        ok(std::string("  ") + b->name() + ": an odd number of rows is refused",
+           threw);
+    }
+}
+
 static void a_tensor_from_the_wrong_backend_is_refused() {
     std::cout << "\na tensor from the wrong backend is refused:\n";
 
@@ -577,7 +761,14 @@ int main() {
 #ifdef HAVE_METAL
         std::shared_ptr<jlib::metal::backend<float> > g;
         try { g.reset(new jlib::metal::backend<float>); b.push_back(g.get()); }
-        catch(std::exception& e) { std::cout << "  (no Metal device: " << e.what() << ")\n"; }
+        catch(std::exception& e) {
+            // A failure, not a note.  HAVE_METAL means Metal was found when
+            // this was configured, so the backend not coming up is a bug here
+            // -- most likely a kernel that no longer compiles.  Reported as a
+            // note, this test went on to pass with only the host backend and
+            // exit 0, which is how a broken kernel reaches a green run.
+            ok("  the Metal backend comes up", false, e.what());
+        }
         one_type<float>("float", b);
         the_reductions<float>("float", b);
         softmax_survives_a_large_score<float>("float", b);
@@ -585,6 +776,9 @@ int main() {
         attention_looks_only_backwards<float>("float", b);
         flat_scores_average_the_values<float>("float", b);
         the_scale_is_applied<float>("float", b);
+        rope_is_a_rotation<float>("float", b);
+        rope_makes_the_score_relative<float>("float", b);
+        the_two_rope_layouts_differ<float>("float", b);
 #else
         one_type<float>("float", b);
         the_reductions<float>("float", b);
@@ -593,6 +787,9 @@ int main() {
         attention_looks_only_backwards<float>("float", b);
         flat_scores_average_the_values<float>("float", b);
         the_scale_is_applied<float>("float", b);
+        rope_is_a_rotation<float>("float", b);
+        rope_makes_the_score_relative<float>("float", b);
+        the_two_rope_layouts_differ<float>("float", b);
 #endif
     }
 
@@ -603,7 +800,7 @@ int main() {
 #ifdef HAVE_METAL
         std::shared_ptr<jlib::metal::backend<_Float16> > g;
         try { g.reset(new jlib::metal::backend<_Float16>); b.push_back(g.get()); }
-        catch(std::exception&) {}
+        catch(std::exception& e) { ok("  the Metal backend comes up", false, e.what()); }
 #endif
         one_type<_Float16>("_Float16", b);
         the_reductions<_Float16>("_Float16", b);
@@ -612,6 +809,9 @@ int main() {
         attention_looks_only_backwards<_Float16>("_Float16", b);
         flat_scores_average_the_values<_Float16>("_Float16", b);
         the_scale_is_applied<_Float16>("_Float16", b);
+        rope_is_a_rotation<_Float16>("_Float16", b);
+        rope_makes_the_score_relative<_Float16>("_Float16", b);
+        the_two_rope_layouts_differ<_Float16>("_Float16", b);
     }
 
     a_tensor_from_the_wrong_backend_is_refused();

--- a/tests/ai_transformer_test.cc
+++ b/tests/ai_transformer_test.cc
@@ -115,11 +115,14 @@ static void load(ai::block<T>& blk, const weights<T>& w) {
 
 template<typename T>
 static matrix<T> run(ai::backend<T>& b, const weights<T>& w, const matrix<T>& x,
-                     bool causal = true)
+                     bool causal = true, bool rope = false)
 {
     ai::block<T> blk(b, D, H, F);
 
     load(blk, w);
+
+    if(rope) blk.set_rope(true);
+
     blk.reserve(N);
 
     typename ai::backend<T>::tensor_ptr tx = b.make(x);
@@ -425,6 +428,83 @@ static void the_branch_input_is_normalised(const char* name,
     }
 }
 
+/**
+ * Position, which the block did not have until now.
+ *
+ * Without a positional encoding and without the mask, a block is
+ * permutation-equivariant: it treats its input columns as a set, so reordering
+ * them just reorders the outputs.  That is not a defect to be worked around --
+ * it is what attention *is*, and it is exactly why a position has to be mixed
+ * in somewhere.
+ *
+ * So this asserts the property both ways round.  Without rope the block
+ * commutes with a permutation; with rope it does not, which is the whole
+ * reason rope exists.  The uncausal run is the one to test on, since the mask
+ * already breaks the symmetry by itself.
+ */
+template<typename T>
+static void rope_gives_the_block_a_sense_of_position(
+    const char* name, std::vector<ai::backend<T>*>& backends)
+{
+    std::cout << "\nrope gives the block a sense of position, " << name << ":\n";
+
+    std::mt19937 gen(43);
+
+    const weights<T> w(gen);
+
+    const matrix<T> x = random_matrix<T>(D, N, gen);
+
+    // One swap is enough to be a permutation, and keeping it simple keeps the
+    // inverse obvious.
+    const unsigned int i = 1;
+    const unsigned int j = 3;
+
+    matrix<T> swapped = x;
+
+    for(unsigned int r = 0; r < D; r++) {
+        swapped(r,i) = x(r,j);
+        swapped(r,j) = x(r,i);
+    }
+
+    for(ai::backend<T>* b : backends) {
+        const matrix<T> plain = run(*b, w, x,       false, false);
+        const matrix<T> perm  = run(*b, w, swapped, false, false);
+
+        // block(swap(x)) should be swap(block(x)).
+        double furthest = 0;
+
+        for(unsigned int c = 0; c < N; c++) {
+            const unsigned int from = (c == i) ? j : (c == j) ? i : c;
+
+            for(unsigned int r = 0; r < D; r++)
+                furthest = std::max(furthest,
+                                    std::fabs(double(float(perm(r,c))) -
+                                              double(float(plain(r,from)))));
+        }
+
+        ok(std::string("  ") + b->name() +
+           ": without rope the block treats its input as a set",
+           furthest < ((sizeof(T) == 2) ? 5e-3 : 1e-5), std::to_string(furthest));
+
+        const matrix<T> rplain = run(*b, w, x,       false, true);
+        const matrix<T> rperm  = run(*b, w, swapped, false, true);
+
+        double moved = 0;
+
+        for(unsigned int c = 0; c < N; c++) {
+            const unsigned int from = (c == i) ? j : (c == j) ? i : c;
+
+            for(unsigned int r = 0; r < D; r++)
+                moved = std::max(moved,
+                                 std::fabs(double(float(rperm(r,c))) -
+                                           double(float(rplain(r,from)))));
+        }
+
+        ok(std::string("  ") + b->name() + ": and with rope it does not",
+           moved > 1e-3, std::to_string(moved));
+    }
+}
+
 template<typename T>
 static void the_backends_agree(const char* name,
                                std::vector<ai::backend<T>*>& backends)
@@ -485,6 +565,7 @@ static void everything(const char* name, std::vector<ai::backend<T>*>& b) {
     heads_are_routed_separately<T>(name, b);
     the_heads_are_summed<T>(name, b);
     the_branch_input_is_normalised<T>(name, b);
+    rope_gives_the_block_a_sense_of_position<T>(name, b);
     silu_is_x_times_sigmoid<T>(name, b);
     the_backends_agree<T>(name, b);
     the_shapes_are_checked<T>(name, *b[0]);
@@ -500,7 +581,14 @@ int main() {
 #ifdef HAVE_METAL
         std::shared_ptr<jlib::metal::backend<float> > g;
         try { g.reset(new jlib::metal::backend<float>); b.push_back(g.get()); }
-        catch(std::exception& e) { std::cout << "  (no Metal device: " << e.what() << ")\n"; }
+        catch(std::exception& e) {
+            // A failure, not a note.  HAVE_METAL means Metal was found when
+            // this was configured, so the backend not coming up is a bug here
+            // -- most likely a kernel that no longer compiles.  Reported as a
+            // note, this test went on to pass with only the host backend and
+            // exit 0, which is how a broken kernel reaches a green run.
+            ok("  the Metal backend comes up", false, e.what());
+        }
 #endif
         everything<float>("float", b);
     }
@@ -512,7 +600,7 @@ int main() {
 #ifdef HAVE_METAL
         std::shared_ptr<jlib::metal::backend<_Float16> > g;
         try { g.reset(new jlib::metal::backend<_Float16>); b.push_back(g.get()); }
-        catch(std::exception&) {}
+        catch(std::exception& e) { ok("  the Metal backend comes up", false, e.what()); }
 #endif
         everything<_Float16>("_Float16", b);
     }
@@ -530,9 +618,17 @@ int main() {
     // they are called w_gate() and w_up() rather than w1() and w3() -- the
     // interface states it because the tests cannot check it.
     //
-    // Not position.  There is no positional encoding at all, so this block is
-    // permutation-equivariant apart from the causal mask -- reorder the input
-    // columns and the outputs reorder with them.  RoPE is its own branch.
+    // Which of the two rope layouts a model wants.  Both are rotations, both
+    // satisfy every property checked above, and they are not compatible with
+    // each other -- so what is exercised here is the wiring, never the choice.
+    // See ai::rope_layout.
+    //
+    // Nor that rope belongs on the queries and keys and not on the values.
+    // Measured: rotating the values as well fails nothing here.  The reason it
+    // is wrong is that a value carries what a position said rather than which
+    // position said it, so rotating it would make the content attended *to*
+    // depend on where it sat -- an argument about meaning, which no property
+    // test reaches.
     //
     // Not a stack.  One block is tested; nothing checks that N of them compose,
     // and pre-norm exists precisely for what happens at depth.


### PR DESCRIPTION
# RoPE

The block worked, on both backends, in both element types — and had no notion of
position. Apart from the causal mask it was permutation-equivariant: reorder the
input columns and the outputs reordered with them. That is not a defect to be
worked around, it is what attention *is*, and it is why a position has to be
mixed in somewhere.

Rotary position embedding rotates each column by an angle that grows with its
position, in `d/2` independent planes each turning at its own rate, applied to
the queries and keys after their projections and before the scores. What it buys
is that the *score* between a query and a key depends on the distance between
them rather than on where the pair sits.

## Two conventions, and why the interface has to name one

RoPE pairs up dimensions before rotating them, and there are two ways to do it:

- `interleaved` — pairs (0,1), (2,3), (4,5)…, the original RoFormer paper and
  what ggml calls the normal rope type
- `split` — pairs (j, j + d/2), what GPT-NeoX introduced and what the
  HuggingFace Llama implementation uses, with weights permuted at conversion to
  match

They are not compatible: a model trained under one and run under the other
produces fluent nonsense rather than an error. **And no test here can tell them
apart** — every property RoPE has holds for both, because both are
block-diagonal rotations differing only in which coordinates share a block.

So it is `enum class rope_layout` and a named parameter, the same answer the
last branch reached for `w_gate()`/`w_up()`. There is now a test that asserts
the two layouts *differ* and that both preserve length — it exists to record
that the tests cannot settle the convention, not to settle it.

## Tests

Three properties of the primitive, which are statements about what the operation
*is* and need no second implementation:

- **It is a rotation** — every column keeps its length, exactly (0.000000 in
  float on both backends).
- **Position zero is the identity**, and a later position is not — the second
  half being the control that stops the first passing on a no-op.
- **The score is relative** — `⟨RoPE(q,m), RoPE(k,n)⟩` is a function of `n-m`
  alone, so shifting both positions by 1, 7 or 40 leaves every inner product
  where it was. This is the one assertion that would fail for almost any other
  way of mixing position into a vector, and it is why RoPE is used instead of
  adding a positional vector to the input.

And one about the wiring, asserted both ways round:

- **Without rope the block treats its input as a set** — swap two input columns
  and the outputs swap with them, to 0.000000 in float.
- **With rope it does not.**

The uncausal path is what that runs on, since the mask breaks the symmetry by
itself.

## A hole in the test harness, found by falling into it

The first version of the Metal kernel declared `const uint half`. `half` is the
fp16 *type* in MSL, so the shader failed to compile — and
`ai_backend_test` **printed a note and exited 0**, having quietly run every
assertion against the host backend alone.

That is not specific to this kernel. Any future breakage in any Metal kernel
would have passed CI the same way, because the test treated "no Metal backend"
as a condition of the machine rather than a bug.

`HAVE_METAL` means Metal was found when this was configured, so the backend
failing to come up is a bug, not a property of the host. Both AI tests now
report it through `ok()` like any other assertion. Verified by breaking the
kernel deliberately: **exit 1 and a `FAIL` line**, where the same break
previously gave exit 0 and a green run.

### Mutation results

| mutation | caught |
| --- | --- |
| break the Metal kernel so it will not compile | **no → now yes**, exit 1 |
| apply rope to the values as well as q and k | **no, and cannot be** |

The second is recorded rather than fixed. Rotating the values gives a different
but self-consistent block. The reason it is wrong is that a value carries *what*
a position said rather than *which* position said it, so rotating it would make
the content attended to depend on where it sat — an argument about meaning,
which no property test reaches.

## Also

`forward()` takes a `base_pos`, so the columns being processed can sit anywhere
in the sequence rather than at the start. Nothing needs it yet; it is what
decoding one token at a time against a cache will need, and adding it later
would have changed the signature.

`set_rope()` checks that `d_model / heads` is even at the point the caller makes
the choice, rather than at the first `forward()`, since `d_head` is fixed at
construction and a shape error is worth having early.

## Verification

- macOS `make check`: 69 tests, 65 pass, 4 skip, 0 fail.
- Container `make check`: no Metal there, so the host path stands alone.

## What this does not establish

**Which layout, and whether the values should be rotated** — both above, both
by measurement.

**Long sequences.** The angle is `position × frequency` and grows without bound;
the host computes it in double and the GPU in float. At the lengths anything
here runs they agree to well under fp16's resolution. At tens of thousands of
positions the float angle would drift, and the fix then is a precomputed table
rather than more precision in the kernel — written down in the kernel itself.

**Not a correct transformer, still.** Nothing compares against a reference
implementation, because there is no loader and so no real weights. That remains
true of every branch on this path so far, and it is the reason GGUF loading is
the natural next step: after it, "self-consistent" can become "agrees with
llama.cpp".
