### PR TITLE
Lay conversations out the way the file's chat template says, so TinyLlama answers a question instead of ignoring it

### DIFF
--- a/jlib/ai/Makefile.am
+++ b/jlib/ai/Makefile.am
@@ -2,7 +2,7 @@ AM_CPPFLAGS = -I$(top_srcdir)
 
 lib_LTLIBRARIES = libjai.la
 libjai_la_SOURCES = environment.cc agent.cc percept.cc action.cc vacuum.cc \
-                    backend.cc gguf.cc tokenizer.cc sampler.cc
+                    backend.cc gguf.cc tokenizer.cc sampler.cc chat.cc
 libjai_la_LDFLAGS = -version-info $(LIBJ_SO_VERSION) -release $(JLIB_RELEASE) -no-undefined
 libjai_la_LIBADD = $(top_builddir)/jlib/util/libjutil.la \
                    $(top_builddir)/jlib/sys/libjsys.la
@@ -10,4 +10,4 @@ libjai_la_LIBADD = $(top_builddir)/jlib/util/libjutil.la \
 libjaiincludedir = $(includedir)/jlib-1.2/jlib/ai
 libjaiinclude_HEADERS = environment.hh agent.hh percept.hh action.hh vacuum.hh \
                         neural.hh backend.hh attention.hh transformer.hh \
-                        gguf.hh model.hh tokenizer.hh sampler.hh generate.hh
+                        gguf.hh model.hh tokenizer.hh sampler.hh generate.hh chat.hh

