### PR TITLE
Add a BPE tokenizer driven by the file's merge list, since every score in it is zero, and feed the model real text

### DIFF
--- a/jlib/ai/Makefile.am
+++ b/jlib/ai/Makefile.am
@@ -2,7 +2,7 @@ AM_CPPFLAGS = -I$(top_srcdir)
 
 lib_LTLIBRARIES = libjai.la
 libjai_la_SOURCES = environment.cc agent.cc percept.cc action.cc vacuum.cc \
-                    backend.cc gguf.cc
+                    backend.cc gguf.cc tokenizer.cc
 libjai_la_LDFLAGS = -version-info $(LIBJ_SO_VERSION) -release $(JLIB_RELEASE) -no-undefined
 libjai_la_LIBADD = $(top_builddir)/jlib/util/libjutil.la \
                    $(top_builddir)/jlib/sys/libjsys.la
@@ -10,4 +10,4 @@ libjai_la_LIBADD = $(top_builddir)/jlib/util/libjutil.la \
 libjaiincludedir = $(includedir)/jlib-1.2/jlib/ai
 libjaiinclude_HEADERS = environment.hh agent.hh percept.hh action.hh vacuum.hh \
                         neural.hh backend.hh attention.hh transformer.hh \
-                        gguf.hh model.hh
+                        gguf.hh model.hh tokenizer.hh

