### PR TITLE
Read a real GGUF: header, typed metadata, the tensor index, and Q8_0 dequantisation checked against the bytes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -38,3 +38,8 @@ m4/lt~obsolete.m4
 .libs/
 .deps/
 *~
+
+# Model files, which are gigabytes and which no container test needs -- the
+# Dockerfile copies named paths rather than the tree, so this is belt and
+# braces against that changing.  ai_gguf_test skips without one.
+*.gguf

--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,10 @@ m4/lt~obsolete.m4
 #   curl -O https://pjreddie.com/media/files/mnist_train.csv
 #   curl -O https://pjreddie.com/media/files/mnist_test.csv
 mnist_*.csv
+
+# GGUF model files, fetched rather than vendored: the smallest one worth
+# testing against is over a gigabyte, and ai_gguf_test takes its path on the
+# command line and skips when it is absent.
+#
+#   curl -LO https://huggingface.co/TheBloke/TinyLlama-1.1B-Chat-v1.0-GGUF/resolve/main/tinyllama-1.1b-chat-v1.0.Q8_0.gguf
+*.gguf

--- a/jlib/ai/Makefile.am
+++ b/jlib/ai/Makefile.am
@@ -2,11 +2,12 @@ AM_CPPFLAGS = -I$(top_srcdir)
 
 lib_LTLIBRARIES = libjai.la
 libjai_la_SOURCES = environment.cc agent.cc percept.cc action.cc vacuum.cc \
-                    backend.cc
+                    backend.cc gguf.cc
 libjai_la_LDFLAGS = -version-info $(LIBJ_SO_VERSION) -release $(JLIB_RELEASE) -no-undefined
 libjai_la_LIBADD = $(top_builddir)/jlib/util/libjutil.la \
                    $(top_builddir)/jlib/sys/libjsys.la
 
 libjaiincludedir = $(includedir)/jlib-1.2/jlib/ai
 libjaiinclude_HEADERS = environment.hh agent.hh percept.hh action.hh vacuum.hh \
-                        neural.hh backend.hh attention.hh transformer.hh
+                        neural.hh backend.hh attention.hh transformer.hh \
+                        gguf.hh