--- a/jlib/ai/chat.cc
+++ b/jlib/ai/chat.cc
@@ -1,0 +1,144 @@
+/* -*- mode: C++ c-basic-offset: 4  -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+#include <jlib/ai/chat.hh>
+
+#include <sstream>
+
+namespace jlib {
+namespace ai {
+
+chat::chat(const gguf& g, const std::string& eos)
+    : chat(g.has("tokenizer.chat_template")
+               ? g.str("tokenizer.chat_template")
+               : throw exception("the file carries no chat template, so there "
+                                 "is no way to know how it wants a "
+                                 "conversation laid out"),
+           eos)
+{
+}
+
+chat::chat(const std::string& tmpl, const std::string& eos)
+    : m_template(tmpl),
+      m_eos(eos)
+{
+
+    // Every <|...|> in the template, in order, with the inner text taken as
+    // the role.  That holds for the Zephyr family, where the marker is named
+    // after the turn it opens; where it does not hold, the checks below fail
+    // and the constructor throws rather than laying turns out wrongly.
+    for(std::size_t at = 0; ; ) {
+        const std::size_t open = m_template.find("<|", at);
+
+        if(open == std::string::npos) break;
+
+        const std::size_t close = m_template.find("|>", open + 2);
+
+        if(close == std::string::npos) break;
+
+        const std::string role = m_template.substr(open + 2, close - open - 2);
+
+        at = close + 2;
+
+        // Every marker is a candidate role, with no filtering on what it looks
+        // like.  There was a check here rejecting anything but lowercase and
+        // underscores, on the theory that it kept ChatML's "<|im_start|>" from
+        // registering a role -- and a mutation showed it rejected nothing that
+        // mattered.  ChatML is caught below by not naming user and assistant,
+        // and "im_start" would have passed the check anyway.
+        //
+        // A stray marker such as "<|endoftext|>" therefore does appear in
+        // roles(), and is harmless: format() only ever looks up the roles a
+        // caller names, and a caller naming "endoftext" has said what it meant.
+        if(role.empty()) continue;
+
+        if(m_marker.find(role) == m_marker.end()) {
+            m_marker[role] = "<|" + role + "|>";
+            m_roles.push_back(role);
+        }
+    }
+
+    // The two a conversation cannot do without.  A template that names neither
+    // is not this shape at all, and one naming only a system prompt is some
+    // other arrangement entirely.
+    if(m_marker.find("user") == m_marker.end() ||
+       m_marker.find("assistant") == m_marker.end())
+    {
+        std::ostringstream e;
+
+        e << "this reads templates that mark turns with <|user|> and "
+          << "<|assistant|>, and that one names ";
+
+        if(m_roles.empty()) e << "no roles at all";
+        else {
+            e << "only";
+
+            for(std::size_t i = 0; i < m_roles.size(); i++)
+                e << " <|" << m_roles[i] << "|>";
+        }
+
+        e << " -- see chat.hh for what is and is not covered";
+
+        throw exception(e.str());
+    }
+}
+
+std::string chat::marker(const std::string& role) const {
+    std::map<std::string, std::string>::const_iterator i = m_marker.find(role);
+
+    return i == m_marker.end() ? std::string() : i->second;
+}
+
+std::string chat::format(const std::vector<message>& turns,
+                         bool add_generation_prompt) const
+{
+    std::string out;
+
+    for(std::size_t i = 0; i < turns.size(); i++) {
+        const std::string m = marker(turns[i].role);
+
+        if(m.empty())
+            throw exception("the template has no marker for the role '" +
+                            turns[i].role + "'");
+
+        // Marker, newline, content, end-of-sequence, newline.  The newlines
+        // come from the template's own layout rather than from taste: Jinja
+        // emits the one inside the marker literal and the one after the
+        // expression that wrote it.
+        out += m;
+        out += "\n";
+        out += turns[i].content;
+        out += m_eos;
+        out += "\n";
+    }
+
+    // And the bare marker, which is the whole point of the exercise: it puts
+    // the model at the start of the assistant's turn, so its next token begins
+    // a reply instead of continuing the user's sentence.
+    if(add_generation_prompt) {
+        out += marker("assistant");
+        out += "\n";
+    }
+
+    return out;
+}
+
+}
+}

--- a/jlib/ai/chat.hh
+++ b/jlib/ai/chat.hh
@@ -1,0 +1,133 @@
+/* -*- mode: C++ c-basic-offset: 4  -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+#ifndef JLIB_AI_CHAT_HH
+#define JLIB_AI_CHAT_HH
+
+#include <jlib/ai/gguf.hh>
+
+#include <exception>
+#include <map>
+#include <string>
+#include <vector>
+
+namespace jlib {
+namespace ai {
+
+/** One turn of a conversation. */
+struct message {
+    std::string role;       ///< "system", "user" or "assistant"
+    std::string content;
+};
+
+/**
+ * Laying a conversation out the way an instruct model expects it.
+ *
+ * A chat model is trained on turns wrapped in markers, and given a bare prompt
+ * it does what the generation branch showed: continues the text rather than
+ * answering it. The markers live in the file, as
+ * `tokenizer.chat_template`, and TinyLlama's is
+ *
+ *     <|user|>
+ *     {content}</s>
+ *     <|assistant|>
+ *
+ * ### This is not a Jinja interpreter, and refuses rather than guesses
+ *
+ * The template is a Jinja2 program. Running it properly means implementing
+ * Jinja, which is a project rather than a function, so this does something
+ * narrower and says so: it reads the `<|...|>` markers out of the template
+ * text and lays the turns out in the shape those markers imply -- marker,
+ * newline, content, end-of-sequence, newline, and a bare marker at the end to
+ * hand the turn to the model.
+ *
+ * That covers the Zephyr family, which is what TinyLlama and a good many other
+ * small chat models use. It does **not** cover ChatML
+ * (`<|im_start|>user ... <|im_end|>`), Llama-2's `[INST]`, or anything with
+ * conditional logic that matters. A template it cannot recognise makes the
+ * constructor throw, because a mis-laid conversation does not fail visibly --
+ * the model simply answers a question nobody asked, and that is far worse to
+ * debug than a refusal at the point of construction.
+ *
+ * The markers are read from the file rather than hardcoded, so a model of the
+ * same shape with different names works, and a model of a different shape is
+ * caught.
+ */
+class chat {
+public:
+    class exception : public std::exception {
+    public:
+        exception(const std::string& msg)
+            : m_msg("jlib::ai::chat::exception: " + msg) {}
+
+        const char* what() const throw() { return m_msg.c_str(); }
+
+    private:
+        std::string m_msg;
+    };
+
+    /**
+     * @param g a file carrying tokenizer.chat_template
+     * @param eos what to close each turn with, usually the tokenizer's
+     * @throws exception if there is no template, or none this can read
+     */
+    chat(const gguf& g, const std::string& eos = "</s>");
+
+    /**
+     * From the template text directly.
+     *
+     * Which is how the refusals are tested: a template this cannot read has to
+     * be constructible from somewhere, and requiring a second model file to
+     * show that ChatML is rejected would mean the check never ran.
+     */
+    chat(const std::string& tmpl, const std::string& eos);
+
+    /** The template as the file gave it, for a caller that wants to look. */
+    const std::string& tmpl() const { return m_template; }
+
+    /** The marker for a role, e.g. "<|user|>", or empty if it has none. */
+    std::string marker(const std::string& role) const;
+
+    /** Every role the template mentions, in the order it mentioned them. */
+    const std::vector<std::string>& roles() const { return m_roles; }
+
+    /**
+     * The prompt text for a conversation.
+     *
+     * @param add_generation_prompt end with the bare assistant marker, so the
+     *        model's next token begins its reply rather than continuing the
+     *        user's turn.  What you want for asking; not what you want for
+     *        scoring an exchange that already happened.
+     */
+    std::string format(const std::vector<message>& turns,
+                       bool add_generation_prompt = true) const;
+
+private:
+    std::string m_template;
+    std::string m_eos;
+
+    std::map<std::string, std::string> m_marker;
+    std::vector<std::string> m_roles;
+};
+
+}
+}
+
+#endif // JLIB_AI_CHAT_HH

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -66,6 +66,7 @@ TESTS = \
 	ai_model_test \
 	ai_tokenizer_test \
 	ai_sampler_test \
