### PR TITLE
Add sampling and a generation loop, so jlib writes text: greedy TinyLlama continues its prompt through Madrid

### DIFF
--- a/jlib/ai/Makefile.am
+++ b/jlib/ai/Makefile.am
@@ -2,7 +2,7 @@ AM_CPPFLAGS = -I$(top_srcdir)
 
 lib_LTLIBRARIES = libjai.la
 libjai_la_SOURCES = environment.cc agent.cc percept.cc action.cc vacuum.cc \
-                    backend.cc gguf.cc tokenizer.cc
+                    backend.cc gguf.cc tokenizer.cc sampler.cc
 libjai_la_LDFLAGS = -version-info $(LIBJ_SO_VERSION) -release $(JLIB_RELEASE) -no-undefined
 libjai_la_LIBADD = $(top_builddir)/jlib/util/libjutil.la \
                    $(top_builddir)/jlib/sys/libjsys.la
@@ -10,4 +10,4 @@ libjai_la_LIBADD = $(top_builddir)/jlib/util/libjutil.la \
 libjaiincludedir = $(includedir)/jlib-1.2/jlib/ai
 libjaiinclude_HEADERS = environment.hh agent.hh percept.hh action.hh vacuum.hh \
                         neural.hh backend.hh attention.hh transformer.hh \
-                        gguf.hh model.hh tokenizer.hh
+                        gguf.hh model.hh tokenizer.hh sampler.hh generate.hh

--- a/jlib/ai/generate.hh
+++ b/jlib/ai/generate.hh
@@ -1,0 +1,129 @@
+/* -*- mode: C++ c-basic-offset: 4  -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+#ifndef JLIB_AI_GENERATE_HH
+#define JLIB_AI_GENERATE_HH
+
+#include <jlib/ai/model.hh>
+#include <jlib/ai/sampler.hh>
+
+#include <functional>
+#include <vector>
+
+namespace jlib {
+namespace ai {
+
+/**
+ * The logits for the last position of a sequence, as floats.
+ *
+ * Pulled out because sampling is defined on one column and the model produces
+ * a matrix, and because reading a (vocab x seq) matrix back to get one column
+ * of it is the sort of thing worth having a name for.
+ */
+template<typename T>
+std::vector<float> last_logits(const math::matrix<T>& logits) {
+    if(logits.N == 0)
+        throw backend_error("last_logits: no positions");
+
+    std::vector<float> out(logits.M);
+
+    for(unsigned int v = 0; v < logits.M; v++)
+        out[v] = float(logits(v, logits.N - 1));
+
+    return out;
+}
+
+/**
+ * Generate tokens, one at a time, until eos or a limit.
+ *
+ * **The whole sequence is re-run for every token.** There is no cache here, so
+ * generating n tokens from a prompt of m costs n forward passes over sequences
+ * of m+1, m+2, ... m+n -- quadratic work for what should be linear. That is
+ * the honest first version and it is deliberately the *reference*: a key-value
+ * cache is a separate piece of work whose correctness condition is that it
+ * produces exactly this, token for token, and it cannot be checked against
+ * something that does not exist yet.
+ *
+ * What that costs, measured rather than assumed, is less than the paragraph
+ * above suggests. TinyLlama in fp16 on an M5, generating 49 tokens from a
+ * 20-token prompt, takes 11.7s -- between 0.15 and 0.30s per token, **with no
+ * growth visible** as the prefix runs from 20 to 69.
+ *
+ * The reason is that a pass at these lengths is not spent on the prefix. It is
+ * spent streaming 2.2GB of weights through the GPU, which happens once per
+ * pass whatever the sequence length is, and against which the attention work
+ * for a few dozen positions does not register. So the quadratic term is real
+ * and is simply not the term that matters yet; it would be at a context of
+ * thousands.
+ *
+ * Worth saying because it bounds what a cache is worth here: it removes work
+ * that currently is not the bottleneck, and the honest claim for it is about
+ * long contexts rather than about this.
+ *
+ * @param on_token called with each new token as it is produced, for a caller
+ *                 that wants to stream rather than wait
+ * @return the prompt followed by everything generated
+ */
+template<typename T>
+std::vector<int> generate(model<T>& m, backend<T>& b,
+                          const std::vector<int>& prompt,
+                          unsigned int max_new,
+                          sampler& s,
+                          int eos = -1,
+                          std::function<void(int)> on_token = nullptr)
+{
+    if(prompt.empty())
+        throw backend_error("generate: an empty prompt has no last position");
+
+    std::vector<int> ids = prompt;
+
+    for(unsigned int step = 0; step < max_new; step++) {
+        const unsigned int n = static_cast<unsigned int>(ids.size());
+
+        if(m.conf().context && n > m.conf().context)
+            break;
+
+        // Re-reserved every step because the sequence grew.  This reallocates
+        // every intermediate in every block, which sounds worse than it is --
+        // it is a few hundred allocations against a forward pass over a
+        // billion parameters.  The cache branch removes the growth, not this.
+        m.reserve(n);
+
+        typename backend<T>::tensor_ptr logits = b.make(m.conf().vocab, n);
+
+        m.forward(ids, logits);
+        b.wait();
+
+        const int next = s.pick(last_logits(logits->read()));
+
+        ids.push_back(next);
+
+        if(on_token) on_token(next);
+
+        if(eos >= 0 && next == eos) break;
+    }
+
+    return ids;
+}
+
+}
+}
+
+#endif // JLIB_AI_GENERATE_HH

