### PR TITLE
Keep 75% of the weights in the file's q8_0 -- 4.5x load, 1.5x memory -- and find dispatch, not bandwidth, is the cost

### DIFF
--- a/jlib/ai/backend.hh
+++ b/jlib/ai/backend.hh
@@ -23,6 +23,7 @@
 #include <jlib/math/matrix.hh>
 
 #include <cmath>
+#include <cstring>
 #include <vector>
 #include <memory>
 #include <limits>
@@ -167,8 +168,48 @@ public:
     /** What this is, for a caller that wants to say where it ran. */
     virtual std::string name() const = 0;
 
+    /**
+     * A weight kept in the encoding the file used, rather than dequantised.
+     *
+     * The point is bandwidth. A forward pass streams every weight through the
+     * GPU once, and at these sizes that is what it spends its time on -- so a
+     * weight that arrives as q8_0 and stays that way moves 1.06 bytes per
+     * parameter instead of 2, and the kernel that reads it dequantises as it
+     * goes. Measured on a 2048x2048 matrix-vector product: 39us against MPS's
+     * 68us in fp16, both at about 120GB/s, which is the whole story -- the same
+     * bandwidth, moving half as much.
+     *
+     * Rows is the *contiguous* dimension, which for a GGUF weight is its
+     * input width. See gguf.hh on why that is the orientation to keep.
+     */
+    class quantised {
+    public:
+        virtual ~quantised() {}
+
+        virtual unsigned int rows() const = 0;
+        virtual unsigned int cols() const = 0;
+    };
+
+    typedef std::shared_ptr<quantised> quantised_ptr;
+
     virtual tensor_ptr make(unsigned int rows, unsigned int cols) = 0;
     virtual tensor_ptr make(const math::matrix<T>& m) = 0;
