### PR TITLE
Let a reply be interrupted: on_token returns whether to continue, and jchat stops the reply rather than the session

### DIFF
--- a/jlib/ai/generate.hh
+++ b/jlib/ai/generate.hh
@@ -91,7 +91,17 @@ std::vector<float> last_logits(const math::matrix<T>& logits) {
  * the cache rather than competing with it.
  *
  * @param on_token called with each new token as it is produced, for a caller
- *                 that wants to stream rather than wait
+ *                 that wants to stream rather than wait.  **Return false to
+ *                 stop**, which ends the generation after that token rather
+ *                 than before it -- so what a caller has already printed is
+ *                 what the result contains, and a partial reply is a real
+ *                 reply rather than something to be undone.
+ *
+ *                 This is how an interrupt reaches the loop: a signal handler
+ *                 sets a flag, the callback reads it, and generation ends
+ *                 between tokens at a point where nothing is half-written. A
+ *                 caller passing no callback cannot stop early, which is the
+ *                 honest consequence of there being nothing to ask.
  * @return the prompt followed by everything generated
  */
 template<typename T>
@@ -100,7 +110,7 @@ std::vector<int> generate(model<T>& m, backend<T>& b,
                           unsigned int max_new,
                           sampler& s,
                           int eos = -1,
-                          std::function<void(int)> on_token = nullptr)
+                          std::function<bool(int)> on_token = nullptr)
 {
     if(prompt.empty())
         throw backend_error("generate: an empty prompt has no last position");
@@ -128,7 +138,7 @@ std::vector<int> generate(model<T>& m, backend<T>& b,
 
         ids.push_back(next);
 
-        if(on_token) on_token(next);
+        if(on_token && !on_token(next)) break;
 
         if(eos >= 0 && next == eos) break;
     }

--- a/jlib/apps/jchat.cc
+++ b/jlib/apps/jchat.cc
@@ -41,6 +41,7 @@
 #endif
 
 #include <chrono>
+#include <csignal>
 #include <cstdlib>
 #include <cstring>
 #include <iostream>
@@ -51,6 +52,41 @@
 namespace ai = jlib::ai;
 
 namespace {
+
+/**
+ * Set by the interrupt handler, read between tokens.
+ *
+ * sig_atomic_t and volatile because a handler may run between any two
+ * instructions, and nothing else in here is safe to touch from one -- no
+ * allocation, no iostreams, no locks. The handler sets a number; everything
+ * that has to happen because of it happens in the generation loop, where it is
+ * allowed to.
+ */
+volatile std::sig_atomic_t g_interrupted = 0;
+
+void interrupted(int) { g_interrupted = 1; }
+
+/**
+ * Ask for SIGINT **without** SA_RESTART.
+ *
+ * signal(2) on a BSD restarts an interrupted read, which is usually what you
+ * want and here is not: with it, Ctrl-C at the prompt would be noticed only
+ * after the next line was typed. sigaction with no flags lets getline fail so
+ * the loop can see it.
+ */
+void catch_interrupts() {
+    struct sigaction sa;
+
+    std::memset(&sa, 0, sizeof(sa));
+
+    sa.sa_handler = interrupted;
+
+    sigemptyset(&sa.sa_mask);
+
+    sa.sa_flags = 0;
+
+    sigaction(SIGINT, &sa, 0);
+}
 
 struct options {
     std::string model;
@@ -139,17 +175,26 @@ double now() {
     return duration<double>(steady_clock::now().time_since_epoch()).count();
 }
 
+/** What one exchange produced, and whether it got to finish. */
+struct reply {
+    std::string text;
+    bool stopped = false;
+};
+
 /**
  * One exchange: lay out the turns, generate, stream the reply to stdout.
  *
- * @return the reply, so the caller can put it in the history
+ * Reports whether it was interrupted rather than leaving the caller to read
+ * the flag afterwards -- this clears it, so a caller checking it later would
+ * always see zero, which is a mistake this returned a bare string long enough
+ * to make.
  */
 template<typename T>
-std::string answer(ai::model<T>& m, ai::backend<T>& b, const ai::tokenizer& tok,
+reply answer(ai::model<T>& m, ai::backend<T>& b, const ai::tokenizer& tok,
                    const std::vector<int>& ids, const options& o,
                    ai::sampler& s)
 {
-    std::string reply;
+    reply said;
     bool first = true;
 
     const double start = now();
@@ -167,9 +212,13 @@ std::string answer(ai::model<T>& m, ai::backend<T>& b, const ai::tokenizer& tok,
                 first = false;
             }
 
-            reply += p;
+            said.text += p;
 
             std::cout << p << std::flush;
+
+            // Between tokens, which is where it is safe to stop: nothing is
+            // half-printed and the reply so far is a whole thing.
+            return g_interrupted == 0;
         });
 
     std::cout << "\n";
@@ -177,10 +226,20 @@ std::string answer(ai::model<T>& m, ai::backend<T>& b, const ai::tokenizer& tok,
     const double took = now() - start;
     const std::size_t made = out.size() - ids.size();
 
-    std::cerr << "[" << made << " tokens in " << took << "s, "
-              << (took > 0 ? double(made) / took : 0.0) << "/s]\n";
+    if(g_interrupted) {
+        said.stopped = true;
 
-    return reply;
+        std::cerr << "[stopped after " << made << " tokens]\n";
+
+        // Cleared here rather than by the handler, so the next reply starts
+        // fresh and a second Ctrl-C at the prompt is a separate decision.
+        g_interrupted = 0;
+    }
+    else
+        std::cerr << "[" << made << " tokens in " << took << "s, "
+                  << (took > 0 ? double(made) / took : 0.0) << "/s]\n";
+
+    return said;
 }
 
 /**
@@ -231,6 +290,8 @@ int run(ai::backend<T>& b, const ai::gguf& g, const options& o) {
 
     std::cerr << "[loaded in " << (now() - t0) << "s]\n";
 
+    catch_interrupts();
+
     ai::sampler s(o.sampling);
 
     // Raw mode never lays anything out, so it needs no template -- which is
@@ -265,9 +326,10 @@ int run(ai::backend<T>& b, const ai::gguf& g, const options& o) {
             ids = ch->encode(turns, tok);
         }
 
-        answer(m, b, tok, ids, o, s);
-
-        return 0;
+        // 128 + SIGINT, which is what a shell reports for a program that was
+        // interrupted -- true here even though it was handled rather than
+        // fatal, because a script wants to know the answer is not complete.
+        return answer(m, b, tok, ids, o, s).stopped ? 130 : 0;
     }
 
     if(o.raw) {
@@ -283,7 +345,13 @@ int run(ai::backend<T>& b, const ai::gguf& g, const options& o) {
 
         std::string line;
 
-        if(!std::getline(std::cin, line)) break;
+        if(!std::getline(std::cin, line)) {
+            // Either the input ended or Ctrl-C arrived while waiting for it.
+            // Both mean stop; only one of them is an interruption.
+            if(g_interrupted) { std::cerr << "\n"; return 130; }
+
+            break;
+        }
 
         if(line.empty()) continue;
 
@@ -291,10 +359,11 @@ int run(ai::backend<T>& b, const ai::gguf& g, const options& o) {
 
         fit(turns, *ch, tok, c.context, o.tokens);
 
-        const std::string said =
-            answer(m, b, tok, ch->encode(turns, tok), o, s);
-
-        turns.push_back({ "assistant", said });
+        // Kept whether or not it finished: a stopped reply is still what the
+        // model said, and dropping it would leave the conversation with a
+        // question nobody answered.
+        turns.push_back({ "assistant",
+                          answer(m, b, tok, ch->encode(turns, tok), o, s).text });
     }
 
     std::cerr << "\n";

--- a/tests/ai_model_test.cc
+++ b/tests/ai_model_test.cc
@@ -331,19 +331,110 @@ static void it_answers_a_question(const char* name, ai::backend<T>& b,
     }
 }
 
+/**
+ * Generation stops when the callback says to, and not before.
+ *
+ * On a model of zeros rather than a real one: eight wide, one layer, and every
+ * weight left at its initial zero, so the logits are zero, greedy always picks
+ * token 0, and what comes out depends on the loop alone. No file, so this runs
+ * wherever the tests do -- which matters, because it is the mechanism an
+ * interrupt reaches the generation through, and a signal is not something the
+ * piped tests can send.
+ */
+static void generation_stops_when_asked() {
+    std::cout << "\ngeneration stops when asked:\n";
+
+    typename ai::model<float>::config c;
+
+    c.d_model = 8;
+    c.heads = 2;
+    c.kv_heads = 1;
+    c.d_ff = 16;
+    c.layers = 1;
+    c.vocab = 32;
+    c.context = 64;
+
+    ai::host_backend<float> b;
+    ai::model<float> m(b, c);
+
+    ai::sampler::config sc;
+    sc.temperature = 0.0f;
+
+    const std::vector<int> prompt{ 1, 2, 3 };
+
+    {
+        ai::sampler s(sc);
+
+        const std::vector<int> out = ai::generate<float>(m, b, prompt, 10, s);
+
+        ok("  with no callback it runs to the limit",
+           out.size() == prompt.size() + 10,
+           std::to_string(out.size() - prompt.size()));
+    }
+
+    {
+        ai::sampler s(sc);
+        int seen = 0;
+
+        const std::vector<int> out = ai::generate<float>(
+            m, b, prompt, 10, s, -1, [&](int) { seen++; return true; });
+
+        ok("  and a callback that keeps saying yes changes nothing",
+           out.size() == prompt.size() + 10 && seen == 10,
+           std::to_string(seen));
+    }
+
+    {
+        ai::sampler s(sc);
+        int seen = 0;
+
+        const std::vector<int> out = ai::generate<float>(
+            m, b, prompt, 10, s, -1, [&](int) { return ++seen < 3; });
+
+        // Three, not two: the token that prompted the stop is already made and
+        // already streamed, so it belongs to the result.  A partial reply is a
+        // real reply rather than something to be taken back.
+        ok("  saying no ends it after that token, not before",
+           out.size() == prompt.size() + 3,
+           std::to_string(out.size() - prompt.size()));
+
+        ok("  and the callback saw exactly the tokens produced", seen == 3,
+           std::to_string(seen));
+    }
+
+    {
+        ai::sampler s(sc);
+
+        // Stopping at once is a whole token, not none: there is no way to
+        // refuse the first, only to decline the second.
+        const std::vector<int> out = ai::generate<float>(
+            m, b, prompt, 10, s, -1, [&](int) { return false; });
+
+        ok("  refusing immediately still yields one", out.size() == prompt.size() + 1,
+           std::to_string(out.size() - prompt.size()));
+    }
+}
+
 int main(int argc, char** argv) {
     std::cout << std::unitbuf;
 
     const std::string path = find_model(argc, argv);
 
+    // Runs with or without a model, so the generation loop is covered on a
+    // machine that has neither the file nor a GPU.
+    generation_stops_when_asked();
+
     if(path.empty()) {
-        std::cout << "ai_model_test: no model file; pass one as an argument or "
-                  << "set JLIB_GGUF.\n"
+        std::cout << "\n  (no model file, so only the generation loop is "
+                  << "exercised)\n"
                   << "  curl -LO https://huggingface.co/TheBloke/"
                   << "TinyLlama-1.1B-Chat-v1.0-GGUF/resolve/main/"
                   << "tinyllama-1.1b-chat-v1.0.Q8_0.gguf\n";
 
-        return 77;
+        std::cout << "\n" << (failures ? "FAILED" : "PASSED") << ": "
+                  << failures << " failure(s)\n";
+
+        return failures ? 1 : 0;
     }
 
     std::cout << "ai_model_test: " << path << "\n";


### PR DESCRIPTION
# Interrupting a reply

Reported the way these things usually are — by hitting it:

```
> write a Hello World program in Erlang
I can't write a program in er^C
axoloki@xolotl build %
```

Ctrl-C ended the session rather than the answer. This is #157.

```
> write a long detailed essay about the history of cheese
Cheese is a staple food in many cultures around the world, and its history
dates back thousands of years. From its earliest origins^C
[stopped after 30 tokens]
> what is 2+2?
2 + 2 = 4.
```

## The mechanism is in generate(), not in the app

`on_token` now returns `bool` — false stops. A signal handler sets a flag, the
callback reads it, and generation ends **between tokens**, where nothing is
half-written and the reply so far is a whole thing.

The token that prompts the stop is kept. It has already been made and already
streamed, so the alternative is printing something the result does not contain.
A partial reply is a real reply rather than something to be taken back, and in
the REPL it stays in the history — dropping it would leave the conversation with
a question nobody answered.

A caller passing no callback cannot stop early, which is the honest consequence
of there being nothing to ask.

## Signal handling, and the two details that matter

`sigaction` with **no** `SA_RESTART`. `signal(2)` on a BSD restarts an
interrupted read, which is usually what you want and here is not: with it,
Ctrl-C at the prompt would only be noticed after the next line was typed.

The handler sets a `volatile sig_atomic_t` and does nothing else. No allocation,
no iostreams, no locks — everything that must happen because of the interrupt
happens in the generation loop, where it is allowed to.

- **while generating**: the reply ends, the session continues
- **at the prompt**: exits, reporting **130** (128 + SIGINT), which is what a
  shell reports for an interrupted program
- **one-shot**: prints what it had and exits 130, so a script knows the answer
  is incomplete

## Why not Esc

Asked, and worth recording since it was a real question. Esc does not need
curses: `tcsetattr` with `ICANON` off plus a `poll()` on stdin between tokens is
about forty lines of POSIX. What it does need is the terminal restored on normal
exit, on an exception, and on a signal — get that wrong and the shell is left
with no echo, a worse failure than the one being fixed. It also does nothing for
piped input, which is how the tests drive jchat, so the signal path is required
regardless.

And doing *only* Esc would be a trap: SIGINT left at its default still kills the
process, so the reported bug would survive.

So Ctrl-C now, and Esc with the curses front end, where the terminal handling is
curses' job rather than hand-rolled.

## Tests

The interrupt itself is a signal to a terminal, which the piped tests cannot
send. What they can test is the mechanism it arrives through, and that is now
covered on **a model of zeros** — eight wide, one layer, every weight at its
initial zero, so the logits are zero, greedy always picks token 0, and what
comes out depends on the loop alone.

No file and no GPU, so `ai_model_test` now runs this part everywhere rather than
skipping wholesale:

- no callback runs to the limit; one that keeps saying yes changes nothing
- saying no ends it **after** that token, not before — three, not two
- refusing immediately still yields one, because there is no way to refuse the
  first, only to decline the second

| mutation | caught |
| --- | --- |
| ignore the callback's answer | 3 failures |
| drop the token that prompted the stop | 2 failures |

And by hand, since a signal cannot be: interrupting a one-shot reply stops it
and exits 130; interrupting inside the REPL stops the reply, keeps it in the
history, and answers the next question.

## One bug of mine, caught before it was tested

`answer()` cleared the interrupt flag before returning, so the one-shot exit
code read it afterwards and always saw zero — it would never have reported 130.
It now returns whether it was stopped rather than leaving the caller to read a
flag that has already been reset.

## Verification

- macOS `make check`: 75 tests, 71 pass, 4 skip, 0 fail.
- Container: `ai_model_test` no longer skips wholesale; the generation-loop half
  runs there.

## What this does not establish

**That the signal path works** — no test sends one. The contract it reaches
through is tested; the wiring from SIGINT to that contract was checked by hand,
twice, and is four lines.

**Nothing about a signal arriving anywhere else.** During model loading, during
tokenization, or between the prompt and the first token, the flag is set and
nothing reads it until the next token boundary — so an interrupt during a four
second load is noticed only when the first token appears. That is a real wait
and nothing here shortens it.

**And nothing about Esc**, which is not implemented. See above for why, and #157
is closed by this rather than by that.