--- a/jlib/ai/sampler.cc
+++ b/jlib/ai/sampler.cc
@@ -1,0 +1,159 @@
+/* -*- mode: C++ c-basic-offset: 4  -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+#include <jlib/ai/sampler.hh>
+
+#include <algorithm>
+#include <cmath>
+
+namespace jlib {
+namespace ai {
+
+sampler::sampler(const config& c)
+    : m_conf(c),
+      m_gen(c.seed)
+{
+    if(c.temperature < 0)
+        throw exception("a negative temperature");
+
+    if(c.top_p <= 0 || c.top_p > 1)
+        throw exception("top_p must be above zero and at most one");
+}
+
+void sampler::reseed(std::uint64_t seed) {
+    m_conf.seed = seed;
+    m_gen.seed(seed);
+}
+
+int sampler::argmax(const std::vector<float>& logits) {
+    if(logits.empty())
+        throw exception("argmax of nothing");
+
+    int best = 0;
+
+    for(std::size_t i = 1; i < logits.size(); i++)
+        if(logits[i] > logits[std::size_t(best)]) best = int(i);
+
+    return best;
+}
+
+std::vector<std::pair<int, float> >
+sampler::distribution(const std::vector<float>& logits) const {
+    std::vector<std::pair<int, float> > kept;
+
+    if(logits.empty()) return kept;
+
+    kept.reserve(logits.size());
+
+    for(std::size_t i = 0; i < logits.size(); i++)
+        kept.push_back(std::make_pair(int(i), logits[i]));
+
+    // Descending, breaking ties by token so the result does not depend on the
+    // sort being stable or on the order the vocabulary happens to be in.
+    std::sort(kept.begin(), kept.end(),
+              [](const std::pair<int, float>& a, const std::pair<int, float>& b) {
+                  return a.second > b.second ||
+                         (a.second == b.second && a.first < b.first);
+              });
+
+    // top-k first, on the order alone.  Cutting here rather than after the
+    // softmax is what makes the discarded mass go back to the survivors.
+    if(m_conf.top_k > 0 && kept.size() > m_conf.top_k)
+        kept.resize(m_conf.top_k);
+
+    const float t = m_conf.temperature;
+
+    // Softmax, with the maximum subtracted -- which is free here, the list
+    // being sorted, and is the same guard against exp() overflowing that
+    // backend::softmax carries.
+    const float top = kept[0].second;
+
+    double sum = 0;
+
+    for(std::size_t i = 0; i < kept.size(); i++) {
+        const double e = std::exp(double(kept[i].second - top) /
+                                  double(t > 0 ? t : 1.0f));
+
+        kept[i].second = float(e);
+        sum += e;
+    }
+
+    for(std::size_t i = 0; i < kept.size(); i++)
+        kept[i].second = float(double(kept[i].second) / sum);
+
+    // And top-p, which needs the probabilities that only now exist.  At least
+    // one survives however small p is: a nucleus of nothing is not a choice.
+    if(m_conf.top_p < 1.0f) {
+        double running = 0;
+        std::size_t keep = 0;
+
+        for(; keep < kept.size(); keep++) {
+            running += double(kept[keep].second);
+
+            if(running >= double(m_conf.top_p)) { keep++; break; }
+        }
+
+        // No floor needed, and there was one here until a mutation showed it
+        // could never fire: kept is non-empty by now, so the loop runs at least
+        // once and leaves keep at 1 or more either way it exits.  A guard that
+        // cannot trigger reads as though the case it names is possible.
+        kept.resize(keep);
+
+        double again = 0;
+
+        for(std::size_t i = 0; i < kept.size(); i++) again += double(kept[i].second);
+
+        for(std::size_t i = 0; i < kept.size(); i++)
+            kept[i].second = float(double(kept[i].second) / again);
+    }
+
+    return kept;
+}
+
+int sampler::pick(const std::vector<float>& logits) {
+    if(logits.empty())
+        throw exception("a choice between no tokens");
+
+    // Greedy is not temperature zero taken to a limit, it is the absence of a
+    // draw -- so the generator does not consume randomness and two runs at
+    // temperature zero agree whatever the seeds were.
+    if(m_conf.temperature <= 0) return argmax(logits);
+
+    const std::vector<std::pair<int, float> > d = distribution(logits);
+
+    std::uniform_real_distribution<double> u(0.0, 1.0);
+
+    const double r = u(m_gen);
+
+    double running = 0;
+
+    for(std::size_t i = 0; i < d.size(); i++) {
+        running += double(d[i].second);
+
+        if(r <= running) return d[i].first;
+    }
+
+    // Only reachable if the probabilities sum to slightly under one, which
+    // rounding can manage.  The last is the honest answer, not an error.
+    return d.back().first;
+}
+
+}
+}

--- a/jlib/ai/sampler.hh
+++ b/jlib/ai/sampler.hh
@@ -1,0 +1,127 @@
+/* -*- mode: C++ c-basic-offset: 4  -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+#ifndef JLIB_AI_SAMPLER_HH
+#define JLIB_AI_SAMPLER_HH
+
+#include <cstdint>
+#include <exception>
+#include <random>
+#include <string>
+#include <vector>
+
+namespace jlib {
+namespace ai {
+
+/**
+ * How a sampler chooses, hoisted out of the class that uses it.
+ *
+ * At namespace scope rather than nested, for the same reason sys::server_policy
+ * is: a default argument is a complete-class context, so `sampler(const config&
+ * c = config())` cannot see a nested aggregate's member initializers while
+ * sampler is still incomplete. Defining it first removes the problem instead of
+ * routing around it, and `sampler::config` still spells.
+ */
+struct sampler_config {
+    /** 0 is greedy; the draw is skipped entirely. */
+    float temperature = 0.8f;
+
+    /** How many of the highest to keep before normalising; 0 keeps all. */
+    unsigned int top_k = 40;
+
+    /** Keep the smallest set summing to this; 1 keeps all. */
+    float top_p = 0.95f;
+
+    std::uint64_t seed = 0;
+};
+
+/**
+ * Turning a column of logits into one token.
+ *
+ * The steps are the usual ones and the order matters: temperature, then top-k,
+ * then softmax over what is left, then top-p, then a draw.
+ *
+ * - **temperature** divides the logits. Below one it sharpens the distribution
+ *   and above one it flattens it. Zero means greedy -- take the largest and
+ *   draw nothing -- which is a different code path rather than a division by
+ *   zero, and is what makes a run reproducible without reference to a seed.
+ * - **top-k** keeps the k highest and discards the rest before anything is
+ *   normalised, so the discarded mass is redistributed rather than merely
+ *   unlikely.
+ * - **top-p** (nucleus) keeps the smallest set whose probabilities already sum
+ *   to p. It adapts where top-k cannot: a confident position keeps one or two
+ *   tokens and an uncertain one keeps many.
+ *
+ * top-p is applied *after* the softmax because it is defined on probabilities,
+ * and top-k *before* it because it is defined on order -- which is why they are
+ * not interchangeable and why both exist.
+ *
+ * The RNG is the sampler's own, seeded explicitly. Two samplers with the same
+ * seed and the same logits give the same tokens, which is what lets a test of
+ * anything downstream be a test rather than an observation.
+ */
+class sampler {
+public:
+    class exception : public std::exception {
+    public:
+        exception(const std::string& msg)
+            : m_msg("jlib::ai::sampler::exception: " + msg) {}
+
+        const char* what() const throw() { return m_msg.c_str(); }
+
+    private:
+        std::string m_msg;
+    };
+
+    typedef sampler_config config;
+
+    explicit sampler(const config& c = config());
+
+    const config& conf() const { return m_conf; }
+
+    /** Start the sequence again from the configured seed. */
+    void reseed(std::uint64_t seed);
+
+    /** One token from one column of logits. */
+    int pick(const std::vector<float>& logits);
+
+    /** The largest, with no randomness anywhere. */
+    static int argmax(const std::vector<float>& logits);
+
+    /**
+     * The probabilities pick() would draw from, for a caller that wants to see
+     * them -- and for a test that wants to check the shape of the
+     * distribution rather than which token came out of it.
+     *
+     * Returns pairs of (token, probability), ordered most likely first and
+     * summing to one. Empty only if the logits are.
+     */
+    std::vector<std::pair<int, float> > distribution(
+        const std::vector<float>& logits) const;
+
+private:
+    config m_conf;
+    std::mt19937_64 m_gen;
+};
+
+}
+}
+
+#endif // JLIB_AI_SAMPLER_HH

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -65,6 +65,7 @@ TESTS = \
 	ai_gguf_test \
 	ai_model_test \
 	ai_tokenizer_test \