+
+    /**
+     * Take a q8_0 tensor's bytes exactly as a file holds them.
+     *
+     * Blocks of 32: a two-byte scale then thirty-two signed quants, 34 bytes
+     * for 32 values. Nothing is rearranged, so this is a copy to the device
+     * and not a conversion.
+     *
+     * @throws backend_error if the bytes do not match the shape
+     */
+    virtual quantised_ptr make_q8_0(unsigned int rows, unsigned int cols,
+                                    const void* blocks, std::size_t bytes) = 0;
+
+    /** c = alpha * a^T * b + beta * c, with a held quantised. */
+    virtual void multiply_tn(const quantised_ptr& a, const tensor_ptr& b,
+                             tensor_ptr& c, T alpha = T(1), T beta = T(0)) = 0;
 
     /** c = alpha * a * b + beta * c */
     virtual void multiply(const tensor_ptr& a, const tensor_ptr& b,
@@ -335,6 +376,15 @@ public:
     tensor_ptr make(unsigned int rows, unsigned int cols);
     tensor_ptr make(const math::matrix<T>& m);
 
+    typename backend<T>::quantised_ptr make_q8_0(unsigned int rows,
+                                                 unsigned int cols,
+                                                 const void* blocks,
+                                                 std::size_t bytes);
+
+    void multiply_tn(const typename backend<T>::quantised_ptr& a,
+                     const tensor_ptr& b, tensor_ptr& c,
+                     T alpha = T(1), T beta = T(0));
+
     void multiply(const tensor_ptr& a, const tensor_ptr& b, tensor_ptr& c,
                   T alpha = T(1), T beta = T(0));
     void multiply_tn(const tensor_ptr& a, const tensor_ptr& b, tensor_ptr& c,
@@ -448,6 +498,59 @@ math::matrix<T> slope_matrix(activation a, const math::matrix<T>& out) {
 
     return d;
 }
+
+/**
+ * The host's quantised weight, which is not quantised at all.
+ *
+ * It dequantises once at construction and keeps a plain matrix. That saves no
+ * memory and no bandwidth, and is not meant to: this is the reference the GPU
+ * kernel is checked against, so it should be the obvious thing rather than a
+ * second implementation of the same cleverness. What it does establish is that
+ * the *interface* is usable without a GPU, and that dequantising early and
+ * dequantising late agree.
+ */
+template<typename T>
+class host_quantised : public backend<T>::quantised {
+public:
+    host_quantised(unsigned int rows, unsigned int cols, const void* blocks,
+                   std::size_t bytes)
+        : m(rows, cols)
+    {
+        const std::size_t n = std::size_t(rows) * cols;
+
+        if(n % 32)
+            throw backend_error("make_q8_0: the element count is not a multiple "
+                                "of the block size");
+
+        if(bytes != (n / 32) * 34)
+            throw backend_error("make_q8_0: the bytes do not match the shape");
+
+        const char* raw = static_cast<const char*>(blocks);
+
+        // Rows is the contiguous dimension and a block runs along it, so a
+        // block never straddles two columns.
+        for(std::size_t b = 0; b < n / 32; b++) {
+            const char* p = raw + b * 34;
+
+            _Float16 d;
+
+            std::memcpy(&d, p, sizeof(d));
+
+            const signed char* q = reinterpret_cast<const signed char*>(p + 2);
+
+            for(std::size_t i = 0; i < 32; i++) {
+                const std::size_t at = b * 32 + i;
+
+                m(uint(at % rows), uint(at / rows)) = T(float(d) * float(q[i]));
+            }
+        }
+    }
+
+    unsigned int rows() const { return m.M; }
+    unsigned int cols() const { return m.N; }
+
+    math::matrix<T> m;
+};
 
 /** A tensor that is just a matrix. */
 template<typename T>
@@ -646,6 +749,29 @@ void host_backend<T>::copy_columns(const tensor_ptr& src, tensor_ptr& dst,
     for(uint c = 0; c < a.N; c++)
         for(uint r = 0; r < a.M; r++)
             b(r, dst_first + c) = a(r, c);
+}
+
+template<typename T>
+typename backend<T>::quantised_ptr
+host_backend<T>::make_q8_0(unsigned int rows, unsigned int cols,
+                           const void* blocks, std::size_t bytes)
+{
+    return typename backend<T>::quantised_ptr(
+        new host_quantised<T>(rows, cols, blocks, bytes));
+}
+
+template<typename T>
+void host_backend<T>::multiply_tn(const typename backend<T>::quantised_ptr& a,
+                                  const tensor_ptr& b, tensor_ptr& c,
+                                  T alpha, T beta)
+{
+    host_quantised<T>* q = dynamic_cast<host_quantised<T>*>(a.get());
+
+    if(!q)
+        throw backend_error("multiply_tn: that quantised weight belongs to "
+                            "another backend");
+
+    detail::blend(q->m.transpose() * at(b), at(c), alpha, beta);
 }
 
 template<typename T>

--- a/jlib/ai/generate.hh
+++ b/jlib/ai/generate.hh
@@ -69,9 +69,19 @@ std::vector<float> last_logits(const math::matrix<T>& logits) {
  *      pass  0.132  0.145  0.177  0.208  0.301  0.463  seconds
  *
  * which is **linear in the context**, not quadratic: `t = 0.127 + 0.00033n`
- * fits every point within a few percent. The constant is the cost of streaming
- * 2.2GB of weights through the GPU, which happens once per pass whatever the
- * length; the small slope is the activations growing with it.
+ * fits every point within a few percent. The slope is the activations growing.
+ *
+ * **The constant is not what this said until it was measured.** It claimed the
+ * cost of streaming 2.2GB of weights, and that is wrong by about seven times:
+ * 2.2GB at the ~120GB/s the device reaches is 18ms, not 127. The constant is
+ * **dispatch overhead**, nearly all of it the per-head attention loop -- 22
+ * layers times 32 heads times about seven operations is some 4900 dispatches
+ * per token at roughly 25us each.
+ *
+ * Measured directly: a (2048 x 64) matrix-vector product, which is what one
+ * head's projection is, runs at 12.3GB/s, while the same arithmetic for all 32
+ * heads in one (2048 x 2048) call runs at 118.8GB/s -- thirty-two times the
+ * work for 3.3 times the time. See #163.
  *
  * So generating n tokens from a prompt of p costs about
  * `n*0.127 + 0.00033*(n*p + n*n/2)` -- quadratic in n, but with a coefficient
@@ -81,14 +91,16 @@ std::vector<float> last_logits(const math::matrix<T>& logits) {
  * ### What a cache is worth, in numbers
  *
  * A key-value cache removes the growing term and leaves the constant exactly
- * where it is, because the weights still stream once per token either way. So
- * it is worth about **1.35x at 230 tokens and 2.3x at a thousand**, and
- * approaches nothing as the generation gets short.
+ * where it is, since a pass is dispatched the same number of times either way.
+ * So it is worth about **1.35x at 230 tokens and 2.3x at a thousand**, and
+ * approaches nothing as the generation gets short. Observed: 1.48x on a real
+ * 230-token run.
  *
- * Worth writing down because the larger lever is elsewhere: that 0.127s floor
- * is weight bandwidth, so holding the weights quantised and dequantising
- * inside the kernel would roughly halve it at every length, and compounds with
- * the cache rather than competing with it.
+ * The larger lever is therefore batching the heads, not moving fewer bytes.
+ * Keeping the weights quantised was tried on the mistaken premise and is worth
+ * 1.12x end to end -- real, and a tenth of what the reasoning predicted,
+ * because it shrinks a nine percent slice of the cost rather than the ninety
+ * percent one. It does buy 4.5x on load and 1.5x on memory.
  *
  * @param on_token called with each new token as it is produced, for a caller
  *                 that wants to stream rather than wait.  **Return false to

--- a/jlib/ai/gguf.cc
+++ b/jlib/ai/gguf.cc
@@ -410,5 +410,43 @@ math::matrix<float> gguf::read(const std::string& name) const {
     return read(tensor(name));
 }
 
+std::uint64_t gguf::stored_bytes(tensor_type t, std::uint64_t n) {
+    switch(t) {
+    case tensor_type::f32:  return n * 4;
+    case tensor_type::f16:  return n * 2;
+    case tensor_type::q8_0: return (n / Q8_0_BLOCK) * Q8_0_BYTES;
+    default: break;
+    }
+
+    throw exception("stored_bytes: " + type_name(t) + " has no size here");
+}
+
+std::vector<char> gguf::read_raw(const tensor_info& t) const {
+    const std::uint64_t n = t.elements();
+
+    if(t.type == tensor_type::q8_0 && (n % Q8_0_BLOCK))
+        throw exception("tensor '" + t.name + "' is q8_0 but its element count "
+                        "is not a multiple of the block size");
+
+    std::vector<char> raw(static_cast<std::size_t>(stored_bytes(t.type, n)));
+
+    m_file.clear();
+    m_file.seekg(static_cast<std::streamoff>(m_data_offset + t.offset));
+
+    if(!m_file)
+        throw exception("could not seek to tensor '" + t.name + "'");
+
+    m_file.read(raw.data(), static_cast<std::streamsize>(raw.size()));
+
+    if(!m_file)
+        throw exception("the file ended while reading tensor '" + t.name + "'");
+
+    return raw;
+}
+
+std::vector<char> gguf::read_raw(const std::string& name) const {
+    return read_raw(tensor(name));
+}
+
 }
 }

--- a/jlib/ai/gguf.hh
+++ b/jlib/ai/gguf.hh
@@ -164,6 +164,21 @@ public:
     math::matrix<float> read(const tensor_info& t) const;
     math::matrix<float> read(const std::string& name) const;
 
+    /**
+     * The tensor's bytes exactly as the file holds them, undecoded.
+     *
+     * For a weight that is going to stay in the encoding it arrived in: a
+     * q8_0 tensor dequantised at load costs twice the memory and twice the
+     * bandwidth of one dequantised inside the kernel that reads it.
+     *
+     * The caller has to know what the bytes mean, which is what `type` is for.
+     */
+    std::vector<char> read_raw(const tensor_info& t) const;
+    std::vector<char> read_raw(const std::string& name) const;
+
+    /** How many bytes a tensor of this type and size occupies. */
+    static std::uint64_t stored_bytes(tensor_type t, std::uint64_t elements);
+
     /** The name of a ggml type, for an error message worth reading. */
     static std::string type_name(tensor_type t);
 

--- a/jlib/ai/model.hh
+++ b/jlib/ai/model.hh
@@ -49,6 +49,7 @@ template<typename T>
 class model {
 public:
     typedef typename backend<T>::tensor_ptr tensor_ptr;
+    typedef typename backend<T>::quantised_ptr quantised_ptr;
 
     /** What a file says about its own shape. */
     struct config {
@@ -89,6 +90,14 @@ public:
 
     /** (d_model x vocab), read through multiply_tn -- see the note on load(). */
     tensor_ptr& head() { return m_head; }
+
+    /**
+     * The head kept in the encoding the file used.
+     *
+     * Free to quantise: it is already in the file's orientation and already
+     * read with multiply_tn, so nothing about its shape or its use changes.
+     */
+    void set_head(const quantised_ptr& q) { m_head_q = q; m_head.reset(); }
 
     /**
      * Place every weight in the file.
@@ -173,6 +182,7 @@ private:
     std::vector<std::shared_ptr<block<T> > > m_layers;
 
     tensor_ptr m_embed, m_final_norm, m_head;
+    quantised_ptr m_head_q;
     tensor_ptr m_x, m_y;
 
     unsigned int m_seq = 0;
@@ -306,7 +316,17 @@ void model<T>::load(const gguf& g) {
     m_embed->write(narrowed(g.read("token_embd.weight")));
 
     expect(g, "output.weight", d, m_conf.vocab);
-    m_head->write(narrowed(g.read("output.weight")));
+
+    // Kept quantised where the file quantised it.  These are the tensors whose
+    // blocks run along the dimension they are used on, so nothing has to be
+    // rearranged and the file's bytes go to the device unchanged.
+    if(g.tensor("output.weight").type == gguf::tensor_type::q8_0) {
+        const std::vector<char> raw = g.read_raw("output.weight");
+
+        set_head(m_b.make_q8_0(d, m_conf.vocab, raw.data(), raw.size()));
+    }
+    else
+        m_head->write(narrowed(g.read("output.weight")));
 
     expect(g, "output_norm.weight", d, 1);
     m_final_norm->write(narrowed(g.read("output_norm.weight")));
@@ -354,9 +374,26 @@ void model<T>::load(const gguf& g) {
         expect(g, p + "ffn_up.weight", d, m_conf.d_ff);
         expect(g, p + "ffn_down.weight", m_conf.d_ff, d);
 
-        l.w_gate()->write(col_slice_t(g.read(p + "ffn_gate.weight"), 0, m_conf.d_ff));
-        l.w_up()->write(col_slice_t(g.read(p + "ffn_up.weight"), 0, m_conf.d_ff));
-        l.w_down()->write(col_slice_t(g.read(p + "ffn_down.weight"), 0, d));
+        // Straight across in the file's orientation -- no transpose, so the
+        // quantisation blocks still run along the dimension they were built
+        // for, and the bytes can go to the device as they are.
+        struct { const char* name; unsigned int rows; unsigned int cols;
+                 void (block<T>::*set)(const quantised_ptr&);
+                 tensor_ptr& (block<T>::*get)(); } ffn[] = {
+            { "ffn_gate.weight", d, m_conf.d_ff, &block<T>::set_gate, &block<T>::w_gate },
+            { "ffn_up.weight",   d, m_conf.d_ff, &block<T>::set_up,   &block<T>::w_up },
+            { "ffn_down.weight", m_conf.d_ff, d, &block<T>::set_down, &block<T>::w_down }
+        };
+
+        for(const auto& e : ffn) {
+            if(g.tensor(p + e.name).type == gguf::tensor_type::q8_0) {
+                const std::vector<char> raw = g.read_raw(p + e.name);
+
+                (l.*e.set)(m_b.make_q8_0(e.rows, e.cols, raw.data(), raw.size()));
+            }
+            else
+                (l.*e.get)()->write(narrowed(g.read(p + e.name)));
+        }
     }
 }
 
@@ -414,7 +451,8 @@ void model<T>::forward(const std::vector<int>& ids, tensor_ptr& logits,
     }
 
     m_b.rms_norm(m_x, m_final_norm, m_y, m_conf.rms_eps);
-    m_b.multiply_tn(m_head, m_y, logits);
+    if(m_head_q) m_b.multiply_tn(m_head_q, m_y, logits);
+    else m_b.multiply_tn(m_head, m_y, logits);
 }
 
 }

--- a/jlib/ai/transformer.hh
+++ b/jlib/ai/transformer.hh
@@ -74,6 +74,7 @@ template<typename T>
 class block {
 public:
     typedef typename backend<T>::tensor_ptr tensor_ptr;
+    typedef typename backend<T>::quantised_ptr quantised_ptr;
 
     /**
      * @param heads    must divide d_model
@@ -125,8 +126,14 @@ public:
     /**
      * The feed-forward's three matrices, named for their roles.
      *
-     * Gate and up are both (d_ff x d_model) and down is (d_model x d_ff), and
-     * the only thing that distinguishes gate from up is that **silu is applied
+     * **In the file's orientation**, which is the transpose of the obvious one:
+     * gate and up are (d_model x d_ff) and down is (d_ff x d_model), each
+     * multiplied with multiply_tn. That is what a GGUF holds -- see gguf.hh --
+     * and holding it the same way means a weight can stay in the quantisation
+     * it arrived in, whose blocks run along the contiguous dimension and would
+     * not survive being transposed.
+     *
+     * The only thing that distinguishes gate from up is that **silu is applied
      * to the gate**. That is a convention, not a property: swap them and the
      * result is a different but equally self-consistent network, which no test
      * here can tell from this one -- verified by mutation. It is only pinned by
@@ -139,6 +146,22 @@ public:
     tensor_ptr& w_gate() { return m_gate; }
     tensor_ptr& w_up() { return m_up; }
     tensor_ptr& w_down() { return m_down; }
+
+    /**
+     * The same three weights, kept in the encoding a file used.
+     *
+     * Setting one **releases** the tensor above for that weight, which is the
+     * point: holding both costs more than holding neither saves. The shape and
+     * the arithmetic are identical, only the storage differs. These three are 69%
+     * of a Llama's parameters and none of them is sliced, which is why they are
+     * the ones that can be kept quantised -- see the notes on the branch for
+     * what stops the attention weights joining them.
+     */
+    void set_gate(const quantised_ptr& q) { m_gate_q = q; m_gate.reset(); }
+    void set_up(const quantised_ptr& q) { m_up_q = q; m_up.reset(); }
+    void set_down(const quantised_ptr& q) { m_down_q = q; m_down.reset(); }
+
+    bool ffn_quantised() const { return bool(m_gate_q); }
 
     /** (d_model x 1) each: the learned RMS norm scales. */
     tensor_ptr& attn_norm() { return m_attn_norm; }
@@ -252,6 +275,7 @@ private:
 
     std::vector<tensor_ptr> m_wq, m_wk, m_wv, m_wo;
     tensor_ptr m_gate, m_down, m_up;
+    quantised_ptr m_gate_q, m_up_q, m_down_q;
     tensor_ptr m_attn_norm, m_ffn_norm;
 
     tensor_ptr m_norm, m_q, m_scores, m_probs, m_head, m_attn;
@@ -305,9 +329,10 @@ block<T>::block(backend<T>& b, unsigned int d_model, unsigned int heads,
         m_wv.push_back(b.make(m_d_head, d_model));
     }
 
-    m_gate = b.make(d_ff, d_model);
-    m_up = b.make(d_ff, d_model);
-    m_down = b.make(d_model, d_ff);
+    // The file's orientation; see w_gate().
+    m_gate = b.make(d_model, d_ff);
+    m_up = b.make(d_model, d_ff);
+    m_down = b.make(d_ff, d_model);
 
     m_attn_norm = b.make(d_model, 1);
     m_ffn_norm = b.make(d_model, 1);
@@ -491,8 +516,11 @@ void block<T>::forward(const tensor_ptr& x, tensor_ptr& out, bool causal,
 
     m_b.rms_norm(out, m_ffn_norm, m_norm, m_eps);
 
-    m_b.multiply(m_gate, m_norm, m_h1);
-    m_b.multiply(m_up, m_norm, m_h3);
+    if(m_gate_q) m_b.multiply_tn(m_gate_q, m_norm, m_h1);
+    else m_b.multiply_tn(m_gate, m_norm, m_h1);
+
+    if(m_up_q) m_b.multiply_tn(m_up_q, m_norm, m_h3);
+    else m_b.multiply_tn(m_up, m_norm, m_h3);
 
     // Both in place; see the note on aliasing above.  silu on the gate and not
     // on the up projection, which is the whole of what makes this SwiGLU --
@@ -500,7 +528,8 @@ void block<T>::forward(const tensor_ptr& x, tensor_ptr& out, bool causal,
     m_b.activate(activation::silu, m_h1, m_h1);
     m_b.hadamard(m_h1, m_h3, m_h1);
 
-    m_b.multiply(m_down, m_h1, m_ffn);
+    if(m_down_q) m_b.multiply_tn(m_down_q, m_h1, m_ffn);
+    else m_b.multiply_tn(m_down, m_h1, m_ffn);
 
     m_b.add_scaled(T(1), m_ffn, out);
 

--- a/jlib/metal/backend.hh
+++ b/jlib/metal/backend.hh
@@ -55,6 +55,15 @@ public:
     tensor_ptr make(unsigned int rows, unsigned int cols);
     tensor_ptr make(const math::matrix<T>& m);
 
+    typename ai::backend<T>::quantised_ptr make_q8_0(unsigned int rows,
+                                                     unsigned int cols,
+                                                     const void* blocks,
+                                                     std::size_t bytes);
+
+    void multiply_tn(const typename ai::backend<T>::quantised_ptr& a,
+                     const tensor_ptr& b, tensor_ptr& c,
+                     T alpha = T(1), T beta = T(0));
+
     void multiply(const tensor_ptr& a, const tensor_ptr& b, tensor_ptr& c,
                   T alpha = T(1), T beta = T(0));
     void multiply_tn(const tensor_ptr& a, const tensor_ptr& b, tensor_ptr& c,

--- a/jlib/metal/backend.mm
+++ b/jlib/metal/backend.mm
@@ -165,6 +165,45 @@ void backend<T>::causal_mask(tensor_ptr& s, unsigned int key_offset) {
     m_stream->causal_mask(at<T>(s), key_offset);
 }
 
+/** What make_q8_0 hands back: a device-side weight, and nothing else. */
+template<typename T>
+class metal_quantised : public ai::backend<T>::quantised {
+public:
+    metal_quantised(std::shared_ptr<device> d, unsigned int rows,
+                    unsigned int cols, const void* blocks, std::size_t bytes)
+        : w(d, rows, cols, blocks, bytes) {}
+
+    unsigned int rows() const { return w.rows(); }
+    unsigned int cols() const { return w.cols(); }
+
+    qweight w;
+};
+
+template<typename T>
+typename ai::backend<T>::quantised_ptr
+backend<T>::make_q8_0(unsigned int rows, unsigned int cols, const void* blocks,
+                      std::size_t bytes)
+{
+    return typename ai::backend<T>::quantised_ptr(
+        new metal_quantised<T>(m_device, rows, cols, blocks, bytes));
+}
+
+template<typename T>
+void backend<T>::multiply_tn(const typename ai::backend<T>::quantised_ptr& a,
+                             const tensor_ptr& b, tensor_ptr& c,
+                             T alpha, T beta)
+{
+    // dynamic_cast, as everywhere here: a weight made by another backend would
+    // otherwise be reinterpreted rather than refused.
+    metal_quantised<T>* q = dynamic_cast<metal_quantised<T>*>(a.get());
+
+    if(!q)
+        throw ai::backend_error("multiply_tn: that quantised weight belongs to "
+                                "another backend");
+
+    m_stream->multiply_tn(q->w, at<T>(b), at<T>(c), float(alpha), float(beta));
+}
+
 template<typename T>
 void backend<T>::copy_columns(const tensor_ptr& src, tensor_ptr& dst,
                               unsigned int dst_first)

--- a/jlib/metal/device.hh
+++ b/jlib/metal/device.hh
@@ -102,6 +102,9 @@ private:
     // definition then collides with it.
     template<typename> friend class tensor;
     template<typename> friend class stream;
+
+    // Not a template: a quantised weight has no element type to be one over.
+    friend class qweight;
 };
 
 }

--- a/jlib/metal/tensor.hh
+++ b/jlib/metal/tensor.hh
@@ -82,6 +82,46 @@ template<> struct supported<_Float16> { static constexpr bool value = true; };
  * Column-major, matching math::matrix -- see stream::multiply for why that
  * costs nothing.
  */
+/**
+ * A q8_0 weight living on the device, holding the file's bytes unchanged.
+ *
+ * Separate from tensor<T> because it is not one: there is no element type to
+ * template on, the storage is blocks rather than values, and the only thing
+ * that can be done with it is to be the left operand of a multiply_tn. Keeping
+ * it a different type means nothing can pass it where a tensor is wanted and
+ * get silently wrong arithmetic.
+ */
+class qweight {
+public:
+    /**
+     * @param rows the contiguous dimension, which for a GGUF weight is its
+     *        input width
+     * @param blocks 34 bytes per 32 values, exactly as a file holds them
+     */
+    qweight(std::shared_ptr<device> d, unsigned int rows, unsigned int cols,
+            const void* blocks, std::size_t bytes);
+
+    ~qweight();
+
+    unsigned int rows() const { return m_rows; }
+    unsigned int cols() const { return m_cols; }
+
+    /** How many bytes it occupies on the device. */
+    std::size_t bytes() const { return m_bytes; }
+
+private:
+    struct impl;
+
+    std::shared_ptr<device> m_device;
+    std::shared_ptr<impl> m_impl;
+
+    unsigned int m_rows = 0;
+    unsigned int m_cols = 0;
+    std::size_t m_bytes = 0;
+
+    template<typename U> friend class stream;
+};
+
 template<typename T>
 class tensor {
     static_assert(supported<T>::value,
@@ -201,6 +241,10 @@ public:
     /** Column gather: out[:,i] = table[:,ids[i]]. */
     void gather(const tensor<T>& table, const std::vector<int>& ids,
                 tensor<T>& out);
+
+    /** y = alpha * W^T x + beta * y, with W held quantised. */
+    void multiply_tn(const qweight& w, const tensor<T>& x, tensor<T>& y,
+                     float alpha, float beta);
 
     /** RMS normalisation down each column, scaled by a per-row weight. */
     void rms_norm(const tensor<T>& in, const tensor<T>& weight, tensor<T>& out,

--- a/jlib/metal/tensor.mm
+++ b/jlib/metal/tensor.mm
@@ -320,6 +320,66 @@ kernel void k_gather(device const T* table [[buffer(0)]],
     out[(ulong)c * rows + r] = table[(ulong)ids[c] * rows + r];
 }
 
+/**
+ * c = alpha * W^T b + beta * c, with W held as q8_0 exactly as a file wrote it.
+ *
+ * A block is a two-byte scale then thirty-two signed quants, 34 bytes for 32
+ * values, and the file's bytes are used unchanged -- so the scale is read two
+ * bytes at a time and reassembled rather than loaded as a half, which at an
+ * offset of 34n would be misaligned.
+ *
+ * One thread per output element. That is enough because the work is bound by
+ * reading W, not by arithmetic: it moves 1.06 bytes per parameter where fp16
+ * moves 2, and measured against MPS on a 2048-square matrix-vector product it
+ * takes 39us to MPS's 68us at about the same bandwidth.
+ */
+template<typename T>
+kernel void k_q8_gemv(device const uchar* w [[buffer(0)]],
+                      device const T* x [[buffer(1)]],
+                      device T* y [[buffer(2)]],
+                      constant uint& K [[buffer(3)]],
+                      constant uint& N [[buffer(4)]],
+                      constant uint& ncols [[buffer(5)]],
+                      constant float& alpha [[buffer(6)]],
+                      constant float& beta [[buffer(7)]],
+                      uint gid [[thread_position_in_grid]])
+{
+    const uint j = gid % N;
+    const uint c = gid / N;
+
+    if(c >= ncols) return;
+
+    const uint nb = K / 32;
+
+    device const uchar* base = w + (ulong)j * nb * 34;
+    device const T* xc = x + (ulong)c * K;
+
+    float sum = 0.0f;
+
+    for(uint b = 0; b < nb; b++) {
+        device const uchar* p = base + (ulong)b * 34;
+
+        const ushort bits = ushort(p[0]) | (ushort(p[1]) << 8);
+        const float d = float(as_type<half>(bits));
+
+        device const char* q = (device const char*)(p + 2);
+
+        float acc = 0.0f;
+
+        for(uint i = 0; i < 32; i++)
+            acc += float(q[i]) * float(xc[b * 32 + i]);
+
+        sum += d * acc;
+    }
+
+    const ulong at = (ulong)c * N + j;
+
+    // beta of zero does not read y, which is what BLAS specifies -- and what
+    // the host got wrong until a cache left -infinity in an output.
+    y[at] = T(beta == 0.0f ? alpha * sum
+                           : alpha * sum + beta * float(y[at]));
+}
+
 #define INSTANTIATE(NAME, T, SUFFIX)                                        \
     template [[host_name(#NAME SUFFIX)]] kernel void NAME<T>
 
@@ -357,6 +417,14 @@ INSTANTIATE(k_copy_columns, float, "_f32")(device const float*, device float*,
 INSTANTIATE(k_copy_columns, half, "_f16")(device const half*, device half*,
                                           constant uint&, constant uint&,
                                           constant uint&, uint);
+INSTANTIATE(k_q8_gemv, float, "_f32")(device const uchar*, device const float*,
+                                      device float*, constant uint&,
+                                      constant uint&, constant uint&,
+                                      constant float&, constant float&, uint);
+INSTANTIATE(k_q8_gemv, half, "_f16")(device const uchar*, device const half*,
+                                     device half*, constant uint&,
+                                     constant uint&, constant uint&,
+                                     constant float&, constant float&, uint);
 INSTANTIATE(k_gather, float, "_f32")(device const float*, device float*,
                                      device const int*, constant uint&,
                                      constant uint&, uint);
@@ -483,6 +551,7 @@ struct stream<T>::impl {
     id<MTLComputePipelineState> copy_columns = nil;
     id<MTLComputePipelineState> rope = nil;
     id<MTLComputePipelineState> gather = nil;
+    id<MTLComputePipelineState> q8_gemv = nil;
     id<MTLComputePipelineState> rms_norm = nil;
 
     // Buffers made for one encoded operation and needed until the command
@@ -508,6 +577,7 @@ struct pipelines {
     id<MTLComputePipelineState> copy_columns = nil;
     id<MTLComputePipelineState> rope = nil;
     id<MTLComputePipelineState> gather = nil;
+    id<MTLComputePipelineState> q8_gemv = nil;
     id<MTLComputePipelineState> rms_norm = nil;
 };
 
@@ -563,6 +633,7 @@ pipelines& compiled(id<MTLDevice> gpu) {
         { "k_copy_columns", &p.copy_columns },
         { "k_rope",       &p.rope },
         { "k_gather",     &p.gather },
+        { "k_q8_gemv",    &p.q8_gemv },
         { "k_rms_norm",   &p.rms_norm },
     };
 
@@ -630,6 +701,7 @@ stream<T>::stream(std::shared_ptr<device> d)
     m_impl->copy_columns = p.copy_columns;
     m_impl->rope = p.rope;
     m_impl->gather = p.gather;
+    m_impl->q8_gemv = p.q8_gemv;
     m_impl->held = [NSMutableArray array];
     m_impl->rms_norm = p.rms_norm;
 }
@@ -912,6 +984,72 @@ void stream<T>::gather(const tensor<T>& table, const std::vector<int>& ids,
     [m_impl->enc setBytes:&n length:sizeof(n) atIndex:4];
 
     dispatch(m_impl->enc, m_impl->gather, rows * n);
+
+    m_impl->pending++;
+}
+
+struct qweight::impl {
+    id<MTLBuffer> buf = nil;
+};
+
+qweight::qweight(std::shared_ptr<device> d, unsigned int rows, unsigned int cols,
+                 const void* blocks, std::size_t bytes)
+    : m_device(d),
+      m_impl(new impl),
+      m_rows(rows),
+      m_cols(cols),
+      m_bytes(bytes)
+{
+    const std::size_t n = std::size_t(rows) * cols;
+
+    if(n % 32)
+        throw std::runtime_error("jlib::metal::qweight: the element count is "
+                                 "not a multiple of the block size");
+
+    if(bytes != (n / 32) * 34)
+        throw std::runtime_error("jlib::metal::qweight: the bytes do not match "
+                                 "the shape");
+
+    m_impl->buf = [d->m_impl->gpu newBufferWithBytes:blocks
+                                              length:bytes
+                                             options:MTLResourceStorageModeShared];
+
+    if(m_impl->buf == nil)
+        throw std::runtime_error("jlib::metal::qweight: could not allocate");
+}
+
+qweight::~qweight() {}
+
+template<typename T>
+void stream<T>::multiply_tn(const qweight& w, const tensor<T>& x, tensor<T>& y,
+                            float alpha, float beta)
+{
+    const unsigned int K = w.rows();
+    const unsigned int N = w.cols();
+
+    if(x.rows() != K)
+        throw typename tensor<T>::exception("q8 multiply_tn: the input is not "
+                                            "as tall as the weight is wide");
+
+    if(y.rows() != N || y.cols() != x.cols())
+        throw typename tensor<T>::exception("q8 multiply_tn: the output shape "
+                                            "does not match");
+
+    open();
+
+    const unsigned int ncols = x.cols();
+
+    [m_impl->enc setComputePipelineState:m_impl->q8_gemv];
+    [m_impl->enc setBuffer:w.m_impl->buf offset:0 atIndex:0];
+    [m_impl->enc setBuffer:x.m_impl->buf offset:0 atIndex:1];
+    [m_impl->enc setBuffer:y.m_impl->buf offset:0 atIndex:2];
+    [m_impl->enc setBytes:&K length:sizeof(K) atIndex:3];
+    [m_impl->enc setBytes:&N length:sizeof(N) atIndex:4];
+    [m_impl->enc setBytes:&ncols length:sizeof(ncols) atIndex:5];
+    [m_impl->enc setBytes:&alpha length:sizeof(alpha) atIndex:6];
+    [m_impl->enc setBytes:&beta length:sizeof(beta) atIndex:7];
+
+    dispatch(m_impl->enc, m_impl->q8_gemv, N * ncols);
 
     m_impl->pending++;
 }

--- a/tests/ai_backend_test.cc
+++ b/tests/ai_backend_test.cc
@@ -36,6 +36,7 @@
 #endif
 
 #include <cmath>
+#include <cstring>
 #include <iostream>
 #include <memory>
 #include <random>
@@ -984,6 +985,158 @@ static void beta_zero_does_not_read_the_output(const char* name,
     }
 }
 
+/**
+ * Encode a matrix the way a GGUF file would: blocks of 32 down the columns.
+ *
+ * Rows must be a multiple of 32 so a block never straddles two columns, which
+ * is true of every weight in a real file and is checked when one is made.
+ */
+template<typename T>
+static std::vector<char> as_q8_0(const matrix<T>& m) {
+    const std::size_t n = std::size_t(m.M) * m.N;
+
+    std::vector<char> out((n / 32) * 34);
+
+    for(std::size_t b = 0; b < n / 32; b++) {
+        float amax = 0;
+
+        for(std::size_t i = 0; i < 32; i++) {
+            const std::size_t at = b * 32 + i;
+
+            amax = std::max(amax, std::fabs(float(m(uint(at % m.M), uint(at / m.M)))));
+        }
+
+        const float scale = amax / 127.0f;
+        const _Float16 d = _Float16(scale);
+
+        char* p = out.data() + b * 34;
+
+        std::memcpy(p, &d, sizeof(d));
+
+        for(std::size_t i = 0; i < 32; i++) {
+            const std::size_t at = b * 32 + i;
+            const float v = float(m(uint(at % m.M), uint(at / m.M)));
+            const int q = scale > 0 ? int(std::lround(double(v / scale))) : 0;
+
+            p[2 + i] = char(q < -127 ? -127 : (q > 127 ? 127 : q));
+        }
+    }
+
+    return out;
+}
+
+/** And decode it again, which is what a weight kept quantised has to match. */
+template<typename T>
+static matrix<T> from_q8_0(const std::vector<char>& raw, uint rows, uint cols) {
+    matrix<T> m(rows, cols);
+
+    for(std::size_t b = 0; b < raw.size() / 34; b++) {
+        const char* p = raw.data() + b * 34;
+
+        _Float16 d;
+
+        std::memcpy(&d, p, sizeof(d));
+
+        for(std::size_t i = 0; i < 32; i++) {
+            const std::size_t at = b * 32 + i;
+
+            m(uint(at % rows), uint(at / rows)) =
+                T(float(d) * float(reinterpret_cast<const signed char*>(p + 2)[i]));
+        }
+    }
+
+    return m;
+}
+
+/**
+ * A weight kept quantised multiplies like the same weight dequantised.
+ *
+ * That is the whole contract: the kernel dequantises as it reads, so what
+ * comes out has to be what would have come out if the dequantising had
+ * happened first. Not approximately -- the same numbers, to whatever the
+ * element type can hold.
+ *
+ * It is checked against a *dequantised* reference rather than against the
+ * original matrix, deliberately. Quantising loses precision and there is no
+ * point measuring that here; what is being tested is that the two orders of
+ * doing the same arithmetic agree.
+ */
+template<typename T>
+static void a_quantised_weight_multiplies(const char* name,
+                                          std::vector<ai::backend<T>*>& backends)
+{
+    std::cout << "\na quantised weight multiplies, " << name << ":\n";
+
+    const uint K = 64;
+    const uint N = 8;
+
+    std::mt19937 gen(97);
+
+    const matrix<T> w = random_matrix<T>(K, N, gen);
+
+    const std::vector<char> raw = as_q8_0(w);
+    const matrix<T> dequantised = from_q8_0<T>(raw, K, N);
+
+    for(uint ncols : { 1u, 5u }) {
+        const matrix<T> x = random_matrix<T>(K, ncols, gen);
+
+        for(ai::backend<T>* b : backends) {
+            typename ai::backend<T>::quantised_ptr q =
+                b->make_q8_0(K, N, raw.data(), raw.size());
+
+            ok(std::string("  ") + b->name() + ": it knows its own shape",
+               q->rows() == K && q->cols() == N);
+
+            typename ai::backend<T>::tensor_ptr tx = b->make(x);
+            typename ai::backend<T>::tensor_ptr got = b->make(N, ncols);
+
+            b->multiply_tn(q, tx, got);
+
+            // The reference: dequantise first, then the ordinary multiply.
+            typename ai::backend<T>::tensor_ptr td = b->make(dequantised);
+            typename ai::backend<T>::tensor_ptr want = b->make(N, ncols);
+
+            b->multiply_tn(td, tx, want);
+            b->wait();
+
+            const double d = worst(got->read(), want->read());
+
+            ok(std::string("  ") + b->name() + ": " + std::to_string(ncols) +
+               " column(s) match dequantising first",
+               d < ((sizeof(T) == 2) ? 5e-2 : 1e-3), std::to_string(d));
+        }
+    }
+
+    for(ai::backend<T>* b : backends) {
+        bool threw = false;
+
+        try { b->make_q8_0(K, N, raw.data(), raw.size() - 34); }
+        catch(std::exception&) { threw = true; }
+
+        ok(std::string("  ") + b->name() + ": bytes that do not match the shape "
+           "are refused", threw);
+
+        // And a weight from the other backend is refused rather than read.
+        if(backends.size() > 1) {
+            ai::backend<T>* other = (b == backends[0]) ? backends[1] : backends[0];
+
+            typename ai::backend<T>::quantised_ptr foreign =
+                other->make_q8_0(K, N, raw.data(), raw.size());
+
+            typename ai::backend<T>::tensor_ptr tx = b->make(K, 1);
+            typename ai::backend<T>::tensor_ptr out = b->make(N, 1);
+
+            threw = false;
+
+            try { b->multiply_tn(foreign, tx, out); b->wait(); }
+            catch(std::exception&) { threw = true; }
+
+            ok(std::string("  ") + b->name() + ": and one from another backend is too",
+               threw);
+        }
+    }
+}
+
 static void a_tensor_from_the_wrong_backend_is_refused() {
     std::cout << "\na tensor from the wrong backend is refused:\n";
 
@@ -1050,6 +1203,7 @@ int main() {
         the_column_copy<float>("float", b);
         the_offset_mask<float>("float", b);
         beta_zero_does_not_read_the_output<float>("float", b);
+        a_quantised_weight_multiplies<float>("float", b);
 #else
         one_type<float>("float", b);
         the_reductions<float>("float", b);
@@ -1065,6 +1219,7 @@ int main() {
         the_column_copy<float>("float", b);
         the_offset_mask<float>("float", b);
         beta_zero_does_not_read_the_output<float>("float", b);
+        a_quantised_weight_multiplies<float>("float", b);
 #endif
     }
 
@@ -1091,6 +1246,7 @@ int main() {
         the_column_copy<_Float16>("_Float16", b);
         the_offset_mask<_Float16>("_Float16", b);
         beta_zero_does_not_read_the_output<_Float16>("_Float16", b);
+        a_quantised_weight_multiplies<_Float16>("_Float16", b);
     }
 
     a_tensor_from_the_wrong_backend_is_refused();

--- a/tests/ai_model_test.cc
+++ b/tests/ai_model_test.cc
@@ -459,9 +459,11 @@ static void fill_randomly(ai::model<float>& m, std::mt19937& gen) {
             l.wv(h)->write(rnd(dh, c.d_model));
         }
 
-        l.w_gate()->write(rnd(c.d_ff, c.d_model));
-        l.w_up()->write(rnd(c.d_ff, c.d_model));
-        l.w_down()->write(rnd(c.d_model, c.d_ff));
+        // The file's orientation: gate and up are (d_model x d_ff), down the
+        // other way, each read with multiply_tn.
+        l.w_gate()->write(rnd(c.d_model, c.d_ff));
+        l.w_up()->write(rnd(c.d_model, c.d_ff));
+        l.w_down()->write(rnd(c.d_ff, c.d_model));
     }
 }
 

--- a/tests/ai_transformer_test.cc
+++ b/tests/ai_transformer_test.cc
@@ -88,7 +88,7 @@ struct weights {
 
     weights(std::mt19937& gen, unsigned int nh = H, unsigned int nkv = H)
         : heads(nh), kv(nkv),
-          w1(F, D), w3(F, D), w2(D, F), an(D, 1), fn(D, 1)
+          w1(D, F), w3(D, F), w2(F, D), an(D, 1), fn(D, 1)
     {
         for(unsigned int h = 0; h < heads; h++) {
             wq.push_back(random_matrix<T>(D / heads, D, gen, 0.5f));
@@ -100,9 +100,9 @@ struct weights {
             wv.push_back(random_matrix<T>(D / heads, D, gen, 0.5f));
         }
 
-        w1 = random_matrix<T>(F, D, gen, 0.5f);
-        w3 = random_matrix<T>(F, D, gen, 0.5f);
-        w2 = random_matrix<T>(D, F, gen, 0.5f);
+        w1 = random_matrix<T>(D, F, gen, 0.5f);
+        w3 = random_matrix<T>(D, F, gen, 0.5f);
+        w2 = random_matrix<T>(F, D, gen, 0.5f);
 
         for(unsigned int r = 0; r < D; r++) { an(r,0) = T(1.0f); fn(r,0) = T(1.0f); }
     }
@@ -172,8 +172,8 @@ static void a_zeroed_block_is_the_identity(const char* name,
             for(unsigned int c = 0; c < D / H; c++)
                 w.wo[h](r,c) = T(0.0f);
 
-    for(unsigned int r = 0; r < D; r++)
-        for(unsigned int c = 0; c < F; c++)
+    for(unsigned int r = 0; r < F; r++)
+        for(unsigned int c = 0; c < D; c++)
             w.w2(r,c) = T(0.0f);
 
     const matrix<T> x = random_matrix<T>(D, N, gen);
@@ -411,8 +411,8 @@ static void the_branch_input_is_normalised(const char* name,
 
     weights<T> w(gen);
 
-    for(unsigned int r = 0; r < D; r++)
-        for(unsigned int c = 0; c < F; c++)
+    for(unsigned int r = 0; r < F; r++)
+        for(unsigned int c = 0; c < D; c++)
             w.w2(r,c) = T(0.0f);
 
     const matrix<T> x = random_matrix<T>(D, N, gen);


### PR DESCRIPTION
# Weights kept quantised, and a premise of mine that was wrong

#158 said the 0.127s per-token floor was weight bandwidth, so keeping weights
in the file's q8_0 and dequantising inside the kernel should roughly halve it.
The kernel works and is faster than MPS at every real shape. The floor is not
weight bandwidth, and the end-to-end gain is a tenth of what I predicted.

| | before | after | |
| --- | --- | --- | --- |
| load | 4.28s | 0.95s | **4.5x** |
| memory | 4.05GB | 2.63GB | **1.5x** |
| generation | 7.54 tok/s | 8.45 | 1.12x |

## The kernel does what it was supposed to

A q8_0 matrix-vector product, weights read in the file's encoding and
dequantised as they are consumed, against MPS in fp16:

| K x N | what it is | MPS | q8_0 | |
| --- | --- | --- | --- | --- |
| 2048 x 2048 | a whole projection | 70.6us | 44.1us | **1.60x** |
| 2048 x 5632 | ffn_gate, ffn_up | 185.4us | 114.7us | **1.62x** |
| 5632 x 2048 | ffn_down | 192.3us | 119.9us | **1.60x** |
| 2048 x 32000 | the head | 1003.6us | 684.1us | **1.47x** |

Both run at about the same bandwidth; the win is entirely that q8_0 moves 1.06
bytes per parameter where fp16 moves 2.

## What is quantised, and what stops the rest

75% of the parameters: the three feed-forward matrices (69%) and the head (6%).
Those are the ones nothing slices, so their blocks still run along the dimension
they were built for.

The attention weights are not, and the reason is worth recording. Q8_0 blocks
are 32 consecutive elements in the file's layout, so a slice that is contiguous
keeps them and a slice that is strided destroys them. Per head, `attn_q`, `k`
and `v` are **column** ranges -- contiguous, fine -- but `attn_output` is a
**row** range, because the heads are concatenated on its input side. Quantising
it means not slicing it, which means not accumulating the heads one at a time,
which is a change to how attention is assembled rather than to how a weight is
stored.

The feed-forward weights moved to the file's orientation to make this possible:
gate and up are now `(d_model x d_ff)` and down `(d_ff x d_model)`, each read
with `multiply_tn`. `gguf.hh` has called that "very likely the better design"
since the loader was written; this is the branch that needed it.

## The floor is dispatch, not bandwidth

The end-to-end number was 1.12x where the byte count predicted 1.5x, and the
arithmetic says why -- it was there to be done at any point and I did not do it.
**2.2GB at the ~120GB/s this device reaches is 18ms.** The floor is 127ms.
Weight streaming was never more than a seventh of it.

Measuring the shape attention actually uses:

| shape | | bandwidth |
| --- | --- | --- |
| 2048 x 64, one head's projection | 21.4us | **12.3 GB/s** |
| 2048 x 2048, all 32 heads at once | 70.6us | 118.8 GB/s |

**Thirty-two times the work for 3.3 times the time.** The per-head call spends
its time being launched, not reading memory.

Per token that is 22 layers x 32 heads x ~7 operations, some 4900 dispatches at
roughly 25us -- about 122ms, against the 124ms observed. It accounts for
essentially the whole floor.

The quantised kernel is *worse* at those shapes, 0.51x, for the same reason: a
fixed overhead with less work to hide behind.

**Why it went unseen.** Everything measured until now varied the sequence
length, and dispatch count does not depend on it. It looked like a constant, and
I attributed a constant to bandwidth without dividing 2.2GB by 120GB/s. The
number was available the whole time.

`generate.hh` carried the wrong claim and now carries the measurement. #158 is
commented with the correction and #163 is filed for the real lever: batching the
heads would take ~64 dispatches per layer to ~4.

## Tests

- **a quantised weight multiplies like the same weight dequantised** -- checked
  against a dequantised reference rather than the original matrix, deliberately:
  quantising loses precision and that is not what is being tested. Both element
  types, both backends, one column and five. Agreement 1e-6.
- bytes that do not match the shape are refused, and a weight from another
  backend is refused rather than reinterpreted
- the real model still answers **Rome**, and still continues with the exact
  string `"Rome. The capital of Spain is Madrid. The capital of"` -- so the
  quantised path generates the same tokens

And one thing no single test asserts, because it spans three branches. The same
prompt has now produced the **same 230 tokens, byte for byte**, from three
materially different implementations: recomputing the whole sequence per token,
a key-value cache, and now 75% of the weights never dequantised at all. Same
Erlang module, same muddled explanation of it, same `erl -pa .` that never calls
`hello:main()`.

Each branch checked itself against the one before, so nothing about that is
luck; but it is a stronger statement than any of those pairwise checks, and it
is the kind of invariant worth naming since no assertion holds it.

The host's `quantised` dequantises once at construction and keeps a matrix. It
saves nothing and is not meant to: it is the reference the kernel is checked
against, and should be the obvious thing rather than the same cleverness twice.

One bug this branch introduced and fixed: `set_gate` and friends left the fp16
tensor allocated beside the quantised weight, so memory went *up*. They release
it now -- 4.05GB to 2.63GB.

## Verification

- macOS `make check`: 75 tests, 71 pass, 4 skip, 0 fail.
- Container: the quantised tests need no GPU, so they run there.

## What this does not establish

**That quantising the rest would help much.** It would take memory further, and
on the measurement above it would move perhaps another 1.1x of generation. The
attention weights are also the ones whose dispatch pattern is the actual
problem, so the work to make them quantisable overlaps with the work to make
them fast -- which is an argument for doing #163 first and revisiting.

**Nothing about accuracy.** The tests check that a quantised weight multiplies
like the same weight dequantised, which is a statement about the kernel and not
about q8_0. Whether 8-bit weights answer as well as 16-bit ones is a question
about the model, and this changes nothing there: the file was q8_0 already and
was being expanded at load.

**And nothing about other quantisations.** Only q8_0 is read. Q4_K is a
superblock format and would need its own kernel as well as its own loader.