--- a/jlib/ai/tokenizer.cc
+++ b/jlib/ai/tokenizer.cc
@@ -1,0 +1,285 @@
+/* -*- mode: C++ c-basic-offset: 4  -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+#include <jlib/ai/tokenizer.hh>
+
+#include <sstream>
+
+namespace jlib {
+namespace ai {
+
+namespace {
+
+    /** U+2581 LOWER ONE EIGHTH BLOCK, which stands in for a space. */
+    const char* MARKER = "\xe2\x96\x81";
+
+    /** Two hex digits to a byte, for reading a <0xXX> token's name. */
+    int hex_pair(const std::string& s, std::size_t at) {
+        int v = 0;
+
+        for(int i = 0; i < 2; i++) {
+            const char c = s[at + i];
+
+            v <<= 4;
+
+            if(c >= '0' && c <= '9') v |= (c - '0');
+            else if(c >= 'a' && c <= 'f') v |= (c - 'a' + 10);
+            else if(c >= 'A' && c <= 'F') v |= (c - 'A' + 10);
+            else return -1;
+        }
+
+        return v;
+    }
+
+}
+
+tokenizer::tokenizer(const gguf& g)
+    : m_byte_token(256, -1)
+{
+    if(!g.has("tokenizer.ggml.tokens"))
+        throw exception("the file carries no vocabulary");
+
+    m_tokens = g.get("tokenizer.ggml.tokens").strings;
+
+    if(m_tokens.empty())
+        throw exception("an empty vocabulary");
+
+    m_types.assign(m_tokens.size(), normal);
+
+    if(g.has("tokenizer.ggml.token_type")) {
+        const std::vector<double>& t = g.get("tokenizer.ggml.token_type").numbers;
+
+        if(t.size() != m_tokens.size())
+            throw exception("as many token types as tokens, or none");
+
+        for(std::size_t i = 0; i < t.size(); i++)
+            m_types[i] = static_cast<type>(int(t[i]));
+    }
+
+    for(std::size_t i = 0; i < m_tokens.size(); i++) {
+        // First wins.  A vocabulary should not repeat a piece, and if one does
+        // the lower id is the one every conversion tool would have used.
+        if(m_by_piece.find(m_tokens[i]) == m_by_piece.end())
+            m_by_piece[m_tokens[i]] = int(i);
+
+        // <0xXX>, which is how a byte with no token of its own is spelled.
+        if(m_types[i] == byte && m_tokens[i].size() == 6 &&
+           m_tokens[i].compare(0, 3, "<0x") == 0 && m_tokens[i][5] == '>')
+        {
+            const int v = hex_pair(m_tokens[i], 3);
+
+            if(v >= 0) m_byte_token[std::size_t(v)] = int(i);
+        }
+    }
+
+    if(!g.has("tokenizer.ggml.merges"))
+        throw exception("the file carries no merge list, and the scores in "
+                        "these files are not usable -- see tokenizer.hh");
+
+    const std::vector<std::string>& merges =
+        g.get("tokenizer.ggml.merges").strings;
+
+    if(merges.empty())
+        throw exception("an empty merge list");
+
+    for(std::size_t i = 0; i < merges.size(); i++) {
+        // Stored already in the form the lookup wants, so the split is only to
+        // reject a line that has no space in it at all.
+        if(merges[i].find(' ') == std::string::npos) {
+            std::ostringstream e;
+
+            e << "merge " << i << " has no space in it: '" << merges[i] << "'";
+
+            throw exception(e.str());
+        }
+
+        if(m_rank.find(merges[i]) == m_rank.end())
+            m_rank[merges[i]] = int(i);
+    }
+
+    if(g.has("tokenizer.ggml.bos_token_id"))
+        m_bos = int(g.integer("tokenizer.ggml.bos_token_id"));
+
+    if(g.has("tokenizer.ggml.eos_token_id"))
+        m_eos = int(g.integer("tokenizer.ggml.eos_token_id"));
+
+    if(g.has("tokenizer.ggml.unknown_token_id"))
+        m_unk = int(g.integer("tokenizer.ggml.unknown_token_id"));
+}
+
+const std::string& tokenizer::token(int id) const {
+    if(id < 0 || std::size_t(id) >= m_tokens.size()) {
+        std::ostringstream e;
+
+        e << "token id " << id << " is outside a vocabulary of "
+          << m_tokens.size();
+
+        throw exception(e.str());
+    }
+
+    return m_tokens[std::size_t(id)];
+}
+
+tokenizer::type tokenizer::token_type(int id) const {
+    if(id < 0 || std::size_t(id) >= m_types.size())
+        throw exception("token type asked for an id outside the vocabulary");
+
+    return m_types[std::size_t(id)];
+}
+
+int tokenizer::id_of(const std::string& piece) const {
+    std::map<std::string, int>::const_iterator i = m_by_piece.find(piece);
+
+    return i == m_by_piece.end() ? -1 : i->second;
+}
+
+std::size_t tokenizer::char_len(const std::string& s, std::size_t at) {
+    const unsigned char c = static_cast<unsigned char>(s[at]);
+
+    std::size_t n = 1;
+
+    if((c & 0xE0) == 0xC0) n = 2;
+    else if((c & 0xF0) == 0xE0) n = 3;
+    else if((c & 0xF8) == 0xF0) n = 4;
+
+    // Truncated or malformed input gets one byte, which the byte fallback then
+    // handles.  Refusing here would mean a tokenizer that throws on input it
+    // could perfectly well represent.
+    if(at + n > s.size()) n = 1;
+
+    return n;
+}
+
+std::vector<int> tokenizer::encode(const std::string& text, bool add_bos) const {
+    std::vector<int> out;
+
+    if(add_bos && m_bos >= 0) out.push_back(m_bos);
+
+    // Empty in, nothing but the sentence marker out.  Without this the dummy
+    // prefix below would be the whole input and encode to a lone space token,
+    // which is a word that was never written.
+    if(text.empty()) return out;
+
+    // The marker for every space, and one in front: see the header.
+    std::string prepared = MARKER;
+
+    for(std::size_t i = 0; i < text.size(); i++) {
+        if(text[i] == ' ') prepared += MARKER;
+        else prepared += text[i];
+    }
+
+    // One symbol per character to begin with, which is what the merge table
+    // was built over.
+    std::vector<std::string> syms;
+
+    for(std::size_t i = 0; i < prepared.size(); ) {
+        const std::size_t n = char_len(prepared, i);
+
+        syms.push_back(prepared.substr(i, n));
+
+        i += n;
+    }
+
+    // Merge the best-ranked adjacent pair until none is left.  Quadratic, and
+    // the header says why that is allowed to stand.
+    for(;;) {
+        int best = -1;
+        std::size_t at = 0;
+
+        for(std::size_t i = 0; i + 1 < syms.size(); i++) {
+            std::map<std::string, int>::const_iterator r =
+                m_rank.find(syms[i] + " " + syms[i + 1]);
+
+            if(r != m_rank.end() && (best < 0 || r->second < best)) {
+                best = r->second;
+                at = i;
+            }
+        }
+
+        if(best < 0) break;
+
+        syms[at] += syms[at + 1];
+
+        syms.erase(syms.begin() + long(at) + 1);
+    }
+
+    for(std::size_t i = 0; i < syms.size(); i++) {
+        const int id = id_of(syms[i]);
+
+        if(id >= 0) {
+            out.push_back(id);
+
+            continue;
+        }
+
+        // No token for this piece, so spell it out in bytes.  Every one of the
+        // 256 exists in a Llama vocabulary, so this cannot fail -- but if a
+        // vocabulary were missing one, <unk> is the honest answer.
+        for(std::size_t b = 0; b < syms[i].size(); b++) {
+            const unsigned char c = static_cast<unsigned char>(syms[i][b]);
+            const int bt = m_byte_token[c];
+
+            out.push_back(bt >= 0 ? bt : m_unk);
+        }
+    }
+
+    return out;
+}
+
+std::string tokenizer::decode(const std::vector<int>& ids) const {
+    std::string out;
+
+    for(std::size_t i = 0; i < ids.size(); i++) {
+        const int id = ids[i];
+
+        if(id < 0 || std::size_t(id) >= m_tokens.size())
+            throw exception("decode: an id outside the vocabulary");
+
+        // <s> and </s> mark the text rather than appearing in it.
+        if(m_types[std::size_t(id)] == control) continue;
+
+        if(m_types[std::size_t(id)] == byte) {
+            const int v = hex_pair(m_tokens[std::size_t(id)], 3);
+
+            if(v >= 0) { out += char(v); continue; }
+        }
+
+        const std::string& piece = m_tokens[std::size_t(id)];
+
+        for(std::size_t at = 0; at < piece.size(); ) {
+            if(piece.compare(at, 3, MARKER) == 0) {
+                out += ' ';
+                at += 3;
+            }
+            else {
+                out += piece[at];
+                at++;
+            }
+        }
+    }
+
+    // And the dummy prefix, which encode() put there and no caller asked for.
+    if(!out.empty() && out[0] == ' ') out.erase(0, 1);
+
+    return out;
+}
+
+}
+}