--- a/jlib/ai/gguf.cc
+++ b/jlib/ai/gguf.cc
@@ -1,0 +1,414 @@
+/* -*- mode: C++ c-basic-offset: 4  -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+#include <jlib/ai/gguf.hh>
+
+#include <cstring>
+#include <sstream>
+
+namespace jlib {
+namespace ai {
+
+namespace {
+
+    /** Q8_0: one fp16 scale then 32 signed bytes, 34 bytes for 32 values. */
+    const std::uint64_t Q8_0_BLOCK = 32;
+    const std::uint64_t Q8_0_BYTES = 34;
+
+    /**
+     * A bound on how long a string in the metadata may be.
+     *
+     * Not a format limit -- there is none -- but a length is read from the
+     * file before it is trusted, and a corrupt one would otherwise ask for an
+     * allocation of whatever the bytes happened to say.  The longest string in
+     * a real file is a chat template of a few kilobytes.
+     */
+    const std::uint64_t MAX_STRING = 64u * 1024u * 1024u;
+
+    /** And the same for counts, which are read before anything validates them. */
+    const std::uint64_t MAX_COUNT = 64u * 1024u * 1024u;
+
+}
+
+std::uint64_t gguf::tensor_info::elements() const {
+    std::uint64_t n = 1;
+
+    for(std::uint64_t d : shape) n *= d;
+
+    return n;
+}
+
+template<typename U>
+U gguf::read_pod() {
+    U v;
+
+    m_file.read(reinterpret_cast<char*>(&v), sizeof(U));
+
+    if(!m_file)
+        throw exception("the file ended in the middle of a value");
+
+    return v;
+}
+
+std::string gguf::read_string() {
+    const std::uint64_t len = read_pod<std::uint64_t>();
+
+    if(len > MAX_STRING) {
+        std::ostringstream o;
+
+        o << "a string of " << len << " bytes, which is longer than anything "
+          << "this will believe";
+
+        throw exception(o.str());
+    }
+
+    std::string s(static_cast<std::size_t>(len), '\0');
+
+    if(len) {
+        m_file.read(&s[0], static_cast<std::streamsize>(len));
+
+        if(!m_file)
+            throw exception("the file ended in the middle of a string");
+    }
+
+    return s;
+}
+
+gguf::value gguf::read_value(value_type t) {
+    value v;
+
+    v.type = t;
+
+    switch(t) {
+    case value_type::uint8:   v.i = read_pod<std::uint8_t>();  break;
+    case value_type::int8:    v.i = read_pod<std::int8_t>();   break;
+    case value_type::uint16:  v.i = read_pod<std::uint16_t>(); break;
+    case value_type::int16:   v.i = read_pod<std::int16_t>();  break;
+    case value_type::uint32:  v.i = read_pod<std::uint32_t>(); break;
+    case value_type::int32:   v.i = read_pod<std::int32_t>();  break;
+    case value_type::uint64:  v.i = static_cast<std::int64_t>(read_pod<std::uint64_t>()); break;
+    case value_type::int64:   v.i = read_pod<std::int64_t>();  break;
+    case value_type::boolean: v.i = read_pod<std::uint8_t>() ? 1 : 0; break;
+    case value_type::float32: v.d = read_pod<float>();         break;
+    case value_type::float64: v.d = read_pod<double>();        break;
+    case value_type::string:  v.s = read_string();             break;
+
+    case value_type::array: {
+        const value_type et = static_cast<value_type>(read_pod<std::uint32_t>());
+        const std::uint64_t n = read_pod<std::uint64_t>();
+
+        if(n > MAX_COUNT) {
+            std::ostringstream o;
+
+            o << "an array of " << n << " elements, which is more than this "
+              << "will believe";
+
+            throw exception(o.str());
+        }
+
+        v.element = et;
+
+        if(et == value_type::array)
+            throw exception("an array of arrays, which the format does not "
+                            "nest and this does not read");
+
+        // Every element, one at a time, even when only a few are wanted:
+        // strings are variable length, so there is no seeking past the tail of
+        // one of these.  tokenizer.ggml.merges is sixty thousand of them.
+        for(std::uint64_t k = 0; k < n; k++) {
+            const value e = read_value(et);
+
+            if(et == value_type::string) v.strings.push_back(e.s);
+            else if(et == value_type::float32 || et == value_type::float64)
+                v.numbers.push_back(e.d);
+            else v.numbers.push_back(double(e.i));
+        }
+
+        break;
+    }
+
+    default: {
+        std::ostringstream o;
+
+        o << "unknown metadata value type " << static_cast<int>(t);
+
+        throw exception(o.str());
+    }
+    }
+
+    return v;
+}
+
+void gguf::read_metadata(std::uint64_t count) {
+    for(std::uint64_t k = 0; k < count; k++) {
+        const std::string key = read_string();
+        const value_type t = static_cast<value_type>(read_pod<std::uint32_t>());
+
+        m_meta[key] = read_value(t);
+    }
+
+    // Read after the loop rather than assumed, because the alignment is itself
+    // one of the keys and the padding below depends on it.
+    if(has("general.alignment")) {
+        const std::int64_t a = integer("general.alignment");
+
+        if(a <= 0 || (a & (a - 1)))
+            throw exception("general.alignment is not a positive power of two");
+
+        m_alignment = static_cast<std::uint64_t>(a);
+    }
+}
+
+void gguf::read_index(std::uint64_t count) {
+    for(std::uint64_t k = 0; k < count; k++) {
+        tensor_info t;
+
+        t.name = read_string();
+
+        const std::uint32_t nd = read_pod<std::uint32_t>();
+
+        if(nd > 4)
+            throw exception("a tensor of more than four dimensions");
+
+        for(std::uint32_t d = 0; d < nd; d++)
+            t.shape.push_back(read_pod<std::uint64_t>());
+
+        t.type = static_cast<tensor_type>(read_pod<std::uint32_t>());
+        t.offset = read_pod<std::uint64_t>();
+
+        m_by_name[t.name] = m_tensors.size();
+        m_tensors.push_back(t);
+    }
+}
+
+gguf::gguf(const std::string& path)
+    : m_path(path),
+      m_file(path, std::ios::binary)
+{
+    if(!m_file)
+        throw exception("could not open " + path);
+
+    char magic[4];
+
+    m_file.read(magic, 4);
+
+    if(!m_file || std::memcmp(magic, "GGUF", 4))
+        throw exception(path + " does not begin with GGUF");
+
+    m_version = read_pod<std::uint32_t>();
+
+    if(m_version < 2 || m_version > 3) {
+        std::ostringstream o;
+
+        o << "GGUF version " << m_version << ", where this reads 2 and 3";
+
+        throw exception(o.str());
+    }
+
+    const std::uint64_t tensor_count = read_pod<std::uint64_t>();
+    const std::uint64_t kv_count = read_pod<std::uint64_t>();
+
+    if(tensor_count > MAX_COUNT || kv_count > MAX_COUNT)
+        throw exception("a header claiming more tensors or keys than this will "
+                        "believe");
+
+    read_metadata(kv_count);
+    read_index(tensor_count);
+
+    // The data begins at the next multiple of the alignment after the index.
+    const std::uint64_t here = static_cast<std::uint64_t>(m_file.tellg());
+
+    m_data_offset = here + ((m_alignment - (here % m_alignment)) % m_alignment);
+}
+
+bool gguf::has(const std::string& key) const {
+    return m_meta.find(key) != m_meta.end();
+}
+
+const gguf::value& gguf::get(const std::string& key) const {
+    std::map<std::string, value>::const_iterator i = m_meta.find(key);
+
+    if(i == m_meta.end())
+        throw exception("no metadata key '" + key + "'");
+
+    return i->second;
+}
+
+std::string gguf::str(const std::string& key) const {
+    const value& v = get(key);
+
+    if(v.type != value_type::string)
+        throw exception("metadata key '" + key + "' is not a string");
+
+    return v.s;
+}
+
+std::int64_t gguf::integer(const std::string& key) const {
+    const value& v = get(key);
+
+    switch(v.type) {
+    case value_type::uint8: case value_type::int8:
+    case value_type::uint16: case value_type::int16:
+    case value_type::uint32: case value_type::int32:
+    case value_type::uint64: case value_type::int64:
+    case value_type::boolean:
+        return v.i;
+    default:
+        throw exception("metadata key '" + key + "' is not an integer");
+    }
+}
+
+double gguf::real(const std::string& key) const {
+    const value& v = get(key);
+
+    if(v.type == value_type::float32 || v.type == value_type::float64)
+        return v.d;
+
+    // An integer where a real was asked for is a widening and not a surprise;
+    // the other direction would be a loss and is refused above.
+    return double(integer(key));
+}
+
+bool gguf::has_tensor(const std::string& name) const {
+    return m_by_name.find(name) != m_by_name.end();
+}
+
+const gguf::tensor_info& gguf::tensor(const std::string& name) const {
+    std::map<std::string, std::size_t>::const_iterator i = m_by_name.find(name);
+
+    if(i == m_by_name.end())
+        throw exception("no tensor named '" + name + "'");
+
+    return m_tensors[i->second];
+}
+
+std::string gguf::type_name(tensor_type t) {
+    switch(t) {
+    case tensor_type::f32:  return "f32";
+    case tensor_type::f16:  return "f16";
+    case tensor_type::q4_0: return "q4_0";
+    case tensor_type::q4_1: return "q4_1";
+    case tensor_type::q5_0: return "q5_0";
+    case tensor_type::q5_1: return "q5_1";
+    case tensor_type::q8_0: return "q8_0";
+    case tensor_type::q8_1: return "q8_1";
+    case tensor_type::q2_k: return "q2_K";
+    case tensor_type::q3_k: return "q3_K";
+    case tensor_type::q4_k: return "q4_K";
+    case tensor_type::q5_k: return "q5_K";
+    case tensor_type::q6_k: return "q6_K";
+    case tensor_type::q8_k: return "q8_K";
+    }
+
+    std::ostringstream o;
+
+    o << "ggml type " << static_cast<int>(t);
+
+    return o.str();
+}
+
+math::matrix<float> gguf::read(const tensor_info& t) const {
+    const std::uint64_t n = t.elements();
+
+    const unsigned int rows = t.shape.empty()
+        ? 1u : static_cast<unsigned int>(t.shape[0]);
+
+    const unsigned int cols = (n && rows)
+        ? static_cast<unsigned int>(n / rows) : 0u;
+
+    math::matrix<float> out(rows, cols);
+
+    // Column-major and dims[0]-contiguous are the same arrangement, so the
+    // elements arrive in exactly the order the matrix wants them.  See the
+    // header.
+    float* into = static_cast<math::buffer<float> >(out).data();
+
+    m_file.clear();
+    m_file.seekg(static_cast<std::streamoff>(m_data_offset + t.offset));
+
+    if(!m_file)
+        throw exception("could not seek to tensor '" + t.name + "'");
+
+    switch(t.type) {
+    case tensor_type::f32: {
+        m_file.read(reinterpret_cast<char*>(into),
+                    static_cast<std::streamsize>(n * sizeof(float)));
+        break;
+    }
+
+    case tensor_type::f16: {
+        std::vector<_Float16> raw(static_cast<std::size_t>(n));
+
+        m_file.read(reinterpret_cast<char*>(raw.data()),
+                    static_cast<std::streamsize>(n * sizeof(_Float16)));
+
+        for(std::uint64_t i = 0; i < n; i++) into[i] = float(raw[i]);
+
+        break;
+    }
+
+    case tensor_type::q8_0: {
+        if(n % Q8_0_BLOCK)
+            throw exception("tensor '" + t.name + "' is q8_0 but its element "
+                            "count is not a multiple of the block size");
+
+        const std::uint64_t blocks = n / Q8_0_BLOCK;
+
+        std::vector<char> raw(static_cast<std::size_t>(blocks * Q8_0_BYTES));
+
+        m_file.read(raw.data(), static_cast<std::streamsize>(raw.size()));
+
+        for(std::uint64_t b = 0; b < blocks; b++) {
+            const char* p = raw.data() + b * Q8_0_BYTES;
+
+            // The scale, then thirty-two signed bytes scaled by it.  memcpy
+            // rather than a cast: the block is two bytes then thirty-two, so
+            // nothing after the first is aligned for a _Float16 load.
+            _Float16 d;
+
+            std::memcpy(&d, p, sizeof(d));
+
+            const signed char* q = reinterpret_cast<const signed char*>(p + 2);
+
+            for(std::uint64_t i = 0; i < Q8_0_BLOCK; i++)
+                into[b * Q8_0_BLOCK + i] = float(d) * float(q[i]);
+        }
+
+        break;
+    }
+
+    default:
+        throw exception("tensor '" + t.name + "' is " + type_name(t.type) +
+                        ", which this does not dequantise -- f32, f16 and q8_0 "
+                        "are all it reads");
+    }
+
+    if(!m_file)
+        throw exception("the file ended while reading tensor '" + t.name + "'");
+
+    return out;
+}
+
+math::matrix<float> gguf::read(const std::string& name) const {
+    return read(tensor(name));
+}
+
+}
+}

