### PR TITLE
Assemble the model and run TinyLlama: embed, 22 blocks, norm, head -- and it answers with Rome, not noise

### DIFF
--- a/jlib/ai/Makefile.am
+++ b/jlib/ai/Makefile.am
@@ -10,4 +10,4 @@ libjai_la_LIBADD = $(top_builddir)/jlib/util/libjutil.la \
 libjaiincludedir = $(includedir)/jlib-1.2/jlib/ai
 libjaiinclude_HEADERS = environment.hh agent.hh percept.hh action.hh vacuum.hh \
                         neural.hh backend.hh attention.hh transformer.hh \
-                        gguf.hh
+                        gguf.hh model.hh

--- a/jlib/ai/backend.hh
+++ b/jlib/ai/backend.hh
@@ -23,6 +23,7 @@
 #include <jlib/math/matrix.hh>
 
 #include <cmath>
+#include <vector>
 #include <memory>
 #include <limits>
 #include <sstream>
@@ -229,6 +230,24 @@ public:
     virtual void causal_mask(tensor_ptr& s) = 0;
 
     /**
+     * Pick columns out of a table: out[:,i] = table[:,ids[i]].
+     *
+     * The embedding lookup.  A token is an index into a table of vectors, and
+     * a column is a sample here, so a token's vector is a column and this is a
+     * column gather.  GGUF stores token_embd.weight as [d_model, vocab], which
+     * lands as exactly that table with no rearrangement.
+     *
+     * ids are host-side ints rather than a tensor because they are indices,
+     * not arithmetic: routing them through T would lose them.  fp16 represents
+     * integers exactly only to 2048, and vocabularies are far larger than
+     * that, so a token id in a half is a silently wrong token.
+     *
+     * @throws backend_error if any id is outside the table
+     */
+    virtual void gather(const tensor_ptr& table, const std::vector<int>& ids,
+                        tensor_ptr& out) = 0;
+
+    /**
      * Rotary position embedding, in place.
      *
      * Rotates each column by an angle that grows with its position, in
@@ -304,6 +323,8 @@ public:
     void assign(const tensor_ptr& src, tensor_ptr& dst);
     void softmax(const tensor_ptr& in, tensor_ptr& out);
     void causal_mask(tensor_ptr& s);
+    void gather(const tensor_ptr& table, const std::vector<int>& ids,
+                tensor_ptr& out);
     void rope(tensor_ptr& x, unsigned int base_pos = 0, float theta = 10000.0f,
               rope_layout layout = rope_layout::interleaved);
     void rms_norm(const tensor_ptr& in, const tensor_ptr& weight,
@@ -574,6 +595,32 @@ void host_backend<T>::causal_mask(tensor_ptr& s) {
     for(uint c = 0; c < x.N; c++)
         for(uint r = c + 1; r < x.M; r++)
             x(r,c) = neg_inf;
+}
+
+template<typename T>
+void host_backend<T>::gather(const tensor_ptr& table, const std::vector<int>& ids,
+                             tensor_ptr& out)
+{
+    const math::matrix<T>& t = at(table);
+    math::matrix<T>& o = at(out);
+
+    if(o.M != t.M || o.N != ids.size())
+        throw backend_error("gather: out must be the table's height by the "
+                            "number of ids");
+
+    for(std::size_t i = 0; i < ids.size(); i++) {
+        if(ids[i] < 0 || std::size_t(ids[i]) >= t.N) {
+            std::ostringstream e;
+
+            e << "gather: token id " << ids[i] << " is outside a table of "
+              << t.N;
+
+            throw backend_error(e.str());
+        }
+
+        for(uint r = 0; r < t.M; r++)
+            o(r, uint(i)) = t(r, uint(ids[i]));
+    }
 }
 
 template<typename T>

--- a/jlib/ai/model.hh
+++ b/jlib/ai/model.hh
@@ -1,0 +1,388 @@
+/* -*- mode: C++ c-basic-offset: 4  -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+#ifndef JLIB_AI_MODEL_HH
+#define JLIB_AI_MODEL_HH
+
+#include <jlib/ai/gguf.hh>
+#include <jlib/ai/transformer.hh>
+
+#include <memory>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace jlib {
+namespace ai {
+
+/**
+ * A Llama-architecture language model: embed, a stack of blocks, norm, project.
+ *
+ *   x = embedding[:, ids]
+ *   x = block_i(x)                 for each of layers
+ *   x = rms_norm(x, final_norm)
+ *   logits = head^T x              (vocab x positions)
+ *
+ * Nothing here is new arithmetic -- every step is a primitive or a block. What
+ * is new is that the weights come from a file somebody else wrote, which is
+ * what makes this the first thing in the library that can be *wrong* in a way
+ * the tests could not have told it was.
+ */
+template<typename T>
+class model {
+public:
+    typedef typename backend<T>::tensor_ptr tensor_ptr;
+
+    /** What a file says about its own shape. */
+    struct config {
+        unsigned int d_model = 0;
+        unsigned int heads = 0;
+        unsigned int kv_heads = 0;
+        unsigned int d_ff = 0;
+        unsigned int layers = 0;
+        unsigned int vocab = 0;
+        unsigned int context = 0;
+
+        float rope_theta = 10000.0f;
+        float rms_eps = 1e-5f;
+
+        rope_layout layout = rope_layout::interleaved;
+
+        /**
+         * Read the llama.* keys.
+         *
+         * head_count_kv is optional in the format and absent on models from
+         * before grouped-query attention existed; absent means every query
+         * head has its own, which is what head_count says.
+         */
+        static config from(const gguf& g);
+    };
+
+    model(backend<T>& b, const config& c);
+
+    const config& conf() const { return m_conf; }
+
+    block<T>& layer(unsigned int i) { return *m_layers[i]; }
+
+    /** (d_model x vocab): one column per token, which is how gather wants it. */
+    tensor_ptr& embedding() { return m_embed; }
+
+    /** (d_model x 1). */
+    tensor_ptr& final_norm() { return m_final_norm; }
+
+    /** (d_model x vocab), read through multiply_tn -- see the note on load(). */
+    tensor_ptr& head() { return m_head; }
+
+    /**
+     * Place every weight in the file.
+     *
+     * ### Orientation, which is where the work is
+     *
+     * gguf.hh explains that a GGUF weight arrives as `[n_in, n_out]` and that
+     * the product a layer wants is therefore `W^T x`. Two of the tensors are
+     * used exactly that way and need no rearrangement at all: the embedding is
+     * a table of columns, and the head is multiplied with multiply_tn.
+     *
+     * The block's weights are the other case. It holds `wq(h)` as
+     * (d_head x d_model) and multiplies straight, so each head's slice has to
+     * be transposed as it is placed -- and the slice differs by role:
+     *
+     *   attn_q, attn_k, attn_v   a *column* range, transposed
+     *   attn_output              a *row* range, transposed
+     *   ffn_gate, ffn_up, down   the whole matrix, transposed
+     *
+     * The alternative is to store the block's weights in the file's
+     * orientation and reach for multiply_tn there too, which would make this
+     * function a memcpy. That is very likely the better design and it is not
+     * this branch's to make: it changes block's public shapes and every test
+     * that fills them. Written down here so the choice is visible rather than
+     * inherited.
+     *
+     * @throws gguf::exception or backend_error if a tensor is missing or the
+     *         wrong shape for what the config said
+     */
+    void load(const gguf& g);
+
+    /** Size every intermediate for a sequence of this length. */
+    void reserve(unsigned int seq);
+
+    /**
+     * ids -> logits, which come back (vocab x positions).
+     *
+     * One column of logits per input position, not just for the last one. A
+     * generator wants only the last; a perplexity measurement wants them all,
+     * and dropping the rest here would be deciding that for both.
+     */
+    void forward(const std::vector<int>& ids, tensor_ptr& logits,
+                 unsigned int base_pos = 0);
+
+private:
+    /** Columns [c0, c0+n) of W, transposed: result(a,b) = W(b, c0+a). */
+    static math::matrix<T> col_slice_t(const math::matrix<float>& w,
+                                       unsigned int c0, unsigned int n);
+
+    /** Rows [r0, r0+n) of W, transposed: result(a,b) = W(r0+b, a). */
+    static math::matrix<T> row_slice_t(const math::matrix<float>& w,
+                                       unsigned int r0, unsigned int n);
+
+    /** Straight across, narrowing to T. */
+    static math::matrix<T> narrowed(const math::matrix<float>& w);
+
+    void expect(const gguf& g, const std::string& name,
+                unsigned int d0, unsigned int d1) const;
+
+    backend<T>& m_b;
+    config m_conf;
+
+    std::vector<std::shared_ptr<block<T> > > m_layers;
+
+    tensor_ptr m_embed, m_final_norm, m_head;
+    tensor_ptr m_x, m_y;
+
+    unsigned int m_seq = 0;
+};
+
+template<typename T>
+typename model<T>::config model<T>::config::from(const gguf& g) {
+    config c;
+
+    const std::string arch = g.str("general.architecture");
+
+    if(arch != "llama")
+        throw backend_error("model: this reads llama-architecture files, and "
+                            "that one says '" + arch + "'");
+
+    c.d_model = static_cast<unsigned int>(g.integer("llama.embedding_length"));
+    c.heads   = static_cast<unsigned int>(g.integer("llama.attention.head_count"));
+    c.d_ff    = static_cast<unsigned int>(g.integer("llama.feed_forward_length"));
+    c.layers  = static_cast<unsigned int>(g.integer("llama.block_count"));
+    c.context = static_cast<unsigned int>(g.integer("llama.context_length"));
+
+    c.kv_heads = g.has("llama.attention.head_count_kv")
+        ? static_cast<unsigned int>(g.integer("llama.attention.head_count_kv"))
+        : c.heads;
+
+    if(g.has("llama.rope.freq_base"))
+        c.rope_theta = static_cast<float>(g.real("llama.rope.freq_base"));
+
+    if(g.has("llama.attention.layer_norm_rms_epsilon"))
+        c.rms_eps = static_cast<float>(
+            g.real("llama.attention.layer_norm_rms_epsilon"));
+
+    // The vocabulary is not a llama.* key.  It is the length of the token
+    // array, and the head's width has to agree with it -- which load() checks.
+    c.vocab = static_cast<unsigned int>(
+        g.get("tokenizer.ggml.tokens").strings.size());
+
+    return c;
+}
+
+template<typename T>
+model<T>::model(backend<T>& b, const config& c)
+    : m_b(b),
+      m_conf(c)
+{
+    if(!c.d_model || !c.heads || !c.kv_heads || !c.d_ff || !c.layers || !c.vocab)
+        throw backend_error("model: a config with a zero in it");
+
+    for(unsigned int i = 0; i < c.layers; i++) {
+        std::shared_ptr<block<T> > l(
+            new block<T>(b, c.d_model, c.heads, c.kv_heads, c.d_ff));
+
+        l->set_eps(c.rms_eps);
+        l->set_rope(true, c.rope_theta, c.layout);
+
+        m_layers.push_back(l);
+    }
+
+    m_embed = b.make(c.d_model, c.vocab);
+    m_final_norm = b.make(c.d_model, 1);
+    m_head = b.make(c.d_model, c.vocab);
+}
+
+template<typename T>
+math::matrix<T> model<T>::col_slice_t(const math::matrix<float>& w,
+                                      unsigned int c0, unsigned int n)
+{
+    math::matrix<T> out(n, w.M);
+
+    for(unsigned int a = 0; a < n; a++)
+        for(unsigned int b = 0; b < w.M; b++)
+            out(a, b) = T(w(b, c0 + a));
+
+    return out;
+}
+
+template<typename T>
+math::matrix<T> model<T>::row_slice_t(const math::matrix<float>& w,
+                                      unsigned int r0, unsigned int n)
+{
+    math::matrix<T> out(w.N, n);
+
+    for(unsigned int a = 0; a < w.N; a++)
+        for(unsigned int b = 0; b < n; b++)
+            out(a, b) = T(w(r0 + b, a));
+
+    return out;
+}
+
+template<typename T>
+math::matrix<T> model<T>::narrowed(const math::matrix<float>& w) {
+    math::matrix<T> out(w.M, w.N);
+
+    for(unsigned int r = 0; r < w.M; r++)
+        for(unsigned int c = 0; c < w.N; c++)
+            out(r, c) = T(w(r, c));
+
+    return out;
+}
+
+template<typename T>
+void model<T>::expect(const gguf& g, const std::string& name,
+                      unsigned int d0, unsigned int d1) const
+{
+    const gguf::tensor_info& t = g.tensor(name);
+
+    const unsigned int got0 = t.shape.size() > 0
+        ? static_cast<unsigned int>(t.shape[0]) : 0;
+    const unsigned int got1 = t.shape.size() > 1
+        ? static_cast<unsigned int>(t.shape[1]) : 1;
+
+    if(got0 != d0 || got1 != d1) {
+        std::ostringstream e;
+
+        e << "model: " << name << " is " << got0 << "x" << got1
+          << " where the metadata implies " << d0 << "x" << d1;
+
+        throw backend_error(e.str());
+    }
+}
+
+template<typename T>
+void model<T>::load(const gguf& g) {
+    const unsigned int d = m_conf.d_model;
+    const unsigned int dh = d / m_conf.heads;
+
+    // No transposition for either of these.  The embedding is a table of
+    // columns and gather reads columns; the head is used through multiply_tn,
+    // which wants exactly the file's orientation.
+    expect(g, "token_embd.weight", d, m_conf.vocab);
+    m_embed->write(narrowed(g.read("token_embd.weight")));
+
+    expect(g, "output.weight", d, m_conf.vocab);
+    m_head->write(narrowed(g.read("output.weight")));
+
+    expect(g, "output_norm.weight", d, 1);
+    m_final_norm->write(narrowed(g.read("output_norm.weight")));
+
+    for(unsigned int i = 0; i < m_conf.layers; i++) {
+        const std::string p = "blk." + std::to_string(i) + ".";
+
+        block<T>& l = *m_layers[i];
+
+        expect(g, p + "attn_norm.weight", d, 1);
+        l.attn_norm()->write(narrowed(g.read(p + "attn_norm.weight")));
+
+        expect(g, p + "ffn_norm.weight", d, 1);
+        l.ffn_norm()->write(narrowed(g.read(p + "ffn_norm.weight")));
+
+        // A column range per head, transposed.
+        expect(g, p + "attn_q.weight", d, m_conf.heads * dh);
+
+        const math::matrix<float> wq = g.read(p + "attn_q.weight");
+
+        for(unsigned int h = 0; h < m_conf.heads; h++)
+            l.wq(h)->write(col_slice_t(wq, h * dh, dh));
+
+        expect(g, p + "attn_k.weight", d, m_conf.kv_heads * dh);
+        expect(g, p + "attn_v.weight", d, m_conf.kv_heads * dh);
+
+        const math::matrix<float> wk = g.read(p + "attn_k.weight");
+        const math::matrix<float> wv = g.read(p + "attn_v.weight");
+
+        for(unsigned int h = 0; h < m_conf.kv_heads; h++) {
+            l.wk(h)->write(col_slice_t(wk, h * dh, dh));
+            l.wv(h)->write(col_slice_t(wv, h * dh, dh));
+        }
+
+        // A *row* range per head for the output projection, because the heads
+        // are concatenated on its input side rather than its output side.
+        expect(g, p + "attn_output.weight", d, d);
+
+        const math::matrix<float> wo = g.read(p + "attn_output.weight");
+
+        for(unsigned int h = 0; h < m_conf.heads; h++)
+            l.wo(h)->write(row_slice_t(wo, h * dh, dh));
+
+        expect(g, p + "ffn_gate.weight", d, m_conf.d_ff);
+        expect(g, p + "ffn_up.weight", d, m_conf.d_ff);
+        expect(g, p + "ffn_down.weight", m_conf.d_ff, d);
+
+        l.w_gate()->write(col_slice_t(g.read(p + "ffn_gate.weight"), 0, m_conf.d_ff));
+        l.w_up()->write(col_slice_t(g.read(p + "ffn_up.weight"), 0, m_conf.d_ff));
+        l.w_down()->write(col_slice_t(g.read(p + "ffn_down.weight"), 0, d));
+    }
+}
+
+template<typename T>
+void model<T>::reserve(unsigned int seq) {
+    if(seq == 0)
+        throw backend_error("model: a sequence of no positions");
+
+    m_seq = seq;
+
+    m_x = m_b.make(m_conf.d_model, seq);
+    m_y = m_b.make(m_conf.d_model, seq);
+
+    for(std::size_t i = 0; i < m_layers.size(); i++)
+        m_layers[i]->reserve(seq);
+}
+
+template<typename T>
+void model<T>::forward(const std::vector<int>& ids, tensor_ptr& logits,
+                       unsigned int base_pos)
+{
+    if(m_seq == 0)
+        throw backend_error("model: forward before reserve");
+
+    if(ids.size() != m_seq)
+        throw backend_error("model: as many ids as the reserved length");
+
+    if(logits->rows() != m_conf.vocab || logits->cols() != m_seq)
+        throw backend_error("model: logits must be vocab by the reserved length");
+
+    m_b.gather(m_embed, ids, m_x);
+
+    // Ping-pong rather than in place: block::forward writes its output while
+    // still reading its input.
+    for(std::size_t i = 0; i < m_layers.size(); i++) {
+        m_layers[i]->forward(m_x, m_y, true, base_pos);
+
+        m_x.swap(m_y);
+    }
+
+    m_b.rms_norm(m_x, m_final_norm, m_y, m_conf.rms_eps);
+    m_b.multiply_tn(m_head, m_y, logits);
+}
+
+}
+}
+
+#endif // JLIB_AI_MODEL_HH