+	ai_chat_test \
 	math_object_test \
 	tensor_test \
 \
@@ -313,6 +314,9 @@ metal_gemm_test_LDADD   = $(top_builddir)/jlib/metal/libjmetal.la $(METAL_LIBS)
 
 metal_tensor_test_SOURCES = metal_tensor_test.cc
 metal_tensor_test_LDADD   = $(top_builddir)/jlib/metal/libjmetal.la $(JUTIL_LA) $(JSYS_LA) $(METAL_LIBS)
+
+ai_chat_test_SOURCES  = ai_chat_test.cc
+ai_chat_test_LDADD    = $(JAI_LA) $(JUTIL_LA) $(JSYS_LA)
 
 ai_sampler_test_SOURCES  = ai_sampler_test.cc
 ai_sampler_test_LDADD    = $(JAI_LA) $(JUTIL_LA) $(JSYS_LA)

--- a/tests/ai_chat_test.cc
+++ b/tests/ai_chat_test.cc
@@ -1,0 +1,256 @@
+/* -*- mode: C++ c-basic-offset: 4 -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+#include <jlib/ai/chat.hh>
+
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace ai = jlib::ai;
+
+static int failures = 0;
+
+static void ok(const std::string& what, bool good, const std::string& detail = "") {
+    if(!good) ++failures;
+    std::cout << (good ? "  ok   " : "  FAIL ") << what;
+    if(!detail.empty()) std::cout << ": " << detail;
+    std::cout << "\n";
+}
+
+/** Newlines shown, so a difference in them is visible in the output. */
+static std::string shown(const std::string& s) {
+    std::string out;
+
+    for(std::size_t i = 0; i < s.size(); i++) {
+        if(s[i] == '\n') out += "\\n";
+        else out += s[i];
+    }
+
+    return out;
+}
+
+/** TinyLlama's, as it appears in the file. */
+static const char* ZEPHYR =
+    "{% for message in messages %}\n"
+    "{% if message['role'] == 'user' %}\n"
+    "{{ '<|user|>\n' + message['content'] + eos_token }}\n"
+    "{% elif message['role'] == 'system' %}\n"
+    "{{ '<|system|>\n' + message['content'] + eos_token }}\n"
+    "{% elif message['role'] == 'assistant' %}\n"
+    "{{ '<|assistant|>\n'  + message['content'] + eos_token }}\n"
+    "{% endif %}\n"
+    "{% if loop.last and add_generation_prompt %}\n"
+    "{{ '<|assistant|>' }}\n"
+    "{% endif %}\n"
+    "{% endfor %}";
+
+static void it_reads_the_markers_out_of_the_template() {
+    std::cout << "\nit reads the markers out of the template:\n";
+
+    const ai::chat c(ZEPHYR, "</s>");
+
+    ok("  three roles, in the order the template names them",
+       c.roles() == std::vector<std::string>({ "user", "system", "assistant" }),
+       std::to_string(c.roles().size()));
+
+    ok("  each with its own marker",
+       c.marker("user") == "<|user|>" && c.marker("system") == "<|system|>" &&
+       c.marker("assistant") == "<|assistant|>");
+
+    ok("  and a role it does not name has none", c.marker("tool").empty());
+}
+
+/**
+ * A marker that is not a turn is carried along rather than filtered out.
+ *
+ * Documented behaviour rather than an accident: what decides whether a
+ * template can be read is that it names user and assistant, and everything
+ * else it mentions is simply available. Filtering candidates by how they look
+ * was tried and removed -- see chat.cc -- because it rejected nothing the
+ * user/assistant check did not already catch.
+ */
+static void a_stray_marker_is_harmless() {
+    std::cout << "\na stray marker is harmless:\n";
+
+    const ai::chat c(
+        "{% for m in messages %}{{ '<|user|>\n' + m['content'] + '<|endoftext|>' }}"
+        "{{ '<|assistant|>\n' }}{% endfor %}", "</s>");
+
+    ok("  it is offered as a role", c.marker("endoftext") == "<|endoftext|>");
+
+    // And changes nothing about laying out the turns that matter.
+    ok("  and the conversation is laid out as usual",
+       c.format({ { "user", "Hi" } }) == "<|user|>\nHi</s>\n<|assistant|>\n",
+       shown(c.format({ { "user", "Hi" } })));
+}
+
+static void it_lays_a_turn_out() {
+    std::cout << "\nit lays a turn out:\n";
+
+    const ai::chat c(ZEPHYR, "</s>");
+
+    const std::string one = c.format({ { "user", "What is the capital of Italy?" } });
+
+    ok("  a question ends at the assistant's marker",
+       one == "<|user|>\nWhat is the capital of Italy?</s>\n<|assistant|>\n",
+       shown(one));
+
+    // Which is the whole point: without the trailing marker the model is still
+    // inside the user's turn and continues the question.
+    const std::string bare = c.format({ { "user", "Hello" } }, false);
+
+    ok("  and without the generation prompt it does not",
+       bare == "<|user|>\nHello</s>\n", shown(bare));
+
+    const std::string three = c.format({ { "system", "Be brief." },
+                                         { "user", "Hi" },
+                                         { "assistant", "Hello." },
+                                         { "user", "Again?" } });
+
+    ok("  a whole conversation keeps its order",
+       three == "<|system|>\nBe brief.</s>\n"
+                "<|user|>\nHi</s>\n"
+                "<|assistant|>\nHello.</s>\n"
+                "<|user|>\nAgain?</s>\n"
+                "<|assistant|>\n",
+       shown(three));
+
+    bool threw = false;
+    try { c.format({ { "moderator", "no such role" } }); }
+    catch(ai::chat::exception&) { threw = true; }
+
+    ok("  and a role the template never named is refused", threw);
+}
+
+/**
+ * A template it cannot read is refused, not guessed at.
+ *
+ * This is the assertion the whole design turns on. A mis-laid conversation
+ * does not fail visibly -- the model answers a question nobody asked -- so the
+ * failure has to happen at construction, where it can be seen.
+ */
+static void a_template_it_cannot_read_is_refused() {
+    std::cout << "\na template it cannot read is refused:\n";
+
+    struct { const char* what; const char* tmpl; } cases[] = {
+        { "ChatML, whose markers are not role names",
+          "{% for m in messages %}{{ '<|im_start|>' + m['role'] + '\n' + "
+          "m['content'] + '<|im_end|>' }}{% endfor %}" },
+        { "Llama 2, which brackets instead",
+          "{% for m in messages %}{{ '[INST] ' + m['content'] + ' [/INST]' }}"
+          "{% endfor %}" },
+        { "a template naming only a system prompt",
+          "{{ '<|system|>\n' + system }}" },
+        { "and one with no markers at all",
+          "{% for m in messages %}{{ m['content'] }}{% endfor %}" }
+    };
+
+    for(const auto& e : cases) {
+        bool threw = false;
+        std::string why;
+
+        try { ai::chat c(e.tmpl, "</s>"); }
+        catch(ai::chat::exception& x) { threw = true; why = x.what(); }
+
+        ok(std::string("  ") + e.what, threw);
+
+        // And the message says what it looked for, since somebody hitting this
+        // needs to know whether to write a template reader or a different one.
+        if(threw)
+            ok("    saying what it wanted",
+               why.find("<|user|>") != std::string::npos &&
+               why.find("chat.hh") != std::string::npos);
+    }
+}
+
+/** And against the real file, which is where the markers actually come from. */
+static bool exists(const std::string& p) {
+    std::ifstream f(p, std::ios::binary);
+
+    return bool(f);
+}
+
+static void the_file_says_the_same(int argc, char** argv) {
+    std::string path;
+
+    if(argc > 1 && exists(argv[1])) path = argv[1];
+    else if(const char* e = std::getenv("JLIB_GGUF")) { if(exists(e)) path = e; }
+
+    if(path.empty()) {
+        const char* names[] = {
+            "tinyllama-1.1b-chat-v1.0.Q8_0.gguf",
+            "../tinyllama-1.1b-chat-v1.0.Q8_0.gguf",
+            "../../tinyllama-1.1b-chat-v1.0.Q8_0.gguf",
+            "../../../tinyllama-1.1b-chat-v1.0.Q8_0.gguf"
+        };
+
+        for(const char* n : names) if(exists(n)) { path = n; break; }
+    }
+
+    if(path.empty()) {
+        std::cout << "\n  (no model file, so the template is only exercised "
+                  << "from the copy above)\n";
+
+        return;
+    }
+
+    std::cout << "\nthe file says the same:\n";
+
+    const ai::gguf g(path);
+    const ai::chat c(g);
+
+    ok("  the same three roles come out of the real template",
+       c.roles() == std::vector<std::string>({ "user", "system", "assistant" }));
+
+    ok("  and the layout matches the one built from the copy",
+       c.format({ { "user", "Hi" } }) ==
+       ai::chat(ZEPHYR, "</s>").format({ { "user", "Hi" } }));
+}
+
+int main(int argc, char** argv) {
+    std::cout << std::unitbuf;
+
+    it_reads_the_markers_out_of_the_template();
+    it_lays_a_turn_out();
+    a_stray_marker_is_harmless();
+    a_template_it_cannot_read_is_refused();
+    the_file_says_the_same(argc, argv);
+
+    // What a green run does not establish.
+    //
+    // That the layout is byte-for-byte what Jinja would produce.  It was read
+    // off the template by hand -- marker, newline, content, eos, newline --
+    // and checked the only way that matters here, by asking the model a
+    // question and getting an answer rather than a continuation.  A stray
+    // newline would probably still answer, and nothing here would notice.
+    //
+    // That any template outside the Zephyr family works.  Four are checked to
+    // be *refused*, which is the claim being made; none is checked to work.
+    //
+    // And nothing about the roles beyond their names.  A template that used
+    // <|user|> to mean something else would pass every assertion here.
+    std::cout << "\n" << (failures ? "FAILED" : "PASSED") << ": " << failures
+              << " failure(s)\n";
+
+    return failures ? 1 : 0;
+}