--- a/jlib/ai/tokenizer.hh
+++ b/jlib/ai/tokenizer.hh
@@ -1,0 +1,141 @@
+/* -*- mode: C++ c-basic-offset: 4  -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+#ifndef JLIB_AI_TOKENIZER_HH
+#define JLIB_AI_TOKENIZER_HH
+
+#include <jlib/ai/gguf.hh>
+
+#include <exception>
+#include <map>
+#include <string>
+#include <vector>
+
+namespace jlib {
+namespace ai {
+
+/**
+ * Byte-pair encoding against a vocabulary carried in a GGUF file.
+ *
+ * ### Merges, not scores, and why
+ *
+ * A Llama vocabulary can be driven two ways. SentencePiece merges by
+ * **score** -- take whichever adjacent pair produces the highest-scoring token
+ * -- and byte-pair encoding merges by **rank**, applying an ordered list of
+ * learned pairs from the most frequent down. A GGUF can carry both:
+ * `tokenizer.ggml.scores` and `tokenizer.ggml.merges`.
+ *
+ * This uses the merges, because in the file it was written against **every one
+ * of the 32000 scores is zero**. Not approximately zero and not zero for the
+ * control tokens alone -- checked against the raw bytes, the array is 128000
+ * zero bytes. Score-driven merging cannot work at all on such a file: every
+ * candidate pair ties, and what happens next is whatever the tie-break happens
+ * to be rather than what the vocabulary meant.
+ *
+ * The merges are real. There are 61249 of them and they begin `▁ t`, `e r`,
+ * `i n` -- the most frequent pairs in English, in descending frequency, which
+ * is exactly what a BPE merge table is. So rank is the file's actual signal
+ * and score is vestigial.
+ *
+ * That this is the right reading is not an inference: `encode("Hello world")`
+ * gives `[1, 15043, 3186]`, which is the published Llama tokenization, and the
+ * whole test suite rests on agreeing with ids that were established
+ * independently.
+ *
+ * ### The dummy prefix
+ *
+ * Spaces become U+2581 (▁) and one is prepended to the text, so "Hello" and
+ * " Hello" tokenize alike and a word carries its own leading space. decode()
+ * undoes both. This is SentencePiece's convention and the vocabulary is built
+ * for it -- `▁The` is a token and `The` is a different one.
+ */
+class tokenizer {
+public:
+    class exception : public std::exception {
+    public:
+        exception(const std::string& msg)
+            : m_msg("jlib::ai::tokenizer::exception: " + msg) {}
+
+        const char* what() const throw() { return m_msg.c_str(); }
+
+    private:
+        std::string m_msg;
+    };
+
+    /** The token types GGUF gives, of which only BYTE and CONTROL matter here. */
+    enum type { undefined = 0, normal = 1, unknown = 2, control = 3,
+                user_defined = 4, unused = 5, byte = 6 };
+
+    explicit tokenizer(const gguf& g);
+
+    std::size_t size() const { return m_tokens.size(); }
+
+    const std::string& token(int id) const;
+    type token_type(int id) const;
+
+    /** The id of an exact piece, or -1. */
+    int id_of(const std::string& piece) const;
+
+    int bos() const { return m_bos; }
+    int eos() const { return m_eos; }
+    int unk() const { return m_unk; }
+
+    /**
+     * Text to token ids.
+     *
+     * A character with no token of its own becomes its UTF-8 bytes, each as a
+     * `<0xXX>` token -- so any input encodes, and nothing silently becomes
+     * `<unk>`.
+     *
+     * Cost is quadratic in the number of symbols: each merge rescans for the
+     * best remaining pair. A priority queue over the pairs would make it
+     * roughly linear, which llama.cpp does and this does not, because a prompt
+     * is short and being able to read this one matters more. Measured at about
+     * a millisecond for the twenty-token prompt in the tests.
+     */
+    std::vector<int> encode(const std::string& text, bool add_bos = true) const;
+
+    /** Ids back to text, undoing the space marker and the dummy prefix. */
+    std::string decode(const std::vector<int>& ids) const;
+
+private:
+    /** How many bytes the UTF-8 character starting here occupies. */
+    static std::size_t char_len(const std::string& s, std::size_t at);
+
+    std::vector<std::string> m_tokens;
+    std::vector<type> m_types;
+
+    std::map<std::string, int> m_by_piece;
+
+    /** "left right" as it appears in the file -> its rank, lowest first. */
+    std::map<std::string, int> m_rank;
+
+    /** The 256 byte tokens, by byte value, so fallback is a lookup. */
+    std::vector<int> m_byte_token;
+
+    int m_bos = -1;
+    int m_eos = -1;
+    int m_unk = -1;
+};
+
+}
+}
+
+#endif // JLIB_AI_TOKENIZER_HH

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -64,6 +64,7 @@ TESTS = \
 	ai_transformer_test \
 	ai_gguf_test \
 	ai_model_test \