--- a/jlib/ai/transformer.hh
+++ b/jlib/ai/transformer.hh
@@ -160,6 +160,17 @@ public:
     void set_rope(bool on, float theta = 10000.0f,
                   rope_layout layout = rope_layout::interleaved);
 
+    /**
+     * The epsilon both RMS norms are computed with.
+     *
+     * A model states its own -- llama.attention.layer_norm_rms_epsilon -- and
+     * while every Llama so far has said 1e-5, taking it from the file costs
+     * nothing and a model that said otherwise would otherwise be quietly
+     * normalised wrong.
+     */
+    void set_eps(float eps) { m_eps = eps; }
+    float eps() const { return m_eps; }
+
     /** Size every intermediate for a sequence of this length. */
     void reserve(unsigned int seq);
 
@@ -183,6 +194,7 @@ private:
     unsigned int m_d_ff;
     unsigned int m_seq = 0;
 
+    float m_eps = 1e-5f;
     bool m_rope = false;
     float m_theta = 10000.0f;
     rope_layout m_layout = rope_layout::interleaved;
@@ -298,7 +310,7 @@ void block<T>::forward(const tensor_ptr& x, tensor_ptr& out, bool causal,
 
     // --- attention, around a residual ---
 
-    m_b.rms_norm(x, m_attn_norm, m_norm);
+    m_b.rms_norm(x, m_attn_norm, m_norm, m_eps);
 
     // Every key and value first, once each.  Computing them inside the query
     // loop instead would give the same answer and do the work heads/kv_heads
@@ -333,7 +345,7 @@ void block<T>::forward(const tensor_ptr& x, tensor_ptr& out, bool causal,
 
     // --- gated feed-forward, around a second residual ---
 
-    m_b.rms_norm(out, m_ffn_norm, m_norm);
+    m_b.rms_norm(out, m_ffn_norm, m_norm, m_eps);
 
     m_b.multiply(m_gate, m_norm, m_h1);
     m_b.multiply(m_up, m_norm, m_h3);

--- a/jlib/metal/backend.hh
+++ b/jlib/metal/backend.hh
@@ -70,6 +70,8 @@ public:
     void assign(const tensor_ptr& src, tensor_ptr& dst);
     void softmax(const tensor_ptr& in, tensor_ptr& out);
     void causal_mask(tensor_ptr& s);
+    void gather(const tensor_ptr& table, const std::vector<int>& ids,
+                tensor_ptr& out);
     void rope(tensor_ptr& x, unsigned int base_pos = 0, float theta = 10000.0f,
               ai::rope_layout layout = ai::rope_layout::interleaved);
     void rms_norm(const tensor_ptr& in, const tensor_ptr& weight,

--- a/jlib/metal/backend.mm
+++ b/jlib/metal/backend.mm
@@ -166,6 +166,13 @@ void backend<T>::causal_mask(tensor_ptr& s) {
 }
 
 template<typename T>
+void backend<T>::gather(const tensor_ptr& table, const std::vector<int>& ids,
+                        tensor_ptr& out)
+{
+    m_stream->gather(at<T>(table), ids, at<T>(out));
+}
+
+template<typename T>
 void backend<T>::rope(tensor_ptr& x, unsigned int base_pos, float theta,
                       ai::rope_layout layout)
 {

--- a/jlib/metal/tensor.hh
+++ b/jlib/metal/tensor.hh
@@ -194,6 +194,10 @@ public:
     /** Rotary position embedding, in place; see ai::backend::rope. */
     void rope(tensor<T>& x, unsigned int base_pos, float theta, bool split);
 
+    /** Column gather: out[:,i] = table[:,ids[i]]. */
+    void gather(const tensor<T>& table, const std::vector<int>& ids,
+                tensor<T>& out);
+
     /** RMS normalisation down each column, scaled by a per-row weight. */
     void rms_norm(const tensor<T>& in, const tensor<T>& weight, tensor<T>& out,
                   float eps = 1e-5f);

--- a/jlib/metal/tensor.mm
+++ b/jlib/metal/tensor.mm
@@ -277,6 +277,31 @@ kernel void k_rope(device T* x [[buffer(0)]],
     col[b] = T(xa * si + xb * co);
 }
 
+/**
+ * Column gather: out[:,i] = table[:,ids[i]].
+ *
+ * One thread per output element rather than per column, because the columns
+ * are d_model long and there are only as many of them as there are tokens.
+ * Bounds on the ids are checked on the host before this runs -- a kernel has no
+ * way to refuse, and an out-of-range column here would read whatever else is in
+ * the buffer.
+ */
+template<typename T>
+kernel void k_gather(device const T* table [[buffer(0)]],
+                     device T* out [[buffer(1)]],
+                     device const int* ids [[buffer(2)]],
+                     constant uint& rows [[buffer(3)]],
+                     constant uint& n [[buffer(4)]],
+                     uint i [[thread_position_in_grid]])
+{
+    if(i >= rows * n) return;
+
+    const uint c = i / rows;
+    const uint r = i % rows;
+
+    out[(ulong)c * rows + r] = table[(ulong)ids[c] * rows + r];
+}
+
 #define INSTANTIATE(NAME, T, SUFFIX)                                        \
     template [[host_name(#NAME SUFFIX)]] kernel void NAME<T>
 
@@ -308,6 +333,12 @@ INSTANTIATE(k_causal_mask, float, "_f32")(device float*, constant uint&,
                                           constant uint&, uint);
 INSTANTIATE(k_causal_mask, half, "_f16")(device half*, constant uint&,
                                          constant uint&, uint);
+INSTANTIATE(k_gather, float, "_f32")(device const float*, device float*,
+                                     device const int*, constant uint&,
+                                     constant uint&, uint);
+INSTANTIATE(k_gather, half, "_f16")(device const half*, device half*,
+                                    device const int*, constant uint&,
+                                    constant uint&, uint);
 INSTANTIATE(k_rope, float, "_f32")(device float*, constant uint&, constant uint&,
                                    constant uint&, constant float&,
                                    constant uint&, uint);
@@ -426,7 +457,15 @@ struct stream<T>::impl {
     id<MTLComputePipelineState> softmax = nil;
     id<MTLComputePipelineState> causal_mask = nil;
     id<MTLComputePipelineState> rope = nil;
+    id<MTLComputePipelineState> gather = nil;
     id<MTLComputePipelineState> rms_norm = nil;
+
+    // Buffers made for one encoded operation and needed until the command
+    // buffer has run.  Metal does retain what an encoder binds, so this is
+    // belt and braces -- but the failure it guards against is a use-after-free
+    // that would show up as an occasional wrong answer, which is the worst
+    // kind to go looking for later.
+    NSMutableArray* held = nil;
 
     unsigned int pending = 0;
 };
@@ -442,6 +481,7 @@ struct pipelines {
     id<MTLComputePipelineState> softmax = nil;
     id<MTLComputePipelineState> causal_mask = nil;
     id<MTLComputePipelineState> rope = nil;
+    id<MTLComputePipelineState> gather = nil;
     id<MTLComputePipelineState> rms_norm = nil;
 };
 
@@ -495,6 +535,7 @@ pipelines& compiled(id<MTLDevice> gpu) {
         { "k_softmax",    &p.softmax },
         { "k_causal_mask", &p.causal_mask },
         { "k_rope",       &p.rope },
+        { "k_gather",     &p.gather },
         { "k_rms_norm",   &p.rms_norm },
     };
 
@@ -560,6 +601,8 @@ stream<T>::stream(std::shared_ptr<device> d)
     m_impl->softmax = p.softmax;
     m_impl->causal_mask = p.causal_mask;
     m_impl->rope = p.rope;
+    m_impl->gather = p.gather;
+    m_impl->held = [NSMutableArray array];
     m_impl->rms_norm = p.rms_norm;
 }
 
@@ -768,6 +811,52 @@ void stream<T>::rope(tensor<T>& x, unsigned int base_pos, float theta,
 }
 
 template<typename T>
+void stream<T>::gather(const tensor<T>& table, const std::vector<int>& ids,
+                       tensor<T>& out)
+{
+    const unsigned int rows = table.rows();
+    const unsigned int n = static_cast<unsigned int>(ids.size());
+
+    if(out.rows() != rows || out.cols() != n)
+        throw typename tensor<T>::exception("gather: out must be the table's "
+                                            "height by the number of ids");
+
+    // Here, where there is somewhere to throw from.
+    for(std::size_t i = 0; i < ids.size(); i++) {
+        if(ids[i] < 0 || static_cast<unsigned int>(ids[i]) >= table.cols()) {
+            std::ostringstream e;
+
+            e << "gather: token id " << ids[i] << " is outside a table of "
+              << table.cols();
+
+            throw typename tensor<T>::exception(e.str());
+        }
+    }
+
+    if(n == 0) return;
+
+    open();
+
+    id<MTLBuffer> idbuf =
+        [m_device->m_impl->gpu newBufferWithBytes:ids.data()
+                                           length:ids.size() * sizeof(int)
+                                          options:MTLResourceStorageModeShared];
+
+    [m_impl->held addObject:idbuf];
+
+    [m_impl->enc setComputePipelineState:m_impl->gather];
+    [m_impl->enc setBuffer:table.m_impl->buf offset:0 atIndex:0];
+    [m_impl->enc setBuffer:out.m_impl->buf offset:0 atIndex:1];
+    [m_impl->enc setBuffer:idbuf offset:0 atIndex:2];
+    [m_impl->enc setBytes:&rows length:sizeof(rows) atIndex:3];
+    [m_impl->enc setBytes:&n length:sizeof(n) atIndex:4];
+
+    dispatch(m_impl->enc, m_impl->gather, rows * n);
+
+    m_impl->pending++;
+}
+
+template<typename T>
 void stream<T>::rms_norm(const tensor<T>& in, const tensor<T>& weight,
                          tensor<T>& out, float eps)
 {
@@ -919,6 +1008,8 @@ void stream<T>::wait() {
 
     m_impl->cmd = nil;
     m_impl->pending = 0;
+
+    [m_impl->held removeAllObjects];
 
     if(failed)
         throw exception("the command buffer failed");

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -63,6 +63,7 @@ TESTS = \
 	ai_backend_test \
 	ai_transformer_test \
 	ai_gguf_test \
+	ai_model_test \
 	math_object_test \
 	tensor_test \
 \
@@ -310,6 +311,10 @@ metal_gemm_test_LDADD   = $(top_builddir)/jlib/metal/libjmetal.la $(METAL_LIBS)
 
 metal_tensor_test_SOURCES = metal_tensor_test.cc
 metal_tensor_test_LDADD   = $(top_builddir)/jlib/metal/libjmetal.la $(JUTIL_LA) $(JSYS_LA) $(METAL_LIBS)
+
+ai_model_test_SOURCES  = ai_model_test.cc
+ai_model_test_CPPFLAGS = $(AM_CPPFLAGS) $(METAL_CPPFLAGS)
+ai_model_test_LDADD    = $(JAI_LA) $(JUTIL_LA) $(JSYS_LA) $(METAL_LA)
 
 ai_gguf_test_SOURCES  = ai_gguf_test.cc
 ai_gguf_test_LDADD    = $(JAI_LA) $(JUTIL_LA) $(JSYS_LA)

--- a/tests/ai_backend_test.cc
+++ b/tests/ai_backend_test.cc
@@ -717,6 +717,64 @@ static void the_two_rope_layouts_differ(const char* name,
     }
 }
 
+/** The embedding lookup: pick columns out of a table by index. */
+template<typename T>
+static void the_gather(const char* name, std::vector<ai::backend<T>*>& backends) {
+    std::cout << "\ngather, " << name << ":\n";
+
+    const uint d = 5;
+    const uint vocab = 7;
+
+    matrix<T> table(d, vocab);
+
+    // Distinct per column, so a gather that took the wrong one is visible.
+    for(uint c = 0; c < vocab; c++)
+        for(uint r = 0; r < d; r++)
+            table(r,c) = T(float(c) * 10.0f + float(r));
+
+    // Out of order and with a repeat, because a token can occur twice and
+    // nothing says the ids ascend.
+    const std::vector<int> ids{ 3, 0, 6, 3 };
+
+    for(ai::backend<T>* b : backends) {
+        typename ai::backend<T>::tensor_ptr t = b->make(table);
+        typename ai::backend<T>::tensor_ptr out = b->make(d, uint(ids.size()));
+
+        b->gather(t, ids, out);
+        b->wait();
+
+        const matrix<T> got = out->read();
+
+        double furthest = 0;
+
+        for(std::size_t i = 0; i < ids.size(); i++)
+            for(uint r = 0; r < d; r++)
+                furthest = std::max(furthest,
+                                    std::fabs(double(float(got(r, uint(i)))) -
+                                              double(float(table(r, uint(ids[i]))))));
+
+        ok(std::string("  ") + b->name() + ": every column is the one asked for",
+           furthest == 0.0, std::to_string(furthest));
+
+        // An id off the end reads whatever is next in the buffer if nothing
+        // checks it, which is a wrong token rather than a crash -- so it is
+        // checked, and on the GPU it has to be checked before the kernel runs.
+        bool threw = false;
+
+        try { b->gather(t, std::vector<int>{ 0, 7 }, out); b->wait(); }
+        catch(std::exception&) { threw = true; }
+
+        ok(std::string("  ") + b->name() + ": an id past the end is refused", threw);
+
+        threw = false;
+
+        try { b->gather(t, std::vector<int>{ 0, -1 }, out); b->wait(); }
+        catch(std::exception&) { threw = true; }
+
+        ok(std::string("  ") + b->name() + ": and so is a negative one", threw);
+    }
+}
+
 static void a_tensor_from_the_wrong_backend_is_refused() {
     std::cout << "\na tensor from the wrong backend is refused:\n";
 
@@ -779,6 +837,7 @@ int main() {
         rope_is_a_rotation<float>("float", b);
         rope_makes_the_score_relative<float>("float", b);
         the_two_rope_layouts_differ<float>("float", b);
+        the_gather<float>("float", b);
 #else
         one_type<float>("float", b);
         the_reductions<float>("float", b);
@@ -790,6 +849,7 @@ int main() {
         rope_is_a_rotation<float>("float", b);
         rope_makes_the_score_relative<float>("float", b);
         the_two_rope_layouts_differ<float>("float", b);
+        the_gather<float>("float", b);
 #endif
     }
 
@@ -812,6 +872,7 @@ int main() {
         rope_is_a_rotation<_Float16>("_Float16", b);
         rope_makes_the_score_relative<_Float16>("_Float16", b);
         the_two_rope_layouts_differ<_Float16>("_Float16", b);
+        the_gather<_Float16>("_Float16", b);
     }
 
     a_tensor_from_the_wrong_backend_is_refused();

--- a/tests/ai_model_test.cc
+++ b/tests/ai_model_test.cc
@@ -1,0 +1,275 @@
+/* -*- mode: C++ c-basic-offset: 4 -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+#include <jlib/ai/model.hh>
+
+#ifdef HAVE_METAL
+#include <jlib/metal/backend.hh>
+#endif
+
+#include <cmath>
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace ai = jlib::ai;
+
+/** The SentencePiece space marker, U+2581, which every word piece begins with. */
+#define SP "\xe2\x96\x81"
+
+static int failures = 0;
+
+static void ok(const std::string& what, bool good, const std::string& detail = "") {
+    if(!good) ++failures;
+    std::cout << (good ? "  ok   " : "  FAIL ") << what;
+    if(!detail.empty()) std::cout << ": " << detail;
+    std::cout << "\n";
+}
+
+static bool exists(const std::string& p) {
+    std::ifstream f(p, std::ios::binary);
+
+    return bool(f);
+}
+
+static std::string find_model(int argc, char** argv) {
+    if(argc > 1 && exists(argv[1])) return argv[1];
+
+    if(const char* env = std::getenv("JLIB_GGUF"))
+        if(exists(env)) return env;
+
+    const char* names[] = {
+        "tinyllama-1.1b-chat-v1.0.Q8_0.gguf",
+        "../tinyllama-1.1b-chat-v1.0.Q8_0.gguf",
+        "../../tinyllama-1.1b-chat-v1.0.Q8_0.gguf",
+        "../../../tinyllama-1.1b-chat-v1.0.Q8_0.gguf"
+    };
+
+    for(const char* n : names)
+        if(exists(n)) return n;
+
+    return "";
+}
+
+/** The config a file states about itself. */
+static void the_config_comes_from_the_file(const ai::gguf& g) {
+    std::cout << "\nthe config comes from the file:\n";
+
+    typedef ai::model<_Float16>::config config;
+
+    const config c = config::from(g);
+
+    ok("  2048 wide, 22 layers", c.d_model == 2048 && c.layers == 22);
+    ok("  32 heads over 4 key-value heads",
+       c.heads == 32 && c.kv_heads == 4);
+    ok("  5632 of feed-forward", c.d_ff == 5632, std::to_string(c.d_ff));
+
+    // Not a llama.* key: the vocabulary is however long the token array is.
+    ok("  32000 of vocabulary", c.vocab == 32000, std::to_string(c.vocab));
+
+    ok("  rope base 10000 and rms epsilon 1e-5",
+       std::fabs(c.rope_theta - 10000.0f) < 1e-3f &&
+       std::fabs(c.rms_eps - 1e-5f) < 1e-9f);
+}
+
+/**
+ * The whole stack, against a real model, with an answer that is either right
+ * or is not.
+ *
+ * "The capital of France is Paris.  The capital of Germany is Berlin.  The
+ * capital of Italy is ___" -- long enough that position matters, and
+ * structured so the answer depends on which of three repeated clauses is being
+ * finished rather than on the last few words alone.
+ *
+ * Every orientation decision in load() has to be right for this to work, and
+ * so does every convention that no property test could settle. Measured, with
+ * this prompt:
+ *
+ *   as shipped              Rome 19.1, Roma 13.0, Florence 12.3
+ *   rope layout split       the, a, home          -- no city at all
+ *   swiglu gate and up swapped   space, comma, in
+ *   grouped-query striped   lip, sterreich, etto  -- word fragments
+ *
+ * So this one assertion stands behind the SwiGLU gate assignment, the RoPE
+ * pairing and the grouped-query mapping at once. Each of those has a comment
+ * elsewhere saying a reference is the only thing that can settle it; this is
+ * that reference.
+ */
+template<typename T>
+static void it_knows_the_capital_of_italy(const char* name, ai::backend<T>& b,
+                                          const ai::gguf& g)
+{
+    std::cout << "\nit knows the capital of italy, " << name << ":\n";
+
+    const std::vector<std::string>& toks =
+        g.get("tokenizer.ggml.tokens").strings;
+
+    const char* pieces[] = {
+        "<s>",
+        SP "The", SP "capital", SP "of", SP "France", SP "is", SP "Paris", ".",
+        SP "The", SP "capital", SP "of", SP "Germany", SP "is", SP "Berlin", ".",
+        SP "The", SP "capital", SP "of", SP "Italy", SP "is"
+    };
+
+    std::vector<int> ids;
+
+    for(const char* piece : pieces) {
+        int found = -1;
+
+        for(std::size_t i = 0; i < toks.size(); i++)
+            if(toks[i] == piece) { found = int(i); break; }
+
+        if(found < 0) {
+            ok(std::string("  the vocabulary has ") + piece, false);
+
+            return;
+        }
+
+        ids.push_back(found);
+    }
+
+    ok("  every piece of the prompt is in the vocabulary", true,
+       std::to_string(ids.size()) + " tokens");
+
+    typename ai::model<T>::config c = ai::model<T>::config::from(g);
+
+    ai::model<T> m(b, c);
+
+    m.load(g);
+    m.reserve(static_cast<unsigned int>(ids.size()));
+
+    typename ai::backend<T>::tensor_ptr logits =
+        b.make(c.vocab, static_cast<unsigned int>(ids.size()));
+
+    m.forward(ids, logits);
+    b.wait();
+
+    const jlib::math::matrix<T> l = logits->read();
+
+    ok("  logits are vocabulary by position",
+       l.M == c.vocab && l.N == ids.size(),
+       std::to_string(l.M) + "x" + std::to_string(l.N));
+
+    const unsigned int last = l.N - 1;
+
+    int best = -1;
+    int second = -1;
+    double best_v = -1e30;
+    double second_v = -1e30;
+    bool finite = true;
+
+    for(unsigned int v = 0; v < l.M; v++) {
+        const double x = double(float(l(v, last)));
+
+        if(!std::isfinite(x)) finite = false;
+
+        if(x > best_v) {
+            second = best; second_v = best_v;
+            best = int(v); best_v = x;
+        }
+        else if(x > second_v) {
+            second = int(v); second_v = x;
+        }
+    }
+
+    ok("  every logit is finite", finite);
+
+    ok("  and the most likely next token is Rome",
+       best >= 0 && toks[std::size_t(best)] == SP "Rome",
+       best >= 0 ? toks[std::size_t(best)] + " at " + std::to_string(best_v)
+                 : "nothing");
+
+    // Not a close-run thing.  Every wrong convention measured above dropped
+    // this margin to nothing or produced no city at all, so requiring daylight
+    // is what makes the assertion mean something rather than a coin landing.
+    ok("  by a wide margin", best_v - second_v > 3.0,
+       std::to_string(best_v - second_v) + " over " +
+       (second >= 0 ? toks[std::size_t(second)] : "nothing"));
+}
+
+int main(int argc, char** argv) {
+    std::cout << std::unitbuf;
+
+    const std::string path = find_model(argc, argv);
+
+    if(path.empty()) {
+        std::cout << "ai_model_test: no model file; pass one as an argument or "
+                  << "set JLIB_GGUF.\n"
+                  << "  curl -LO https://huggingface.co/TheBloke/"
+                  << "TinyLlama-1.1B-Chat-v1.0-GGUF/resolve/main/"
+                  << "tinyllama-1.1b-chat-v1.0.Q8_0.gguf\n";
+
+        return 77;
+    }
+
+    std::cout << "ai_model_test: " << path << "\n";
+
+    try {
+        const ai::gguf g(path);
+
+        the_config_comes_from_the_file(g);
+
+        // fp16, which halves a 1.1B-parameter model to about 2.2GB and is what
+        // inference runs in anyway.  Not the host backend: its GEMM accumulates
+        // in the element type, and a 2048-long dot product summed in fp16
+        // would lose the answer.  MPS accumulates in fp32.
+#ifdef HAVE_METAL
+        std::shared_ptr<jlib::metal::backend<_Float16> > gpu;
+
+        try { gpu.reset(new jlib::metal::backend<_Float16>); }
+        catch(std::exception& e) {
+            ok("  the Metal backend comes up", false, e.what());
+        }
+
+        if(gpu) it_knows_the_capital_of_italy<_Float16>("fp16 on the GPU", *gpu, g);
+#else
+        std::cout << "\n  (no Metal: the forward pass needs a backend whose "
+                  << "GEMM accumulates wider than fp16)\n";
+#endif
+    }
+    catch(std::exception& e) {
+        std::cerr << "ai_model_test: " << e.what() << "\n";
+
+        return 1;
+    }
+
+    // What a green run does not establish.
+    //
+    // That the numbers match llama.cpp, only that the answer is right.  A small
+    // error -- an epsilon in the wrong place, a rounding difference -- would
+    // leave Rome on top and go unnoticed here.  Comparing logits with a
+    // reference implementation is the stronger check and is not done.
+    //
+    // Nothing beyond one prompt of twenty tokens on one model.  Long contexts,
+    // where the rope angle grows and fp16 accumulation has more to lose, are
+    // untested.
+    //
+    // And nothing about generation: this is one forward pass over a prompt.
+    // There is no sampling, no cache, and no tokenizer -- the prompt above is
+    // spelled out piece by piece and looked up by exact string, which is not
+    // tokenization and does not pretend to be.
+    std::cout << "\n" << (failures ? "FAILED" : "PASSED") << ": " << failures
+              << " failure(s)\n";
+
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
# The model, and the first thing that was ever checked against reality

Every branch on this path ended the same way, and each `pr.txt` said so in its
own words: the code was **self-consistent, never compared with anyone else's**.
Three of them went further and named specific decisions that no test here could
settle — the SwiGLU gate, the RoPE pairing, the grouped-query mapping — each
recorded as a convention that only a reference could confirm.

This branch is that reference. `ai::model<T>` assembles the stack, loads
TinyLlama-1.1B-Chat from the GGUF, and runs it.

```
The capital of France is Paris.  The capital of Germany is Berlin.
The capital of Italy is ___
```

**▁Rome, logit 19.11.** Next is ▁Roma at 13.0, then ▁Florence at 12.3 — the top
three are all Italian cities. 4.1s to load, 0.85s for the forward pass, 5s for
the whole test.

## The three conventions, settled by measurement

Each was written down as unsettleable by any property test. All three are now
measured, by running the model with the wrong one and seeing what happens:

| variant | top three |
| --- | --- |
| **as shipped** | ▁Rome **19.1**, ▁Roma 13.0, ▁Florence 12.3 |
| RoPE `split` instead of `interleaved` | ▁the, ▁a, ▁home — no city at all |
| SwiGLU gate and up swapped | ▁, `,`, ▁in |
| grouped-query striped instead of grouped | lip, sterreich, etto — word fragments, top logit 8.0 |

So one assertion now stands behind all three at once, and the comments that say
"only a reference can settle this" can point at it.

Worth recording how nearly this was missed. The first prompt was five tokens —
"The capital of France is" — and under the wrong RoPE layout it *still* answered
Paris, by a margin of 0.07 instead of 1.13. A short prompt barely exercises
position, so it barely discriminates a positional convention. The twenty-token
version, where the answer depends on which of three repeated clauses is being
finished, separates them completely.

## Orientation is where the work is

`gguf.hh` already recorded that a GGUF weight arrives `[n_in, n_out]` and the
product wanted is `Wᵀx`. Two tensors need nothing done to them: the embedding is
a table of columns and `gather` reads columns; the head is multiplied with
`multiply_tn`. The block's weights are the other case, and the slice differs by
role:

- `attn_q`, `attn_k`, `attn_v` — a **column** range per head, transposed
- `attn_output` — a **row** range per head, because the heads are concatenated
  on its input side
- `ffn_gate`, `ffn_up`, `ffn_down` — the whole matrix, transposed

The alternative is to hold the block's weights in the file's orientation and
reach for `multiply_tn` there too, which would make `load()` a memcpy. That is
probably the better design; it changes `block`'s public shapes and every test
that fills them, so it is not this branch's to make. Written down in `load()`
rather than left to be rediscovered.

## One new primitive

`gather(table, ids, out)` — the embedding lookup, host and Metal. ids are
host-side `int`, deliberately: they are indices, not arithmetic, and fp16
represents integers exactly only to 2048 while vocabularies are far larger, so a
token id routed through `T` is a silently wrong token. Out-of-range ids are
refused, and on Metal that check happens **before** the dispatch, since a kernel
cannot refuse and would otherwise read whatever is next in the buffer — a wrong
token rather than a crash.

`block` also gained `set_eps()`, so the RMS epsilon comes from the file rather
than from a default that happens to match.

## Tests

`ai_model_test` loads the real file and asserts the config, the logits' shape
and finiteness, that the argmax is Rome, and that it wins **by more than 3
logits** — the margin matters, because every wrong convention above either
collapsed it or produced no city, so requiring daylight is what makes the
assertion mean something.

It runs in fp16 on Metal: 1.1B parameters at 2.2GB rather than 4.4, which is
what inference uses anyway. Not the host backend, and the test says why — its
GEMM accumulates in the element type, and a 2048-long dot product summed in fp16
would lose the answer. MPS accumulates in fp32.

`gather` is tested in `ai_backend_test` with the other primitives: out-of-order
ids with a repeat, and both directions of out-of-range.

## Verification

- macOS `make check`: 71 tests (was 70), 67 pass, 4 skip, 0 fail.
- Container: no model and no Metal, so `ai_model_test` reports SKIP.

## What this does not establish

**That the numbers match llama.cpp, only that the answer is right.** A small
error — an epsilon misplaced, a rounding difference — would leave Rome on top
and go unnoticed. Comparing logits against a reference implementation is the
stronger check and is not done.

**One prompt, twenty tokens, one model.** Long contexts, where the RoPE angle
grows and fp16 has more to lose, are untested.

**No generation.** One forward pass over a prompt: no sampling, no KV cache, and
no tokenizer — the prompt is spelled out piece by piece and looked up by exact
string, which is not tokenization and does not pretend to be. That is the next
branch, and after this one it is the only thing between here and text.