--- a/jlib/ai/gguf.hh
+++ b/jlib/ai/gguf.hh
@@ -1,0 +1,194 @@
+/* -*- mode: C++ c-basic-offset: 4  -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+#ifndef JLIB_AI_GGUF_HH
+#define JLIB_AI_GGUF_HH
+
+#include <jlib/math/matrix.hh>
+
+#include <cstdint>
+#include <exception>
+#include <fstream>
+#include <map>
+#include <string>
+#include <vector>
+
+namespace jlib {
+namespace ai {
+
+/**
+ * A GGUF model file: its metadata, its tensor index, and its weights.
+ *
+ * GGUF is the container llama.cpp writes and everything else has followed. A
+ * file is a header, a block of typed key/value metadata, an index of tensors,
+ * and then the tensor data, aligned.
+ *
+ * Metadata and the index are read at construction; **tensor data is not**. The
+ * smallest model worth testing against is over a gigabyte, so read() seeks and
+ * dequantises one tensor at a time. That makes read() the only expensive call
+ * and the file handle shared mutable state -- one gguf is not safe to read
+ * from two threads.
+ *
+ * ### Layout, and the happy accident in it
+ *
+ * GGUF dimensions are given fastest-varying first: `dims[0]` is the contiguous
+ * one. jlib's math::matrix is column-major, so element (r,c) lives at
+ * `c*rows + r` -- which is the *same* arrangement with `rows = dims[0]`. A
+ * GGUF tensor therefore loads into a matrix of `dims[0] x dims[1]` with no
+ * transposition and no shuffling, and `token_embd.weight` arrives as one
+ * column per token, which is the orientation the rest of this library already
+ * wants.
+ *
+ * What that costs is stated here so nobody rediscovers it: ggml's convention
+ * makes a weight `[n_in, n_out]`, so the product a layer wants is `W^T x`, not
+ * `W x`. Use backend::multiply_tn on a matrix loaded this way. Transposing at
+ * load time would be the other option and a worse one -- it would touch every
+ * byte of a gigabyte to save a flag.
+ *
+ * ### Endianness
+ *
+ * Little-endian only. The spec permits big-endian files and this reads the
+ * bytes natively, so it would misread one; it does not pretend to detect that,
+ * because no such file has ever been seen in the wild and a check that has
+ * never run is not worth more than a sentence saying it is missing.
+ */
+class gguf {
+public:
+    class exception : public std::exception {
+    public:
+        exception(const std::string& msg)
+            : m_msg("jlib::ai::gguf::exception: " + msg) {}
+
+        const char* what() const throw() { return m_msg.c_str(); }
+
+    private:
+        std::string m_msg;
+    };
+
+    /** The metadata value types, with the spec's numbering. */
+    enum class value_type {
+        uint8 = 0, int8 = 1, uint16 = 2, int16 = 3, uint32 = 4, int32 = 5,
+        float32 = 6, boolean = 7, string = 8, array = 9, uint64 = 10,
+        int64 = 11, float64 = 12
+    };
+
+    /** The ggml tensor types, of which only a few are read here. */
+    enum class tensor_type {
+        f32 = 0, f16 = 1, q4_0 = 2, q4_1 = 3, q5_0 = 6, q5_1 = 7, q8_0 = 8,
+        q8_1 = 9, q2_k = 10, q3_k = 11, q4_k = 12, q5_k = 13, q6_k = 14,
+        q8_k = 15
+    };
+
+    /**
+     * One metadata value.
+     *
+     * A flat struct rather than a variant: every integer width lands in `i`
+     * and every float width in `d`, because a caller asking for
+     * llama.block_count does not want to know whether the file said uint32 or
+     * uint64. `type` is kept so it can still be asked.
+     */
+    struct value {
+        value_type type = value_type::uint32;
+
+        std::int64_t i = 0;             ///< every integer width, and bool
+        double d = 0;                   ///< float32 and float64
+        std::string s;                  ///< string
+
+        value_type element = value_type::uint32;   ///< an array's element type
+        std::vector<std::string> strings;          ///< an array of strings
+        std::vector<double> numbers;               ///< an array of anything else
+    };
+
+    struct tensor_info {
+        std::string name;
+        std::vector<std::uint64_t> shape;   ///< dims[0] is the contiguous one
+        tensor_type type = tensor_type::f32;
+        std::uint64_t offset = 0;           ///< from the start of the data section
+
+        /** How many elements, which is the product of the shape. */
+        std::uint64_t elements() const;
+    };
+
+    explicit gguf(const std::string& path);
+
+    unsigned int version() const { return m_version; }
+
+    /** Where the tensor data begins, after the index and its padding. */
+    std::uint64_t data_offset() const { return m_data_offset; }
+
+    std::uint64_t alignment() const { return m_alignment; }
+
+    const std::map<std::string, value>& metadata() const { return m_meta; }
+
+    bool has(const std::string& key) const;
+
+    /** Throws unless the key is present and of a compatible kind. */
+    const value& get(const std::string& key) const;
+
+    std::string str(const std::string& key) const;
+    std::int64_t integer(const std::string& key) const;
+    double real(const std::string& key) const;
+
+    const std::vector<tensor_info>& tensors() const { return m_tensors; }
+
+    bool has_tensor(const std::string& name) const;
+    const tensor_info& tensor(const std::string& name) const;
+
+    /**
+     * Read one tensor, dequantised, as (shape[0] rows x shape[1] cols).
+     *
+     * A one-dimensional tensor -- every norm weight is one -- comes back as a
+     * single column. Always float: dequantisation lands there naturally, and a
+     * caller wanting fp16 can narrow afterwards with the loss it chose.
+     *
+     * f32, f16 and q8_0 are understood. Anything else throws naming the type
+     * rather than returning something plausible.
+     */
+    math::matrix<float> read(const tensor_info& t) const;
+    math::matrix<float> read(const std::string& name) const;
+
+    /** The name of a ggml type, for an error message worth reading. */
+    static std::string type_name(tensor_type t);
+
+private:
+    std::string m_path;
+    mutable std::ifstream m_file;
+
+    unsigned int m_version = 0;
+    std::uint64_t m_alignment = 32;
+    std::uint64_t m_data_offset = 0;
+
+    std::map<std::string, value> m_meta;
+    std::vector<tensor_info> m_tensors;
+    std::map<std::string, std::size_t> m_by_name;
+
+    void read_metadata(std::uint64_t count);
+    void read_index(std::uint64_t count);
+
+    value read_value(value_type t);
+    std::string read_string();
+
+    template<typename U> U read_pod();
+};
+
+}
+}
+
+#endif // JLIB_AI_GGUF_HH

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -62,6 +62,7 @@ TESTS = \
 	ai_neural_test \
 	ai_backend_test \
 	ai_transformer_test \
