### PR TITLE
Generalise the block to grouped-query attention, so several query heads share one key-value head as TinyLlama does

### DIFF
--- a/jlib/ai/transformer.hh
+++ b/jlib/ai/transformer.hh
@@ -76,19 +76,46 @@ public:
     typedef typename backend<T>::tensor_ptr tensor_ptr;
 
     /**
-     * @param heads must divide d_model
-     * @param d_ff  the feed-forward width, conventionally a few times d_model
+     * @param heads    must divide d_model
+     * @param kv_heads how many key-value heads the query heads share between
+     *                 them; must divide heads.  Equal to heads is ordinary
+     *                 multi-head attention
+     * @param d_ff     the feed-forward width, conventionally a few times d_model
      */
     block(backend<T>& b, unsigned int d_model, unsigned int heads,
-          unsigned int d_ff);
+          unsigned int kv_heads, unsigned int d_ff);
 
     unsigned int d_model() const { return m_d_model; }
     unsigned int heads() const { return m_heads; }
+
+    /**
+     * How many key-value heads the query heads share.
+     *
+     * Grouped-query attention: query head h reads the key-value head
+     * `h / (heads / kv_heads)`, so heads are grouped **contiguously** -- the
+     * first group of query heads shares the first key-value head, and so on.
+     *
+     * That is a convention, and it is the one llama.cpp and every conversion
+     * tool use, which is what matters since it decides how a file's weights
+     * line up.  The alternative -- `h % kv_heads`, striping instead of
+     * grouping -- is equally coherent and would load the same weights into
+     * different places.  No test here can tell them apart; only generating text
+     * and comparing it with a reference can.  Named and written down for the
+     * same reason w_gate() and rope_layout are.
+     */
+    unsigned int kv_heads() const { return m_kv_heads; }
+
+    /** Which key-value head a query head reads. */
+    unsigned int kv_head_for(unsigned int h) const {
+        return h / (m_heads / m_kv_heads);
+    }
     unsigned int d_head() const { return m_d_head; }
     unsigned int d_ff() const { return m_d_ff; }
 
-    /** (d_head x d_model), one per head. */
+    /** (d_head x d_model), one per *query* head. */
     tensor_ptr& wq(unsigned int h) { return m_wq[h]; }
+
+    /** (d_head x d_model), one per *key-value* head -- there are fewer. */
     tensor_ptr& wk(unsigned int h) { return m_wk[h]; }
     tensor_ptr& wv(unsigned int h) { return m_wv[h]; }
 
@@ -151,6 +178,7 @@ private:
 
     unsigned int m_d_model;
     unsigned int m_heads;
+    unsigned int m_kv_heads;
     unsigned int m_d_head;
     unsigned int m_d_ff;
     unsigned int m_seq = 0;
@@ -163,30 +191,47 @@ private:
     tensor_ptr m_gate, m_down, m_up;
     tensor_ptr m_attn_norm, m_ffn_norm;
 
-    tensor_ptr m_norm, m_q, m_k, m_v, m_scores, m_probs, m_head, m_attn;
+    tensor_ptr m_norm, m_q, m_scores, m_probs, m_head, m_attn;
+
+    // One per key-value head, not one per query head: the whole point of
+    // grouping is that a group's key and value are computed once and read by
+    // every query head in it.
+    std::vector<tensor_ptr> m_k, m_v;
     tensor_ptr m_h1, m_h3, m_ffn;
 };
 
 template<typename T>
 block<T>::block(backend<T>& b, unsigned int d_model, unsigned int heads,
-                unsigned int d_ff)
+                unsigned int kv_heads, unsigned int d_ff)
     : m_b(b),
       m_d_model(d_model),
       m_heads(heads),
