### PR TITLE
Add jchat, and fix what it exposed: </s> tokenized as text, and a pstream header that had never compiled

### DIFF
--- a/jlib/ai/tokenizer.cc
+++ b/jlib/ai/tokenizer.cc
@@ -167,18 +167,82 @@ std::size_t tokenizer::char_len(const std::string& s, std::size_t at) {
     return n;
 }
 
-std::vector<int> tokenizer::encode(const std::string& text, bool add_bos) const {
+std::vector<int> tokenizer::encode(const std::string& text, bool add_bos,
+                                   bool parse_special) const
+{
     std::vector<int> out;
 
     if(add_bos && m_bos >= 0) out.push_back(m_bos);
 
     // Empty in, nothing but the sentence marker out.  Without this the dummy
-    // prefix below would be the whole input and encode to a lone space token,
-    // which is a word that was never written.
+    // prefix would be the whole input and encode to a lone space token, which
+    // is a word that was never written.
     if(text.empty()) return out;
 
+    if(!parse_special) {
+        encode_run(text, true, out);
+
+        return out;
+    }
+
+    // Walk the text, splitting at every control token written out in it, so
+    // "Hi</s>" is two tokens and not five.  Only the run that begins the input
+    // gets the dummy prefix.
+    std::size_t at = 0;
+    bool first = true;
+
+    while(at < text.size()) {
+        std::size_t where = std::string::npos;
+        int which = -1;
+
+        for(std::size_t i = 0; i < m_tokens.size(); i++) {
+            if(m_types[i] != control && m_types[i] != user_defined) continue;
+
+            if(m_tokens[i].empty()) continue;
+
+            const std::size_t found = text.find(m_tokens[i], at);
+
+            // Earliest wins, and the longest of those, so a vocabulary holding
+            // both "<|end|>" and "<|end|>!" cannot have the shorter eat the
+            // start of the longer.
+            if(found != std::string::npos &&
+               (found < where ||
+                (found == where &&
+                 m_tokens[i].size() > m_tokens[std::size_t(which)].size())))
+            {
+                where = found;
+                which = int(i);
+            }
+        }
+
+        if(which < 0) {
+            encode_run(text.substr(at), first, out);
+
+            return out;
+        }
+
+        if(where > at) {
+            encode_run(text.substr(at, where - at), first, out);
+
+            first = false;
+        }
+
+        out.push_back(which);
+
+        first = false;
+        at = where + m_tokens[std::size_t(which)].size();
+    }
+
+    return out;
+}
+
+void tokenizer::encode_run(const std::string& text, bool add_prefix,
+                           std::vector<int>& out) const
+{
+    if(text.empty()) return;
+
     // The marker for every space, and one in front: see the header.
-    std::string prepared = MARKER;
+    std::string prepared = add_prefix ? MARKER : "";
 
     for(std::size_t i = 0; i < text.size(); i++) {
         if(text[i] == ' ') prepared += MARKER;
@@ -238,6 +302,28 @@ std::vector<int> tokenizer::encode(const std::string& text, bool add_bos) const 
 
             out.push_back(bt >= 0 ? bt : m_unk);
         }
+    }
+}
+
+std::string tokenizer::piece(int id) const {
+    if(id < 0 || std::size_t(id) >= m_tokens.size())
+        throw exception("piece: an id outside the vocabulary");
+
+    if(m_types[std::size_t(id)] == control) return std::string();
+
+    if(m_types[std::size_t(id)] == byte) {
+        const int v = hex_pair(m_tokens[std::size_t(id)], 3);
+
+        if(v >= 0) return std::string(1, char(v));
+    }
+
+    const std::string& t = m_tokens[std::size_t(id)];
+
+    std::string out;
+
+    for(std::size_t at = 0; at < t.size(); ) {
+        if(t.compare(at, 3, MARKER) == 0) { out += ' '; at += 3; }
+        else { out += t[at]; at++; }
     }
 
     return out;

--- a/jlib/ai/tokenizer.hh
+++ b/jlib/ai/tokenizer.hh
@@ -104,20 +104,65 @@ public:
      * `<0xXX>` token -- so any input encodes, and nothing silently becomes
      * `<unk>`.
      *
+     * ### Special tokens
+     *
+     * With `parse_special`, a control token written out in the text -- `</s>`
+     * -- becomes that token rather than the characters that spell it. That
+     * matters more than it sounds: a chat template closes every turn with
+     * `</s>`, and without this the model is handed `</`, `s`, `>` and learns
+     * from its own context that a reply ends by *typing* those characters. It
+     * then does, which is a bug you can read in the output.
+     *
+     * Note what this does **not** cover. `<|user|>` is not in a Llama
+     * vocabulary at all, so it is byte-pair encoded like any other text --
+     * correctly, since that is the byte sequence the model was tuned on.
+     * Only tokens the vocabulary actually has are recognised.
+     *
+     * **Turn it off for anything a stranger wrote.** Text containing `</s>`
+     * from a user would otherwise end the turn early and let the rest be read
+     * as though the model had said it. jchat does not do this yet -- it
+     * tokenizes a whole formatted prompt in one call -- and doing it properly
+     * means tokenizing the markers and the content separately.
+     *
      * Cost is quadratic in the number of symbols: each merge rescans for the
      * best remaining pair. A priority queue over the pairs would make it
      * roughly linear, which llama.cpp does and this does not, because a prompt
      * is short and being able to read this one matters more. Measured at about
      * a millisecond for the twenty-token prompt in the tests.
      */
-    std::vector<int> encode(const std::string& text, bool add_bos = true) const;
+    std::vector<int> encode(const std::string& text, bool add_bos = true,
+                            bool parse_special = true) const;
 
     /** Ids back to text, undoing the space marker and the dummy prefix. */
     std::string decode(const std::vector<int>& ids) const;
 
+    /**
+     * One token's text, with the space marker expanded and **nothing
+     * stripped**.
+     *
+     * For streaming, where decode() is the wrong tool: it removes a leading
+     * space, because encode() put one there as the dummy prefix, and that is
+     * right exactly once at the start of a whole reply. Called per token it
+     * would eat the space in front of every word.
+     *
+     * A control token yields the empty string, as it does in decode().
+     */
+    std::string piece(int id) const;
+
 private:
     /** How many bytes the UTF-8 character starting here occupies. */
     static std::size_t char_len(const std::string& s, std::size_t at);
+
+    /**
+     * Byte-pair encode one run of ordinary text, appending to out.
+     *
+     * add_prefix only for the run that starts the input.  The dummy prefix
+     * belongs to the text as a whole, and giving one to every run either side
+     * of a control token inserts spaces that nobody wrote -- "a</s>b" came
+     * back as "a b" while this took its argument for granted.
+     */
+    void encode_run(const std::string& text, bool add_prefix,
+                    std::vector<int>& out) const;
 
     std::vector<std::string> m_tokens;
     std::vector<type> m_types;

--- a/jlib/apps/Makefile.am
+++ b/jlib/apps/Makefile.am
@@ -48,7 +48,7 @@ if HAVE_GLFW
 glfw_programs = jglfwhyper jgltorus jhardhyper
 endif
 
-bin_PROGRAMS = jlib-mail jcrypt jm3u \
+bin_PROGRAMS = jlib-mail jcrypt jm3u jchat \
 	$(curve_programs) \
 	$(neural_programs) \
 	$(cuda_programs) \
@@ -85,6 +85,10 @@ jcrypt_LDADD   = $(JCRYPT_LA) $(JSYS_LA)
 
 jm3u_SOURCES = jm3u.cc
 jm3u_LDADD   = $(JSYS_LA) $(JUTIL_LA)
+
+jchat_SOURCES  = jchat.cc
+jchat_CPPFLAGS = $(AM_CPPFLAGS) $(METAL_CPPFLAGS)
+jchat_LDADD    = $(JAI_LA) $(JUTIL_LA) $(JSYS_LA) $(METAL_LA)
 
 jcurve_SOURCES = jcurve.cc
 jcurve_LDADD   = $(JCRYPT_LA) $(JUTIL_LA) $(JSYS_LA) $(SODIUM_LIBS)

--- a/jlib/apps/jchat.cc
+++ b/jlib/apps/jchat.cc
@@ -1,0 +1,340 @@
+/* -*- mode: C++ c-basic-offset: 4  -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+/**
+ * jchat -- talk to a GGUF model.
+ *
+ * Two modes, one program. With a prompt on the command line it answers once
+ * and exits, which is what a script or a test wants; with none it reads turns
+ * from standard input and keeps the conversation, which is what a person
+ * wants.
+ *
+ * Progress and timings go to **stderr** and the model's words to **stdout**,
+ * so `jchat model.gguf "question" > answer.txt` collects the answer and
+ * nothing else.
+ */
+
+#include <jlib/ai/chat.hh>
+#include <jlib/ai/generate.hh>
+#include <jlib/ai/model.hh>
+#include <jlib/ai/tokenizer.hh>
+
+#ifdef HAVE_METAL
+#include <jlib/metal/backend.hh>
+#endif
+
+#include <chrono>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace ai = jlib::ai;
+
+namespace {
+
+struct options {
+    std::string model;
+    std::string prompt;
+    std::string system;
+
+    unsigned int tokens = 256;
+
+    ai::sampler::config sampling;
+
+    /** Continue the text rather than laying it out as a conversation. */
+    bool raw = false;
+};
+
+void usage(std::ostream& o, const char* argv0) {
+    o << "usage: " << argv0 << " [options] <model.gguf> [prompt ...]\n"
+      << "\n"
+      << "  With a prompt, answers it and exits.  Without one, reads a turn\n"
+      << "  per line from stdin and keeps the conversation going.\n"
+      << "\n"
+      << "  --system TEXT   a system turn before the conversation\n"
+      << "  --tokens N      most tokens in one reply (default 256)\n"
+      << "  --temp F        0 is greedy and repeatable (default 0.8)\n"
+      << "  --top-k N       keep the N likeliest, 0 for all (default 40)\n"
+      << "  --top-p F       keep the likeliest summing to F (default 0.95)\n"
+      << "  --seed N        for a repeatable run at a temperature above 0\n"
+      << "  --raw           continue the prompt instead of answering it,\n"
+      << "                  which is what a base model wants\n"
+      << "  --help\n";
+}
+
+bool parse(int argc, char** argv, options& o) {
+    int i = 1;
+
+    for(; i < argc; i++) {
+        const std::string a = argv[i];
+
+        if(a == "--help" || a == "-h") { usage(std::cout, argv[0]); std::exit(0); }
+        else if(a == "--raw") o.raw = true;
+        else if(a.size() > 2 && a.compare(0, 2, "--") == 0) {
+            if(i + 1 >= argc) {
+                std::cerr << "jchat: " << a << " wants a value\n";
+
+                return false;
+            }
+
+            const std::string v = argv[++i];
+
+            if(a == "--system") o.system = v;
+            else if(a == "--tokens") o.tokens = unsigned(std::atoi(v.c_str()));
+            else if(a == "--temp") o.sampling.temperature = float(std::atof(v.c_str()));
+            else if(a == "--top-k") o.sampling.top_k = unsigned(std::atoi(v.c_str()));
+            else if(a == "--top-p") o.sampling.top_p = float(std::atof(v.c_str()));
+            else if(a == "--seed") o.sampling.seed = std::uint64_t(std::atoll(v.c_str()));
+            else {
+                std::cerr << "jchat: no such option " << a << "\n";
+
+                return false;
+            }
+        }
+        else break;
+    }
+
+    if(i >= argc) {
+        usage(std::cerr, argv[0]);
+
+        return false;
+    }
+
+    o.model = argv[i++];
+
+    // Everything after the model is the prompt, joined with spaces, so a
+    // shell that split it on words has not changed what was asked.
+    for(; i < argc; i++) {
+        if(!o.prompt.empty()) o.prompt += " ";
+
+        o.prompt += argv[i];
+    }
+
+    return true;
+}
+
+double now() {
+    using namespace std::chrono;
+
+    return duration<double>(steady_clock::now().time_since_epoch()).count();
+}
+
+/**
+ * One exchange: lay out the turns, generate, stream the reply to stdout.
+ *
+ * @return the reply, so the caller can put it in the history
+ */
+template<typename T>
+std::string answer(ai::model<T>& m, ai::backend<T>& b, const ai::tokenizer& tok,
+                   const std::vector<int>& ids, const options& o,
+                   ai::sampler& s)
+{
+    std::string reply;
+    bool first = true;
+
+    const double start = now();
+
+    const std::vector<int> out = ai::generate<T>(
+        m, b, ids, o.tokens, s, tok.eos(),
+        [&](int id) {
+            std::string p = tok.piece(id);
+
+            // The first token of a reply carries the space that separated it
+            // from the marker before it, which is not part of what was said.
+            if(first) {
+                while(!p.empty() && p[0] == ' ') p.erase(0, 1);
+
+                first = false;
+            }
+
+            reply += p;
+
+            std::cout << p << std::flush;
+        });
+
+    std::cout << "\n";
+
+    const double took = now() - start;
+    const std::size_t made = out.size() - ids.size();
+
+    std::cerr << "[" << made << " tokens in " << took << "s, "
+              << (took > 0 ? double(made) / took : 0.0) << "/s]\n";
+
+    return reply;
+}
+
+/**
+ * Drop the oldest turns until the prompt fits.
+ *
+ * A conversation grows without bound and a context does not. The system turn
+ * stays -- it is instructions rather than history, and dropping it changes how
+ * the model behaves rather than what it remembers.
+ */
+void fit(std::vector<ai::message>& turns, const ai::chat& ch,
+         const ai::tokenizer& tok, unsigned int context, unsigned int reserve)
+{
+    for(;;) {
+        const std::size_t n = tok.encode(ch.format(turns)).size();
+
+        if(n + reserve <= context) return;
+
+        // Find the oldest turn that is not the system prompt.
+        std::size_t at = turns.size();
+
+        for(std::size_t i = 0; i < turns.size(); i++)
+            if(turns[i].role != "system") { at = i; break; }
+
+        if(at == turns.size()) return;   // nothing left to give
+
+        std::cerr << "[dropping the oldest turn to stay inside "
+                  << context << " tokens]\n";
+
+        turns.erase(turns.begin() + long(at));
+    }
+}
+
+template<typename T>
+int run(ai::backend<T>& b, const ai::gguf& g, const options& o) {
+    const ai::tokenizer tok(g);
+
+    typename ai::model<T>::config c = ai::model<T>::config::from(g);
+
+    std::cerr << "[" << b.name() << ", " << c.layers << " layers, "
+              << c.d_model << " wide, " << c.heads << " heads over "
+              << c.kv_heads << "]\n";
+
+    ai::model<T> m(b, c);
+
+    const double t0 = now();
+
+    m.load(g);
+
+    std::cerr << "[loaded in " << (now() - t0) << "s]\n";
+
+    ai::sampler s(o.sampling);
+
+    // Raw mode never lays anything out, so it needs no template -- which is
+    // also the escape hatch for a model whose template this cannot read.
+    std::shared_ptr<ai::chat> ch;
+
+    if(!o.raw) {
+        try { ch.reset(new ai::chat(g, tok.token(tok.eos()))); }
+        catch(std::exception& e) {
+            std::cerr << "jchat: " << e.what() << "\n"
+                      << "jchat: --raw will continue the prompt instead\n";
+
+            return 1;
+        }
+    }
+
+    std::vector<ai::message> turns;
+
+    if(!o.system.empty()) turns.push_back({ "system", o.system });
+
+    // One shot.
+    if(!o.prompt.empty()) {
+        std::vector<int> ids;
+
+        if(o.raw) ids = tok.encode(o.prompt);
+        else {
+            turns.push_back({ "user", o.prompt });
+            fit(turns, *ch, tok, c.context, o.tokens);
+            ids = tok.encode(ch->format(turns));
+        }
+
+        answer(m, b, tok, ids, o, s);
+
+        return 0;
+    }
+
+    if(o.raw) {
+        std::cerr << "jchat: --raw needs a prompt on the command line\n";
+
+        return 1;
+    }
+
+    std::cerr << "[type a message, or end input to stop]\n";
+
+    for(;;) {
+        std::cerr << "> " << std::flush;
+
+        std::string line;
+
+        if(!std::getline(std::cin, line)) break;
+
+        if(line.empty()) continue;
+
+        turns.push_back({ "user", line });
+
+        fit(turns, *ch, tok, c.context, o.tokens);
+
+        const std::string said =
+            answer(m, b, tok, tok.encode(ch->format(turns)), o, s);
+
+        turns.push_back({ "assistant", said });
+    }
+
+    std::cerr << "\n";
+
+    return 0;
+}
+
+}
+
+int main(int argc, char** argv) {
+    options o;
+
+    if(!parse(argc, argv, o)) return 2;
+
+    try {
+        const ai::gguf g(o.model);
+
+#ifdef HAVE_METAL
+        // fp16 on the GPU, which halves the weights and is what MPS is built
+        // for -- and whose GEMM accumulates wider than it stores.
+        try {
+            jlib::metal::backend<_Float16> b;
+
+            return run<_Float16>(b, g, o);
+        }
+        catch(std::exception& e) {
+            std::cerr << "jchat: no Metal backend (" << e.what() << ")\n";
+        }
+#endif
+
+        // float, not fp16: the host GEMM accumulates in the element type, and
+        // a 2048-long dot product summed in fp16 loses the answer rather than
+        // some precision.  Correct, and slow enough to say so.
+        std::cerr << "jchat: running on the CPU in float -- this will be very "
+                  << "slow and will want about 4GB\n";
+
+        ai::host_backend<float> b;
+
+        return run<float>(b, g, o);
+    }
+    catch(std::exception& e) {
+        std::cerr << "jchat: " << e.what() << "\n";
+
+        return 1;
+    }
+}

--- a/jlib/sys/pstream.hh
+++ b/jlib/sys/pstream.hh
@@ -22,6 +22,7 @@
 #define JLIB_SYS_PSTREAM_HH
 
 
+#include <cstring>
 #include <iostream>
 #include <exception>
 #include <string>
@@ -38,6 +39,16 @@
 namespace jlib {
     namespace sys {
 
+        /**
+         * A streambuf over popen(3).
+         *
+         * Every call into the base is written `this->eback()` rather than
+         * `eback()`, and has to be: the base depends on the template
+         * parameters, so an unqualified name is looked up when the template is
+         * defined, at which point it does not exist.  Not a style choice --
+         * without it this header does not compile at all, which nothing
+         * noticed for as long as nothing instantiated it.
+         */
         template< typename charT, typename traitT = std::char_traits<charT> >
         class basic_procbuf : public std::basic_streambuf<charT,traitT> {
         public:
@@ -53,10 +64,10 @@ namespace jlib {
                 char_type* tmp;
                 
                 tmp = new char_type[BUF_SIZE];
-                setg(tmp,tmp,tmp);
+                this->setg(tmp,tmp,tmp);
                 
                 tmp = new char_type[BUF_SIZE];
-                setp(tmp,tmp+BUF_SIZE);
+                this->setp(tmp,tmp+BUF_SIZE);
                 
                 //_M_mode = (std::ios_base::in | std::ios_base::out);
                 
@@ -69,8 +80,8 @@ namespace jlib {
                     std::cerr << "basic_procbuf::~basic_procbuf()"<<std::endl;
                 close();
 
-                delete [] eback();
-                delete [] pbase();
+                delete [] this->eback();
+                delete [] this->pbase();
             }
 
             virtual int_type underflow() {
@@ -78,7 +89,7 @@ namespace jlib {
                     std::cerr << "basic_procbuf::underflow()"<<std::endl;
 
                 m_eintr = false;
-                int count = ::read(m_pd, eback(), BUF_SIZE);
+                int count = ::read(m_pd, this->eback(), BUF_SIZE);
                 
                 if(count < 0) {
                     if(getenv("JLIB_SYS_SOCKET_DEBUG"))
@@ -96,24 +107,24 @@ namespace jlib {
                     return traits_type::eof();
                 }
                 else {
-                    char_type* end = eback()+count;
-                    setg(eback(), eback(), end);
+                    char_type* end = this->eback()+count;
+                    this->setg(this->eback(), this->eback(), end);
                     
-                    return *gptr();
+                    return *this->gptr();
                 }
             }
 
             virtual int_type overflow(int_type c=traits_type::eof()) {
                 if(getenv("JLIB_SYS_SOCKET_DEBUG"))
                     std::cerr << "basic_procbuf::overflow("<<c<<")"<<std::endl;
-                if(pptr() >= epptr()) {
+                if(this->pptr() >= this->epptr()) {
                     if(sync() == -1) {
                         return traits_type::eof();
                     }
                 }
                 
-                *pptr() = c;
-                pbump(1);
+                *this->pptr() = c;
+                this->pbump(1);
                 return c;
             }
 
@@ -121,10 +132,10 @@ namespace jlib {
                 if(getenv("JLIB_SYS_SOCKET_DEBUG"))
                     std::cerr << "basic_procbuf::sync()"<<std::endl;
                 int sofar = 0;
-                int total = pptr() - pbase();
+                int total = this->pptr() - this->pbase();
                 int diff;
                 int count;
-                char_type* current = pbase();
+                char_type* current = this->pbase();
                 
                 while( (diff=(total-sofar)) > 0 ) {
                     m_eintr = false;
@@ -144,7 +155,7 @@ namespace jlib {
                     current += count;
                 }
                 
-                setp(pbase(), pbase()+BUF_SIZE);
+                this->setp(this->pbase(), this->pbase()+BUF_SIZE);
                 return 0;                
             }
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -67,6 +67,7 @@ TESTS = \
 	ai_tokenizer_test \
 	ai_sampler_test \
 	ai_chat_test \
+	app_jchat_test \
 	math_object_test \
 	tensor_test \
 \
@@ -314,6 +315,9 @@ metal_gemm_test_LDADD   = $(top_builddir)/jlib/metal/libjmetal.la $(METAL_LIBS)
 
 metal_tensor_test_SOURCES = metal_tensor_test.cc
 metal_tensor_test_LDADD   = $(top_builddir)/jlib/metal/libjmetal.la $(JUTIL_LA) $(JSYS_LA) $(METAL_LIBS)
+
+app_jchat_test_SOURCES  = app_jchat_test.cc
+app_jchat_test_LDADD    = $(JSYS_LA)
 
 ai_chat_test_SOURCES  = ai_chat_test.cc
 ai_chat_test_LDADD    = $(JAI_LA) $(JUTIL_LA) $(JSYS_LA)

--- a/tests/ai_tokenizer_test.cc
+++ b/tests/ai_tokenizer_test.cc
@@ -166,6 +166,93 @@ static void anything_encodes(const ai::tokenizer& t) {
        t.encode("") == std::vector<int>({ 1 }), spell(t, t.encode("")));
 }
 
+/**
+ * piece() is decode() without the one thing decode() must do.
+ *
+ * decode() strips a leading space because encode() adds one as the dummy
+ * prefix, and that is right exactly once for a whole reply. Streaming calls it
+ * per token, where it would eat the space in front of every word -- so the
+ * assertion is that concatenating pieces gives back what decode() gives,
+ * except for that single leading space.
+ */
+/**
+ * A control token written out in the text is that token.
+ *
+ * Found by reading jchat's output: the second reply of a conversation ended
+ * with a literal "</s>". A chat template closes every turn with it, and
+ * without this it was handed to the model as `</`, `s`, `>` -- so the model
+ * learned from its own context that a reply ends by typing those characters,
+ * and did.
+ */
+static void a_control_token_in_the_text_is_that_token(const ai::tokenizer& t) {
+    std::cout << "\na control token in the text is that token:\n";
+
+    ok("  </s> is one token, not three",
+       t.encode("</s>", false) == std::vector<int>({ 2 }),
+       spell(t, t.encode("</s>", false)));
+
+    ok("  and <s> likewise",
+       t.encode("<s>", false) == std::vector<int>({ 1 }),
+       spell(t, t.encode("<s>", false)));
+
+    // The dummy prefix belongs to the text, not to each run either side of a
+    // split.  Giving one to every run put a space in that nobody wrote.
+    const std::vector<int> around = t.encode("a</s>b", false);
+
+    ok("  the text around it keeps its shape", around.size() == 3 &&
+       around[1] == 2, spell(t, around));
+
+    ok("  with no space invented at the split",
+       t.decode(around) == "a</s>b" || t.decode(around) == "ab",
+       "\"" + t.decode(around) + "\"");
+
+    // Off, for text a stranger wrote: otherwise "</s>" typed by a user ends
+    // the turn and the rest is read as though the model had said it.
+    const std::vector<int> literal = t.encode("</s>", false, false);
+
+    ok("  and with parse_special off it is spelled out again",
+       literal.size() > 1 && literal[0] != 2, spell(t, literal));
+
+    // The whole reason it matters: a formatted turn has exactly one of them.
+    int twos = 0;
+
+    for(int id : t.encode("<|user|>\nHi</s>\n<|assistant|>\n"))
+        if(id == 2) twos++;
+
+    ok("  so a formatted turn carries one end-of-sequence", twos == 1,
+       std::to_string(twos));
+}
+
+static void pieces_concatenate_to_the_whole(const ai::tokenizer& t) {
+    std::cout << "\npieces concatenate to the whole:\n";
+
+    const std::string text = "The capital of Italy is Rome.";
+
+    const std::vector<int> ids = t.encode(text);
+
+    std::string joined;
+
+    for(std::size_t i = 0; i < ids.size(); i++) joined += t.piece(ids[i]);
+
+    ok("  the pieces put back together are the text, with its leading space",
+       joined == " " + text, "\"" + joined + "\"");
+
+    ok("  and decode is that with the space gone", t.decode(ids) == text);
+
+    // Which is the failure mode this exists to avoid: a per-token decode()
+    // loses the space in front of every word, and the result is unreadable.
+    std::string wrong;
+
+    for(std::size_t i = 0; i < ids.size(); i++)
+        wrong += t.decode(std::vector<int>(1, ids[i]));
+
+    ok("  where decoding token by token would run the words together",
+       wrong.find("capitalof") != std::string::npos ||
+       wrong.find("Thecapital") != std::string::npos, "\"" + wrong + "\"");
+
+    ok("  a control token has no text of its own", t.piece(t.bos()).empty());
+}
+
 static void it_round_trips(const ai::tokenizer& t) {
     std::cout << "\nit round trips:\n";
 
@@ -237,7 +324,9 @@ int main(int argc, char** argv) {
         the_vocabulary_is_what_the_file_said(t);
         the_space_marker_and_the_dummy_prefix(t);
         anything_encodes(t);
-        it_round_trips(t);
+        a_control_token_in_the_text_is_that_token(t);
+    pieces_concatenate_to_the_whole(t);
+    it_round_trips(t);
         it_is_quick_enough(t);
     }
     catch(std::exception& e) {
@@ -252,6 +341,13 @@ int main(int argc, char** argv) {
     // checked against ids from outside this library, and the rest is
     // round-tripping -- which a consistently wrong encoder would also pass,
     // since decode() only has to invert whatever encode() did.
+    //
+    // That a conversation is safe against what a user types.  encode() takes
+    // parse_special and jchat does not use it: a whole formatted prompt goes
+    // through in one call, so a user writing "</s>" ends the turn early and
+    // what follows is read as though the model said it.  Doing it properly
+    // means tokenizing the markers and the content separately, which nothing
+    // here does.
     //
     // Nothing about the score-driven path.  The file this was written against
     // has all-zero scores, so merges are the only usable signal in it; a

--- a/tests/app_jchat_test.cc
+++ b/tests/app_jchat_test.cc
@@ -1,0 +1,240 @@
+/* -*- mode: C++ c-basic-offset: 4 -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+#include <jlib/sys/sys.hh>
+#include <jlib/sys/pstream.hh>
+
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <vector>
+
+static int failures = 0;
+
+static void ok(const std::string& what, bool good, const std::string& detail = "") {
+    if(!good) ++failures;
+    std::cout << (good ? "  ok   " : "  FAIL ") << what;
+    if(!detail.empty()) std::cout << ": " << detail;
+    std::cout << "\n";
+}
+
+static bool exists(const std::string& p) {
+    std::ifstream f(p, std::ios::binary);
+
+    return bool(f);
+}
+
+static std::string find_one(const char* const* names, std::size_t n) {
+    for(std::size_t i = 0; i < n; i++)
+        if(exists(names[i])) return names[i];
+
+    return "";
+}
+
+/**
+ * The app itself, which is beside this test in the build tree.
+ *
+ * Not $PATH: an installed jchat from an older build would be tested instead of
+ * the one just compiled, and it would pass.
+ */
+static std::string find_jchat() {
+    const char* names[] = {
+        "../jlib/apps/jchat", "./jlib/apps/jchat", "../../build/jlib/apps/jchat"
+    };
+
+    return find_one(names, sizeof(names) / sizeof(names[0]));
+}
+
+static std::string find_model() {
+    if(const char* e = std::getenv("JLIB_GGUF")) if(exists(e)) return e;
+
+    const char* names[] = {
+        "tinyllama-1.1b-chat-v1.0.Q8_0.gguf",
+        "../tinyllama-1.1b-chat-v1.0.Q8_0.gguf",
+        "../../tinyllama-1.1b-chat-v1.0.Q8_0.gguf",
+        "../../../tinyllama-1.1b-chat-v1.0.Q8_0.gguf"
+    };
+
+    return find_one(names, sizeof(names) / sizeof(names[0]));
+}
+
+/** These need no model, so they run wherever the app was built. */
+static void it_explains_itself(const std::string& jchat) {
+    std::cout << "\nit explains itself:\n";
+
+    std::string out, err;
+
+    const int rc = jlib::sys::run({ jchat, "--help" }, out, err);
+
+    ok("  --help succeeds", rc == 0, std::to_string(rc));
+
+    ok("  and says how to call it",
+       out.find("usage:") != std::string::npos &&
+       out.find("--system") != std::string::npos &&
+       out.find("--raw") != std::string::npos);
+
+    out.clear(); err.clear();
+
+    const int bad = jlib::sys::run({ jchat, "--nonesuch", "x" }, out, err);
+
+    ok("  an option it does not have is refused", bad != 0, std::to_string(bad));
+
+    ok("  saying which one", err.find("--nonesuch") != std::string::npos, err);
+
+    out.clear(); err.clear();
+
+    const int none = jlib::sys::run({ jchat }, out, err);
+
+    ok("  and with no model at all it prints the usage",
+       none != 0 && err.find("usage:") != std::string::npos, std::to_string(none));
+}
+
+static void it_answers_from_the_command_line(const std::string& jchat,
+                                             const std::string& model)
+{
+    std::cout << "\nit answers from the command line:\n";
+
+    std::string out, err;
+
+    const int rc = jlib::sys::run({ jchat, "--temp", "0", "--tokens", "40",
+                                    model, "What is the capital of Italy?" },
+                                  out, err);
+
+    ok("  it runs", rc == 0, std::to_string(rc) + " " + err);
+
+    ok("  and answers Rome", out.find("Rome") != std::string::npos,
+       "\"" + out + "\"");
+
+    // The reason the split exists: a caller redirecting stdout gets the answer
+    // and none of the progress.
+    ok("  with the timings on stderr and not in the answer",
+       out.find("loaded in") == std::string::npos &&
+       out.find("tokens in") == std::string::npos &&
+       err.find("loaded in") != std::string::npos,
+       "\"" + out + "\"");
+
+    // Greedy, so the same question twice is the same answer.
+    std::string again, ignored;
+
+    jlib::sys::run({ jchat, "--temp", "0", "--tokens", "40",
+                     model, "What is the capital of Italy?" }, again, ignored);
+
+    ok("  and at temperature zero it repeats exactly", again == out);
+}
+
+/**
+ * The conversation is kept, which is the whole reason it is not one-shot only.
+ *
+ * "And Italy?" is answerable only by something that remembers being asked
+ * about a capital -- a fresh prompt has no idea what is being asked.
+ */
+static void it_remembers_the_conversation(const std::string& jchat,
+                                          const std::string& model)
+{
+    std::cout << "\nit remembers the conversation:\n";
+
+    // Through a file rather than down a pipe: sys::pstream is popen, so it
+    // runs one direction at a time and has no way to say "that is all the
+    // input" -- and without an end of input the conversation loop never
+    // returns.  A redirect gives the child a stdin that ends.
+    const std::string in = "jchat-turns.txt";
+
+    {
+        std::ofstream f(in.c_str());
+
+        f << "What is the capital of France?\n"
+          << "And Italy?\n";
+    }
+
+    // The shell is involved here, which library code would avoid -- sys::run
+    // exists for exactly that reason.  In a test, with strings this file
+    // wrote, a redirect is worth more than the principle.
+    jlib::sys::pstream p(jchat + " --temp 0 --tokens 40 " + model +
+                         " < " + in + " 2>&1", std::ios::in);
+
+    std::string all;
+    std::string line;
+
+    while(std::getline(p, line)) all += line + "\n";
+
+    p.close();
+
+    std::remove(in.c_str());
+
+    ok("  the first answer is Paris", all.find("Paris") != std::string::npos,
+       "\"" + all + "\"");
+
+    ok("  and the follow-up is answered from the history",
+       all.find("Rome") != std::string::npos, "\"" + all + "\"");
+}
+
+int main(int argc, char** argv) {
+    std::cout << std::unitbuf;
+
+    const std::string jchat = argc > 1 && exists(argv[1]) ? argv[1] : find_jchat();
+
+    if(jchat.empty()) {
+        std::cout << "app_jchat_test: no jchat binary beside this test\n";
+
+        return 77;
+    }
+
+    std::cout << "app_jchat_test: " << jchat << "\n";
+
+    try {
+        it_explains_itself(jchat);
+
+        const std::string model = find_model();
+
+        if(model.empty())
+            std::cout << "\n  (no model file, so only the argument handling "
+                      << "is exercised)\n";
+        else {
+            it_answers_from_the_command_line(jchat, model);
+            it_remembers_the_conversation(jchat, model);
+        }
+    }
+    catch(std::exception& e) {
+        std::cerr << "app_jchat_test: " << e.what() << "\n";
+
+        return 1;
+    }
+
+    // What a green run does not establish.
+    //
+    // Anything about what the model says beyond one word of it.  "Rome" is in
+    // the answer; whether the sentence around it is good is not something a
+    // test can hold, and a greedy run only pins it for this model at this
+    // quantisation.
+    //
+    // Nothing about the interactive experience.  Input is piped here, so there
+    // is no terminal, no editing and no interrupt handling -- and Ctrl-C part
+    // way through a reply is exactly the case a person will hit first.
+    //
+    // And nothing about the CPU path.  These run on whatever backend jchat
+    // chose, which where there is Metal is the GPU; the float fallback is
+    // reached only on a machine without it.
+    std::cout << "\n" << (failures ? "FAILED" : "PASSED") << ": " << failures
+              << " failure(s)\n";
+
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
# jchat

Everything on this path has run from tests. `jlib/apps/jchat` is the program.

```
$ jchat model.gguf "What is the capital of Italy?"
[Apple M5 (unified memory), 22 layers, 2048 wide, 32 heads over 4]
[loaded in 4.08s]
The capital of Italy is Rome.
[8 tokens in 1.35s, 5.93/s]
```

Two modes, one program. With a prompt it answers once and exits, which is what a
script or a test wants; with none it reads a turn per line and keeps the
conversation:

```
> What is the capital of France?
The capital of France is Paris.
> And Italy?
Italy's capital city is Rome.
```

"And Italy?" is answerable only by something that remembers being asked about a
capital, which is the whole reason the app is not one-shot only.

Progress and timings go to **stderr**, the model's words to **stdout**, so
`jchat model.gguf "..." > answer.txt` collects the answer and nothing else.
`--system`, `--tokens`, `--temp`, `--top-k`, `--top-p`, `--seed`, and `--raw`
to continue a prompt rather than answer it — which is also the escape hatch for
a model whose chat template `ai::chat` refuses.

## Why line-oriented rather than curses

The ask was a curses interface, transcript above and prompt below, and it is not
too much: ncurses is present on both platforms and `configure.ac` already gates
optional dependencies cleanly. But a TUI is a presentation layer over exactly
this loop — load, format, encode, stream, append — so building it first would
mean debugging model loading and window layout together, and a curses program
cannot be tested in `make check` without a pty. It would have been the only
untested program in a tree that tests everything.

So the loop is here and proven, and a curses front end is now a shell around
something that works. That was agreed before any of it was written.

## Streaming needed something the tokenizer did not have

`decode()` strips a leading space, because `encode()` adds one as the dummy
prefix, and that is right exactly once for a whole reply. Called per token while
streaming it eats the space in front of every word:

```
"ThecapitalofItalyisRome."
```

which is what the test asserts a per-token `decode()` produces. `tokenizer::piece()`
is `decode()` without that one step, and the assertion is that concatenating
pieces gives back what `decode()` gives except for the single leading space.

## The bug jchat found in the tokenizer

Running the REPL by hand turned up something the tests had not. The second reply
of a conversation ended like this:

```
> what would monty python say it was?
Monty Python would say it is: "The fastest bird in the air."</s>
```

That `</s>` is printed, not a marker. `ai::chat` closes every turn with the
literal text `</s>`, and `encode()` byte-pair encoded it like any other text
into `</`, `s`, `>`. So the model was handed turn boundaries spelled out as
characters, saw in its own context that a reply ends by *typing* them, and did.

`encode()` now takes `parse_special`, on by default, and splits the text at any
control token the vocabulary actually has. `</s>` is token 2 again.

Two things worth recording about the fix. The first attempt gave the **dummy
prefix to every run** either side of a split, so `a</s>b` came back as `"a b"` --
a space nobody wrote. The prefix belongs to the text as a whole and now goes to
the first run only.

And what this does *not* cover: `<|user|>` is not in a Llama vocabulary at all,
so it is still byte-pair encoded into `▁<`, `|`, `|`, `user`... and that is
correct, because it is the byte sequence the model was tuned on. Only tokens the
vocabulary has are recognised.

The answers changed once it was fixed -- different figures, longer replies --
which is the evidence that the old tokenization was materially wrong rather than
merely untidy.

**And a gap this leaves open**, written into the test rather than quietly: jchat
tokenizes a whole formatted prompt in one call with `parse_special` on, so a
user who types `</s>` ends the turn early and has the rest read as though the
model said it. Doing it properly means tokenizing the markers and the content
separately.

## And a header that had never compiled

The multi-turn test needs to give the app a conversation and then an end of
input. `jlib::sys::pstream` looked like the tool, and **it does not compile**:
`basic_procbuf` derives from `std::basic_streambuf<charT,traitT>` and calls
`eback()`, `pbase()`, `gptr()`, `pbump()` and the rest unqualified. The base
depends on the template parameters, so those names are looked up when the
template is defined, at which point they do not exist.

It is an installed public header in `libjsysinclude_HEADERS`, and **nothing has
ever included it** — so nothing ever instantiated it, and it was never
type-checked. The same shape as `math::tensor`'s products: a template that
looks finished because no caller ever asked it to compile.

Twenty calls now say `this->`, with a comment saying why it is not a style
choice. This test is the first instantiation the header has had.

**And it had a second defect that only gcc sees.** With the qualification done,
macOS built and the container did not: `strerror` is used with no
`#include <cstring>`, which clang pulls in transitively and gcc 13 does not. A
header that has never been compiled has never been compiled *by anything*, so
the platform differences went unfound along with the rest. Both fixes are one
line each and neither would exist without a caller.

It still cannot do what was wanted — `popen` runs one direction at a time and
offers no way to say "that is all the input" — so the test writes the turns to a
file and redirects. That uses the shell, which library code avoids and
`sys::run` exists to avoid; in a test, with strings the test itself wrote, the
redirect is worth more than the principle, and the comment says so.

## Tests

`app_jchat_test` runs the app rather than the library.

- **argument handling needs no model**, so it runs in the container: `--help`
  succeeds and describes the options, an unknown option exits non-zero *saying
  which one*, and no arguments prints the usage.
- **it answers from the command line**, the answer contains Rome, and — the
  reason the stream split exists — the timings are on stderr and not in the
  answer. At temperature zero the same question twice gives byte-identical
  output.
- **it remembers the conversation**: Paris, then Rome from "And Italy?".

The app is found beside the test in the build tree rather than on `$PATH`, so an
older installed `jchat` cannot be tested in place of the one just built and pass.

## Verification

- macOS `make check`: 75 tests (was 74), 71 pass, 4 skip, 0 fail.
- Container: the argument-handling half runs; the model-dependent half skips.
  The first container run of this branch **failed to build** on the `strerror`
  above, which is what found it.

## What this does not establish

**Anything about the interactive experience.** Input is piped in the test, so
there is no terminal, no line editing, and no interrupt handling — and Ctrl-C
part way through a reply is the first thing a person will hit. That is worth a
branch on its own, and it is worth having before a curses front end rather than
after.

**Anything about what the model says beyond one word.** "Rome" is in the answer;
whether the sentence around it is any good is not something a test can hold.

**Nothing about the CPU path.** `jchat` falls back to `host_backend<float>` — float
and not fp16, because the host GEMM accumulates in the element type and a
2048-long dot product summed in fp16 loses the answer rather than some precision.
It warns that it will be slow and want 4GB. Nothing here runs it.

**That a conversation is safe against what a user types** -- the
`parse_special` gap above.

**And `pstream` is compiled, not exercised.** One instantiation in read mode
through a shell redirect is what it now has. Its write mode, its `exitval()` and
its `interrupted()` remain as untested as they were.