+	ai_gguf_test \
 	math_object_test \
 	tensor_test \
 \
@@ -309,6 +310,9 @@ metal_gemm_test_LDADD   = $(top_builddir)/jlib/metal/libjmetal.la $(METAL_LIBS)
 
 metal_tensor_test_SOURCES = metal_tensor_test.cc
 metal_tensor_test_LDADD   = $(top_builddir)/jlib/metal/libjmetal.la $(JUTIL_LA) $(JSYS_LA) $(METAL_LIBS)
+
+ai_gguf_test_SOURCES  = ai_gguf_test.cc
+ai_gguf_test_LDADD    = $(JAI_LA) $(JUTIL_LA) $(JSYS_LA)
 
 ai_transformer_test_SOURCES  = ai_transformer_test.cc
 ai_transformer_test_CPPFLAGS = $(AM_CPPFLAGS) $(METAL_CPPFLAGS)

--- a/tests/ai_gguf_test.cc
+++ b/tests/ai_gguf_test.cc
@@ -1,0 +1,412 @@
+/* -*- mode: C++ c-basic-offset: 4 -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+#include <jlib/ai/gguf.hh>
+
+#include <cmath>
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace ai = jlib::ai;
+
+static int failures = 0;
+
+static void ok(const std::string& what, bool good, const std::string& detail = "") {
+    if(!good) ++failures;
+    std::cout << (good ? "  ok   " : "  FAIL ") << what;
+    if(!detail.empty()) std::cout << ": " << detail;
+    std::cout << "\n";
+}
+
+static bool exists(const std::string& p) {
+    std::ifstream f(p, std::ios::binary);
+
+    return bool(f);
+}
+
+/**
+ * Where the model might be.
+ *
+ * Not vendored -- it is over a gigabyte -- so this looks in the places it
+ * plausibly sits and reports SKIP when it is nowhere, which is how the other
+ * tests here treat a missing display or audio device.
+ */
+static std::string find_model(int argc, char** argv) {
+    if(argc > 1 && exists(argv[1])) return argv[1];
+
+    if(const char* env = std::getenv("JLIB_GGUF"))
+        if(exists(env)) return env;
+
+    const char* names[] = {
+        "tinyllama-1.1b-chat-v1.0.Q8_0.gguf",
+        "../tinyllama-1.1b-chat-v1.0.Q8_0.gguf",
+        "../../tinyllama-1.1b-chat-v1.0.Q8_0.gguf",
+        "../../../tinyllama-1.1b-chat-v1.0.Q8_0.gguf"
+    };
+
+    for(const char* n : names)
+        if(exists(n)) return n;
+
+    if(const char* s = std::getenv("srcdir")) {
+        const std::string p = std::string(s) + "/../tinyllama-1.1b-chat-v1.0.Q8_0.gguf";
+
+        if(exists(p)) return p;
+    }
+
+    return "";
+}
+
+static void the_header_and_metadata(const ai::gguf& g) {
+    std::cout << "\nthe header and metadata:\n";
+
+    ok("  version 3", g.version() == 3, std::to_string(g.version()));
+    ok("  201 tensors", g.tensors().size() == 201,
+       std::to_string(g.tensors().size()));
+    ok("  23 metadata keys", g.metadata().size() == 23,
+       std::to_string(g.metadata().size()));
+
+    // Pinned to the value, not derived from the parser.  The tensor data in
+    // this file begins at 1709440: the index ends at 1709436 and the alignment
+    // is 32, so four bytes of padding follow it.  Checking it against anything
+    // the parser computed would be checking it against itself -- and the first
+    // version of this test did exactly that further down, where a hand-decoded
+    // block was read at an offset taken from g.data_offset(), so dropping the
+    // padding moved both and agreed.
+    ok("  the alignment is 32", g.alignment() == 32,
+       std::to_string(g.alignment()));
+
+    ok("  and the tensor data begins at 1709440", g.data_offset() == 1709440,
+       std::to_string(g.data_offset()));
+
+    ok("  the architecture is llama", g.str("general.architecture") == "llama",
+       g.str("general.architecture"));
+
+    // Every one of these is read off the file rather than off a config.json,
+    // which is the point: this is the first thing in the library that checks
+    // itself against a document somebody else wrote.
+    struct { const char* key; std::int64_t want; } ints[] = {
+        { "llama.block_count",              22 },
+        { "llama.embedding_length",       2048 },
+        { "llama.feed_forward_length",    5632 },
+        { "llama.attention.head_count",     32 },
+        { "llama.attention.head_count_kv",   4 },
+        { "llama.rope.dimension_count",     64 },
+        { "llama.context_length",         2048 }
+    };
+
+    for(const auto& e : ints)
+        ok(std::string("  ") + e.key, g.integer(e.key) == e.want,
+           std::to_string(g.integer(e.key)));
+
+    ok("  rope frequency base is 10000",
+       std::fabs(g.real("llama.rope.freq_base") - 10000.0) < 1e-6,
+       std::to_string(g.real("llama.rope.freq_base")));
+
+    ok("  and the rms epsilon is 1e-5",
+       std::fabs(g.real("llama.attention.layer_norm_rms_epsilon") - 1e-5) < 1e-9,
+       std::to_string(g.real("llama.attention.layer_norm_rms_epsilon")));
+
+    // An integer read as a real is a widening; a string read as an integer is
+    // not, and is refused.
+    ok("  an integer widens when read as a real",
+       std::fabs(g.real("llama.block_count") - 22.0) < 1e-9);
+
+    bool threw = false;
+    try { g.integer("general.architecture"); }
+    catch(ai::gguf::exception&) { threw = true; }
+
+    ok("  while a string read as an integer is refused", threw);
+
+    threw = false;
+    try { g.str("no.such.key"); }
+    catch(ai::gguf::exception&) { threw = true; }
+
+    ok("  as is a key that is not there", threw);
+}
+
+static void the_tokenizer_arrays(const ai::gguf& g) {
+    std::cout << "\nthe tokenizer arrays:\n";
+
+    const ai::gguf::value& toks = g.get("tokenizer.ggml.tokens");
+
+    ok("  32000 tokens", toks.strings.size() == 32000,
+       std::to_string(toks.strings.size()));
+
+    ok("  beginning unk, bos, eos",
+       toks.strings.size() > 2 && toks.strings[0] == "<unk>" &&
+       toks.strings[1] == "<s>" && toks.strings[2] == "</s>");
+
+    // 61249 of them, each variable length.  This is the assertion that says
+    // the array walk did not seek past anything it could not seek past.
+    ok("  61249 merges", g.get("tokenizer.ggml.merges").strings.size() == 61249,
+       std::to_string(g.get("tokenizer.ggml.merges").strings.size()));
+
+    ok("  a score per token",
+       g.get("tokenizer.ggml.scores").numbers.size() == 32000,
+       std::to_string(g.get("tokenizer.ggml.scores").numbers.size()));
+
+    ok("  and a type per token",
+       g.get("tokenizer.ggml.token_type").numbers.size() == 32000,
+       std::to_string(g.get("tokenizer.ggml.token_type").numbers.size()));
+
+    ok("  bos is 1 and eos is 2",
+       g.integer("tokenizer.ggml.bos_token_id") == 1 &&
+       g.integer("tokenizer.ggml.eos_token_id") == 2);
+}
+
+/**
+ * The index has to agree with the metadata.
+ *
+ * Two independent parts of the same file, written by a tool that had no reason
+ * to make them agree unless they do.  This is cross-validation rather than
+ * self-consistency, which is what nothing on this path has had until now.
+ */
+static void the_index_agrees_with_the_metadata(const ai::gguf& g) {
+    std::cout << "\nthe index agrees with the metadata:\n";
+
+    const std::int64_t blocks = g.integer("llama.block_count");
+    const std::int64_t embd = g.integer("llama.embedding_length");
+    const std::int64_t ff = g.integer("llama.feed_forward_length");
+    const std::int64_t heads = g.integer("llama.attention.head_count");
+    const std::int64_t kv = g.integer("llama.attention.head_count_kv");
+
+    const char* per_block[] = {
+        "attn_norm.weight", "attn_q.weight", "attn_k.weight", "attn_v.weight",
+        "attn_output.weight", "ffn_norm.weight", "ffn_gate.weight",
+        "ffn_up.weight", "ffn_down.weight"
+    };
+
+    bool all_there = true;
+
+    for(std::int64_t b = 0; b < blocks; b++)
+        for(const char* n : per_block)
+            if(!g.has_tensor("blk." + std::to_string(b) + "." + n))
+                all_there = false;
+
+    ok("  every block has all nine of its tensors", all_there);
+
+    // 22 blocks of 9, plus the embedding, the final norm and the head.
+    ok("  which accounts for every tensor in the file",
+       g.tensors().size() == std::size_t(blocks * 9 + 3),
+       std::to_string(g.tensors().size()) + " vs " +
+       std::to_string(blocks * 9 + 3));
+
+    const ai::gguf::tensor_info& q = g.tensor("blk.0.attn_q.weight");
+    const ai::gguf::tensor_info& k = g.tensor("blk.0.attn_k.weight");
+
+    ok("  attn_q is embedding by embedding",
+       q.shape.size() == 2 && q.shape[0] == std::uint64_t(embd) &&
+       q.shape[1] == std::uint64_t(embd));
+
+    // The one that shows this model is grouped-query: k is narrower than q by
+    // exactly the ratio of key-value heads to attention heads.
+    ok("  attn_k is narrower by the head-count ratio",
+       k.shape.size() == 2 && k.shape[0] == std::uint64_t(embd) &&
+       k.shape[1] == std::uint64_t(embd * kv / heads),
+       std::to_string(k.shape[1]) + " vs " + std::to_string(embd * kv / heads));
+
+    const ai::gguf::tensor_info& gate = g.tensor("blk.0.ffn_gate.weight");
+
+    ok("  ffn_gate is embedding by feed-forward",
+       gate.shape.size() == 2 && gate.shape[0] == std::uint64_t(embd) &&
+       gate.shape[1] == std::uint64_t(ff));
+
+    // And the vocabulary appears twice, in two unrelated places.
+    const ai::gguf::tensor_info& out = g.tensor("output.weight");
+
+    ok("  the head is as wide as the token array is long",
+       out.shape.size() == 2 &&
+       out.shape[1] == g.get("tokenizer.ggml.tokens").strings.size(),
+       std::to_string(out.shape[1]));
+
+    ok("  the norms are unquantised and the matrices are not",
+       g.tensor("blk.0.attn_norm.weight").type == ai::gguf::tensor_type::f32 &&
+       q.type == ai::gguf::tensor_type::q8_0);
+}
+
+/** Dequantisation, checked against the bytes rather than against itself. */
+static void the_weights_come_back(const ai::gguf& g, const std::string& path) {
+    std::cout << "\nthe weights come back:\n";
+
+    const jlib::math::matrix<float> norm = g.read("blk.0.attn_norm.weight");
+
+    ok("  a norm weight is one column of embedding_length",
+       norm.M == 2048 && norm.N == 1,
+       std::to_string(norm.M) + "x" + std::to_string(norm.N));
+
+    bool finite = true;
+    double biggest = 0;
+
+    for(unsigned int r = 0; r < norm.M; r++) {
+        if(!std::isfinite(norm(r,0))) finite = false;
+
+        biggest = std::max(biggest, std::fabs(double(norm(r,0))));
+    }
+
+    ok("  every value of it is finite", finite);
+
+    // A range check, and specifically not a check that the mean is near one.
+    // That was the first version of this assertion and it failed: this file's
+    // blk.0.attn_norm.weight has mean 0.0058, running from -0.58 to 0.77, and
+    // an independent read of the raw bytes agrees.  RMS norm scales are simply
+    // not near one -- across this model they run from 0.006 at block 0 to 1.91
+    // at output_norm -- so "near one" was a folk belief about what weights look
+    // like rather than anything the format or the model promises.
+    //
+    // What is left is worth having anyway.  A float misread with its bytes in
+    // the wrong order lands in the exponent, so it comes back astronomical or
+    // denormal; requiring every value inside a sane band and at least one of
+    // them not vanishingly small is the canary for that, and for a stride
+    // mistake that reads into the middle of neighbouring values.
+    ok("  and they sit in a range floats read the wrong way round would not",
+       biggest > 0.1 && biggest < 100.0, std::to_string(biggest));
+
+    // The same canary where the scales are large, so the band is exercised
+    // from both ends rather than only near zero.
+    const jlib::math::matrix<float> tail = g.read("output_norm.weight");
+
+    double tail_mean = 0;
+
+    for(unsigned int r = 0; r < tail.M; r++) tail_mean += tail(r,0);
+
+    tail_mean /= double(tail.M);
+
+    ok("  while the final norm's scales are of order one", 
+       tail_mean > 0.5 && tail_mean < 5.0, std::to_string(tail_mean));
+
+    const ai::gguf::tensor_info& info = g.tensor("blk.0.attn_q.weight");
+    const jlib::math::matrix<float> q = g.read(info);
+
+    ok("  a q8_0 weight comes back at its stated shape",
+       q.M == info.shape[0] && q.N == info.shape[1],
+       std::to_string(q.M) + "x" + std::to_string(q.N));
+
+    // Independently: open the file again, seek past the header by the offset
+    // asserted above, and decode blocks by hand.  q8_0 is one fp16 scale then
+    // thirty-two signed bytes, so every value in a block is an integer multiple
+    // of one scale -- a structure a wrong stride cannot reproduce.
+    //
+    // Blocks 0, 1 and 1000, not block 0 alone.  Block 0 begins at the start of
+    // the tensor whatever the stride is believed to be, so checking only it
+    // says nothing about the block size: the first version of this test passed
+    // with the block declared 36 bytes wide.
+    std::ifstream raw(path, std::ios::binary);
+
+    const std::uint64_t DATA = 1709440;
+
+    double furthest = 0;
+    bool integral = true;
+
+    for(std::uint64_t b : { std::uint64_t(0), std::uint64_t(1), std::uint64_t(1000) }) {
+        raw.seekg(std::streamoff(DATA + info.offset + b * 34));
+
+        char block[34];
+
+        raw.read(block, 34);
+
+        _Float16 d;
+
+        std::memcpy(&d, block, sizeof(d));
+
+        const signed char* qs = reinterpret_cast<const signed char*>(block + 2);
+
+        for(int i = 0; i < 32; i++) {
+            const std::uint64_t at = b * 32 + i;
+
+            // Column-major, so the flat index walks down a column first.
+            const float got = q(static_cast<unsigned int>(at % q.M),
+                                static_cast<unsigned int>(at / q.M));
+
+            furthest = std::max(furthest, std::fabs(double(float(d) * float(qs[i]) - got)));
+
+            if(float(d) != 0.0f &&
+               std::fabs(double(got / float(d)) - std::round(double(got / float(d)))) > 1e-3)
+                integral = false;
+        }
+    }
+
+    ok("  matching blocks 0, 1 and 1000 decoded by hand from the file",
+       furthest == 0.0, std::to_string(furthest));
+
+    ok("  with every value an integer multiple of its block's scale", integral);
+
+    bool threw = false;
+    try { g.read("no.such.tensor"); }
+    catch(ai::gguf::exception&) { threw = true; }
+
+    ok("  and a tensor that is not there is refused", threw);
+}
+
+int main(int argc, char** argv) {
+    std::cout << std::unitbuf;
+
+    const std::string path = find_model(argc, argv);
+
+    if(path.empty()) {
+        std::cout << "ai_gguf_test: no model file; pass one as an argument or "
+                  << "set JLIB_GGUF.\n"
+                  << "  curl -LO https://huggingface.co/TheBloke/"
+                  << "TinyLlama-1.1B-Chat-v1.0-GGUF/resolve/main/"
+                  << "tinyllama-1.1b-chat-v1.0.Q8_0.gguf\n";
+
+        return 77;
+    }
+
+    std::cout << "ai_gguf_test: " << path << "\n";
+
+    try {
+        const ai::gguf g(path);
+
+        the_header_and_metadata(g);
+        the_tokenizer_arrays(g);
+        the_index_agrees_with_the_metadata(g);
+        the_weights_come_back(g, path);
+    }
+    catch(std::exception& e) {
+        std::cerr << "ai_gguf_test: " << e.what() << "\n";
+
+        return 1;
+    }
+
+    // What a green run does not establish.
+    //
+    // That the weights are *right*, only that they are the bytes the file
+    // holds, decoded the way the format says.  Nothing here runs the model, so
+    // a systematic error that preserved the block structure -- a transposed
+    // matrix, say -- would pass everything above.  That is settled by
+    // generating text and comparing it with llama.cpp, which needs the rest of
+    // the stack.
+    //
+    // Only one file, and only the types in it: f32 and q8_0.  f16 is
+    // implemented and untested, because this model has none.  Every k-quant is
+    // refused by name, which is a different thing from being handled.
+    //
+    // And nothing about big-endian, which the format permits and this reads
+    // wrongly by construction -- though the range check on the norm weights
+    // would notice, since a byte-swapped float lands in its exponent.
+    std::cout << "\n" << (failures ? "FAILED" : "PASSED") << ": " << failures
+              << " failure(s)\n";
+
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
# Reading a GGUF

Every branch on this path has ended at the same limit, and each `pr.txt` said
so: the code was **self-consistent, never compared against anyone else's
work**. This is the branch that changes what is possible, by reading a file
somebody else wrote.

`jlib::ai::gguf` parses TinyLlama-1.1B-Chat Q8_0 — 1.1 GB, 201 tensors, 23
metadata keys — and hands back its weights.

## Written against the file, not against memory

The format came from the spec, but the *contents* came from parsing the real
file in Python first and writing the C++ against what was actually there. Two
things that produced which memory would not have:

**The Q8_0 block size, derived rather than recalled.** `output.weight` spans
offset 0 to 69632000 for 2048×32000 elements — 2,048,000 blocks of 32, so
**34 bytes per block**, which is one fp16 scale plus 32 signed bytes. Confirmed
from the file before a line of the decoder was written.

**A string array cannot be skipped.** The Python probe read the first three of
`tokenizer.ggml.tokens` and seeked on, and every subsequent read was garbage —
strings are length-prefixed and variable, so the parser must walk all 32000 of
them, and all 61249 merges. That constraint is now a comment in the array reader
and an assertion in the test.

## The layout works out, and the part that doesn't is written down

GGUF gives dimensions fastest-varying first, so `dims[0]` is contiguous.
`math::matrix` is column-major, putting `(r,c)` at `c*rows + r` — **the same
arrangement** with `rows = dims[0]`. So a tensor loads with no transposition and
no shuffling, and `token_embd.weight` arrives as one column per token, which is
the orientation this library already wants.

The part that does not work out is stated in the header so nobody rediscovers
it: ggml's convention makes a weight `[n_in, n_out]`, so the product a layer
wants is `Wᵀx`. Use `multiply_tn` on a matrix loaded this way. Transposing at
load time would touch every byte of a gigabyte to save a flag.

## Cross-validation, which is the new thing

The tests check two independent parts of the same file against each other —
written by a tool with no reason to agree unless they do:

- every one of 22 blocks has all nine expected tensors, and 22×9+3 accounts for
  all 201
- `attn_q` is `[2048, 2048]` while `attn_k` is `[2048, 256]` — **narrower by
  exactly the ratio of KV heads to attention heads**, which is this model
  telling us it is grouped-query
- `output.weight`'s second dimension equals the length of the token array, the
  vocabulary appearing in two unrelated places
- the norms are `f32` and the matrices are `q8_0`

And Q8_0 decoding is checked against the bytes: the test opens the file again
and decodes blocks by hand, requiring every value to be an integer multiple of
its block's scale — a structure a wrong stride cannot fake.

## Two bugs in my own test, found by mutation

| mutation | first | after |
| --- | --- | --- |
| Q8_0 block declared 36 bytes | **0 failures** | 2 |
| skip the alignment padding | **0 failures** | 3 |
| block holds 16 values not 32 | — | 2 |
| do not walk a string array's tail | — | 3 |
| quants start at byte 1 not 2 | 1 | 1 |

**The block-size miss**: the hand-decode checked block *0*, which begins at the
start of the tensor whatever the stride is believed to be. It now checks blocks
0, 1 and 1000.

**The alignment miss is the worse one**: the "independent" read took its offset
from `g.data_offset()`, so dropping the padding moved the parser and the check
together and they agreed. It was not independent at all. The data offset is now
pinned to its value — 1709440, the index ending at 1709436 with 32-byte
alignment — asserted directly rather than derived from the thing under test.

## And one assertion of mine that was simply wrong

The first version checked that a norm weight's mean was "somewhere near one".
It failed at 0.0058, and an independent read of the raw bytes agreed with the
parser: `blk.0.attn_norm.weight` runs from −0.58 to 0.77 with mean 0.0058. RMS
norm scales are not near one — across this model they run from 0.006 at block 0
to 1.91 at `output_norm`. That was a folk belief about what weights look like,
not anything the format or the model promises.

What replaced it is a range check that earns its place: a float read with its
bytes reversed lands in the exponent and comes back astronomical or denormal, so
requiring the values inside a sane band, at both ends of the model, is a
byte-order and stride canary rather than a guess about training.

## Verification

- macOS `make check`: 70 tests (was 69), 66 pass, 4 skip, 0 fail —
  `ai_gguf_test` finds the model by relative path and passes.
- Container `make check`: the model is not in the image, so it reports SKIP.

`ai_gguf_test` takes a path as `argv[1]`, honours `JLIB_GGUF`, looks in the
obvious relative places, and exits **77** with the download command when it
finds nothing — the same way the tests needing a display or an audio device
report a headless machine. `*.gguf` is added to `.gitignore` and
`.dockerignore`.

## What this does not establish

**That the weights are right, only that they are the bytes the file holds,
decoded the way the format says.** Nothing here runs the model, so a systematic
error that preserved block structure — a transposed matrix — passes everything
above. That is settled by generating text and comparing with llama.cpp, which
needs the rest of the stack.

**One file, and only the types in it**: f32 and q8_0. f16 is implemented and
**untested**, because this model has none. Every k-quant is refused by name,
which is a different thing from being handled — Q4_K would roughly halve the
download and is a superblock format, a branch of its own.

**Nothing about big-endian**, which the format permits and this reads wrongly by
construction — though the range check above would notice.

## What this makes possible next

The file states its own architecture, and it does not match what jlib built:
**32 attention heads sharing 4 key-value heads**. `ai::block` makes a `wk`/`wv`
per query head, so it cannot load this model as it stands. GQA is now the
blocking item, and it has an exact regression property — with `kv_heads ==
heads` it must reproduce today's output bit-for-bit.