+	ai_sampler_test \
 	math_object_test \
 	tensor_test \
 \
@@ -312,6 +313,9 @@ metal_gemm_test_LDADD   = $(top_builddir)/jlib/metal/libjmetal.la $(METAL_LIBS)
 
 metal_tensor_test_SOURCES = metal_tensor_test.cc
 metal_tensor_test_LDADD   = $(top_builddir)/jlib/metal/libjmetal.la $(JUTIL_LA) $(JSYS_LA) $(METAL_LIBS)
+
+ai_sampler_test_SOURCES  = ai_sampler_test.cc
+ai_sampler_test_LDADD    = $(JAI_LA) $(JUTIL_LA) $(JSYS_LA)
 
 ai_tokenizer_test_SOURCES  = ai_tokenizer_test.cc
 ai_tokenizer_test_LDADD    = $(JAI_LA) $(JUTIL_LA) $(JSYS_LA)

--- a/tests/ai_model_test.cc
+++ b/tests/ai_model_test.cc
@@ -18,6 +18,7 @@
  *
  */
 
+#include <jlib/ai/generate.hh>
 #include <jlib/ai/model.hh>
 #include <jlib/ai/tokenizer.hh>
 
@@ -202,6 +203,70 @@ static void it_knows_the_capital_of_italy(const char* name, ai::backend<T>& b,
        (second >= 0 ? toks[std::size_t(second)] : "nothing"));
 }
 