+	ai_tokenizer_test \
 	math_object_test \
 	tensor_test \
 \
@@ -311,6 +312,9 @@ metal_gemm_test_LDADD   = $(top_builddir)/jlib/metal/libjmetal.la $(METAL_LIBS)
 
 metal_tensor_test_SOURCES = metal_tensor_test.cc
 metal_tensor_test_LDADD   = $(top_builddir)/jlib/metal/libjmetal.la $(JUTIL_LA) $(JSYS_LA) $(METAL_LIBS)
+
+ai_tokenizer_test_SOURCES  = ai_tokenizer_test.cc
+ai_tokenizer_test_LDADD    = $(JAI_LA) $(JUTIL_LA) $(JSYS_LA)
 
 ai_model_test_SOURCES  = ai_model_test.cc
 ai_model_test_CPPFLAGS = $(AM_CPPFLAGS) $(METAL_CPPFLAGS)

--- a/tests/ai_model_test.cc
+++ b/tests/ai_model_test.cc
@@ -19,6 +19,7 @@
  */
 
 #include <jlib/ai/model.hh>
+#include <jlib/ai/tokenizer.hh>
 
 #ifdef HAVE_METAL
 #include <jlib/metal/backend.hh>
@@ -124,32 +125,26 @@ static void it_knows_the_capital_of_italy(const char* name, ai::backend<T>& b,
     const std::vector<std::string>& toks =
         g.get("tokenizer.ggml.tokens").strings;
 
-    const char* pieces[] = {
-        "<s>",
-        SP "The", SP "capital", SP "of", SP "France", SP "is", SP "Paris", ".",
-        SP "The", SP "capital", SP "of", SP "Germany", SP "is", SP "Berlin", ".",
-        SP "The", SP "capital", SP "of", SP "Italy", SP "is"
-    };
+    // Real tokenization now, rather than the prompt spelled out piece by piece
+    // and looked up by exact string.  That is what this test did before there
+    // was a tokenizer, and the ids it produced by hand are the ones
+    // ai_tokenizer_test still asserts encode() reproduces -- so this is the
+    // same twenty tokens arrived at from the other direction.
+    const ai::tokenizer tok(g);
 
-    std::vector<int> ids;
+    const std::string prompt =
+        "The capital of France is Paris. The capital of Germany is Berlin. "
+        "The capital of Italy is";
 
-    for(const char* piece : pieces) {
-        int found = -1;
+    const std::vector<int> ids = tok.encode(prompt);
 
-        for(std::size_t i = 0; i < toks.size(); i++)
-            if(toks[i] == piece) { found = int(i); break; }
+    ok("  the prompt tokenizes to twenty tokens", ids.size() == 20,
+       std::to_string(ids.size()));
 
-        if(found < 0) {
-            ok(std::string("  the vocabulary has ") + piece, false);
-
-            return;
-        }
-
-        ids.push_back(found);
-    }
-
-    ok("  every piece of the prompt is in the vocabulary", true,
-       std::to_string(ids.size()) + " tokens");
+    // And it says what it meant to say.  A tokenizer that produced twenty of
+    // the wrong tokens would still be twenty.
+    ok("  which say what the prompt said", tok.decode(ids) == prompt,
+       tok.decode(ids));
 
     typename ai::model<T>::config c = ai::model<T>::config::from(g);
 
@@ -265,9 +260,8 @@ int main(int argc, char** argv) {
     // untested.
     //
     // And nothing about generation: this is one forward pass over a prompt.
-    // There is no sampling, no cache, and no tokenizer -- the prompt above is
-    // spelled out piece by piece and looked up by exact string, which is not
-    // tokenization and does not pretend to be.
+    // There is no sampling and no cache, so nothing here produces a second
+    // token, let alone a sentence.
     std::cout << "\n" << (failures ? "FAILED" : "PASSED") << ": " << failures
               << " failure(s)\n";
 

--- a/tests/ai_tokenizer_test.cc
+++ b/tests/ai_tokenizer_test.cc
@@ -1,0 +1,268 @@
+/* -*- mode: C++ c-basic-offset: 4 -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+#include <jlib/ai/tokenizer.hh>
+
+#include <chrono>
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace ai = jlib::ai;
+
+static int failures = 0;
+
+static void ok(const std::string& what, bool good, const std::string& detail = "") {
+    if(!good) ++failures;
+    std::cout << (good ? "  ok   " : "  FAIL ") << what;
+    if(!detail.empty()) std::cout << ": " << detail;
+    std::cout << "\n";
+}
+
+static bool exists(const std::string& p) {
+    std::ifstream f(p, std::ios::binary);
+
+    return bool(f);
+}
+
+static std::string find_model(int argc, char** argv) {
+    if(argc > 1 && exists(argv[1])) return argv[1];
+
+    if(const char* env = std::getenv("JLIB_GGUF"))
+        if(exists(env)) return env;
+
+    const char* names[] = {
+        "tinyllama-1.1b-chat-v1.0.Q8_0.gguf",
+        "../tinyllama-1.1b-chat-v1.0.Q8_0.gguf",
+        "../../tinyllama-1.1b-chat-v1.0.Q8_0.gguf",
+        "../../../tinyllama-1.1b-chat-v1.0.Q8_0.gguf"
+    };
+
+    for(const char* n : names)
+        if(exists(n)) return n;
+
+    return "";
+}
+
+static std::string spell(const ai::tokenizer& t, const std::vector<int>& ids) {
+    std::string s;
+
+    for(std::size_t i = 0; i < ids.size(); i++) {
+        if(i) s += " ";
+        s += std::to_string(ids[i]);
+    }
+
+    return s;
+}
+
+/**
+ * The one assertion that is not self-referential.
+ *
+ * [1, 15043, 3186] for "Hello world" is the published Llama tokenization, and
+ * the ids in the second were established independently -- looked up piece by
+ * piece in the vocabulary, before this tokenizer existed, for the prompt the
+ * model test runs. If the merge-versus-score reading were wrong, these would
+ * not come out.
+ */
+static void it_agrees_with_known_tokenizations(const ai::tokenizer& t) {
+    std::cout << "\nit agrees with known tokenizations:\n";
+
+    const std::vector<int> hello = t.encode("Hello world");
+
+    ok("  Hello world is 1, 15043, 3186",
+       hello == std::vector<int>({ 1, 15043, 3186 }), spell(t, hello));
+
+    const std::vector<int> paris = t.encode("The capital of France is Paris.");
+
+    ok("  and the prompt tokenizes to the ids looked up by hand",
+       paris == std::vector<int>({ 1, 450, 7483, 310, 3444, 338, 3681, 29889 }),
+       spell(t, paris));
+}
+
+static void the_vocabulary_is_what_the_file_said(const ai::tokenizer& t) {
+    std::cout << "\nthe vocabulary is what the file said:\n";
+
+    ok("  32000 tokens", t.size() == 32000, std::to_string(t.size()));
+
+    ok("  bos 1, eos 2, unk 0",
+       t.bos() == 1 && t.eos() == 2 && t.unk() == 0);
+
+    ok("  <s> and </s> are control tokens",
+       t.token_type(1) == ai::tokenizer::control &&
+       t.token_type(2) == ai::tokenizer::control);
+
+    ok("  and the 256 byte tokens run from id 3",
+       t.token(3) == "<0x00>" && t.token(258) == "<0xFF>" &&
+       t.token_type(3) == ai::tokenizer::byte);
+
+    bool threw = false;
+    try { t.token(99999); }
+    catch(ai::tokenizer::exception&) { threw = true; }
+
+    ok("  an id outside the vocabulary is refused", threw);
+}
+
+static void the_space_marker_and_the_dummy_prefix(const ai::tokenizer& t) {
+    std::cout << "\nthe space marker and the dummy prefix:\n";
+
+    // The vocabulary has both, and they are not the same token: a word knows
+    // whether it began a word or continued one.
+    ok("  the marked and unmarked forms are different tokens",
+       t.id_of("\xe2\x96\x81" "The") != t.id_of("The") &&
+       t.id_of("\xe2\x96\x81" "The") >= 0 && t.id_of("The") >= 0);
+
+    // Which is what the prefix is for: a leading word gets the marked form, so
+    // it matches the same word appearing mid-sentence.
+    ok("  a leading word gets the marked form anyway",
+       t.encode("The", false) == std::vector<int>({ t.id_of("\xe2\x96\x81" "The") }),
+       spell(t, t.encode("The", false)));
+
+    ok("  add_bos false leaves the sentence marker off",
+       t.encode("Hello world", false) == std::vector<int>({ 15043, 3186 }),
+       spell(t, t.encode("Hello world", false)));
+}
+
+/** Anything encodes, because a character with no token becomes its bytes. */
+static void anything_encodes(const ai::tokenizer& t) {
+    std::cout << "\nanything encodes:\n";
+
+    // An emoji is four UTF-8 bytes and no Llama vocabulary has a token for it.
+    const std::string emoji = "\xf0\x9f\x8e\xb2";
+
+    const std::vector<int> ids = t.encode(emoji, false);
+
+    bool all_bytes = !ids.empty();
+
+    for(std::size_t i = 0; i < ids.size(); i++)
+        if(t.token_type(ids[i]) != ai::tokenizer::byte &&
+           t.token(ids[i]) != "\xe2\x96\x81")
+            all_bytes = false;
+
+    ok("  a character with no token becomes byte tokens", all_bytes,
+       spell(t, ids));
+
+    ok("  and it comes back", t.decode(ids) == emoji, t.decode(ids));
+
+    ok("  the empty string is a sentence marker and nothing else",
+       t.encode("") == std::vector<int>({ 1 }), spell(t, t.encode("")));
+}
+
+static void it_round_trips(const ai::tokenizer& t) {
+    std::cout << "\nit round trips:\n";
+
+    const char* cases[] = {
+        "Hello world",
+        "The capital of France is Paris.",
+        "a",
+        "  double  spaces  ",
+        "line\nbreak\ttab",
+        "Numbers 1234567890 and symbols !@#$%^&*()",
+        "caf\xc3\xa9 na\xc3\xaf""ve \xe2\x80\x94 dashes",
+        "\xf0\x9f\x8e\xb2 \xe4\xb8\xad\xe6\x96\x87 mixed"
+    };
+
+    for(const char* c : cases) {
+        const std::string in = c;
+        const std::string out = t.decode(t.encode(in));
+
+        ok(std::string("  ") + "\"" + in.substr(0, 34) + "\"", out == in,
+           out == in ? "" : "got \"" + out + "\"");
+    }
+}
+
+static void it_is_quick_enough(const ai::tokenizer& t) {
+    std::cout << "\nit is quick enough:\n";
+
+    const std::string prompt =
+        "The capital of France is Paris. The capital of Germany is Berlin. "
+        "The capital of Italy is";
+
+    const auto start = std::chrono::steady_clock::now();
+
+    std::vector<int> ids;
+
+    for(int i = 0; i < 20; i++) ids = t.encode(prompt);
+
+    const double ms = std::chrono::duration<double, std::milli>(
+        std::chrono::steady_clock::now() - start).count() / 20.0;
+
+    // Not a benchmark, a bound.  encode() is quadratic in the symbol count and
+    // the header says so; this is here to notice if that ever stops being fine
+    // for a prompt-sized input rather than to measure how fast it is.
+    ok("  a twenty-token prompt encodes in under 50ms", ms < 50.0,
+       std::to_string(ms) + "ms");
+
+    ok("  and gives the twenty tokens the model test uses", ids.size() == 20,
+       std::to_string(ids.size()));
+}
+
+int main(int argc, char** argv) {
+    std::cout << std::unitbuf;
+
+    const std::string path = find_model(argc, argv);
+
+    if(path.empty()) {
+        std::cout << "ai_tokenizer_test: no model file; pass one as an argument "
+                  << "or set JLIB_GGUF.\n";
+
+        return 77;
+    }
+
+    std::cout << "ai_tokenizer_test: " << path << "\n";
+
+    try {
+        const ai::gguf g(path);
+        const ai::tokenizer t(g);
+
+        it_agrees_with_known_tokenizations(t);
+        the_vocabulary_is_what_the_file_said(t);
+        the_space_marker_and_the_dummy_prefix(t);
+        anything_encodes(t);
+        it_round_trips(t);
+        it_is_quick_enough(t);
+    }
+    catch(std::exception& e) {
+        std::cerr << "ai_tokenizer_test: " << e.what() << "\n";
+
+        return 1;
+    }
+
+    // What a green run does not establish.
+    //
+    // That this matches llama.cpp on arbitrary text.  Two tokenizations are
+    // checked against ids from outside this library, and the rest is
+    // round-tripping -- which a consistently wrong encoder would also pass,
+    // since decode() only has to invert whatever encode() did.
+    //
+    // Nothing about the score-driven path.  The file this was written against
+    // has all-zero scores, so merges are the only usable signal in it; a
+    // vocabulary with real scores would want SentencePiece's algorithm, and
+    // this would tokenize it differently and never say so.
+    //
+    // And no chat template.  The file carries tokenizer.chat_template, which
+    // is how an instruct model expects a conversation to be laid out, and
+    // nothing here reads it.
+    std::cout << "\n" << (failures ? "FAILED" : "PASSED") << ": " << failures
+              << " failure(s)\n";
+
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
# The tokenizer

The model branch ended with the prompt spelled out piece by piece and looked up
by exact string, and said plainly that this "is not tokenization and does not
pretend to be". This is the tokenizer, and the model test now takes text.

## Every score in the file is zero

A Llama vocabulary can be driven two ways. SentencePiece merges by **score** —
take whichever adjacent pair makes the highest-scoring token — and byte-pair
encoding merges by **rank**, applying an ordered list of learned pairs from the
most frequent down. A GGUF can carry both, and this one does:
`tokenizer.ggml.scores` and `tokenizer.ggml.merges`.

The scores are useless. Not approximately, and not only for the control tokens:
checked against the raw bytes at offset 467589, the array is **128000 zero
bytes — 0 non-zero entries out of 32000**. Score-driven merging cannot work on
such a file at all. Every candidate pair ties, and what comes out is whatever
the tie-break happens to be rather than what the vocabulary meant.

The merges are real: 61249 of them, beginning `▁ t`, `e r`, `i n` — the most
frequent pairs in English in descending order, which is exactly what a BPE merge
table is. So rank is the file's live signal and score is vestigial, and this
tokenizer merges by rank.

That reading was checked before any C++ was written, by prototyping the
algorithm in Python against ids established independently. It is not an
inference from the data looking plausible.

## Anchored outside this library

Two assertions do not depend on anything here being right:

- `encode("Hello world")` is `[1, 15043, 3186]`, the published Llama
  tokenization.
- `encode("The capital of France is Paris.")` is
  `[1, 450, 7483, 310, 3444, 338, 3681, 29889]` — the ids the *model* branch
  looked up by hand, piece by piece, before this tokenizer existed.

The second is the useful one. Those ids were arrived at by searching the
vocabulary for exact strings; these are arrived at by running BPE over the merge
table. Two unrelated routes to the same twenty tokens.

## The model test now takes text

```cpp
const std::string prompt = "The capital of France is Paris. ...";
const std::vector<int> ids = tok.encode(prompt);
```

Same twenty tokens, and **▁Rome at logit 19.109375** — bit-identical to the
hand-spelled run, which is what says the tokenizer reproduced exactly those ids
rather than twenty plausible others. The test also asserts `decode(encode(p))`
is the prompt, because twenty of the wrong tokens would still be twenty.

## Details that matter

**The dummy prefix.** Spaces become U+2581 and one is prepended, so `The` at the
start of a sentence gets the same token as `The` in the middle of one. `▁The`
(450) and `The` (1576) are different tokens and the vocabulary is built for it.

**Byte fallback.** A character with no token becomes its UTF-8 bytes as `<0xXX>`
tokens, so anything encodes and nothing silently becomes `<unk>` — an emoji, CJK
and accented Latin all round-trip.

**The empty string.** The first version returned `[1, 29871]`: the dummy prefix
became the whole input and encoded to a lone space token — a word nobody wrote.
llama.cpp guards with `if (!raw_text.empty())` and now so does this. The test
caught it, which is the right way round.

**Cost.** `encode` is quadratic in the symbol count — each merge rescans for the
best remaining pair. A priority queue would make it roughly linear, which
llama.cpp does and this does not, because a prompt is short and reading this one
matters more. Measured at 0.375 ms for the twenty-token prompt, with a test
asserting it stays under 50 ms so that a change of scale is noticed rather than
assumed.

### Mutation results

| mutation | caught |
| --- | --- |
| no dummy prefix | 5 failures |
| merge by highest rank instead of lowest | **2 failures** |
| spaces left as spaces | 4 failures |
| byte fallback emits `<unk>` | 4 failures |

The second is worth its own line. Reversing the merge order fails only the two
known-tokenization assertions — **every round-trip still passes**, because
`decode` only has to invert whatever `encode` did. That is exactly the
limitation the test's closing note claims, now confirmed rather than asserted:
round-tripping is nearly free evidence, and the two externally-anchored ids are
carrying this test.

## Verification

- macOS `make check`: 72 tests (was 71), 68 pass, 4 skip, 0 fail.
- Container: no model there, so the three model-dependent tests report SKIP.

## What this does not establish

**That it matches llama.cpp on arbitrary text.** Two tokenizations are anchored
outside; the rest is round-tripping, which the mutation above shows a
consistently wrong encoder would pass.

**Nothing about the score-driven path.** The file has no usable scores, so
merges are the only signal in it. A vocabulary with real scores wants
SentencePiece's algorithm, and this would tokenize it differently and never say
so — worth a check on the scores at construction if a second model ever turns
up.

**No chat template.** The file carries `tokenizer.chat_template`, which is how an
instruct model expects a conversation laid out, and nothing reads it. TinyLlama
is a *chat* model, so a conversational prompt would want it.

**Still no generation.** One forward pass over a prompt: no sampling and no KV
cache, so nothing produces a second token. That is now the only thing left
between here and text coming out.