--- a/tests/ai_model_test.cc
+++ b/tests/ai_model_test.cc
@@ -18,6 +18,7 @@
  *
  */
 
+#include <jlib/ai/chat.hh>
 #include <jlib/ai/generate.hh>
 #include <jlib/ai/model.hh>
 #include <jlib/ai/tokenizer.hh>
@@ -267,6 +268,69 @@ static void it_continues_the_pattern(const char* name, ai::backend<T>& b,
     ok("  greedy generation repeats exactly", twice == out);
 }
 
+/**
+ * It answers a question, rather than continuing it.
+ *
+ * The difference is the chat layout and nothing else -- same model, same
+ * weights, same greedy sampler, same question. Asked bare, TinyLlama has
+ * nothing to continue and stops immediately. Asked as a conversation, it
+ * replies.
+ *
+ * The bare case is the control, and it is a strong one: it is not that the
+ * formatting improves the answer, it is that without it there is no answer at
+ * all.
+ */
+template<typename T>
+static void it_answers_a_question(const char* name, ai::backend<T>& b,
+                                  const ai::gguf& g)
+{
+    std::cout << "\nit answers a question, " << name << ":\n";
+
+    const ai::tokenizer tok(g);
+    const ai::chat ch(g, tok.token(tok.eos()));
+
+    typename ai::model<T>::config c = ai::model<T>::config::from(g);
+
+    ai::model<T> m(b, c);
+
+    m.load(g);
+
+    const std::string question = "What is the capital of Italy?";
+
+    ai::sampler::config sc;
+    sc.temperature = 0.0f;
+
+    // Laid out as a conversation.
+    {
+        ai::sampler s(sc);
+
+        const std::vector<int> ids = tok.encode(ch.format({ { "user", question } }));
+        const std::vector<int> out = ai::generate<T>(m, b, ids, 24, s, tok.eos());
+
+        const std::string said =
+            tok.decode(std::vector<int>(out.begin() + long(ids.size()), out.end()));
+
+        ok("  it replies", !said.empty(), "\"" + said + "\"");
+
+        ok("  and the reply says Rome",
+           said.find("Rome") != std::string::npos, "\"" + said + "\"");
+    }
+
+    // The same question with no markers at all.
+    {
+        ai::sampler s(sc);
+
+        const std::vector<int> ids = tok.encode(question);
+        const std::vector<int> out = ai::generate<T>(m, b, ids, 24, s, tok.eos());
+
+        const std::string said =
+            tok.decode(std::vector<int>(out.begin() + long(ids.size()), out.end()));
+
+        ok("  while asked bare it says nothing at all", said.empty(),
+           "\"" + said + "\"");
+    }
+}
+
 int main(int argc, char** argv) {
     std::cout << std::unitbuf;
 
@@ -304,6 +368,7 @@ int main(int argc, char** argv) {
         if(gpu) {
             it_knows_the_capital_of_italy<_Float16>("fp16 on the GPU", *gpu, g);
             it_continues_the_pattern<_Float16>("fp16 on the GPU", *gpu, g);
+            it_answers_a_question<_Float16>("fp16 on the GPU", *gpu, g);
         }
 #else
         std::cout << "\n  (no Metal: the forward pass needs a backend whose "


### PR DESCRIPTION
# Chat

The generation branch made jlib write text. It could not make TinyLlama *answer*
anything: asked "What is the capital of Italy?" it produced **nothing at all**,
emitting end-of-sequence immediately, because a bare question is not something a
chat model has been trained to continue.

Laid out the way the file says it wants:

```
<|user|>
What is the capital of Italy?</s>
<|assistant|>
```

it replies **"The capital of Italy is Rome."**

Same model, same weights, same greedy sampler, same question. The only
difference is the layout, and without it there is no answer — which makes the
bare case an unusually strong control.

## Why this and not the cache

The last branch listed a key-value cache as the next step. Its own measurements
argued against that: per-token cost is **0.15–0.30s and flat** as the prefix
grows from 20 tokens to 69, because a pass is spent streaming 2.2GB of weights
rather than on the prefix. A cache removes work that is not currently the
bottleneck.

This is a capability gap rather than a performance one, and it is the difference
between a text continuer and something you can ask a question. The cache is
still worth doing, for long contexts, and now has an exact token-for-token
reference to reproduce.

## Not a Jinja interpreter, and it says so

`tokenizer.chat_template` is a 410-byte Jinja2 program. Running it properly
means implementing Jinja, which is a project rather than a function. So
`ai::chat` does something narrower: it reads the `<|...|>` markers out of the
template text and lays turns out in the shape those markers imply — marker,
newline, content, end-of-sequence, newline, and a bare marker at the end to hand
the turn over.

That covers the Zephyr family. It does **not** cover ChatML, Llama-2's `[INST]`,
or anything whose conditional logic matters.

**A template it cannot recognise makes the constructor throw.** That is the
decision the whole design turns on. A mis-laid conversation does not fail
visibly — the model answers a question nobody asked — so the failure has to
happen where it can be seen. Four unreadable templates are checked to be
refused, and the message is checked to say what it was looking for, since
whoever hits it needs to know whether to write a template reader or a different
one.

The markers come from the file rather than being hardcoded, so a model of the
same shape with different names works and a model of a different shape is
caught.

## Tests

`ai_chat_test` needs no weights — only the template — so most of it runs in the
container too. A second constructor takes the template text directly, which is
how the refusals are tested at all: requiring a second model file to show that
ChatML is rejected would mean the check never ran.

- markers and roles read out of the template, in order
- a single turn, a whole four-turn conversation, and the difference the
  generation prompt makes
- a role the template never named is refused
- **four templates refused**: ChatML, Llama-2, system-only, and one with no
  markers
- the real file agrees with the copy the test builds from

`ai_model_test` gains the end-to-end: the reply contains "Rome", and the same
question asked bare produces the empty string.

### Mutation results

| mutation | caught |
| --- | --- |
| no generation prompt appended | 2 failures |
| end-of-sequence not closing each turn | 3 failures |
| user and assistant not required | 4 failures |
| **reject markers that do not look like role names** | **0** |

The last one was a check that did no work. It rejected anything but lowercase
and underscores, on the theory that it stopped ChatML's `<|im_start|>` being
read as a role — and ChatML is caught anyway by not naming user and assistant,
while `im_start` would have passed the check regardless. It is gone, and the
behaviour it was obscuring is now documented and tested: a stray `<|endoftext|>`
does appear in `roles()` and is harmless, because `format()` only looks up roles
a caller names.

That is the second branch running where a mutation found a guard that could not
fire. Both times the answer was to delete it and write down why it was not
needed, rather than to keep a line that reads as though the case it names were
possible.

## Verification

- macOS `make check`: 74 tests (was 73), 70 pass, 4 skip, 0 fail.
- Container: `ai_chat_test` runs and passes there on the template copy; the
  model-dependent tests skip.

## What this does not establish

**That the layout is byte-for-byte what Jinja would produce.** It was read off
the template by hand and checked the only way that matters here — by asking the
model a question and getting an answer rather than a continuation. A stray
newline would probably still answer, and nothing here would notice.

**That any template outside the Zephyr family works.** Four are checked to be
*refused*, which is the claim being made. None is checked to work.

**Nothing about the roles beyond their names.** A template using `<|user|>` to
mean something else would pass every assertion here.