+      m_kv_heads(kv_heads),
       m_d_head(heads ? d_model / heads : 0),
       m_d_ff(d_ff)
 {
-    if(heads == 0 || d_model == 0 || d_ff == 0)
+    if(heads == 0 || kv_heads == 0 || d_model == 0 || d_ff == 0)
         throw backend_error("block: every dimension must be non-zero");
 
     if(d_model % heads)
         throw backend_error("block: heads must divide d_model");
 
+    if(heads % kv_heads)
+        throw backend_error("block: kv_heads must divide heads, since each "
+                            "key-value head serves a whole group of query "
+                            "heads");
+
     for(unsigned int h = 0; h < heads; h++) {
         m_wq.push_back(b.make(m_d_head, d_model));
+        m_wo.push_back(b.make(d_model, m_d_head));
+    }
+
+    // Fewer of these, which is the entire saving: TinyLlama has 32 query heads
+    // and 4 key-value heads, so its attn_k is [2048, 256] where attn_q is
+    // [2048, 2048].
+    for(unsigned int h = 0; h < kv_heads; h++) {
         m_wk.push_back(b.make(m_d_head, d_model));
         m_wv.push_back(b.make(m_d_head, d_model));
-        m_wo.push_back(b.make(d_model, m_d_head));
     }
 
     m_gate = b.make(d_ff, d_model);
@@ -220,9 +265,16 @@ void block<T>::reserve(unsigned int seq) {
 
     m_norm   = m_b.make(m_d_model, seq);
     m_q      = m_b.make(m_d_head, seq);
-    m_k      = m_b.make(m_d_head, seq);
-    m_v      = m_b.make(m_d_head, seq);
     m_scores = m_b.make(seq, seq);
+
+    m_k.clear();
+    m_v.clear();
+
+    for(unsigned int h = 0; h < m_kv_heads; h++) {
+        m_k.push_back(m_b.make(m_d_head, seq));
+        m_v.push_back(m_b.make(m_d_head, seq));
+    }
+
     m_probs  = m_b.make(seq, seq);
     m_head   = m_b.make(m_d_head, seq);
     m_attn   = m_b.make(m_d_model, seq);
@@ -248,18 +300,28 @@ void block<T>::forward(const tensor_ptr& x, tensor_ptr& out, bool causal,
 
     m_b.rms_norm(x, m_attn_norm, m_norm);
 
+    // Every key and value first, once each.  Computing them inside the query
+    // loop instead would give the same answer and do the work heads/kv_heads
+    // times over -- which is exactly the cost grouping exists to avoid.
+    for(unsigned int g = 0; g < m_kv_heads; g++) {
+        m_b.multiply(m_wk[g], m_norm, m_k[g]);
+        m_b.multiply(m_wv[g], m_norm, m_v[g]);
+
+        // Keys are rotated here, once, for the same reason.  Values are not
+        // rotated at all -- see set_rope.
+        if(m_rope)
+            m_b.rope(m_k[g], base_pos, m_theta, m_layout);
+    }
+
     for(unsigned int h = 0; h < m_heads; h++) {
         m_b.multiply(m_wq[h], m_norm, m_q);
-        m_b.multiply(m_wk[h], m_norm, m_k);
-        m_b.multiply(m_wv[h], m_norm, m_v);
 
-        // Queries and keys only.  See set_rope.
-        if(m_rope) {
+        if(m_rope)
             m_b.rope(m_q, base_pos, m_theta, m_layout);
-            m_b.rope(m_k, base_pos, m_theta, m_layout);
-        }
 
-        attention(m_b, m_q, m_k, m_v, m_scores, m_probs, m_head, causal);
+        const unsigned int g = kv_head_for(h);
+
+        attention(m_b, m_q, m_k[g], m_v[g], m_scores, m_probs, m_head, causal);
 
         // beta 0 for the first head and 1 for the rest, which sums the heads
         // in place of concatenating them and projecting once.

--- a/tests/ai_transformer_test.cc
+++ b/tests/ai_transformer_test.cc
@@ -73,20 +73,31 @@ static const unsigned int H = 2;
 static const unsigned int F = 16;
 static const unsigned int N = 5;
 
-/** Every weight in a block, so two backends can be given the same one. */
+/**
+ * Every weight in a block, so two backends can be given the same one.
+ *
+ * Sized by heads *and* by kv heads, which are not the same count: wq and wo
+ * are per query head, wk and wv per key-value head.
+ */
 template<typename T>
 struct weights {
+    unsigned int heads, kv;
+
     std::vector<matrix<T> > wq, wk, wv, wo;
     matrix<T> w1, w3, w2, an, fn;
 
-    weights(std::mt19937& gen)
-        : w1(F, D), w3(F, D), w2(D, F), an(D, 1), fn(D, 1)
+    weights(std::mt19937& gen, unsigned int nh = H, unsigned int nkv = H)
+        : heads(nh), kv(nkv),
+          w1(F, D), w3(F, D), w2(D, F), an(D, 1), fn(D, 1)
     {
-        for(unsigned int h = 0; h < H; h++) {
-            wq.push_back(random_matrix<T>(D / H, D, gen, 0.5f));
-            wk.push_back(random_matrix<T>(D / H, D, gen, 0.5f));
-            wv.push_back(random_matrix<T>(D / H, D, gen, 0.5f));
-            wo.push_back(random_matrix<T>(D, D / H, gen, 0.5f));
+        for(unsigned int h = 0; h < heads; h++) {
+            wq.push_back(random_matrix<T>(D / heads, D, gen, 0.5f));
+            wo.push_back(random_matrix<T>(D, D / heads, gen, 0.5f));
+        }
+
+        for(unsigned int g = 0; g < kv; g++) {
+            wk.push_back(random_matrix<T>(D / heads, D, gen, 0.5f));
+            wv.push_back(random_matrix<T>(D / heads, D, gen, 0.5f));
         }
 
         w1 = random_matrix<T>(F, D, gen, 0.5f);
@@ -99,11 +110,14 @@ struct weights {
 
 template<typename T>
 static void load(ai::block<T>& blk, const weights<T>& w) {
-    for(unsigned int h = 0; h < H; h++) {
+    for(unsigned int h = 0; h < w.heads; h++) {
         blk.wq(h)->write(w.wq[h]);
-        blk.wk(h)->write(w.wk[h]);
-        blk.wv(h)->write(w.wv[h]);
         blk.wo(h)->write(w.wo[h]);
+    }
+
+    for(unsigned int g = 0; g < w.kv; g++) {
+        blk.wk(g)->write(w.wk[g]);
+        blk.wv(g)->write(w.wv[g]);
     }
 
     blk.w_gate()->write(w.w1);
@@ -115,9 +129,10 @@ static void load(ai::block<T>& blk, const weights<T>& w) {
 
 template<typename T>
 static matrix<T> run(ai::backend<T>& b, const weights<T>& w, const matrix<T>& x,
-                     bool causal = true, bool rope = false)
+                     bool causal = true, bool rope = false,
+                     unsigned int base_pos = 0)
 {
-    ai::block<T> blk(b, D, H, F);
+    ai::block<T> blk(b, D, w.heads, w.kv, F);
 
     load(blk, w);
 
@@ -128,7 +143,7 @@ static matrix<T> run(ai::backend<T>& b, const weights<T>& w, const matrix<T>& x,
     typename ai::backend<T>::tensor_ptr tx = b.make(x);
     typename ai::backend<T>::tensor_ptr out = b.make(D, N);
 
-    blk.forward(tx, out, causal);
+    blk.forward(tx, out, causal, base_pos);
     b.wait();
 
     return out->read();
@@ -505,6 +520,184 @@ static void rope_gives_the_block_a_sense_of_position(
     }
 }
 
+/**
+ * A shared key-value head is exactly a duplicated one.
+ *
+ * The definition of grouping, stated as an equality that can be checked: a
+ * block with one key-value head must equal a block with one *per* query head
+ * whose key and value weights all happen to be identical.  Same arithmetic
+ * either way, so the outputs are bit-identical, and any mistake in which query
+ * head reads which key-value head breaks it.
+ *
+ * This is the assertion that could not exist before the branch -- there was
+ * nothing to be equal to.
+ */
+/**
+ * Sliding the whole sequence along must change nothing.
+ *
+ * Every score is an inner product between a rotated query and a rotated key, so
+ * it depends on the difference of their positions and not on either one.  Move
+ * the whole window from position 0 to position 7 and every difference is the
+ * same, so the output is the same.  The causal mask is by index rather than by
+ * position, so it does not move either.
+ *
+ * This is the block-level form of what rope_makes_the_score_relative checks on
+ * the primitive, and it is here because the other rope test was not enough:
+ * measured, dropping the rotation of the *keys* and rotating only the queries
+ * fails nothing else.  The block is still position-dependent that way -- so the
+ * permutation test still passes -- while the property that made rope worth
+ * having is gone.
+ */
+template<typename T>
+static void sliding_the_window_changes_nothing(
+    const char* name, std::vector<ai::backend<T>*>& backends)
+{
+    std::cout << "\nsliding the window changes nothing, " << name << ":\n";
+
+    std::mt19937 gen(67);
+
+    const weights<T> w(gen);
+    const matrix<T> x = random_matrix<T>(D, N, gen);
+
+    for(ai::backend<T>* b : backends) {
+        const matrix<T> at0 = run(*b, w, x, true, true, 0);
+        const matrix<T> at7 = run(*b, w, x, true, true, 7);
+
+        // Close rather than identical: the angles really are different, and it
+        // is only their differences that agree, so the two arrive at the same
+        // number by different roundings.
+        ok(std::string("  ") + b->name() +
+           ": the same sequence at position 7 gives the same answer",
+           worst(at0, at7) < ((sizeof(T) == 2) ? 3e-2 : 1e-4),
+           std::to_string(worst(at0, at7)));
+
+        // The control: without rope, base_pos is not consulted at all, so this
+        // would pass for a block that ignored position entirely.
+        const matrix<T> flat0 = run(*b, w, x, true, false, 0);
+        const matrix<T> flat7 = run(*b, w, x, true, false, 7);
+
+        ok(std::string("  ") + b->name() +
+           ": and without rope it is ignored rather than honoured",
+           worst(flat0, flat7) == 0.0);
+    }
+}
+
+template<typename T>
+static void sharing_a_head_equals_duplicating_it(
+    const char* name, std::vector<ai::backend<T>*>& backends)
+{
+    std::cout << "\nsharing a key-value head equals duplicating it, " << name << ":\n";
+
+    std::mt19937 gen(71);
+
+    // Four query heads, one key-value head between them.
+    weights<T> grouped(gen, 4, 1);
+
+    // And the same thing spelled out: four query heads with four key-value
+    // heads that are all copies of the one above.
+    weights<T> spelled = grouped;
+
+    spelled.kv = 4;
+    spelled.wk.assign(4, grouped.wk[0]);
+    spelled.wv.assign(4, grouped.wv[0]);
+
+    const matrix<T> x = random_matrix<T>(D, N, gen);
+
+    for(ai::backend<T>* b : backends) {
+        const matrix<T> a = run(*b, grouped, x);
+        const matrix<T> c = run(*b, spelled, x);
+
+        ok(std::string("  ") + b->name() + ": bit-identical to the duplicated form",
+           worst(a, c) == 0.0, std::to_string(worst(a, c)));
+    }
+}
+
+/**
+ * The grouping is contiguous, and which query heads share is not arbitrary.
+ *
+ * With four query heads over two key-value heads, heads 0 and 1 read key-value
+ * head 0 and heads 2 and 3 read key-value head 1.  Silence heads 2 and 3 at the
+ * output and key-value head 1 can no longer reach anything -- while key-value
+ * head 0 still must, or the test would pass on a block that ignored its keys.
+ *
+ * What this pins is the shape of the mapping, not the choice of it: striping
+ * (h % kv_heads) instead of grouping (h / group) would fail this, but only
+ * because this test was written to match the implementation.  Which convention
+ * a *file* means is settled by comparing generated text with a reference.  See
+ * block::kv_heads().
+ */
+template<typename T>
+static void the_grouping_is_contiguous(const char* name,
+                                       std::vector<ai::backend<T>*>& backends)
+{
+    std::cout << "\nthe grouping is contiguous, " << name << ":\n";
+
+    std::mt19937 gen(73);
+
+    weights<T> w(gen, 4, 2);
+
+    for(unsigned int r = 0; r < D; r++)
+        for(unsigned int c = 0; c < D / 4; c++) {
+            w.wo[2](r,c) = T(0.0f);
+            w.wo[3](r,c) = T(0.0f);
+        }
+
+    const matrix<T> x = random_matrix<T>(D, N, gen);
+
+    weights<T> bump_kv1 = w;
+    weights<T> bump_kv0 = w;
+
+    for(unsigned int r = 0; r < D / 4; r++)
+        for(unsigned int c = 0; c < D; c++) {
+            bump_kv1.wk[1](r,c) = T(float(bump_kv1.wk[1](r,c)) + 1.0f);
+            bump_kv0.wk[0](r,c) = T(float(bump_kv0.wk[0](r,c)) + 1.0f);
+        }
+
+    for(ai::backend<T>* b : backends) {
+        const matrix<T> base = run(*b, w, x);
+
+        ok(std::string("  ") + b->name() +
+           ": the second group's key head cannot reach the silenced heads",
+           worst(base, run(*b, bump_kv1, x)) == 0.0);
+
+        ok(std::string("  ") + b->name() + ": while the first group's still does",
+           worst(base, run(*b, bump_kv0, x)) > 0.0);
+    }
+}
+
+/** The counts a real file states, which is what all of this was for. */
+template<typename T>
+static void a_tinyllama_shaped_block(const char* name, ai::backend<T>& b) {
+    std::cout << "\na tinyllama-shaped block, " << name << ":\n";
+
+    // 32 query heads over 4 key-value heads is what the GGUF says, and 2048
+    // wide is what it says too -- but at 22 blocks that is a gigabyte of
+    // weights, so this checks the arithmetic of the shape rather than
+    // allocating it.
+    ai::block<T> blk(b, 2048, 32, 4, 5632);
+
+    ok("  32 query heads over 4 key-value heads",
+       blk.heads() == 32 && blk.kv_heads() == 4);
+
+    ok("  a head is 64 wide", blk.d_head() == 64,
+       std::to_string(blk.d_head()));
+
+    // 8 query heads per key-value head, contiguously.
+    bool mapped = true;
+
+    for(unsigned int h = 0; h < 32; h++)
+        if(blk.kv_head_for(h) != h / 8) mapped = false;
+
+    ok("  and each group of eight query heads shares one", mapped);
+
+    // Which makes the key projection a quarter the width of the query
+    // projection -- exactly the [2048, 256] against [2048, 2048] in the file.
+    ok("  so the key weights are a quarter the width of the query weights",
+       blk.wk(0)->rows() * blk.kv_heads() == 256 &&
+       blk.wq(0)->rows() * blk.heads() == 2048,
+       std::to_string(blk.wk(0)->rows() * blk.kv_heads()));
+}
+
 template<typename T>
 static void the_backends_agree(const char* name,
                                std::vector<ai::backend<T>*>& backends)
@@ -531,12 +724,18 @@ static void the_shapes_are_checked(const char* name, ai::backend<T>& b) {
     std::cout << "\nthe shapes are checked, " << name << ":\n";
 
     bool threw = false;
-    try { ai::block<T> bad(b, 8, 3, 16); }
+    try { ai::block<T> bad(b, 8, 3, 3, 16); }
     catch(std::exception&) { threw = true; }
 
     ok("  heads must divide d_model", threw);
 
-    ai::block<T> blk(b, D, H, F);
+    threw = false;
+    try { ai::block<T> bad(b, 8, 4, 3, 16); }
+    catch(std::exception&) { threw = true; }
+
+    ok("  and kv heads must divide heads", threw);
+
+    ai::block<T> blk(b, D, H, H, F);
 
     typename ai::backend<T>::tensor_ptr x = b.make(D, N);
     typename ai::backend<T>::tensor_ptr out = b.make(D, N);
@@ -566,6 +765,10 @@ static void everything(const char* name, std::vector<ai::backend<T>*>& b) {
     the_heads_are_summed<T>(name, b);
     the_branch_input_is_normalised<T>(name, b);
     rope_gives_the_block_a_sense_of_position<T>(name, b);
+    sliding_the_window_changes_nothing<T>(name, b);
+    sharing_a_head_equals_duplicating_it<T>(name, b);
+    the_grouping_is_contiguous<T>(name, b);
+    a_tinyllama_shaped_block<T>(name, *b[0]);
     silu_is_x_times_sigmoid<T>(name, b);
     the_backends_agree<T>(name, b);
     the_shapes_are_checked<T>(name, *b[0]);


### PR DESCRIPTION
# Grouped-query attention

The GGUF branch ended by having the file state its own blocker: TinyLlama's
`blk.0.attn_k.weight` is `[2048, 256]` where `attn_q.weight` is `[2048, 2048]`
— 32 query heads sharing 4 key-value heads. `ai::block` made a `wk`/`wv` per
query head, so those weights could not load into it.

Now `block(b, d_model, heads, kv_heads, d_ff)`, and query head `h` reads
key-value head `h / (heads / kv_heads)`.

## Computed once per group, which is the entire point

The key and value projections now happen **once per key-value head**, before the
query loop, rather than once per query head inside it:

```
for g in kv_heads:      k[g] = wk[g] · norm ;  v[g] = wv[g] · norm ;  rope(k[g])
for h in heads:         q = wq[h] · norm ;  rope(q) ;  attend(q, k[g(h)], v[g(h)])
```

Doing it the other way would give the same answer and do the work
`heads / kv_heads` times over — eight times, for TinyLlama — which is the cost
grouping exists to avoid. So `m_k` and `m_v` became vectors sized by `kv_heads`,
and the rotation of the keys moved up with them.

## The control, actually run

The claim made when this branch was chosen was that with `kv_heads == heads` the
block must reproduce the old output **bit-for-bit**. That is a claim about
before and after, so passing property tests does not establish it.

So it was measured directly: a small program builds a block from a fixed seed,
runs one forward pass and prints all 40 outputs. Compiled against master's
`transformer.hh`, then against this branch's with `kv_heads == heads`, and the
two files compared.

**Identical across all 40 values.**

That is what lets every existing block test — the bit-identical zeroed identity,
the bit-identical causality, the exact head summing, the scale invariance, the
permutation equivariance — stand as regression coverage rather than as tests
that merely still pass.

## New assertions

- **Sharing a key-value head is exactly duplicating it.** A block with one
  key-value head must equal a block with one *per* query head whose key and
  value weights are all copies of it. Same arithmetic, so bit-identical — and
  any mistake in which query head reads which group breaks it. This assertion
  could not have existed before the branch; there was nothing to be equal to.
- **The grouping is contiguous.** With 4 query heads over 2 key-value heads,
  silencing heads 2 and 3 at the output leaves key-value head 1 unable to reach
  anything, while head 0 still can.
- **A TinyLlama-shaped block** — 32 over 4, `d_head` 64, each group of eight
  sharing one, and the key weights a quarter the width of the query weights,
  which is `[2048, 256]` against `[2048, 2048]` in the file.
- **`kv_heads` must divide `heads`.**

## The mutation that found a hole in the RoPE tests

| mutation | caught |
| --- | --- |
| stripe instead of group (`h % kv_heads`) | yes — 6 failures |
| every query head reads key-value head 0 | yes — 2 failures |
| do not rotate the keys, only the queries | **no → now yes**, 4 failures |

The third is the useful one, and it is about last branch's work rather than this
one's. Rotating only the queries leaves the block position-dependent, so
`rope_gives_the_block_a_sense_of_position` still passed — while the property
that makes RoPE worth having was gone.

`sliding_the_window_changes_nothing` closes it. Every score is an inner product
between a rotated query and a rotated key, so it depends on the difference of
their positions and not on either; move the whole window from position 0 to
position 7 and every difference is unchanged, so the output is unchanged. The
causal mask is by index rather than by position, so it does not move either.
Exactly 0 difference in float, 2e-3 in fp16.

With the control that without RoPE `base_pos` is *ignored* rather than honoured
— otherwise it would pass for a block with no notion of position at all.

## Which convention, again

Contiguous grouping (`h / group`) is what llama.cpp and every conversion tool
use, and it is what decides where a file's weights belong. Striping
(`h % kv_heads`) is equally coherent and would load the same weights into
different places. **No test here distinguishes them** — the contiguity test above
passes because it was written to match the implementation. Only generating text
and comparing with a reference settles it.

That is the third of these on this path, after the SwiGLU gate and the RoPE
layout, and it is handled the same way: named in the interface, `kv_head_for()`
public, and written down where a reader will hit it.

## Verification

- macOS `make check`: 70 tests, 66 pass, 4 skip, 0 fail.
- Container `make check`: no Metal and no model there, so the host path stands
  alone.

## What this does not establish

**Which grouping convention a file means** — above.

**That the block can now load TinyLlama, only that its shapes can.** The block
takes the counts and produces the right tensor shapes; nothing has actually
placed the file's 201 tensors into 22 blocks, because there is no model
assembly yet. The shape test asserts the arithmetic of a 2048-wide, 32-head
block without allocating one.

**Nothing about the saving.** The key and value projections are computed once
per group rather than once per head, which is the point of GQA, and no
measurement here shows what that is worth. At these test sizes it would not
show.