+/**
+ * It writes the next sentences, not just the next token.
+ *
+ * Greedy, so there is nothing random to reproduce and no seed to record: the
+ * output is a function of the weights alone. That is what makes an exact string
+ * a fair assertion here rather than a hostage to an RNG.
+ *
+ * The prompt sets a pattern of three, and continuing it means both finishing
+ * the third clause correctly and inventing a fourth of the same shape. Getting
+ * "Rome" is one token; getting "The capital of Spain is Madrid" after it is the
+ * loop, the sampler, the tokenizer and the model all agreeing over twelve
+ * steps, each fed the output of the last.
+ */
+template<typename T>
+static void it_continues_the_pattern(const char* name, ai::backend<T>& b,
+                                     const ai::gguf& g)
+{
+    std::cout << "\nit continues the pattern, " << name << ":\n";
+
+    const ai::tokenizer tok(g);
+
+    typename ai::model<T>::config c = ai::model<T>::config::from(g);
+
+    ai::model<T> m(b, c);
+
+    m.load(g);
+
+    const std::string prompt =
+        "The capital of France is Paris. The capital of Germany is Berlin. "
+        "The capital of Italy is";
+
+    ai::sampler::config sc;
+    sc.temperature = 0.0f;
+
+    ai::sampler s(sc);
+
+    const std::vector<int> ids = tok.encode(prompt);
+
+    const std::vector<int> out =
+        ai::generate<T>(m, b, ids, 12, s, tok.eos());
+
+    ok("  twelve more tokens came out", out.size() == ids.size() + 12,
+       std::to_string(out.size() - ids.size()));
+
+    // Only what was generated, which is where the prompt stops.
+    const std::vector<int> tail(out.begin() + long(ids.size()), out.end());
+
+    const std::string wrote = tok.decode(tail);
+
+    // Twelve tokens, counted from the run rather than guessed: the first
+    // version of this expected the ten-token continuation and was two short.
+    ok("  and they say what they should",
+       wrote == "Rome. The capital of Spain is Madrid. The capital of",
+       "\"" + wrote + "\"");
+
+    // Nothing random went into that, so a second run is the same run.
+    ai::sampler again(sc);
+
+    const std::vector<int> twice =
+        ai::generate<T>(m, b, ids, 12, again, tok.eos());
+
+    ok("  greedy generation repeats exactly", twice == out);
+}
+
 int main(int argc, char** argv) {
     std::cout << std::unitbuf;
 
@@ -236,7 +301,10 @@ int main(int argc, char** argv) {
             ok("  the Metal backend comes up", false, e.what());
         }
 
-        if(gpu) it_knows_the_capital_of_italy<_Float16>("fp16 on the GPU", *gpu, g);
+        if(gpu) {
+            it_knows_the_capital_of_italy<_Float16>("fp16 on the GPU", *gpu, g);
+            it_continues_the_pattern<_Float16>("fp16 on the GPU", *gpu, g);
+        }
 #else
         std::cout << "\n  (no Metal: the forward pass needs a backend whose "
                   << "GEMM accumulates wider than fp16)\n";
@@ -259,9 +327,11 @@ int main(int argc, char** argv) {
     // where the rope angle grows and fp16 accumulation has more to lose, are
     // untested.
     //
-    // And nothing about generation: this is one forward pass over a prompt.
-    // There is no sampling and no cache, so nothing here produces a second
-    // token, let alone a sentence.
+    // That generation is efficient.  Every token re-runs the whole sequence,
+    // because there is no key-value cache -- measured at 0.15 to 0.30s per
+    // token here, dominated by streaming the weights rather than by the
+    // prefix, so the quadratic term does not bite at these lengths and would
+    // at a context of thousands.  See generate.hh.
     std::cout << "\n" << (failures ? "FAILED" : "PASSED") << ": " << failures
               << " failure(s)\n";
 

--- a/tests/ai_sampler_test.cc
+++ b/tests/ai_sampler_test.cc
@@ -1,0 +1,321 @@
+/* -*- mode: C++ c-basic-offset: 4 -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+#include <jlib/ai/sampler.hh>
+
+#include <cmath>
+#include <iostream>
+#include <map>
+#include <string>
+#include <vector>
+
+namespace ai = jlib::ai;
+
+static int failures = 0;
+
+static void ok(const std::string& what, bool good, const std::string& detail = "") {
+    if(!good) ++failures;
+    std::cout << (good ? "  ok   " : "  FAIL ") << what;
+    if(!detail.empty()) std::cout << ": " << detail;
+    std::cout << "\n";
+}
+
+static void greedy_is_not_a_draw() {
+    std::cout << "\ngreedy is not a draw:\n";
+
+    const std::vector<float> logits{ 1.0f, 3.0f, 2.0f, 0.5f };
+
+    ok("  argmax finds the largest", ai::sampler::argmax(logits) == 1);
+
+    ai::sampler::config c;
+    c.temperature = 0.0f;
+
+    // Two samplers with *different* seeds.  At temperature zero neither draws,
+    // so the seed cannot matter -- which is the property that makes a greedy
+    // run reproducible without anybody recording a seed.
+    c.seed = 1;
+    ai::sampler a(c);
+
+    c.seed = 999999;
+    ai::sampler b(c);
+
+    bool same = true;
+
+    for(int i = 0; i < 20; i++)
+        if(a.pick(logits) != 1 || b.pick(logits) != 1) same = false;
+
+    ok("  and temperature zero always takes it, whatever the seed", same);
+}
+
+static void the_same_seed_gives_the_same_tokens() {
+    std::cout << "\nthe same seed gives the same tokens:\n";
+
+    std::vector<float> logits;
+
+    for(int i = 0; i < 50; i++) logits.push_back(float(i % 7) * 0.5f);
+
+    ai::sampler::config c;
+    c.temperature = 1.0f;
+    c.top_k = 0;
+    c.top_p = 1.0f;
+    c.seed = 42;
+
+    ai::sampler a(c), b(c);
+
+    std::vector<int> first, second;
+
+    for(int i = 0; i < 30; i++) { first.push_back(a.pick(logits));
+                                  second.push_back(b.pick(logits)); }
+
+    ok("  two samplers with one seed agree", first == second);
+
+    c.seed = 43;
+    ai::sampler d(c);
+
+    std::vector<int> third;
+
+    for(int i = 0; i < 30; i++) third.push_back(d.pick(logits));
+
+    // Not a law -- two seeds *could* agree by chance -- but over thirty draws
+    // from a spread distribution it would be remarkable.
+    ok("  and a different seed does not", first != third);
+
+    a.reseed(42);
+
+    std::vector<int> again;
+
+    for(int i = 0; i < 30; i++) again.push_back(a.pick(logits));
+
+    ok("  reseeding starts the sequence over", first == again);
+}
+
+static void top_k_and_top_p_cut_where_they_say() {
+    std::cout << "\ntop k and top p cut where they say:\n";
+
+    const std::vector<float> logits{ 0.0f, 5.0f, 4.0f, 3.0f, 2.0f, 1.0f };
+
+    ai::sampler::config c;
+    c.temperature = 1.0f;
+    c.top_p = 1.0f;
+    c.seed = 7;
+
+    c.top_k = 1;
+    ai::sampler one(c);
+
+    bool always = true;
+
+    for(int i = 0; i < 50; i++) if(one.pick(logits) != 1) always = false;
+
+    ok("  top_k 1 is greedy by another route", always);
+
+    c.top_k = 3;
+    ai::sampler three(c);
+
+    ok("  top_k 3 keeps three", three.distribution(logits).size() == 3,
+       std::to_string(three.distribution(logits).size()));
+
+    bool in_range = true;
+
+    for(int i = 0; i < 200; i++) {
+        const int t = three.pick(logits);
+
+        if(t != 1 && t != 2 && t != 3) in_range = false;
+    }
+
+    ok("  and never draws outside them", in_range);
+
+    // A nucleus of nothing is not a choice, so the smallest p still keeps one.
+    c.top_k = 0;
+    c.top_p = 0.0001f;
+    ai::sampler tiny(c);
+
+    ok("  the smallest top_p still keeps one", tiny.distribution(logits).size() == 1,
+       std::to_string(tiny.distribution(logits).size()));
+
+    bool only_best = true;
+
+    for(int i = 0; i < 50; i++) if(tiny.pick(logits) != 1) only_best = false;
+
+    ok("  which is the likeliest", only_best);
+}
+
+/**
+ * The draw follows the distribution, not merely the order.
+ *
+ * Two tokens whose logits differ by ln(3) should come up three times to one.
+ * Nothing else here checks that the probabilities are *used* -- every other
+ * assertion would pass on a sampler that always returned its first choice.
+ */
+static void the_draw_follows_the_probabilities() {
+    std::cout << "\nthe draw follows the probabilities:\n";
+
+    std::vector<float> logits{ float(std::log(3.0)), 0.0f };
+
+    ai::sampler::config c;
+    c.temperature = 1.0f;
+    c.top_k = 0;
+    c.top_p = 1.0f;
+    c.seed = 11;
+
+    ai::sampler s(c);
+
+    const std::vector<std::pair<int, float> > d = s.distribution(logits);
+
+    ok("  the distribution is 0.75 and 0.25",
+       d.size() == 2 && std::fabs(d[0].second - 0.75f) < 1e-4f &&
+       std::fabs(d[1].second - 0.25f) < 1e-4f,
+       d.size() == 2 ? std::to_string(d[0].second) + " and " +
+                       std::to_string(d[1].second) : "wrong size");
+
+    int zero = 0;
+
+    const int draws = 20000;
+
+    for(int i = 0; i < draws; i++) if(s.pick(logits) == 0) zero++;
+
+    const double got = double(zero) / double(draws);
+
+    // Three sigma for 20000 draws at p=0.75 is about 0.009, so 0.02 is loose
+    // enough never to flake and tight enough that 50/50 or 100/0 fails.
+    ok("  and twenty thousand draws land near it", std::fabs(got - 0.75) < 0.02,
+       std::to_string(got));
+}
+
+/**
+ * Temperature sharpens and flattens, by exactly how much.
+ *
+ * Dividing the logits by t scales their differences by 1/t, so two tokens
+ * ln(3) apart are ln(3)/t apart afterwards and the top probability follows
+ * exactly. Every other assertion here runs at temperature 1, where the
+ * division does nothing -- measured: removing it entirely failed nothing until
+ * this existed.
+ */
+static void temperature_moves_the_mass() {
+    std::cout << "\ntemperature moves the mass:\n";
+
+    const std::vector<float> logits{ float(std::log(3.0)), 0.0f };
+
+    ai::sampler::config c;
+    c.top_k = 0;
+    c.top_p = 1.0f;
+    c.seed = 3;
+
+    struct { float t; double want; const char* what; } cases[] = {
+        // exp(ln3 / t) / (exp(ln3 / t) + 1)
+        { 1.0f, 3.0 / 4.0,                     "at one, three to one" },
+        { 0.5f, 9.0 / 10.0,                    "at a half, nine to one" },
+        { 2.0f, std::sqrt(3.0) / (std::sqrt(3.0) + 1.0), "at two, flatter" }
+    };
+
+    for(const auto& e : cases) {
+        c.temperature = e.t;
+
+        ai::sampler s(c);
+
+        const std::vector<std::pair<int, float> > d = s.distribution(logits);
+
+        ok(std::string("  ") + e.what,
+           d.size() == 2 && std::fabs(double(d[0].second) - e.want) < 1e-4,
+           d.empty() ? "empty" : std::to_string(d[0].second) + " wanted " +
+                                 std::to_string(e.want));
+    }
+
+    // And it is not only the reported distribution that changes: a colder
+    // sampler really does draw the favourite more often.
+    c.temperature = 0.25f;
+    ai::sampler cold(c);
+
+    c.temperature = 4.0f;
+    ai::sampler hot(c);
+
+    int cold_top = 0;
+    int hot_top = 0;
+
+    for(int i = 0; i < 4000; i++) {
+        if(cold.pick(logits) == 0) cold_top++;
+        if(hot.pick(logits) == 0) hot_top++;
+    }
+
+    ok("  and a colder sampler draws the favourite more often",
+       cold_top > hot_top + 400,
+       std::to_string(cold_top) + " against " + std::to_string(hot_top));
+}
+
+static void the_edges_are_refused() {
+    std::cout << "\nthe edges are refused:\n";
+
+    bool threw = false;
+    try { ai::sampler::argmax(std::vector<float>()); }
+    catch(ai::sampler::exception&) { threw = true; }
+
+    ok("  argmax of nothing", threw);
+
+    ai::sampler s;
+
+    threw = false;
+    try { s.pick(std::vector<float>()); }
+    catch(ai::sampler::exception&) { threw = true; }
+
+    ok("  a choice between no tokens", threw);
+
+    ai::sampler::config c;
+
+    c.temperature = -1.0f;
+    threw = false;
+    try { ai::sampler bad(c); }
+    catch(ai::sampler::exception&) { threw = true; }
+
+    ok("  a negative temperature", threw);
+
+    c.temperature = 1.0f;
+    c.top_p = 0.0f;
+    threw = false;
+    try { ai::sampler bad(c); }
+    catch(ai::sampler::exception&) { threw = true; }
+
+    ok("  and a top_p of zero", threw);
+}
+
+int main() {
+    std::cout << std::unitbuf;
+
+    greedy_is_not_a_draw();
+    the_same_seed_gives_the_same_tokens();
+    top_k_and_top_p_cut_where_they_say();
+    the_draw_follows_the_probabilities();
+    temperature_moves_the_mass();
+    the_edges_are_refused();
+
+    // What a green run does not establish.
+    //
+    // That these are the *same* cuts llama.cpp makes.  top-k before the softmax
+    // and top-p after it is the usual order and the one documented in the
+    // header, but a different implementation could apply them the other way
+    // round and be equally defensible -- and would produce different text from
+    // the same seed.  Nothing here compares against another sampler.
+    //
+    // Nothing about repetition penalties, frequency penalties, mirostat or any
+    // of the other knobs a full sampler carries.  What is here is temperature,
+    // top-k and top-p.
+    std::cout << "\n" << (failures ? "FAILED" : "PASSED") << ": " << failures
+              << " failure(s)\n";
+
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
# Generation

`jlib` writes text.

```
prompt:  The capital of France is Paris. The capital of Germany is Berlin.
         The capital of Italy is
output:  Rome. The capital of Spain is Madrid. The capital of Switzerland is
         Zurich. The capital of Turkey is Ankara. The capital of the United
         Kingdom is London. The capital of the United States is Washington, D.C.
```

49 tokens, greedy, stopping at end-of-sequence on its own. It finished the third
clause and then invented a fourth, a fifth and a sixth of the same shape. (It is
wrong about Switzerland — Bern, not Zurich — which is TinyLlama's knowledge and
not this library's arithmetic.)

## Two pieces

**`ai::sampler`** turns a column of logits into one token: temperature, then
top-k, then softmax, then top-p, then a draw. The order is load-bearing and the
header says why — top-k is defined on order so it cuts before normalising, which
redistributes the discarded mass rather than merely making it unlikely; top-p is
defined on probabilities so it cuts after. Temperature zero is not a limit taken
carefully, it is a separate path with no draw at all, which is what makes a
greedy run reproducible without anybody recording a seed.

**`ai::generate`** loops: forward, take the last column, pick, append, repeat
until end-of-sequence or a limit. With a callback for a caller that wants to
stream rather than wait.

`sampler_config` is at namespace scope with `typedef sampler_config config`
inside the class, for the same reason `sys::server_policy` is: a default
argument is a complete-class context, so `sampler(const config& c = config())`
cannot see a nested aggregate's member initialisers while the class is
incomplete. This is the second time that has come up in this codebase and the
second time it was fixed the same way rather than routed around.

## No cache, deliberately, and what that actually costs

Every token re-runs the whole sequence. That is the reference a key-value cache
will have to reproduce token for token, and it cannot be checked against
something that does not exist yet — the same shape as the GQA branch, where
`kv_heads == heads` reproducing the old output bit-for-bit was what made the
change safe.

The first version of that comment claimed "roughly a second per generated
token". **Measured, it is 0.15 to 0.30s, with no growth visible as the prefix
runs from 20 tokens to 69** — 11.7s for 49 tokens. The reason is that a pass at
these lengths is not spent on the prefix at all: it is spent streaming 2.2GB of
weights through the GPU, which happens once per pass whatever the sequence
length, and against which a few dozen positions of attention do not register.

So the quadratic term is real and is not yet the term that matters. That is
written into `generate.hh` because it bounds what the next branch is worth: a
cache removes work that is currently not the bottleneck, and the honest claim
for it is about long contexts.

## Tests

`ai_sampler_test` needs no model, so it is real coverage in the container too:

- **greedy is not a draw** — two samplers with *different* seeds both take the
  argmax every time, which is the property, not merely that argmax works.
- **the same seed gives the same tokens**, a different one does not, and
  reseeding starts the sequence over.
- **top-k 1 is greedy by another route**; top-k 3 keeps three and never draws
  outside them.
- **the draw follows the probabilities** — two tokens ln(3) apart come up 3:1.
  Twenty thousand draws landed at 0.7522 against 0.75. This is the only
  assertion that checks the probabilities are *used*; every other one would pass
  on a sampler that always returned its first choice.
- **temperature moves the mass** — exact values at t = 1, ½ and 2, plus a colder
  sampler drawing the favourite more often than a hotter one.

`ai_model_test` gains the end-to-end: greedy generation of twelve tokens gives
exactly `"Rome. The capital of Spain is Madrid. The capital of"`, and a second
run gives the identical sequence. Greedy means there is nothing random to
reproduce, which is what makes an exact string a fair assertion rather than a
hostage to an RNG.

### Mutation results

| mutation | caught |
| --- | --- |
| top-k applied after the softmax instead of before | 3 failures |
| greedy still draws | 1 failure |
| **temperature ignored entirely** | **0 → now 3** |
| **top-p keeps nothing when p is tiny** | **0, and correctly so** |

The third was a real hole: every test ran at temperature 1, where dividing by it
does nothing, so removing the division failed nothing. `temperature_moves_the_mass`
closes it.

The fourth is the more interesting result. Removing the `if(keep < 1) keep = 1;`
floor from top-p failed nothing — because it can never fire. `kept` is non-empty
by that point, so the loop runs at least once and leaves `keep` at 1 or more
however it exits. The guard was dead code that read as though the case it named
were possible, and it is gone with a comment saying why it is not needed.

## Verification

- macOS `make check`: 73 tests (was 72), 69 pass, 4 skip, 0 fail.
- Container: `ai_sampler_test` runs and passes there; the three model-dependent
  tests skip.

## What this does not establish

**That these are the same cuts llama.cpp makes.** top-k before the softmax and
top-p after is the usual order and the one documented, but another
implementation could do it differently, be equally defensible, and produce
different text from the same seed. Nothing here compares against another
sampler.

**Nothing about the other knobs** — repetition and frequency penalties,
mirostat, min-p. What is here is temperature, top-k and top-p.

**No chat template.** TinyLlama is an instruct model and the file carries
`tokenizer.chat_template`; nothing reads it, so this generates continuations of
a prompt rather than replies to one.

**And generation is not efficient** — above, with numbers.
