### PR TITLE
Add a key-value cache that grows as it fills, and fix the host GEMM's beta of zero, which it turned into nan

### DIFF
--- a/jlib/ai/attention.hh
+++ b/jlib/ai/attention.hh
@@ -71,6 +71,10 @@ namespace ai {
  * is unchecked and untested.
  *
  * @param causal whether a query may see keys that come after it
+ * @param key_offset how many keys precede the first query.  Zero when the
+ *        queries are the whole sequence; with a key-value cache they are its
+ *        tail, and k and v are the cache rather than this step's keys alone.
+ *        See backend::causal_mask, which does two jobs with this one number.
  */
 template<typename T>
 void attention(backend<T>& b,
@@ -80,7 +84,8 @@ void attention(backend<T>& b,
                typename backend<T>::tensor_ptr& scores,
                typename backend<T>::tensor_ptr& probs,
                typename backend<T>::tensor_ptr& out,
-               bool causal = true)
+               bool causal = true,
+               unsigned int key_offset = 0)
 {
     const unsigned int d  = q->rows();
     const unsigned int tq = q->cols();
@@ -107,7 +112,7 @@ void attention(backend<T>& b,
     b.multiply_tn(k, q, scores, T(1.0f / std::sqrt(float(d))), T(0));
 
     if(causal)
-        b.causal_mask(scores);
+        b.causal_mask(scores, key_offset);
 
     b.softmax(scores, probs);
 

--- a/jlib/ai/backend.hh
+++ b/jlib/ai/backend.hh
@@ -225,9 +225,36 @@ public:
      * -infinity rather than a large negative number, because softmax subtracts
      * the column maximum and exp(-inf - m) is exactly zero for finite m.  A
      * fully masked column would give nan; this mask cannot produce one, since
-     * element (c,c) is always kept.
+     * element (c + key_offset, c) is always kept.
+     *
+     * @param key_offset how many keys precede the first query.  Zero when the
+     *        queries are the whole sequence.  With a key-value cache they are
+     *        only its tail, so query column c is at absolute position
+     *        `key_offset + c` and the condition becomes `row > col + offset`.
+     *
+     *        That one number also does a second job.  A cache is allocated for
+     *        the whole context and filled as it goes, so the rows past what
+     *        has been written hold zeros rather than keys -- and they are
+     *        masked by the same test, because a row at or beyond the cache's
+     *        length is always greater than `key_offset + col`.  One mask, both
+     *        jobs, which is why this needs no notion of how full the cache is.
      */
-    virtual void causal_mask(tensor_ptr& s) = 0;
+    virtual void causal_mask(tensor_ptr& s, unsigned int key_offset = 0) = 0;
+
+    /**
+     * Copy src's columns into dst starting at a column: the write half of
+     * gather.
+     *
+     * For appending to a key-value cache, where the keys for the tokens just
+     * processed go after the ones already there. Column-major storage makes a
+     * column range contiguous, so this is a run of memcpy rather than a
+     * gather -- but it is a kernel rather than a memcpy because on a GPU the
+     * destination is device memory.
+     *
+     * @throws backend_error if the columns would not fit
+     */
+    virtual void copy_columns(const tensor_ptr& src, tensor_ptr& dst,
+                              unsigned int dst_first) = 0;
 
     /**
      * Pick columns out of a table: out[:,i] = table[:,ids[i]].
@@ -322,7 +349,9 @@ public:
     void add_scaled(T alpha, const tensor_ptr& x, tensor_ptr& y);
     void assign(const tensor_ptr& src, tensor_ptr& dst);
     void softmax(const tensor_ptr& in, tensor_ptr& out);
-    void causal_mask(tensor_ptr& s);
+    void causal_mask(tensor_ptr& s, unsigned int key_offset = 0);
+    void copy_columns(const tensor_ptr& src, tensor_ptr& dst,
+                      unsigned int dst_first);
     void gather(const tensor_ptr& table, const std::vector<int>& ids,
                 tensor_ptr& out);
     void rope(tensor_ptr& x, unsigned int base_pos = 0, float theta = 10000.0f,
@@ -478,6 +507,24 @@ template<typename T>
 void blend(const math::matrix<T>& p, math::matrix<T>& out, T alpha, T beta) {
     typedef typename compute_in<T>::type C;
 
+    // beta of zero means out is **not read**, which is what BLAS specifies and
+    // is not the same thing as multiplying it by zero.  Whatever is already
+    // there may be uninitialised, or -infinity left by a previous caller's
+    // mask, and `0 * -inf` is nan -- which then poisons the sum and everything
+    // downstream of it.
+    //
+    // Found by a key-value cache reusing one score matrix across steps: the
+    // mask writes -infinity into the rows past the cache, the next step
+    // recomputes the scores with beta zero, and every logit came back nan.
+    // MPS follows the convention, so the GPU was right and this was not.
+    if(beta == T(0)) {
+        for(uint r = 0; r < out.M; r++)
+            for(uint c = 0; c < out.N; c++)
+                out(r,c) = T(C(alpha) * C(p(r,c)));
+
+        return;
+    }
+
     for(uint r = 0; r < out.M; r++)
         for(uint c = 0; c < out.N; c++)
             out(r,c) = T(C(alpha) * C(p(r,c)) + C(beta) * C(out(r,c)));
@@ -584,7 +631,25 @@ void host_backend<T>::softmax(const tensor_ptr& in, tensor_ptr& out) {
 }
 
 template<typename T>
-void host_backend<T>::causal_mask(tensor_ptr& s) {
+void host_backend<T>::copy_columns(const tensor_ptr& src, tensor_ptr& dst,
+                                   unsigned int dst_first)
+{
+    const math::matrix<T>& a = at(src);
+    math::matrix<T>& b = at(dst);
+
+    if(a.M != b.M)
+        throw backend_error("copy_columns: the two must be the same height");
+
+    if(dst_first + a.N > b.N)
+        throw backend_error("copy_columns: the columns would not fit");
+
+    for(uint c = 0; c < a.N; c++)
+        for(uint r = 0; r < a.M; r++)
+            b(r, dst_first + c) = a(r, c);
+}
+
+template<typename T>
+void host_backend<T>::causal_mask(tensor_ptr& s, unsigned int key_offset) {
     math::matrix<T>& x = at(s);
 
     // Through float, not std::numeric_limits<T>: _Float16 is a compiler
@@ -593,7 +658,7 @@ void host_backend<T>::causal_mask(tensor_ptr& s) {
     const T neg_inf = T(-std::numeric_limits<float>::infinity());
 
     for(uint c = 0; c < x.N; c++)
-        for(uint r = c + 1; r < x.M; r++)
+        for(uint r = c + key_offset + 1; r < x.M; r++)
             x(r,c) = neg_inf;
 }
 

--- a/jlib/ai/generate.hh
+++ b/jlib/ai/generate.hh
@@ -117,26 +117,39 @@ std::vector<int> generate(model<T>& m, backend<T>& b,
 
     std::vector<int> ids = prompt;
 
-    for(unsigned int step = 0; step < max_new; step++) {
-        const unsigned int n = static_cast<unsigned int>(ids.size());
+    // With a cache the first pass takes the whole prompt and every later one a
+    // single token; without, each pass takes everything so far.  The rest of
+    // the loop is the same either way, which is the point -- a cache is an
+    // optimisation and not a second way of generating.
+    if(m.caching()) m.reset_cache();
 
-        if(m.conf().context && n > m.conf().context)
+    std::vector<int> feed = ids;
+
+    for(unsigned int step = 0; step < max_new; step++) {
+        const unsigned int n = static_cast<unsigned int>(feed.size());
+
+        if(m.conf().context && ids.size() > m.conf().context)
             break;
 
-        // Re-reserved every step because the sequence grew.  This reallocates
-        // every intermediate in every block, which sounds worse than it is --
-        // it is a few hundred allocations against a forward pass over a
-        // billion parameters.  The cache branch removes the growth, not this.
+        // Re-reserved every step because what is fed changes size -- from the
+        // whole prompt to one token with a cache, and by one more each time
+        // without.  A few hundred small allocations against a forward pass
+        // over a billion parameters.
         m.reserve(n);
 
         typename backend<T>::tensor_ptr logits = b.make(m.conf().vocab, n);
 
-        m.forward(ids, logits);
+        m.forward(feed, logits);
         b.wait();
 
         const int next = s.pick(last_logits(logits->read()));
 
         ids.push_back(next);
+
+        // The cache already holds everything up to here, so the next pass owes
+        // it only the token just chosen.
+        if(m.caching()) feed.assign(1, next);
+        else feed = ids;
 
         if(on_token && !on_token(next)) break;
 

--- a/jlib/ai/model.hh
+++ b/jlib/ai/model.hh
@@ -120,6 +120,25 @@ public:
      */
     void load(const gguf& g);
 
+    /**
+     * Keep every block's keys and values, so a later call supplies only what
+     * is new.  See block::enable_cache.
+     *
+     * Defaults to the context the file declared, which is the most a model can
+     * be asked to hold anyway.
+     */
+    void enable_cache(unsigned int context = 0);
+
+    /** Forget it, for a conversation that starts again. */
+    void reset_cache();
+
+    bool caching() const { return !m_layers.empty() && m_layers[0]->caching(); }
+
+    /** How many positions are cached. */
+    unsigned int cached() const {
+        return m_layers.empty() ? 0 : m_layers[0]->cached();
+    }
+
     /** Size every intermediate for a sequence of this length. */
     void reserve(unsigned int seq);
 
@@ -342,9 +361,25 @@ void model<T>::load(const gguf& g) {
 }
 
 template<typename T>
+void model<T>::enable_cache(unsigned int context) {
+    const unsigned int n = context ? context : m_conf.context;
+
+    for(std::size_t i = 0; i < m_layers.size(); i++)
+        m_layers[i]->enable_cache(n);
+}
+
+template<typename T>
+void model<T>::reset_cache() {
+    for(std::size_t i = 0; i < m_layers.size(); i++)
+        m_layers[i]->reset_cache();
+}
+
+template<typename T>
 void model<T>::reserve(unsigned int seq) {
     if(seq == 0)
         throw backend_error("model: a sequence of no positions");
+
+    if(seq == m_seq) return;   // see block::reserve
 
     m_seq = seq;
 

--- a/jlib/ai/transformer.hh
+++ b/jlib/ai/transformer.hh
@@ -171,6 +171,49 @@ public:
     void set_eps(float eps) { m_eps = eps; }
     float eps() const { return m_eps; }
 
+    /**
+     * Keep the keys and values, so a later call need only supply what is new.
+     *
+     * Without this every call recomputes the whole sequence, which is what
+     * generation did and is the reference this has to reproduce: with a cache,
+     * greedy generation must produce the identical tokens.
+     *
+     * The cache is allocated for the whole context at once and filled as it
+     * goes. What is past its length holds zeros, and is masked by the same
+     * offset test that enforces causality -- see backend::causal_mask, which
+     * is why nothing here has to tell attention how full the cache is.
+     *
+     * ### It grows rather than starting full
+     *
+     * The obvious thing is to allocate the whole context up front, and it is
+     * measurably wrong. Attention reads the *allocated* cache, not the part of
+     * it that holds keys, so a 2048-column cache holding ninety tokens still
+     * reads 2048 columns -- for every query head, in every layer. Measured on
+     * TinyLlama, forty tokens of output: 0.125s per token with a 128-column
+     * cache and 0.330s with a 2048-column one, against 0.146s for no cache at
+     * all. Allocating the context up front made the cache **2.3x slower than
+     * not having one**.
+     *
+     * So the capacity starts at what the first call needs and doubles when it
+     * fills, copying what is there across. That bounds the waste at 2x rather
+     * than at the ratio of the context to the conversation.
+     *
+     * Attending over exactly the valid prefix would be better still, and needs
+     * a tensor that can be a column range of another. This is the version that
+     * does not need one.
+     *
+     * @param context the most it will ever hold -- a ceiling, not an allocation
+     */
+    void enable_cache(unsigned int context);
+
+    /** Forget it, for a conversation that starts again. */
+    void reset_cache() { m_cache_len = 0; }
+
+    bool caching() const { return m_context != 0; }
+
+    /** How many positions are in the cache. */
+    unsigned int cached() const { return m_cache_len; }
+
     /** Size every intermediate for a sequence of this length. */
     void reserve(unsigned int seq);
 
@@ -179,7 +222,10 @@ public:
      *
      * @param base_pos the position of the first column, for decoding against a
      *                 cache where the columns being processed are not at the
-     *                 start of the sequence
+     *                 start of the sequence.  **Ignored when the cache is on**,
+     *                 which knows the position better than a caller does: it
+     *                 is however many tokens it already holds, and taking it
+     *                 from anywhere else is a way for the two to disagree.
      */
     void forward(const tensor_ptr& x, tensor_ptr& out, bool causal = true,
                  unsigned int base_pos = 0);
@@ -195,6 +241,11 @@ private:
     unsigned int m_seq = 0;
 
     float m_eps = 1e-5f;
+
+    /** Non-zero once the cache is on, and then its length. */
+    unsigned int m_context = 0;
+    unsigned int m_cache_len = 0;
+
     bool m_rope = false;
     float m_theta = 10000.0f;
     rope_layout m_layout = rope_layout::interleaved;
@@ -209,6 +260,14 @@ private:
     // grouping is that a group's key and value are computed once and read by
     // every query head in it.
     std::vector<tensor_ptr> m_k, m_v;
+
+    /** (d_head x capacity) each, one pair per key-value head. */
+    std::vector<tensor_ptr> m_kc, m_vc;
+
+    /** What is allocated now, against m_context which is the ceiling. */
+    unsigned int m_capacity = 0;
+
+    void grow_cache(unsigned int need);
     tensor_ptr m_h1, m_h3, m_ffn;
 };
 
@@ -269,15 +328,83 @@ void block<T>::set_rope(bool on, float theta, rope_layout layout) {
 }
 
 template<typename T>
+void block<T>::enable_cache(unsigned int context) {
+    if(context == 0)
+        throw backend_error("block: a cache with no room in it");
+
+    m_context = context;
+    m_cache_len = 0;
+    m_capacity = 0;
+
+    m_kc.clear();
+    m_vc.clear();
+
+    // Nothing allocated yet: the first forward() sizes it to what it needs.
+}
+
+template<typename T>
+void block<T>::grow_cache(unsigned int need) {
+    if(need <= m_capacity) return;
+
+    if(need > m_context)
+        throw backend_error("block: the cache is full");
+
+    // Double, or jump straight to what is asked for when that is more -- a
+    // prompt arrives all at once and there is no reason to reach its length in
+    // steps.
+    unsigned int want = m_capacity ? m_capacity * 2 : need;
+
+    if(want < need) want = need;
+    if(want > m_context) want = m_context;
+
+    std::vector<tensor_ptr> k, v;
+
+    for(unsigned int h = 0; h < m_kv_heads; h++) {
+        k.push_back(m_b.make(m_d_head, want));
+        v.push_back(m_b.make(m_d_head, want));
+
+        if(m_cache_len) {
+            m_b.copy_columns(m_kc[h], k[h], 0);
+            m_b.copy_columns(m_vc[h], v[h], 0);
+        }
+    }
+
+    // Waited for: the old tensors go out of scope at the swap, and on a GPU an
+    // encoded copy has not run yet when the call returns.
+    if(m_cache_len) m_b.wait();
+
+    m_kc.swap(k);
+    m_vc.swap(v);
+
+    m_capacity = want;
+
+    // The scores are as tall as the cache, so they move with it.
+    m_scores = m_b.make(m_capacity, m_seq);
+    m_probs = m_b.make(m_capacity, m_seq);
+}
+
+template<typename T>
 void block<T>::reserve(unsigned int seq) {
     if(seq == 0)
         throw backend_error("block: a sequence of no positions");
+
+    if(m_context && seq > m_context)
+        throw backend_error("block: more positions at once than the cache holds");
+
+    // Nothing to do if the shape has not changed.  Decoding against a cache
+    // asks for one column every time, and rebuilding a dozen identical tensors
+    // per block per token is pure waste -- measured at a third of the step.
+    if(seq == m_seq) return;
 
     m_seq = seq;
 
     m_norm   = m_b.make(m_d_model, seq);
     m_q      = m_b.make(m_d_head, seq);
-    m_scores = m_b.make(seq, seq);
+
+    // As tall as the cache when there is one: the queries are matched against
+    // every key it holds, not only against this batch's.  grow_cache() remakes
+    // these when the capacity changes.
+    m_scores = m_b.make(m_capacity ? m_capacity : seq, seq);
 
     m_k.clear();
     m_v.clear();
@@ -287,7 +414,7 @@ void block<T>::reserve(unsigned int seq) {
         m_v.push_back(m_b.make(m_d_head, seq));
     }
 
-    m_probs  = m_b.make(seq, seq);
+    m_probs  = m_b.make(m_capacity ? m_capacity : seq, seq);
     m_head   = m_b.make(m_d_head, seq);
     m_attn   = m_b.make(m_d_model, seq);
     m_h1     = m_b.make(m_d_ff, seq);
@@ -312,6 +439,12 @@ void block<T>::forward(const tensor_ptr& x, tensor_ptr& out, bool causal,
 
     m_b.rms_norm(x, m_attn_norm, m_norm, m_eps);
 
+    // Where in the sequence these columns sit.  The cache knows; a caller
+    // only knows when there is no cache to disagree with.
+    const unsigned int at = m_context ? m_cache_len : base_pos;
+
+    if(m_context) grow_cache(at + m_seq);
+
     // Every key and value first, once each.  Computing them inside the query
     // loop instead would give the same answer and do the work heads/kv_heads
     // times over -- which is exactly the cost grouping exists to avoid.
@@ -322,18 +455,29 @@ void block<T>::forward(const tensor_ptr& x, tensor_ptr& out, bool causal,
         // Keys are rotated here, once, for the same reason.  Values are not
         // rotated at all -- see set_rope.
         if(m_rope)
-            m_b.rope(m_k[g], base_pos, m_theta, m_layout);
+            m_b.rope(m_k[g], at, m_theta, m_layout);
+
+        // Rotated before they are stored, so a key is rotated once however
+        // many times it is later read.
+        if(m_context) {
+            m_b.copy_columns(m_k[g], m_kc[g], at);
+            m_b.copy_columns(m_v[g], m_vc[g], at);
+        }
     }
 
     for(unsigned int h = 0; h < m_heads; h++) {
         m_b.multiply(m_wq[h], m_norm, m_q);
 
         if(m_rope)
-            m_b.rope(m_q, base_pos, m_theta, m_layout);
+            m_b.rope(m_q, at, m_theta, m_layout);
 
         const unsigned int g = kv_head_for(h);
 
-        attention(m_b, m_q, m_k[g], m_v[g], m_scores, m_probs, m_head, causal);
+        if(m_context)
+            attention(m_b, m_q, m_kc[g], m_vc[g], m_scores, m_probs, m_head,
+                      causal, at);
+        else
+            attention(m_b, m_q, m_k[g], m_v[g], m_scores, m_probs, m_head, causal);
 
         // beta 0 for the first head and 1 for the rest, which sums the heads
         // in place of concatenating them and projecting once.
@@ -359,6 +503,10 @@ void block<T>::forward(const tensor_ptr& x, tensor_ptr& out, bool causal,
     m_b.multiply(m_down, m_h1, m_ffn);
 
     m_b.add_scaled(T(1), m_ffn, out);
+
+    // Advanced after everything has read it, since `at` is the position these
+    // columns occupy rather than the position after them.
+    if(m_context) m_cache_len += m_seq;
 }
 
 }

--- a/jlib/apps/jchat.cc
+++ b/jlib/apps/jchat.cc
@@ -290,6 +290,13 @@ int run(ai::backend<T>& b, const ai::gguf& g, const options& o) {
 
     std::cerr << "[loaded in " << (now() - t0) << "s]\n";
 
+    // Keys and values kept between tokens, so a reply costs one pass per token
+    // rather than one over everything so far.  generate() refills it from the
+    // prompt each time, which is a single pass and correct however the
+    // conversation grew; reusing it across turns would be a further step and
+    // needs the new prompt to really be an extension of the old one.
+    m.enable_cache();
+
     catch_interrupts();
 
     ai::sampler s(o.sampling);

--- a/jlib/metal/backend.hh
+++ b/jlib/metal/backend.hh
@@ -69,7 +69,9 @@ public:
     void add_scaled(T alpha, const tensor_ptr& x, tensor_ptr& y);
     void assign(const tensor_ptr& src, tensor_ptr& dst);
     void softmax(const tensor_ptr& in, tensor_ptr& out);
-    void causal_mask(tensor_ptr& s);
+    void causal_mask(tensor_ptr& s, unsigned int key_offset = 0);
+    void copy_columns(const tensor_ptr& src, tensor_ptr& dst,
+                      unsigned int dst_first);
     void gather(const tensor_ptr& table, const std::vector<int>& ids,
                 tensor_ptr& out);
     void rope(tensor_ptr& x, unsigned int base_pos = 0, float theta = 10000.0f,

--- a/jlib/metal/backend.mm
+++ b/jlib/metal/backend.mm
@@ -161,8 +161,15 @@ void backend<T>::softmax(const tensor_ptr& in, tensor_ptr& out) {
 }
 
 template<typename T>
-void backend<T>::causal_mask(tensor_ptr& s) {
-    m_stream->causal_mask(at<T>(s));
+void backend<T>::causal_mask(tensor_ptr& s, unsigned int key_offset) {
+    m_stream->causal_mask(at<T>(s), key_offset);
+}
+
+template<typename T>
+void backend<T>::copy_columns(const tensor_ptr& src, tensor_ptr& dst,
+                              unsigned int dst_first)
+{
+    m_stream->copy_columns(at<T>(src), at<T>(dst), dst_first);
 }
 
 template<typename T>

--- a/jlib/metal/tensor.hh
+++ b/jlib/metal/tensor.hh
@@ -188,8 +188,12 @@ public:
     /** Softmax down each column, with the column's maximum subtracted. */
     void softmax(const tensor<T>& in, tensor<T>& out);
 
-    /** Set everything strictly below the diagonal to -infinity, in place. */
-    void causal_mask(tensor<T>& s);
+    /** Mask below the diagonal, offset by how many keys precede the queries. */
+    void causal_mask(tensor<T>& s, unsigned int key_offset);
+
+    /** Copy src's columns into dst starting at a column. */
+    void copy_columns(const tensor<T>& src, tensor<T>& dst,
+                      unsigned int dst_first);
 
     /** Rotary position embedding, in place; see ai::backend::rope. */
     void rope(tensor<T>& x, unsigned int base_pos, float theta, bool split);

--- a/jlib/metal/tensor.mm
+++ b/jlib/metal/tensor.mm
@@ -222,14 +222,32 @@ template<typename T>
 kernel void k_causal_mask(device T* s [[buffer(0)]],
                           constant uint& rows [[buffer(1)]],
                           constant uint& cols [[buffer(2)]],
+                          constant uint& key_offset [[buffer(3)]],
                           uint c [[thread_position_in_grid]])
 {
     if(c >= cols) return;
 
     device T* x = s + (ulong)c * rows;
 
-    for(uint r = c + 1; r < rows; r++)
+    for(uint r = c + key_offset + 1; r < rows; r++)
         x[r] = T(-INFINITY);
+}
+
+/** Copy src's columns into dst starting at a column; see ai::backend. */
+template<typename T>
+kernel void k_copy_columns(device const T* src [[buffer(0)]],
+                           device T* dst [[buffer(1)]],
+                           constant uint& rows [[buffer(2)]],
+                           constant uint& n [[buffer(3)]],
+                           constant uint& first [[buffer(4)]],
+                           uint i [[thread_position_in_grid]])
+{
+    if(i >= rows * n) return;
+
+    const uint c = i / rows;
+    const uint r = i % rows;
+
+    dst[(ulong)(first + c) * rows + r] = src[(ulong)c * rows + r];
 }
 
 /**
@@ -330,9 +348,15 @@ INSTANTIATE(k_softmax, float, "_f32")(device const float*, device float*,
 INSTANTIATE(k_softmax, half, "_f16")(device const half*, device half*,
                                      constant uint&, constant uint&, uint);
 INSTANTIATE(k_causal_mask, float, "_f32")(device float*, constant uint&,
-                                          constant uint&, uint);
+                                          constant uint&, constant uint&, uint);
 INSTANTIATE(k_causal_mask, half, "_f16")(device half*, constant uint&,
-                                         constant uint&, uint);
+                                         constant uint&, constant uint&, uint);
+INSTANTIATE(k_copy_columns, float, "_f32")(device const float*, device float*,
+                                           constant uint&, constant uint&,
+                                           constant uint&, uint);
+INSTANTIATE(k_copy_columns, half, "_f16")(device const half*, device half*,
+                                          constant uint&, constant uint&,
+                                          constant uint&, uint);
 INSTANTIATE(k_gather, float, "_f32")(device const float*, device float*,
                                      device const int*, constant uint&,
                                      constant uint&, uint);
@@ -456,6 +480,7 @@ struct stream<T>::impl {
     id<MTLComputePipelineState> add_scaled = nil;
     id<MTLComputePipelineState> softmax = nil;
     id<MTLComputePipelineState> causal_mask = nil;
+    id<MTLComputePipelineState> copy_columns = nil;
     id<MTLComputePipelineState> rope = nil;
     id<MTLComputePipelineState> gather = nil;
     id<MTLComputePipelineState> rms_norm = nil;
@@ -480,6 +505,7 @@ struct pipelines {
     id<MTLComputePipelineState> add_scaled = nil;
     id<MTLComputePipelineState> softmax = nil;
     id<MTLComputePipelineState> causal_mask = nil;
+    id<MTLComputePipelineState> copy_columns = nil;
     id<MTLComputePipelineState> rope = nil;
     id<MTLComputePipelineState> gather = nil;
     id<MTLComputePipelineState> rms_norm = nil;
@@ -534,6 +560,7 @@ pipelines& compiled(id<MTLDevice> gpu) {
         { "k_add_scaled", &p.add_scaled },
         { "k_softmax",    &p.softmax },
         { "k_causal_mask", &p.causal_mask },
+        { "k_copy_columns", &p.copy_columns },
         { "k_rope",       &p.rope },
         { "k_gather",     &p.gather },
         { "k_rms_norm",   &p.rms_norm },
@@ -600,6 +627,7 @@ stream<T>::stream(std::shared_ptr<device> d)
     m_impl->add_scaled = p.add_scaled;
     m_impl->softmax = p.softmax;
     m_impl->causal_mask = p.causal_mask;
+    m_impl->copy_columns = p.copy_columns;
     m_impl->rope = p.rope;
     m_impl->gather = p.gather;
     m_impl->held = [NSMutableArray array];
@@ -765,7 +793,7 @@ void stream<T>::softmax(const tensor<T>& in, tensor<T>& out) {
 }
 
 template<typename T>
-void stream<T>::causal_mask(tensor<T>& s) {
+void stream<T>::causal_mask(tensor<T>& s, unsigned int key_offset) {
     open();
 
     const unsigned int rows = s.rows();
@@ -775,8 +803,40 @@ void stream<T>::causal_mask(tensor<T>& s) {
     [m_impl->enc setBuffer:s.m_impl->buf offset:0 atIndex:0];
     [m_impl->enc setBytes:&rows length:sizeof(rows) atIndex:1];
     [m_impl->enc setBytes:&cols length:sizeof(cols) atIndex:2];
+    [m_impl->enc setBytes:&key_offset length:sizeof(key_offset) atIndex:3];
 
     dispatch(m_impl->enc, m_impl->causal_mask, cols);
+
+    m_impl->pending++;
+}
+
+template<typename T>
+void stream<T>::copy_columns(const tensor<T>& src, tensor<T>& dst,
+                             unsigned int dst_first)
+{
+    if(src.rows() != dst.rows())
+        throw typename tensor<T>::exception("copy_columns: the two must be the "
+                                            "same height");
+
+    if(dst_first + src.cols() > dst.cols())
+        throw typename tensor<T>::exception("copy_columns: the columns would "
+                                            "not fit");
+
+    if(src.cols() == 0) return;
+
+    open();
+
+    const unsigned int rows = src.rows();
+    const unsigned int n = src.cols();
+
+    [m_impl->enc setComputePipelineState:m_impl->copy_columns];
+    [m_impl->enc setBuffer:src.m_impl->buf offset:0 atIndex:0];
+    [m_impl->enc setBuffer:dst.m_impl->buf offset:0 atIndex:1];
+    [m_impl->enc setBytes:&rows length:sizeof(rows) atIndex:2];
+    [m_impl->enc setBytes:&n length:sizeof(n) atIndex:3];
+    [m_impl->enc setBytes:&dst_first length:sizeof(dst_first) atIndex:4];
+
+    dispatch(m_impl->enc, m_impl->copy_columns, rows * n);
 
     m_impl->pending++;
 }

--- a/tests/ai_backend_test.cc
+++ b/tests/ai_backend_test.cc
@@ -775,6 +775,215 @@ static void the_gather(const char* name, std::vector<ai::backend<T>*>& backends)
     }
 }
 
+/** The write half of gather: columns placed where they are asked for. */
+template<typename T>
+static void the_column_copy(const char* name, std::vector<ai::backend<T>*>& backends) {
+    std::cout << "\ncopy_columns, " << name << ":\n";
+
+    const uint d = 4;
+
+    matrix<T> src(d, 2);
+
+    for(uint c = 0; c < 2; c++)
+        for(uint r = 0; r < d; r++)
+            src(r,c) = T(float(c) * 10.0f + float(r) + 1.0f);
+
+    for(ai::backend<T>* b : backends) {
+        typename ai::backend<T>::tensor_ptr s = b->make(src);
+        typename ai::backend<T>::tensor_ptr dst = b->make(d, 6);
+
+        b->copy_columns(s, dst, 3);
+        b->wait();
+
+        const matrix<T> got = dst->read();
+
+        bool placed = true;
+
+        for(uint c = 0; c < 2; c++)
+            for(uint r = 0; r < d; r++)
+                if(float(got(r, 3 + c)) != float(src(r,c))) placed = false;
+
+        ok(std::string("  ") + b->name() + ": the columns land where asked",
+           placed);
+
+        // Everything else untouched, which is what makes this an append rather
+        // than a write.
+        bool rest_zero = true;
+
+        for(uint c = 0; c < 6; c++) {
+            if(c >= 3 && c < 5) continue;
+
+            for(uint r = 0; r < d; r++)
+                if(float(got(r,c)) != 0.0f) rest_zero = false;
+        }
+
+        ok(std::string("  ") + b->name() + ": and nothing else moves", rest_zero);
+
+        bool threw = false;
+
+        try { b->copy_columns(s, dst, 5); b->wait(); }
+        catch(std::exception&) { threw = true; }
+
+        ok(std::string("  ") + b->name() + ": columns that would not fit are refused",
+           threw);
+    }
+}
+
+/**
+ * The offset mask, which has to do two jobs with one number.
+ *
+ * With a key-value cache the queries are the tail of the sequence, so query
+ * column c sits at absolute position `offset + c` and the causal test becomes
+ * `row > col + offset`. The second job is free: a cache is allocated for the
+ * whole context and filled as it goes, so rows past what has been written hold
+ * zeros -- and the same test masks them, because a row at or beyond the
+ * cache's length always exceeds `offset + col`.
+ *
+ * That is the property the whole design rests on, so it is asserted directly
+ * rather than inferred from attention working.
+ */
+template<typename T>
+static void the_offset_mask(const char* name, std::vector<ai::backend<T>*>& backends) {
+    std::cout << "\nthe offset mask, " << name << ":\n";
+
+    // Eight rows of keys, three columns of queries: a cache of six valid keys
+    // with three new tokens just written, in a buffer sized for eight.
+    const uint keys = 8;
+    const uint queries = 3;
+    const uint valid = 6;
+    const uint offset = valid - queries;
+
+    for(ai::backend<T>* b : backends) {
+        matrix<T> ones(keys, queries);
+
+        for(uint r = 0; r < keys; r++)
+            for(uint c = 0; c < queries; c++)
+                ones(r,c) = T(1.0f);
+
+        typename ai::backend<T>::tensor_ptr t = b->make(ones);
+
+        b->causal_mask(t, offset);
+        b->wait();
+
+        const matrix<T> got = t->read();
+
+        bool right = true;
+
+        for(uint c = 0; c < queries; c++)
+            for(uint r = 0; r < keys; r++) {
+                const bool masked = !std::isfinite(float(got(r,c)));
+
+                if(masked != (r > c + offset)) right = false;
+            }
+
+        ok(std::string("  ") + b->name() + ": masks exactly row > col + offset",
+           right);
+
+        // The second job, stated on its own: nothing beyond the cache's length
+        // survives in any column.
+        bool beyond_gone = true;
+
+        for(uint c = 0; c < queries; c++)
+            for(uint r = valid; r < keys; r++)
+                if(std::isfinite(float(got(r,c)))) beyond_gone = false;
+
+        ok(std::string("  ") + b->name() +
+           ": so the rows past the cache are masked in every column", beyond_gone);
+
+        // And the diagonal survives, or a column would be entirely -inf and
+        // softmax would give nan.
+        bool diagonal = true;
+
+        for(uint c = 0; c < queries; c++)
+            if(!std::isfinite(float(got(c + offset, c)))) diagonal = false;
+
+        ok(std::string("  ") + b->name() + ": while each query still sees itself",
+           diagonal);
+    }
+}
+
+/**
+ * A beta of zero does not read the output, which is not the same as
+ * multiplying it by zero.
+ *
+ * BLAS specifies it that way so that whatever is already in C -- uninitialised
+ * memory, or -infinity left by a previous caller -- cannot affect the result.
+ * `0 * -inf` is nan, and a host implementation that wrote the formula out
+ * literally produced one.
+ *
+ * Found through a key-value cache reusing one score matrix across steps: the
+ * mask writes -infinity into the rows past the cache, the next step recomputes
+ * with beta zero, and every logit came back nan. MPS follows the convention,
+ * so the GPU was right and the host was not -- which is exactly the sort of
+ * difference a two-backend comparison exists to find, and did not, because
+ * nothing had ever left -infinity in an output before.
+ */
+template<typename T>
+static void beta_zero_does_not_read_the_output(const char* name,
+                                               std::vector<ai::backend<T>*>& backends)
+{
+    std::cout << "\nbeta zero does not read the output, " << name << ":\n";
+
+    std::mt19937 gen(83);
+
+    const matrix<T> a = random_matrix<T>(4, 3, gen);
+    const matrix<T> b_ = random_matrix<T>(3, 5, gen);
+
+    // What the answer is when the output starts clean.
+    matrix<T> poisoned(4, 5);
+
+    for(uint r = 0; r < 4; r++)
+        for(uint c = 0; c < 5; c++)
+            poisoned(r,c) = T(-std::numeric_limits<float>::infinity());
+
+    for(ai::backend<T>* bk : backends) {
+        typename ai::backend<T>::tensor_ptr ta = bk->make(a);
+        typename ai::backend<T>::tensor_ptr tb = bk->make(b_);
+
+        typename ai::backend<T>::tensor_ptr clean = bk->make(4, 5);
+        typename ai::backend<T>::tensor_ptr dirty = bk->make(poisoned);
+
+        bk->multiply(ta, tb, clean, T(1), T(0));
+        bk->multiply(ta, tb, dirty, T(1), T(0));
+        bk->wait();
+
+        const matrix<T> c1 = clean->read();
+        const matrix<T> c2 = dirty->read();
+
+        bool finite = true;
+
+        for(uint r = 0; r < 4; r++)
+            for(uint c = 0; c < 5; c++)
+                if(!std::isfinite(float(c2(r,c)))) finite = false;
+
+        ok(std::string("  ") + bk->name() + ": no infinity survives into the result",
+           finite);
+
+        ok(std::string("  ") + bk->name() + ": which is what it would have been anyway",
+           worst(c1, c2) == 0.0, std::to_string(worst(c1, c2)));
+
+        // And the transposing forms, which go through the same blend.
+        typename ai::backend<T>::tensor_ptr tn = bk->make(3, 4);
+        typename ai::backend<T>::tensor_ptr d2 = bk->make(poisoned);
+
+        tn->write(random_matrix<T>(3, 4, gen));
+
+        bk->multiply_tn(tn, tb, d2, T(1), T(0));
+        bk->wait();
+
+        bool finite_tn = true;
+
+        const matrix<T> got = d2->read();
+
+        for(uint r = 0; r < 4; r++)
+            for(uint c = 0; c < 5; c++)
+                if(!std::isfinite(float(got(r,c)))) finite_tn = false;
+
+        ok(std::string("  ") + bk->name() + ": and the transposing form agrees",
+           finite_tn);
+    }
+}
+
 static void a_tensor_from_the_wrong_backend_is_refused() {
     std::cout << "\na tensor from the wrong backend is refused:\n";
 
@@ -838,6 +1047,9 @@ int main() {
         rope_makes_the_score_relative<float>("float", b);
         the_two_rope_layouts_differ<float>("float", b);
         the_gather<float>("float", b);
+        the_column_copy<float>("float", b);
+        the_offset_mask<float>("float", b);
+        beta_zero_does_not_read_the_output<float>("float", b);
 #else
         one_type<float>("float", b);
         the_reductions<float>("float", b);
@@ -850,6 +1062,9 @@ int main() {
         rope_makes_the_score_relative<float>("float", b);
         the_two_rope_layouts_differ<float>("float", b);
         the_gather<float>("float", b);
+        the_column_copy<float>("float", b);
+        the_offset_mask<float>("float", b);
+        beta_zero_does_not_read_the_output<float>("float", b);
 #endif
     }
 
@@ -873,6 +1088,9 @@ int main() {
         rope_makes_the_score_relative<_Float16>("_Float16", b);
         the_two_rope_layouts_differ<_Float16>("_Float16", b);
         the_gather<_Float16>("_Float16", b);
+        the_column_copy<_Float16>("_Float16", b);
+        the_offset_mask<_Float16>("_Float16", b);
+        beta_zero_does_not_read_the_output<_Float16>("_Float16", b);
     }
 
     a_tensor_from_the_wrong_backend_is_refused();

--- a/tests/ai_model_test.cc
+++ b/tests/ai_model_test.cc
@@ -28,6 +28,7 @@
 #endif
 
 #include <cmath>
+#include <random>
 #include <cstdlib>
 #include <fstream>
 #include <iostream>
@@ -415,6 +416,148 @@ static void generation_stops_when_asked() {
     }
 }
 
+/** A small model with random weights, so the two paths have something to differ about. */
+static void fill_randomly(ai::model<float>& m, std::mt19937& gen) {
+    std::uniform_real_distribution<float> d(-0.5f, 0.5f);
+
+    auto rnd = [&](unsigned int rows, unsigned int cols) {
+        jlib::math::matrix<float> a(rows, cols);
+
+        for(unsigned int r = 0; r < rows; r++)
+            for(unsigned int c = 0; c < cols; c++)
+                a(r,c) = d(gen);
+
+        return a;
+    };
+
+    const typename ai::model<float>::config& c = m.conf();
+
+    m.embedding()->write(rnd(c.d_model, c.vocab));
+    m.head()->write(rnd(c.d_model, c.vocab));
+
+    jlib::math::matrix<float> ones(c.d_model, 1);
+
+    for(unsigned int r = 0; r < c.d_model; r++) ones(r,0) = 1.0f;
+
+    m.final_norm()->write(ones);
+
+    const unsigned int dh = c.d_model / c.heads;
+
+    for(unsigned int i = 0; i < c.layers; i++) {
+        ai::block<float>& l = m.layer(i);
+
+        l.attn_norm()->write(ones);
+        l.ffn_norm()->write(ones);
+
+        for(unsigned int h = 0; h < c.heads; h++) {
+            l.wq(h)->write(rnd(dh, c.d_model));
+            l.wo(h)->write(rnd(c.d_model, dh));
+        }
+
+        for(unsigned int h = 0; h < c.kv_heads; h++) {
+            l.wk(h)->write(rnd(dh, c.d_model));
+            l.wv(h)->write(rnd(dh, c.d_model));
+        }
+
+        l.w_gate()->write(rnd(c.d_ff, c.d_model));
+        l.w_up()->write(rnd(c.d_ff, c.d_model));
+        l.w_down()->write(rnd(c.d_model, c.d_ff));
+    }
+}
+
+/**
+ * A cache changes what it costs and not what comes out.
+ *
+ * The whole correctness condition, and it is exact: greedy generation with a
+ * key-value cache must produce the identical tokens to generation without one.
+ * Not close, identical -- the arithmetic is the same arithmetic, reordered.
+ *
+ * On a small model with **random** weights rather than the zeros the other
+ * tests here use, because a model of zeros produces token 0 either way and
+ * would agree for reasons that have nothing to do with the cache.
+ */
+static void the_cache_changes_nothing() {
+    std::cout << "\nthe cache changes nothing:\n";
+
+    typename ai::model<float>::config c;
+
+    c.d_model = 16;
+    c.heads = 2;
+    c.kv_heads = 1;
+    c.d_ff = 32;
+    c.layers = 2;
+    c.vocab = 64;
+    c.context = 128;
+
+    ai::host_backend<float> b;
+    ai::model<float> m(b, c);
+
+    std::mt19937 gen(2024);
+
+    fill_randomly(m, gen);
+
+    ai::sampler::config sc;
+    sc.temperature = 0.0f;
+
+    const std::vector<int> prompt{ 1, 7, 13, 2 };
+
+    ai::sampler s1(sc);
+
+    const std::vector<int> plain = ai::generate<float>(m, b, prompt, 12, s1);
+
+    ok("  without a cache it generates", plain.size() == prompt.size() + 12,
+       std::to_string(plain.size() - prompt.size()));
+
+    m.enable_cache();
+
+    ok("  the cache starts empty", m.caching() && m.cached() == 0);
+
+    ai::sampler s2(sc);
+
+    const std::vector<int> cached = ai::generate<float>(m, b, prompt, 12, s2);
+
+    ok("  and with one it generates the identical tokens", plain == cached);
+
+    // Fifteen, not sixteen: four of prompt and eleven fed back.  The twelfth
+    // generated token ends the loop and is never shown to the model, so its
+    // keys are never computed -- counted wrong here first, which is the sort of
+    // arithmetic worth writing down rather than adjusting until it passes.
+    ok("  having cached every position it was shown", m.cached() == 15,
+       std::to_string(m.cached()));
+
+    // The capacity starts at what the prompt needed and doubles, so getting to
+    // sixteen from four means it grew twice.  If growth lost what was in it,
+    // the tokens above would not have matched.
+    ai::sampler s3(sc);
+
+    m.reset_cache();
+
+    ok("  resetting empties it", m.cached() == 0);
+
+    const std::vector<int> again = ai::generate<float>(m, b, prompt, 12, s3);
+
+    ok("  and it generates the same again from a reset cache", again == plain);
+
+    // A cache with less room than the conversation needs has to say so rather
+    // than write past the end.
+    typename ai::model<float>::config small = c;
+
+    ai::model<float> tight(b, small);
+
+    fill_randomly(tight, gen);
+
+    tight.enable_cache(6);
+
+    ai::sampler s4(sc);
+
+    bool threw = false;
+
+    try { ai::generate<float>(tight, b, prompt, 12, s4); }
+    catch(std::exception&) { threw = true; }
+
+    ok("  a cache too small for the conversation is refused", threw);
+}
+
 int main(int argc, char** argv) {
     std::cout << std::unitbuf;
 
@@ -423,6 +566,7 @@ int main(int argc, char** argv) {
     // Runs with or without a model, so the generation loop is covered on a
     // machine that has neither the file nor a GPU.
     generation_stops_when_asked();
+    the_cache_changes_nothing();
 
     if(path.empty()) {
         std::cout << "\n  (no model file, so only the generation loop is "


### PR DESCRIPTION
# A key-value cache

Generation re-ran the whole sequence for every token. Now it keeps the keys and
values, and each step supplies only what is new. #159.

| tokens | uncached | cached | |
| --- | --- | --- | --- |
| 40 | 0.142 s/tok | 0.122 | **1.17x** |
| 49 | 0.144 | 0.113 | **1.28x** |
| 250 (jchat) | 0.196 | 0.128 | **1.53x** |

and the tokens are **identical** at every length, which is the correctness
condition the branch was chosen for.

The cleanest evidence is not from a benchmark. The same prompt was run by hand
before this branch existed and again after, and both produced the same 230
tokens -- the same Erlang module, the same muddled explanation of it, the same
`erl -pa .` instructions that never actually call `hello:main()`:

| | tokens | time | rate |
| --- | --- | --- | --- |
| before | 230 | 45.14s | 5.10/s |
| after | 230 | 30.51s | **7.54/s** |

Byte-identical output, **1.48x faster**. Correctness and speedup in one run, on
a real prompt, against a baseline recorded before there was anything to compare
against.

## Two measurements changed the design

**Allocating the context up front made it 2.3x slower than no cache at all.**
The first version did the obvious thing and reserved all 2048 columns.
Attention reads the *allocated* cache, not the part holding keys, so every
query head in every layer read 2048 columns to use ninety — about 360MB per
token against a 2.2GB weight stream. Measured across capacities, forty tokens
of output:

| capacity | 128 | 256 | 512 | 2048 |
| --- | --- | --- | --- | --- |
| per token | 0.125s | 0.139s | 0.167s | 0.330s |

against 0.146s for no cache. Linear in what is allocated, not in what is used.

So the capacity starts at what the first call needs and **doubles when it
fills**, copying what is there across with the `copy_columns` primitive this
branch adds anyway. That bounds the waste at 2x instead of at the ratio of the
context to the conversation, and is the difference between 0.33 and 0.12.

The second measurement was a wrong guess of mine: I thought re-`reserve`ing
every step was the cost, since decoding asks for one column each time and
rebuilds a dozen tensors per block. Skipping it when the shape has not changed
was worth **6%**. Kept, because it is free, but it was not the problem.

## One mask does two jobs

`causal_mask` gains a key offset: with a cache the queries are the tail of the
sequence, so query column `c` sits at `offset + c` and the test becomes
`row > col + offset`.

The second job is free. A cache is filled as it goes, so rows past its length
hold zeros rather than keys — and the same test masks them, because a row at or
beyond the length always exceeds `offset + col`. That is why nothing has to
tell attention how full the cache is, and it is asserted directly rather than
inferred from attention working.

## The bug it found, which was not the cache's

The cached path produced **nan for every logit** from the third token — on the
host, while Metal was fine. Bisected: prefill matched bit-for-bit, one decode
step matched, growth was innocent (the same failure with the context allocated
up front), and turning off causal masking made it go away.

`host_backend`'s GEMM computed `alpha*AB + beta*C` literally. **BLAS specifies
that a beta of zero means C is not read** — precisely so that uninitialised
memory or a previous caller's `-infinity` cannot reach the result. `0 * -inf`
is nan.

The cache is what exposed it: one score matrix reused across steps, the mask
writing `-infinity` into the rows past the cache, and the next step recomputing
with beta zero. MPS follows the convention, so the GPU was right and the host
was not — which is the sort of difference a two-backend comparison exists to
find, and had not, because nothing had ever left `-infinity` in an output
before.

That fix is the more valuable half of this branch. It is a latent bug in a path
every layer of every model goes through, and it now has a test of its own rather
than being caught only through a cache.

One diagnostic detail worth keeping: the first comparison reported "worst
difference 0" while the tokens differed, which is contradictory — and was,
because `std::max(a, nan)` returns `a`, so the nans were being silently
swallowed by the very check meant to find them.

## Tests

**`the_cache_changes_nothing`** runs on a small model with **random** weights,
not the zeros the other model-free tests use: a model of zeros generates token 0
either way and would agree for reasons having nothing to do with the cache. No
file, so it runs in the container.

- identical tokens with and without, from the same prompt and seed
- the cache reports what it was shown, and resetting empties it
- generating again from a reset cache repeats exactly
- a cache too small for the conversation is refused

**`beta_zero_does_not_read_the_output`** poisons an output with `-infinity`,
multiplies with beta zero, and requires the result to be finite and identical to
the same product into a clean output — for `multiply` and `multiply_tn`, on both
backends.

**`the_offset_mask`** asserts `row > col + offset` exactly, that rows past the
cache are masked in every column, and that each query still sees itself — the
last because a fully masked column is the nan this whole area is prone to.

**`the_column_copy`** places columns where asked, moves nothing else, and
refuses what will not fit.

One test arithmetic of mine was wrong: I expected the cache to hold 16 positions
after a 4-token prompt and 12 generated, and it holds 15 — the twelfth token
ends the loop and is never shown to the model, so its keys are never computed.
Corrected with the reasoning written down rather than adjusted until it passed.

## Verification

- macOS `make check`: 75 tests, 71 pass, 4 skip, 0 fail.
- Container: the cache tests need no model, so they run there too.
- By hand: jchat generating 250 tokens at 7.82/s where it managed 5.09/s before.

## What this does not establish

**That the cache is optimal.** Growth bounds the waste at 2x; attending over
exactly the valid prefix would remove it, and needs a tensor that can be a
column range of another — an offset threaded through every dispatch and the MPS
paths. That is a branch of its own and is why this one does not do it.

**Nothing about reuse across turns.** jchat refills the cache from the whole
prompt each reply, which is one pass and correct however the conversation grew.
A conversation's next prompt really is an extension of the last, so the refill
is avoidable — but only if nothing between them edited the history, and nothing
here checks that.

**And the speedup is bounded by what it cannot touch.** The 0.127s floor is
weight bandwidth, unchanged by any of this. #158 halves that at every length and
compounds; with the cache making each decode step a matrix-vector product, it is
now the easy version of that work rather than a fight with MPS.
