### PR TITLE
Batch attention across heads: one call per step instead of one per head, and a decode step goes 105ms to 24ms

### DIFF
--- a/jlib/ai/backend.hh
+++ b/jlib/ai/backend.hh
@@ -280,7 +280,49 @@ public:
      *        length is always greater than `key_offset + col`.  One mask, both
      *        jobs, which is why this needs no notion of how full the cache is.
      */
-    virtual void causal_mask(tensor_ptr& s, unsigned int key_offset = 0) = 0;
+    /**
+     * @param queries how many columns belong to one head, when the scores hold
+     *        every head side by side.  Zero means the whole width is one head's,
+     *        which is what a single-head caller wants.
+     */
+    virtual void causal_mask(tensor_ptr& s, unsigned int key_offset = 0,
+                             unsigned int queries = 0) = 0;
+
+    /**
+     * Every head's scores in one call: `s[j, h*queries + i]` is the dot product
+     * of query i of head h with key j, scaled.
+     *
+     * ### Why this exists rather than a loop
+     *
+     * The obvious way is one matrix multiply per head, and it is what this did
+     * until it was measured: **the per-head loop was 81.5ms of a 105.7ms
+     * decode step**, 77% of the time to produce one token. Not arithmetic --
+     * 4928 small multiplies per token at about 16us each, almost all of it the
+     * cost of asking for one rather than doing it. The same work in one call
+     * runs at nine times the bandwidth.
+     *
+     * So the head index moves inside the kernel. Nothing here is sliced, no
+     * view is needed, and one dispatch does what 704 did.
+     *
+     * @param q      (heads * d_head) x queries, head h in rows h*d_head
+     * @param k      (kv_heads * d_head) x keys, likewise
+     * @param scores keys x (queries * heads), head h in columns h*queries
+     */
+    virtual void attention_scores(const tensor_ptr& q, const tensor_ptr& k,
+                                  tensor_ptr& scores, unsigned int heads,
+                                  unsigned int kv_heads, unsigned int d_head,
+                                  T scale) = 0;
+
+    /**
+     * The other half: every head's weighted sum over values, in one call.
+     *
+     * `out[h*d_head + d, i] = sum_j v[g*d_head + d, j] * probs[j, h*queries+i]`
+     * with g the key-value head that head h reads.
+     */
+    virtual void attention_weighted(const tensor_ptr& v, const tensor_ptr& probs,
+                                    tensor_ptr& out, unsigned int heads,
+                                    unsigned int kv_heads,
+                                    unsigned int d_head) = 0;
 
     /**
      * Copy src's columns into dst starting at a column: the write half of
@@ -333,13 +375,17 @@ public:
      * for decoding one token at a time against a cache, where the single
      * column being processed is at position n rather than 0.
      *
+     * @param d_head when several heads are stacked in one column, how tall
+     *        each is: the rotation happens inside a head and not across the
+     *        boundary between two.  Zero means the column is one head.
      * @param theta  the frequency base, 10000 by convention
      * @param layout which dimensions get paired; see rope_layout, and note
      *               that no test can check this one for you
      */
     virtual void rope(tensor_ptr& x, unsigned int base_pos = 0,
                       float theta = 10000.0f,
-                      rope_layout layout = rope_layout::interleaved) = 0;
+                      rope_layout layout = rope_layout::interleaved,
+                      unsigned int d_head = 0) = 0;
 
     /**
      * Root-mean-square normalisation down each column, scaled per feature.
@@ -399,13 +445,21 @@ public:
     void add_scaled(T alpha, const tensor_ptr& x, tensor_ptr& y);
     void assign(const tensor_ptr& src, tensor_ptr& dst);
     void softmax(const tensor_ptr& in, tensor_ptr& out);
-    void causal_mask(tensor_ptr& s, unsigned int key_offset = 0);
+    void causal_mask(tensor_ptr& s, unsigned int key_offset = 0,
+                     unsigned int queries = 0);
     void copy_columns(const tensor_ptr& src, tensor_ptr& dst,
                       unsigned int dst_first);
+    void attention_scores(const tensor_ptr& q, const tensor_ptr& k,
+                          tensor_ptr& scores, unsigned int heads,
+                          unsigned int kv_heads, unsigned int d_head, T scale);
+    void attention_weighted(const tensor_ptr& v, const tensor_ptr& probs,
+                            tensor_ptr& out, unsigned int heads,
+                            unsigned int kv_heads, unsigned int d_head);
     void gather(const tensor_ptr& table, const std::vector<int>& ids,
                 tensor_ptr& out);
     void rope(tensor_ptr& x, unsigned int base_pos = 0, float theta = 10000.0f,
-              rope_layout layout = rope_layout::interleaved);
+              rope_layout layout = rope_layout::interleaved,
+              unsigned int d_head = 0);
     void rms_norm(const tensor_ptr& in, const tensor_ptr& weight,
                   tensor_ptr& out, float eps = 1e-5f);
 
@@ -775,7 +829,83 @@ void host_backend<T>::multiply_tn(const typename backend<T>::quantised_ptr& a,
 }
 
 template<typename T>
-void host_backend<T>::causal_mask(tensor_ptr& s, unsigned int key_offset) {
+void host_backend<T>::attention_scores(const tensor_ptr& q, const tensor_ptr& k,
+                                       tensor_ptr& scores, unsigned int heads,
+                                       unsigned int kv_heads,
+                                       unsigned int d_head, T scale)
+{
+    const math::matrix<T>& a = at(q);
+    const math::matrix<T>& b = at(k);
+    math::matrix<T>& s = at(scores);
+
+    const uint queries = a.N;
+    const uint keys = b.N;
+    const uint group = heads / kv_heads;
+
+    if(a.M != heads * d_head || b.M != kv_heads * d_head)
+        throw backend_error("attention_scores: the heads do not fit the shapes");
+
+    if(s.M != keys || s.N != queries * heads)
+        throw backend_error("attention_scores: scores must be keys by queries "
+                            "times heads");
+
+    typedef typename compute_in<T>::type C;
+
+    for(uint h = 0; h < heads; h++) {
+        const uint g = h / group;
+
+        for(uint i = 0; i < queries; i++)
+            for(uint j = 0; j < keys; j++) {
+                C sum = 0;
+
+                for(uint d = 0; d < d_head; d++)
+                    sum += C(a(h * d_head + d, i)) * C(b(g * d_head + d, j));
+
+                s(j, h * queries + i) = T(sum * C(scale));
+            }
+    }
+}
+
+template<typename T>
+void host_backend<T>::attention_weighted(const tensor_ptr& v,
+                                         const tensor_ptr& probs,
+                                         tensor_ptr& out, unsigned int heads,
+                                         unsigned int kv_heads,
+                                         unsigned int d_head)
+{
+    const math::matrix<T>& b = at(v);
+    const math::matrix<T>& p = at(probs);
+    math::matrix<T>& o = at(out);
+
+    const uint keys = b.N;
+    const uint queries = p.N / heads;
+    const uint group = heads / kv_heads;
+
+    if(o.M != heads * d_head || o.N != queries)
+        throw backend_error("attention_weighted: out must be the heads' depth "
+                            "by queries");
+
+    typedef typename compute_in<T>::type C;
+
+    for(uint h = 0; h < heads; h++) {
+        const uint g = h / group;
+
+        for(uint i = 0; i < queries; i++)
+            for(uint d = 0; d < d_head; d++) {
+                C sum = 0;
+
+                for(uint j = 0; j < keys; j++)
+                    sum += C(b(g * d_head + d, j)) * C(p(j, h * queries + i));
+
+                o(h * d_head + d, i) = T(sum);
+            }
+    }
+}
+
+template<typename T>
+void host_backend<T>::causal_mask(tensor_ptr& s, unsigned int key_offset,
+                                  unsigned int queries)
+{
     math::matrix<T>& x = at(s);
 
     // Through float, not std::numeric_limits<T>: _Float16 is a compiler
@@ -783,8 +913,11 @@ void host_backend<T>::causal_mask(tensor_ptr& s, unsigned int key_offset) {
     // float infinity to half gives a half infinity.
     const T neg_inf = T(-std::numeric_limits<float>::infinity());
 
+    // Which query a column belongs to, when the heads sit side by side.
+    const uint per_head = queries ? queries : x.N;
+
     for(uint c = 0; c < x.N; c++)
-        for(uint r = c + key_offset + 1; r < x.M; r++)
+        for(uint r = (c % per_head) + key_offset + 1; r < x.M; r++)
             x(r,c) = neg_inf;
 }
 
@@ -816,15 +949,19 @@ void host_backend<T>::gather(const tensor_ptr& table, const std::vector<int>& id
 
 template<typename T>
 void host_backend<T>::rope(tensor_ptr& x, unsigned int base_pos, float theta,
-                           rope_layout layout)
+                           rope_layout layout, unsigned int d_head)
 {
     math::matrix<T>& m = at(x);
 
-    if(m.M % 2)
-        throw backend_error("rope: rotates in planes, so it needs an even "
-                            "number of rows");
+    // One head unless told otherwise; several heads stacked in a column rotate
+    // inside themselves and never across the boundary between two.
+    const uint dh = d_head ? d_head : m.M;
 
-    const uint half = m.M / 2;
+    if(dh % 2 || (m.M % dh))
+        throw backend_error("rope: rotates in planes, so it needs an even head "
+                            "that divides the column");
+
+    const uint half = dh / 2;
 
     // In double, like softmax and for the same reason: this is the reference
     // the GPU is checked against.  It matters more here than elsewhere -- the
@@ -834,12 +971,15 @@ void host_backend<T>::rope(tensor_ptr& x, unsigned int base_pos, float theta,
     for(uint c = 0; c < m.N; c++) {
         const double pos = double(base_pos + c);
 
+        for(uint head = 0; head < m.M / dh; head++)
         for(uint j = 0; j < half; j++) {
-            const uint a = (layout == rope_layout::split) ? j : 2 * j;
-            const uint b = (layout == rope_layout::split) ? j + half : 2 * j + 1;
+            const uint base = head * dh;
+            const uint a = base + ((layout == rope_layout::split) ? j : 2 * j);
+            const uint b = base + ((layout == rope_layout::split) ? j + half
+                                                                 : 2 * j + 1);
 
             const double freq = std::pow(double(theta),
-                                         -2.0 * double(j) / double(m.M));
+                                         -2.0 * double(j) / double(dh));
             const double angle = pos * freq;
 
             const double co = std::cos(angle);

--- a/jlib/ai/model.hh
+++ b/jlib/ai/model.hh
@@ -102,27 +102,18 @@ public:
     /**
      * Place every weight in the file.
      *
-     * ### Orientation, which is where the work is
+     * ### Orientation
      *
-     * gguf.hh explains that a GGUF weight arrives as `[n_in, n_out]` and that
-     * the product a layer wants is therefore `W^T x`. Two of the tensors are
-     * used exactly that way and need no rearrangement at all: the embedding is
-     * a table of columns, and the head is multiplied with multiply_tn.
+     * There is nothing to do. A GGUF weight arrives as `[n_in, n_out]` and the
+     * product a layer wants is `W^T x`, so every weight is used in the
+     * orientation it came in and this function is a copy.
      *
-     * The block's weights are the other case. It holds `wq(h)` as
-     * (d_head x d_model) and multiplies straight, so each head's slice has to
-     * be transposed as it is placed -- and the slice differs by role:
-     *
-     *   attn_q, attn_k, attn_v   a *column* range, transposed
-     *   attn_output              a *row* range, transposed
-     *   ffn_gate, ffn_up, down   the whole matrix, transposed
-     *
-     * The alternative is to store the block's weights in the file's
-     * orientation and reach for multiply_tn there too, which would make this
-     * function a memcpy. That is very likely the better design and it is not
-     * this branch's to make: it changes block's public shapes and every test
-     * that fills them. Written down here so the choice is visible rather than
-     * inherited.
+     * It was not always. The block used to hold each attention weight sliced
+     * per head and transposed, and this function did that work -- which cost a
+     * transpose of a gigabyte at load and, worse, meant a weight could not stay
+     * in the quantisation it arrived in, since q8_0 blocks run along the
+     * contiguous dimension and do not survive being turned. Both went when the
+     * per-head loop did.
      *
      * @throws gguf::exception or backend_error if a tensor is missing or the
      *         wrong shape for what the config said
@@ -162,14 +153,6 @@ public:
                  unsigned int base_pos = 0);
 
 private:
-    /** Columns [c0, c0+n) of W, transposed: result(a,b) = W(b, c0+a). */
-    static math::matrix<T> col_slice_t(const math::matrix<float>& w,
-                                       unsigned int c0, unsigned int n);
-
-    /** Rows [r0, r0+n) of W, transposed: result(a,b) = W(r0+b, a). */
-    static math::matrix<T> row_slice_t(const math::matrix<float>& w,
-                                       unsigned int r0, unsigned int n);
-
     /** Straight across, narrowing to T. */
     static math::matrix<T> narrowed(const math::matrix<float>& w);
 
@@ -247,32 +230,6 @@ model<T>::model(backend<T>& b, const config& c)
 }
 
 template<typename T>
-math::matrix<T> model<T>::col_slice_t(const math::matrix<float>& w,
-                                      unsigned int c0, unsigned int n)
-{
-    math::matrix<T> out(n, w.M);
-
-    for(unsigned int a = 0; a < n; a++)
-        for(unsigned int b = 0; b < w.M; b++)
-            out(a, b) = T(w(b, c0 + a));
-
-    return out;
-}
-
-template<typename T>
-math::matrix<T> model<T>::row_slice_t(const math::matrix<float>& w,
-                                      unsigned int r0, unsigned int n)
-{
-    math::matrix<T> out(w.N, n);
-
-    for(unsigned int a = 0; a < w.N; a++)
-        for(unsigned int b = 0; b < n; b++)
-            out(a, b) = T(w(r0 + b, a));
-
-    return out;
-}
-
-template<typename T>
 math::matrix<T> model<T>::narrowed(const math::matrix<float>& w) {
     math::matrix<T> out(w.M, w.N);
 
@@ -342,33 +299,30 @@ void model<T>::load(const gguf& g) {
         expect(g, p + "ffn_norm.weight", d, 1);
         l.ffn_norm()->write(narrowed(g.read(p + "ffn_norm.weight")));
 
-        // A column range per head, transposed.
-        expect(g, p + "attn_q.weight", d, m_conf.heads * dh);
+        // Every one of these is a whole matrix in the file's orientation now
+        // -- no slice, no transpose, so all four can stay in the quantisation
+        // they arrived in. The row slicing that kept attn_output out of that
+        // went with the per-head loop that needed it.
+        struct { const char* name; unsigned int rows; unsigned int cols;
+                 void (block<T>::*set)(const quantised_ptr&);
+                 tensor_ptr& (block<T>::*get)(); } attn[] = {
+            { "attn_q.weight",      d, m_conf.heads * dh,    &block<T>::set_wq, &block<T>::wq },
+            { "attn_k.weight",      d, m_conf.kv_heads * dh, &block<T>::set_wk, &block<T>::wk },
+            { "attn_v.weight",      d, m_conf.kv_heads * dh, &block<T>::set_wv, &block<T>::wv },
+            { "attn_output.weight", m_conf.heads * dh, d,    &block<T>::set_wo, &block<T>::wo }
+        };
 
-        const math::matrix<float> wq = g.read(p + "attn_q.weight");
+        for(const auto& e : attn) {
+            expect(g, p + e.name, e.rows, e.cols);
 
-        for(unsigned int h = 0; h < m_conf.heads; h++)
-            l.wq(h)->write(col_slice_t(wq, h * dh, dh));
+            if(g.tensor(p + e.name).type == gguf::tensor_type::q8_0) {
+                const std::vector<char> raw = g.read_raw(p + e.name);
 
-        expect(g, p + "attn_k.weight", d, m_conf.kv_heads * dh);
-        expect(g, p + "attn_v.weight", d, m_conf.kv_heads * dh);
-
-        const math::matrix<float> wk = g.read(p + "attn_k.weight");
-        const math::matrix<float> wv = g.read(p + "attn_v.weight");
-
-        for(unsigned int h = 0; h < m_conf.kv_heads; h++) {
-            l.wk(h)->write(col_slice_t(wk, h * dh, dh));
-            l.wv(h)->write(col_slice_t(wv, h * dh, dh));
+                (l.*e.set)(m_b.make_q8_0(e.rows, e.cols, raw.data(), raw.size()));
+            }
+            else
+                (l.*e.get)()->write(narrowed(g.read(p + e.name)));
         }
-
-        // A *row* range per head for the output projection, because the heads
-        // are concatenated on its input side rather than its output side.
-        expect(g, p + "attn_output.weight", d, d);
-
-        const math::matrix<float> wo = g.read(p + "attn_output.weight");
-
-        for(unsigned int h = 0; h < m_conf.heads; h++)
-            l.wo(h)->write(row_slice_t(wo, h * dh, dh));
 
         expect(g, p + "ffn_gate.weight", d, m_conf.d_ff);
         expect(g, p + "ffn_up.weight", d, m_conf.d_ff);

--- a/jlib/ai/transformer.hh
+++ b/jlib/ai/transformer.hh
@@ -24,6 +24,7 @@
 #include <jlib/ai/attention.hh>
 #include <jlib/ai/backend.hh>
 
+#include <cmath>
 #include <vector>
 
 namespace jlib {
@@ -113,15 +114,33 @@ public:
     unsigned int d_head() const { return m_d_head; }
     unsigned int d_ff() const { return m_d_ff; }
 
-    /** (d_head x d_model), one per *query* head. */
-    tensor_ptr& wq(unsigned int h) { return m_wq[h]; }
+    /**
+     * One matrix each, in the file's orientation, read with multiply_tn.
+     *
+     * Not one per head, which is what these were until the per-head loop was
+     * measured at 77% of the time to produce a token. A projection for every
+     * head is a single (d_model x d_model) multiply; asking for it thirty-two
+     * times costs thirty-two times the asking and the same amount of doing.
+     *
+     *   wq  d_model x (heads * d_head)
+     *   wk  d_model x (kv_heads * d_head)
+     *   wv  d_model x (kv_heads * d_head)
+     *   wo  (heads * d_head) x d_model, the heads concatenated on its input
+     *
+     * Which is also exactly how a GGUF stores them, so loading is a copy and
+     * they can stay in the quantisation they arrived in -- the row slicing
+     * that stopped wo joining the others is gone with the loop that needed it.
+     */
+    tensor_ptr& wq() { return m_wq; }
+    tensor_ptr& wk() { return m_wk; }
+    tensor_ptr& wv() { return m_wv; }
+    tensor_ptr& wo() { return m_wo; }
 
-    /** (d_head x d_model), one per *key-value* head -- there are fewer. */
-    tensor_ptr& wk(unsigned int h) { return m_wk[h]; }
-    tensor_ptr& wv(unsigned int h) { return m_wv[h]; }
-
-    /** (d_model x d_head), one per head; the heads are summed through these. */
-    tensor_ptr& wo(unsigned int h) { return m_wo[h]; }
+    /** The same four kept in the encoding a file used. */
+    void set_wq(const quantised_ptr& q) { m_wq_q = q; m_wq.reset(); }
+    void set_wk(const quantised_ptr& q) { m_wk_q = q; m_wk.reset(); }
+    void set_wv(const quantised_ptr& q) { m_wv_q = q; m_wv.reset(); }
+    void set_wo(const quantised_ptr& q) { m_wo_q = q; m_wo.reset(); }
 
     /**
      * The feed-forward's three matrices, named for their roles.
@@ -273,20 +292,19 @@ private:
     float m_theta = 10000.0f;
     rope_layout m_layout = rope_layout::interleaved;
 
-    std::vector<tensor_ptr> m_wq, m_wk, m_wv, m_wo;
+    tensor_ptr m_wq, m_wk, m_wv, m_wo;
+    quantised_ptr m_wq_q, m_wk_q, m_wv_q, m_wo_q;
     tensor_ptr m_gate, m_down, m_up;
     quantised_ptr m_gate_q, m_up_q, m_down_q;
     tensor_ptr m_attn_norm, m_ffn_norm;
 
-    tensor_ptr m_norm, m_q, m_scores, m_probs, m_head, m_attn;
+    tensor_ptr m_norm, m_scores, m_probs, m_attn;
 
-    // One per key-value head, not one per query head: the whole point of
-    // grouping is that a group's key and value are computed once and read by
-    // every query head in it.
-    std::vector<tensor_ptr> m_k, m_v;
+    /** Every head side by side: q is d_model tall, k and v narrower. */
+    tensor_ptr m_qs, m_ks, m_vs, m_heads_out;
 
-    /** (d_head x capacity) each, one pair per key-value head. */
-    std::vector<tensor_ptr> m_kc, m_vc;
+    /** ((kv_heads * d_head) x capacity), one tensor rather than one per head. */
+    tensor_ptr m_kc, m_vc;
 
     /** What is allocated now, against m_context which is the ceiling. */
     unsigned int m_capacity = 0;
@@ -316,18 +334,13 @@ block<T>::block(backend<T>& b, unsigned int d_model, unsigned int heads,
                             "key-value head serves a whole group of query "
                             "heads");
 
-    for(unsigned int h = 0; h < heads; h++) {
-        m_wq.push_back(b.make(m_d_head, d_model));
-        m_wo.push_back(b.make(d_model, m_d_head));
-    }
-
-    // Fewer of these, which is the entire saving: TinyLlama has 32 query heads
-    // and 4 key-value heads, so its attn_k is [2048, 256] where attn_q is
-    // [2048, 2048].
-    for(unsigned int h = 0; h < kv_heads; h++) {
-        m_wk.push_back(b.make(m_d_head, d_model));
-        m_wv.push_back(b.make(m_d_head, d_model));
-    }
+    // One matrix each, in the file's orientation.  attn_k is narrower than
+    // attn_q by the ratio of key-value heads to query heads -- [2048, 256]
+    // against [2048, 2048] for TinyLlama, which is grouping visible in a shape.
+    m_wq = b.make(d_model, heads * m_d_head);
+    m_wk = b.make(d_model, kv_heads * m_d_head);
+    m_wv = b.make(d_model, kv_heads * m_d_head);
+    m_wo = b.make(heads * m_d_head, d_model);
 
     // The file's orientation; see w_gate().
     m_gate = b.make(d_model, d_ff);
@@ -361,8 +374,8 @@ void block<T>::enable_cache(unsigned int context) {
     m_cache_len = 0;
     m_capacity = 0;
 
-    m_kc.clear();
-    m_vc.clear();
+    m_kc.reset();
+    m_vc.reset();
 
     // Nothing allocated yet: the first forward() sizes it to what it needs.
 }
@@ -382,21 +395,17 @@ void block<T>::grow_cache(unsigned int need) {
     if(want < need) want = need;
     if(want > m_context) want = m_context;
 
-    std::vector<tensor_ptr> k, v;
+    tensor_ptr k = m_b.make(m_kv_heads * m_d_head, want);
+    tensor_ptr v = m_b.make(m_kv_heads * m_d_head, want);
 
-    for(unsigned int h = 0; h < m_kv_heads; h++) {
-        k.push_back(m_b.make(m_d_head, want));
-        v.push_back(m_b.make(m_d_head, want));
+    if(m_cache_len) {
+        m_b.copy_columns(m_kc, k, 0);
+        m_b.copy_columns(m_vc, v, 0);
 
-        if(m_cache_len) {
-            m_b.copy_columns(m_kc[h], k[h], 0);
-            m_b.copy_columns(m_vc[h], v[h], 0);
-        }
+        // Waited for: the old tensors go out of scope at the swap, and on a
+        // GPU an encoded copy has not run yet when the call returns.
+        m_b.wait();
     }
-
-    // Waited for: the old tensors go out of scope at the swap, and on a GPU an
-    // encoded copy has not run yet when the call returns.
-    if(m_cache_len) m_b.wait();
 
     m_kc.swap(k);
     m_vc.swap(v);
@@ -404,8 +413,8 @@ void block<T>::grow_cache(unsigned int need) {
     m_capacity = want;
 
     // The scores are as tall as the cache, so they move with it.
-    m_scores = m_b.make(m_capacity, m_seq);
-    m_probs = m_b.make(m_capacity, m_seq);
+    m_scores = m_b.make(m_capacity, m_seq * m_heads);
+    m_probs = m_b.make(m_capacity, m_seq * m_heads);
 }
 
 template<typename T>
@@ -423,24 +432,19 @@ void block<T>::reserve(unsigned int seq) {
 
     m_seq = seq;
 
-    m_norm   = m_b.make(m_d_model, seq);
-    m_q      = m_b.make(m_d_head, seq);
+    m_norm       = m_b.make(m_d_model, seq);
+    m_qs         = m_b.make(m_heads * m_d_head, seq);
+    m_ks         = m_b.make(m_kv_heads * m_d_head, seq);
+    m_vs         = m_b.make(m_kv_heads * m_d_head, seq);
+    m_heads_out  = m_b.make(m_heads * m_d_head, seq);
 
-    // As tall as the cache when there is one: the queries are matched against
-    // every key it holds, not only against this batch's.  grow_cache() remakes
-    // these when the capacity changes.
-    m_scores = m_b.make(m_capacity ? m_capacity : seq, seq);
+    // As tall as the cache when there is one, and as wide as every head's
+    // queries side by side.  grow_cache() remakes these when the capacity
+    // changes.
+    m_scores = m_b.make(m_capacity ? m_capacity : seq, seq * m_heads);
 
-    m_k.clear();
-    m_v.clear();
 
-    for(unsigned int h = 0; h < m_kv_heads; h++) {
-        m_k.push_back(m_b.make(m_d_head, seq));
-        m_v.push_back(m_b.make(m_d_head, seq));
-    }
-
-    m_probs  = m_b.make(m_capacity ? m_capacity : seq, seq);
-    m_head   = m_b.make(m_d_head, seq);
+    m_probs  = m_b.make(m_capacity ? m_capacity : seq, seq * m_heads);
     m_attn   = m_b.make(m_d_model, seq);
     m_h1     = m_b.make(m_d_ff, seq);
     m_h3     = m_b.make(m_d_ff, seq);
@@ -470,44 +474,58 @@ void block<T>::forward(const tensor_ptr& x, tensor_ptr& out, bool causal,
 
     if(m_context) grow_cache(at + m_seq);
 
-    // Every key and value first, once each.  Computing them inside the query
-    // loop instead would give the same answer and do the work heads/kv_heads
-    // times over -- which is exactly the cost grouping exists to avoid.
-    for(unsigned int g = 0; g < m_kv_heads; g++) {
-        m_b.multiply(m_wk[g], m_norm, m_k[g]);
-        m_b.multiply(m_wv[g], m_norm, m_v[g]);
+    // One call for every head's queries, and one each for the keys and values.
+    // These were thirty-two and four calls; the arithmetic is identical and the
+    // asking is not.
+    if(m_wq_q) m_b.multiply_tn(m_wq_q, m_norm, m_qs);
+    else m_b.multiply_tn(m_wq, m_norm, m_qs);
 
-        // Keys are rotated here, once, for the same reason.  Values are not
-        // rotated at all -- see set_rope.
-        if(m_rope)
-            m_b.rope(m_k[g], at, m_theta, m_layout);
+    if(m_wk_q) m_b.multiply_tn(m_wk_q, m_norm, m_ks);
+    else m_b.multiply_tn(m_wk, m_norm, m_ks);
 
-        // Rotated before they are stored, so a key is rotated once however
-        // many times it is later read.
-        if(m_context) {
-            m_b.copy_columns(m_k[g], m_kc[g], at);
-            m_b.copy_columns(m_v[g], m_vc[g], at);
-        }
+    if(m_wv_q) m_b.multiply_tn(m_wv_q, m_norm, m_vs);
+    else m_b.multiply_tn(m_wv, m_norm, m_vs);
+
+    // Rotated inside each head, never across the boundary between two.  Values
+    // are not rotated at all -- see set_rope.
+    if(m_rope) {
+        m_b.rope(m_qs, at, m_theta, m_layout, m_d_head);
+        m_b.rope(m_ks, at, m_theta, m_layout, m_d_head);
     }
 
-    for(unsigned int h = 0; h < m_heads; h++) {
-        m_b.multiply(m_wq[h], m_norm, m_q);
-
-        if(m_rope)
-            m_b.rope(m_q, at, m_theta, m_layout);
-
-        const unsigned int g = kv_head_for(h);
-
-        if(m_context)
-            attention(m_b, m_q, m_kc[g], m_vc[g], m_scores, m_probs, m_head,
-                      causal, at);
-        else
-            attention(m_b, m_q, m_k[g], m_v[g], m_scores, m_probs, m_head, causal);
-
-        // beta 0 for the first head and 1 for the rest, which sums the heads
-        // in place of concatenating them and projecting once.
-        m_b.multiply(m_wo[h], m_head, m_attn, T(1), h ? T(1) : T(0));
+    // Rotated before they are stored, so a key is rotated once however many
+    // times it is later read.
+    if(m_context) {
+        m_b.copy_columns(m_ks, m_kc, at);
+        m_b.copy_columns(m_vs, m_vc, at);
     }
+
+    const tensor_ptr& keys = m_context ? m_kc : m_ks;
+    const tensor_ptr& values = m_context ? m_vc : m_vs;
+
+    // And the attention itself, four calls for every head rather than four per
+    // head.  The scale rides here rather than in a pass of its own.
+    m_b.attention_scores(m_qs, keys, m_scores, m_heads, m_kv_heads, m_d_head,
+                         T(1.0f / std::sqrt(float(m_d_head))));
+
+    // The offset is how many keys precede the queries, which is not the same
+    // as where the queries are in the sequence. With a cache they differ only
+    // because the cache holds the earlier keys; without one every key belongs
+    // to this batch and the offset is zero however far along base_pos says the
+    // batch sits. Passing `at` here regardless made base_pos shift the mask,
+    // which the uncached rope test caught immediately -- including its control,
+    // where base_pos should not have mattered at all.
+    if(causal) m_b.causal_mask(m_scores, m_context ? at : 0, m_seq);
+
+    m_b.softmax(m_scores, m_probs);
+
+    m_b.attention_weighted(values, m_probs, m_heads_out, m_heads, m_kv_heads,
+                           m_d_head);
+
+    // The heads arrive concatenated, so summing them is one multiply against
+    // the whole output projection rather than an accumulation per head.
+    if(m_wo_q) m_b.multiply_tn(m_wo_q, m_heads_out, m_attn);
+    else m_b.multiply_tn(m_wo, m_heads_out, m_attn);
 
     m_b.assign(x, out);
     m_b.add_scaled(T(1), m_attn, out);

--- a/jlib/metal/backend.hh
+++ b/jlib/metal/backend.hh
@@ -78,13 +78,21 @@ public:
     void add_scaled(T alpha, const tensor_ptr& x, tensor_ptr& y);
     void assign(const tensor_ptr& src, tensor_ptr& dst);
     void softmax(const tensor_ptr& in, tensor_ptr& out);
-    void causal_mask(tensor_ptr& s, unsigned int key_offset = 0);
+    void causal_mask(tensor_ptr& s, unsigned int key_offset = 0,
+                     unsigned int queries = 0);
+    void attention_scores(const tensor_ptr& q, const tensor_ptr& k,
+                          tensor_ptr& scores, unsigned int heads,
+                          unsigned int kv_heads, unsigned int d_head, T scale);
+    void attention_weighted(const tensor_ptr& v, const tensor_ptr& probs,
+                            tensor_ptr& out, unsigned int heads,
+                            unsigned int kv_heads, unsigned int d_head);
     void copy_columns(const tensor_ptr& src, tensor_ptr& dst,
                       unsigned int dst_first);
     void gather(const tensor_ptr& table, const std::vector<int>& ids,
                 tensor_ptr& out);
     void rope(tensor_ptr& x, unsigned int base_pos = 0, float theta = 10000.0f,
-              ai::rope_layout layout = ai::rope_layout::interleaved);
+              ai::rope_layout layout = ai::rope_layout::interleaved,
+              unsigned int d_head = 0);
     void rms_norm(const tensor_ptr& in, const tensor_ptr& weight,
                   tensor_ptr& out, float eps = 1e-5f);
 

--- a/jlib/metal/backend.mm
+++ b/jlib/metal/backend.mm
@@ -161,8 +161,29 @@ void backend<T>::softmax(const tensor_ptr& in, tensor_ptr& out) {
 }
 
 template<typename T>
-void backend<T>::causal_mask(tensor_ptr& s, unsigned int key_offset) {
-    m_stream->causal_mask(at<T>(s), key_offset);
+void backend<T>::causal_mask(tensor_ptr& s, unsigned int key_offset,
+                             unsigned int queries)
+{
+    m_stream->causal_mask(at<T>(s), key_offset, queries);
+}
+
+template<typename T>
+void backend<T>::attention_scores(const tensor_ptr& q, const tensor_ptr& k,
+                                  tensor_ptr& scores, unsigned int heads,
+                                  unsigned int kv_heads, unsigned int d_head,
+                                  T scale)
+{
+    m_stream->attention_scores(at<T>(q), at<T>(k), at<T>(scores), heads,
+                               kv_heads, d_head, float(scale));
+}
+
+template<typename T>
+void backend<T>::attention_weighted(const tensor_ptr& v, const tensor_ptr& probs,
+                                    tensor_ptr& out, unsigned int heads,
+                                    unsigned int kv_heads, unsigned int d_head)
+{
+    m_stream->attention_weighted(at<T>(v), at<T>(probs), at<T>(out), heads,
+                                 kv_heads, d_head);
 }
 
 /** What make_q8_0 hands back: a device-side weight, and nothing else. */
@@ -220,9 +241,10 @@ void backend<T>::gather(const tensor_ptr& table, const std::vector<int>& ids,
 
 template<typename T>
 void backend<T>::rope(tensor_ptr& x, unsigned int base_pos, float theta,
-                      ai::rope_layout layout)
+                      ai::rope_layout layout, unsigned int d_head)
 {
-    m_stream->rope(at<T>(x), base_pos, theta, layout == ai::rope_layout::split);
+    m_stream->rope(at<T>(x), base_pos, theta,
+                   layout == ai::rope_layout::split, d_head);
 }
 
 template<typename T>

--- a/jlib/metal/tensor.hh
+++ b/jlib/metal/tensor.hh
@@ -229,14 +229,26 @@ public:
     void softmax(const tensor<T>& in, tensor<T>& out);
 
     /** Mask below the diagonal, offset by how many keys precede the queries. */
-    void causal_mask(tensor<T>& s, unsigned int key_offset);
+    void causal_mask(tensor<T>& s, unsigned int key_offset,
+                     unsigned int queries);
+
+    /** Every head's scores in one dispatch; see ai::backend. */
+    void attention_scores(const tensor<T>& q, const tensor<T>& k, tensor<T>& s,
+                          unsigned int heads, unsigned int kv_heads,
+                          unsigned int d_head, float scale);
+
+    /** Every head's weighted sum over values, in one dispatch. */
+    void attention_weighted(const tensor<T>& v, const tensor<T>& p,
+                            tensor<T>& out, unsigned int heads,
+                            unsigned int kv_heads, unsigned int d_head);
 
     /** Copy src's columns into dst starting at a column. */
     void copy_columns(const tensor<T>& src, tensor<T>& dst,
                       unsigned int dst_first);
 
     /** Rotary position embedding, in place; see ai::backend::rope. */
-    void rope(tensor<T>& x, unsigned int base_pos, float theta, bool split);
+    void rope(tensor<T>& x, unsigned int base_pos, float theta, bool split,
+              unsigned int d_head);
 
     /** Column gather: out[:,i] = table[:,ids[i]]. */
     void gather(const tensor<T>& table, const std::vector<int>& ids,

--- a/jlib/metal/tensor.mm
+++ b/jlib/metal/tensor.mm
@@ -223,14 +223,95 @@ kernel void k_causal_mask(device T* s [[buffer(0)]],
                           constant uint& rows [[buffer(1)]],
                           constant uint& cols [[buffer(2)]],
                           constant uint& key_offset [[buffer(3)]],
+                          constant uint& queries [[buffer(4)]],
                           uint c [[thread_position_in_grid]])
 {
     if(c >= cols) return;
 
+    // Which query this column is, when every head's scores sit side by side.
+    const uint per_head = queries ? queries : cols;
+    const uint i = c % per_head;
+
     device T* x = s + (ulong)c * rows;
 
-    for(uint r = c + key_offset + 1; r < rows; r++)
+    for(uint r = i + key_offset + 1; r < rows; r++)
         x[r] = T(-INFINITY);
+}
+
+/**
+ * Every head's scores in one dispatch; see ai::backend::attention_scores.
+ *
+ * One thread per element of the result. The head index is arithmetic here
+ * rather than a separate call, which is the whole point: the per-head loop this
+ * replaces was 77% of the time to produce a token, almost all of it the cost of
+ * asking rather than of doing.
+ */
+template<typename T>
+kernel void k_attn_scores(device const T* q [[buffer(0)]],
+                          device const T* k [[buffer(1)]],
+                          device T* s [[buffer(2)]],
+                          constant uint& queries [[buffer(3)]],
+                          constant uint& keys [[buffer(4)]],
+                          constant uint& heads [[buffer(5)]],
+                          constant uint& group [[buffer(6)]],
+                          constant uint& d_head [[buffer(7)]],
+                          constant float& scale [[buffer(8)]],
+                          uint gid [[thread_position_in_grid]])
+{
+    const uint total = keys * queries * heads;
+
+    if(gid >= total) return;
+
+    const uint j = gid % keys;
+    const uint rest = gid / keys;
+    const uint i = rest % queries;
+    const uint h = rest / queries;
+
+    const uint g = h / group;
+
+    device const T* qc = q + (ulong)i * heads * d_head + (ulong)h * d_head;
+    device const T* kc = k + (ulong)j * (heads / group) * d_head + (ulong)g * d_head;
+
+    float sum = 0.0f;
+
+    for(uint d = 0; d < d_head; d++)
+        sum += float(qc[d]) * float(kc[d]);
+
+    s[(ulong)(h * queries + i) * keys + j] = T(sum * scale);
+}
+
+/** The weighted sum over values, every head at once. */
+template<typename T>
+kernel void k_attn_weighted(device const T* v [[buffer(0)]],
+                            device const T* p [[buffer(1)]],
+                            device T* out [[buffer(2)]],
+                            constant uint& queries [[buffer(3)]],
+                            constant uint& keys [[buffer(4)]],
+                            constant uint& heads [[buffer(5)]],
+                            constant uint& group [[buffer(6)]],
+                            constant uint& d_head [[buffer(7)]],
+                            uint gid [[thread_position_in_grid]])
+{
+    const uint total = heads * d_head * queries;
+
+    if(gid >= total) return;
+
+    const uint d = gid % d_head;
+    const uint rest = gid / d_head;
+    const uint h = rest % heads;
+    const uint i = rest / heads;
+
+    const uint g = h / group;
+    const uint kv_heads = heads / group;
+
+    device const T* pc = p + (ulong)(h * queries + i) * keys;
+
+    float sum = 0.0f;
+
+    for(uint j = 0; j < keys; j++)
+        sum += float(v[(ulong)j * kv_heads * d_head + g * d_head + d]) * float(pc[j]);
+
+    out[(ulong)i * heads * d_head + h * d_head + d] = T(sum);
 }
 
 /** Copy src's columns into dst starting at a column; see ai::backend. */
@@ -265,22 +346,30 @@ kernel void k_rope(device T* x [[buffer(0)]],
                    constant uint& base_pos [[buffer(3)]],
                    constant float& theta [[buffer(4)]],
                    constant uint& split [[buffer(5)]],
+                   constant uint& d_head [[buffer(6)]],
                    uint i [[thread_position_in_grid]])
 {
     // Not `half`: that is the fp16 type in MSL, and naming a variable after it
     // fails to compile in a way whose message points at the declaration rather
     // than at the name.
-    const uint planes = rows / 2;
+    // One head unless told otherwise: a rotation happens inside a head and
+    // never across the boundary between two stacked in the same column.
+    const uint dh = d_head ? d_head : rows;
+    const uint planes = dh / 2;
+    const uint per_col = (rows / dh) * planes;
 
-    if(i >= cols * planes) return;
+    if(i >= cols * per_col) return;
 
-    const uint c = i / planes;
-    const uint j = i % planes;
+    const uint c = i / per_col;
+    const uint within = i % per_col;
+    const uint head = within / planes;
+    const uint j = within % planes;
 
-    const uint a = split ? j : 2 * j;
-    const uint b = split ? j + planes : 2 * j + 1;
+    const uint base = head * dh;
+    const uint a = base + (split ? j : 2 * j);
+    const uint b = base + (split ? j + planes : 2 * j + 1);
 
-    const float freq = pow(theta, -2.0f * float(j) / float(rows));
+    const float freq = pow(theta, -2.0f * float(j) / float(dh));
     const float angle = float(base_pos + c) * freq;
 
     const float co = cos(angle);
@@ -408,9 +497,29 @@ INSTANTIATE(k_softmax, float, "_f32")(device const float*, device float*,
 INSTANTIATE(k_softmax, half, "_f16")(device const half*, device half*,
                                      constant uint&, constant uint&, uint);
 INSTANTIATE(k_causal_mask, float, "_f32")(device float*, constant uint&,
-                                          constant uint&, constant uint&, uint);
+                                          constant uint&, constant uint&,
+                                          constant uint&, uint);
 INSTANTIATE(k_causal_mask, half, "_f16")(device half*, constant uint&,
-                                         constant uint&, constant uint&, uint);
+                                         constant uint&, constant uint&,
+                                         constant uint&, uint);
+INSTANTIATE(k_attn_scores, float, "_f32")(device const float*, device const float*,
+                                          device float*, constant uint&,
+                                          constant uint&, constant uint&,
+                                          constant uint&, constant uint&,
+                                          constant float&, uint);
+INSTANTIATE(k_attn_scores, half, "_f16")(device const half*, device const half*,
+                                         device half*, constant uint&,
+                                         constant uint&, constant uint&,
+                                         constant uint&, constant uint&,
+                                         constant float&, uint);
+INSTANTIATE(k_attn_weighted, float, "_f32")(device const float*, device const float*,
+                                            device float*, constant uint&,
+                                            constant uint&, constant uint&,
+                                            constant uint&, constant uint&, uint);
+INSTANTIATE(k_attn_weighted, half, "_f16")(device const half*, device const half*,
+                                           device half*, constant uint&,
+                                           constant uint&, constant uint&,
+                                           constant uint&, constant uint&, uint);
 INSTANTIATE(k_copy_columns, float, "_f32")(device const float*, device float*,
                                            constant uint&, constant uint&,
                                            constant uint&, uint);
@@ -433,10 +542,10 @@ INSTANTIATE(k_gather, half, "_f16")(device const half*, device half*,
                                     constant uint&, uint);
 INSTANTIATE(k_rope, float, "_f32")(device float*, constant uint&, constant uint&,
                                    constant uint&, constant float&,
-                                   constant uint&, uint);
+                                   constant uint&, constant uint&, uint);
 INSTANTIATE(k_rope, half, "_f16")(device half*, constant uint&, constant uint&,
                                   constant uint&, constant float&,
-                                  constant uint&, uint);
+                                  constant uint&, constant uint&, uint);
 INSTANTIATE(k_rms_norm, float, "_f32")(device const float*, device const float*,
                                        device float*, constant uint&,
                                        constant uint&, constant float&, uint);
@@ -552,6 +661,8 @@ struct stream<T>::impl {
     id<MTLComputePipelineState> rope = nil;
     id<MTLComputePipelineState> gather = nil;
     id<MTLComputePipelineState> q8_gemv = nil;
+    id<MTLComputePipelineState> attn_scores = nil;
+    id<MTLComputePipelineState> attn_weighted = nil;
     id<MTLComputePipelineState> rms_norm = nil;
 
     // Buffers made for one encoded operation and needed until the command
@@ -578,6 +689,8 @@ struct pipelines {
     id<MTLComputePipelineState> rope = nil;
     id<MTLComputePipelineState> gather = nil;
     id<MTLComputePipelineState> q8_gemv = nil;
+    id<MTLComputePipelineState> attn_scores = nil;
+    id<MTLComputePipelineState> attn_weighted = nil;
     id<MTLComputePipelineState> rms_norm = nil;
 };
 
@@ -634,6 +747,8 @@ pipelines& compiled(id<MTLDevice> gpu) {
         { "k_rope",       &p.rope },
         { "k_gather",     &p.gather },
         { "k_q8_gemv",    &p.q8_gemv },
+        { "k_attn_scores", &p.attn_scores },
+        { "k_attn_weighted", &p.attn_weighted },
         { "k_rms_norm",   &p.rms_norm },
     };
 
@@ -702,6 +817,8 @@ stream<T>::stream(std::shared_ptr<device> d)
     m_impl->rope = p.rope;
     m_impl->gather = p.gather;
     m_impl->q8_gemv = p.q8_gemv;
+    m_impl->attn_scores = p.attn_scores;
+    m_impl->attn_weighted = p.attn_weighted;
     m_impl->held = [NSMutableArray array];
     m_impl->rms_norm = p.rms_norm;
 }
@@ -865,7 +982,9 @@ void stream<T>::softmax(const tensor<T>& in, tensor<T>& out) {
 }
 
 template<typename T>
-void stream<T>::causal_mask(tensor<T>& s, unsigned int key_offset) {
+void stream<T>::causal_mask(tensor<T>& s, unsigned int key_offset,
+                            unsigned int queries)
+{
     open();
 
     const unsigned int rows = s.rows();
@@ -876,6 +995,7 @@ void stream<T>::causal_mask(tensor<T>& s, unsigned int key_offset) {
     [m_impl->enc setBytes:&rows length:sizeof(rows) atIndex:1];
     [m_impl->enc setBytes:&cols length:sizeof(cols) atIndex:2];
     [m_impl->enc setBytes:&key_offset length:sizeof(key_offset) atIndex:3];
+    [m_impl->enc setBytes:&queries length:sizeof(queries) atIndex:4];
 
     dispatch(m_impl->enc, m_impl->causal_mask, cols);
 
@@ -915,7 +1035,7 @@ void stream<T>::copy_columns(const tensor<T>& src, tensor<T>& dst,
 
 template<typename T>
 void stream<T>::rope(tensor<T>& x, unsigned int base_pos, float theta,
-                     bool split)
+                     bool split, unsigned int d_head)
 {
     if(x.rows() % 2)
         throw typename tensor<T>::exception("rope: rotates in planes, so it "
@@ -934,6 +1054,7 @@ void stream<T>::rope(tensor<T>& x, unsigned int base_pos, float theta,
     [m_impl->enc setBytes:&base_pos length:sizeof(base_pos) atIndex:3];
     [m_impl->enc setBytes:&theta length:sizeof(theta) atIndex:4];
     [m_impl->enc setBytes:&is_split length:sizeof(is_split) atIndex:5];
+    [m_impl->enc setBytes:&d_head length:sizeof(d_head) atIndex:6];
 
     // One thread per rotation plane per column, not per column: d_head is
     // small and the sequence can be long, so this is where the parallelism is.
@@ -1050,6 +1171,60 @@ void stream<T>::multiply_tn(const qweight& w, const tensor<T>& x, tensor<T>& y,
     [m_impl->enc setBytes:&beta length:sizeof(beta) atIndex:7];
 
     dispatch(m_impl->enc, m_impl->q8_gemv, N * ncols);
+
+    m_impl->pending++;
+}
+
+template<typename T>
+void stream<T>::attention_scores(const tensor<T>& q, const tensor<T>& k,
+                                 tensor<T>& s, unsigned int heads,
+                                 unsigned int kv_heads, unsigned int d_head,
+                                 float scale)
+{
+    open();
+
+    const unsigned int queries = q.cols();
+    const unsigned int keys = k.cols();
+    const unsigned int group = heads / kv_heads;
+
+    [m_impl->enc setComputePipelineState:m_impl->attn_scores];
+    [m_impl->enc setBuffer:q.m_impl->buf offset:0 atIndex:0];
+    [m_impl->enc setBuffer:k.m_impl->buf offset:0 atIndex:1];
+    [m_impl->enc setBuffer:s.m_impl->buf offset:0 atIndex:2];
+    [m_impl->enc setBytes:&queries length:sizeof(queries) atIndex:3];
+    [m_impl->enc setBytes:&keys length:sizeof(keys) atIndex:4];
+    [m_impl->enc setBytes:&heads length:sizeof(heads) atIndex:5];
+    [m_impl->enc setBytes:&group length:sizeof(group) atIndex:6];
+    [m_impl->enc setBytes:&d_head length:sizeof(d_head) atIndex:7];
+    [m_impl->enc setBytes:&scale length:sizeof(scale) atIndex:8];
+
+    dispatch(m_impl->enc, m_impl->attn_scores, keys * queries * heads);
+
+    m_impl->pending++;
+}
+
+template<typename T>
+void stream<T>::attention_weighted(const tensor<T>& v, const tensor<T>& p,
+                                   tensor<T>& out, unsigned int heads,
+                                   unsigned int kv_heads, unsigned int d_head)
+{
+    open();
+
+    const unsigned int keys = v.cols();
+    const unsigned int queries = out.cols();
+    const unsigned int group = heads / kv_heads;
+
+    [m_impl->enc setComputePipelineState:m_impl->attn_weighted];
+    [m_impl->enc setBuffer:v.m_impl->buf offset:0 atIndex:0];
+    [m_impl->enc setBuffer:p.m_impl->buf offset:0 atIndex:1];
+    [m_impl->enc setBuffer:out.m_impl->buf offset:0 atIndex:2];
+    [m_impl->enc setBytes:&queries length:sizeof(queries) atIndex:3];
+    [m_impl->enc setBytes:&keys length:sizeof(keys) atIndex:4];
+    [m_impl->enc setBytes:&heads length:sizeof(heads) atIndex:5];
+    [m_impl->enc setBytes:&group length:sizeof(group) atIndex:6];
+    [m_impl->enc setBytes:&d_head length:sizeof(d_head) atIndex:7];
+
+    dispatch(m_impl->enc, m_impl->attn_weighted, heads * d_head * queries);
 
     m_impl->pending++;
 }

--- a/tests/ai_backend_test.cc
+++ b/tests/ai_backend_test.cc
@@ -1137,6 +1137,146 @@ static void a_quantised_weight_multiplies(const char* name,
     }
 }
 
+/**
+ * Every head at once gives what one head at a time gave.
+ *
+ * The per-head loop it replaces was 77% of the time to produce a token -- 4928
+ * small multiplies each costing about 16us to ask for and almost nothing to do.
+ * This is the same arithmetic with the head index moved inside the kernel, and
+ * the reference here is that arithmetic written out per head by hand.
+ */
+template<typename T>
+static void every_head_at_once(const char* name,
+                               std::vector<ai::backend<T>*>& backends)
+{
+    std::cout << "\nevery head at once, " << name << ":\n";
+
+    const uint heads = 4;
+    const uint kv_heads = 2;
+    const uint dh = 6;
+    const uint queries = 3;
+    const uint keys = 5;
+
+    std::mt19937 gen(131);
+
+    const matrix<T> q = random_matrix<T>(heads * dh, queries, gen);
+    const matrix<T> k = random_matrix<T>(kv_heads * dh, keys, gen);
+    const matrix<T> v = random_matrix<T>(kv_heads * dh, keys, gen);
+
+    const float scale = 0.5f;
+
+    // Written out by hand, head by head, which is what the block used to do.
+    matrix<T> want_s(keys, queries * heads);
+    matrix<T> want_o(heads * dh, queries);
+
+    const uint group = heads / kv_heads;
+
+    for(uint h = 0; h < heads; h++) {
+        const uint g = h / group;
+
+        for(uint i = 0; i < queries; i++)
+            for(uint j = 0; j < keys; j++) {
+                double sum = 0;
+
+                for(uint d = 0; d < dh; d++)
+                    sum += double(float(q(h * dh + d, i))) *
+                           double(float(k(g * dh + d, j)));
+
+                want_s(j, h * queries + i) = T(float(sum) * scale);
+            }
+    }
+
+    // The weighted sum uses the scores as its probabilities, which is not what
+    // attention does but is what makes this a test of the multiply alone.
+    for(uint h = 0; h < heads; h++) {
+        const uint g = h / group;
+
+        for(uint i = 0; i < queries; i++)
+            for(uint d = 0; d < dh; d++) {
+                double sum = 0;
+
+                for(uint j = 0; j < keys; j++)
+                    sum += double(float(v(g * dh + d, j))) *
+                           double(float(want_s(j, h * queries + i)));
+
+                want_o(h * dh + d, i) = T(sum);
+            }
+    }
+
+    for(ai::backend<T>* b : backends) {
+        typename ai::backend<T>::tensor_ptr tq = b->make(q);
+        typename ai::backend<T>::tensor_ptr tk = b->make(k);
+        typename ai::backend<T>::tensor_ptr tv = b->make(v);
+
+        typename ai::backend<T>::tensor_ptr ts = b->make(keys, queries * heads);
+        typename ai::backend<T>::tensor_ptr to = b->make(heads * dh, queries);
+
+        b->attention_scores(tq, tk, ts, heads, kv_heads, dh, T(scale));
+        b->attention_weighted(tv, ts, to, heads, kv_heads, dh);
+        b->wait();
+
+        const double ds = worst(ts->read(), want_s);
+        const double dobj = worst(to->read(), want_o);
+
+        ok(std::string("  ") + b->name() + ": the scores match head by head",
+           ds < ((sizeof(T) == 2) ? 2e-2 : 1e-4), std::to_string(ds));
+
+        ok(std::string("  ") + b->name() + ": and so does the weighted sum",
+           dobj < ((sizeof(T) == 2) ? 1e-1 : 1e-3), std::to_string(dobj));
+    }
+}
+
+/** The mask, when every head's scores sit side by side. */
+template<typename T>
+static void the_mask_knows_where_a_head_ends(const char* name,
+                                             std::vector<ai::backend<T>*>& backends)
+{
+    std::cout << "\nthe mask knows where a head ends, " << name << ":\n";
+
+    const uint keys = 6;
+    const uint queries = 3;
+    const uint heads = 2;
+    const uint offset = 2;
+
+    for(ai::backend<T>* b : backends) {
+        matrix<T> ones(keys, queries * heads);
+
+        for(uint r = 0; r < keys; r++)
+            for(uint c = 0; c < queries * heads; c++)
+                ones(r,c) = T(1.0f);
+
+        typename ai::backend<T>::tensor_ptr t = b->make(ones);
+
+        b->causal_mask(t, offset, queries);
+        b->wait();
+
+        const matrix<T> got = t->read();
+
+        bool right = true;
+
+        for(uint c = 0; c < queries * heads; c++) {
+            const uint i = c % queries;      // which query, within its head
+
+            for(uint r = 0; r < keys; r++)
+                if((!std::isfinite(float(got(r,c)))) != (r > i + offset))
+                    right = false;
+        }
+
+        ok(std::string("  ") + b->name() + ": each head is masked from its own "
+           "first query", right);
+
+        // Without the width it would treat the whole row of columns as one
+        // head, and the second head would be masked as though it came later.
+        typename ai::backend<T>::tensor_ptr u = b->make(ones);
+
+        b->causal_mask(u, offset);
+        b->wait();
+
+        ok(std::string("  ") + b->name() + ": which is not what it does without "
+           "being told the width", worst(got, u->read()) > 0.0);
+    }
+}
+
 static void a_tensor_from_the_wrong_backend_is_refused() {
     std::cout << "\na tensor from the wrong backend is refused:\n";
 
@@ -1204,6 +1344,8 @@ int main() {
         the_offset_mask<float>("float", b);
         beta_zero_does_not_read_the_output<float>("float", b);
         a_quantised_weight_multiplies<float>("float", b);
+        every_head_at_once<float>("float", b);
+        the_mask_knows_where_a_head_ends<float>("float", b);
 #else
         one_type<float>("float", b);
         the_reductions<float>("float", b);
@@ -1220,6 +1362,8 @@ int main() {
         the_offset_mask<float>("float", b);
         beta_zero_does_not_read_the_output<float>("float", b);
         a_quantised_weight_multiplies<float>("float", b);
+        every_head_at_once<float>("float", b);
+        the_mask_knows_where_a_head_ends<float>("float", b);
 #endif
     }
 
@@ -1247,6 +1391,8 @@ int main() {
         the_offset_mask<_Float16>("_Float16", b);
         beta_zero_does_not_read_the_output<_Float16>("_Float16", b);
         a_quantised_weight_multiplies<_Float16>("_Float16", b);
+        every_head_at_once<_Float16>("_Float16", b);
+        the_mask_knows_where_a_head_ends<_Float16>("_Float16", b);
     }
 
     a_tensor_from_the_wrong_backend_is_refused();

--- a/tests/ai_model_test.cc
+++ b/tests/ai_model_test.cc
@@ -449,15 +449,11 @@ static void fill_randomly(ai::model<float>& m, std::mt19937& gen) {
         l.attn_norm()->write(ones);
         l.ffn_norm()->write(ones);
 
-        for(unsigned int h = 0; h < c.heads; h++) {
-            l.wq(h)->write(rnd(dh, c.d_model));
-            l.wo(h)->write(rnd(c.d_model, dh));
-        }
-
-        for(unsigned int h = 0; h < c.kv_heads; h++) {
-            l.wk(h)->write(rnd(dh, c.d_model));
-            l.wv(h)->write(rnd(dh, c.d_model));
-        }
+        // One matrix each, in the file's orientation.
+        l.wq()->write(rnd(c.d_model, c.heads * dh));
+        l.wk()->write(rnd(c.d_model, c.kv_heads * dh));
+        l.wv()->write(rnd(c.d_model, c.kv_heads * dh));
+        l.wo()->write(rnd(c.heads * dh, c.d_model));
 
         // The file's orientation: gate and up are (d_model x d_ff), down the
         // other way, each read with multiply_tn.

--- a/tests/ai_transformer_test.cc
+++ b/tests/ai_transformer_test.cc
@@ -81,24 +81,22 @@ static const unsigned int N = 5;
  */
 template<typename T>
 struct weights {
-    unsigned int heads, kv;
+    unsigned int heads, kv, dh;
 
-    std::vector<matrix<T> > wq, wk, wv, wo;
-    matrix<T> w1, w3, w2, an, fn;
+    // One matrix each, in the file's orientation: wq is d_model by every
+    // head's width, wo the other way round with the heads on its input side.
+    matrix<T> wq, wk, wv, wo, w1, w3, w2, an, fn;
 
     weights(std::mt19937& gen, unsigned int nh = H, unsigned int nkv = H)
-        : heads(nh), kv(nkv),
+        : heads(nh), kv(nkv), dh(D / nh),
+          wq(D, nh * (D / nh)), wk(D, nkv * (D / nh)), wv(D, nkv * (D / nh)),
+          wo(nh * (D / nh), D),
           w1(D, F), w3(D, F), w2(F, D), an(D, 1), fn(D, 1)
     {
-        for(unsigned int h = 0; h < heads; h++) {
-            wq.push_back(random_matrix<T>(D / heads, D, gen, 0.5f));
-            wo.push_back(random_matrix<T>(D, D / heads, gen, 0.5f));
-        }
-
-        for(unsigned int g = 0; g < kv; g++) {
-            wk.push_back(random_matrix<T>(D / heads, D, gen, 0.5f));
-            wv.push_back(random_matrix<T>(D / heads, D, gen, 0.5f));
-        }
+        wq = random_matrix<T>(D, heads * dh, gen, 0.5f);
+        wk = random_matrix<T>(D, kv * dh, gen, 0.5f);
+        wv = random_matrix<T>(D, kv * dh, gen, 0.5f);
+        wo = random_matrix<T>(heads * dh, D, gen, 0.5f);
 
         w1 = random_matrix<T>(D, F, gen, 0.5f);
         w3 = random_matrix<T>(D, F, gen, 0.5f);
@@ -106,19 +104,34 @@ struct weights {
 
         for(unsigned int r = 0; r < D; r++) { an(r,0) = T(1.0f); fn(r,0) = T(1.0f); }
     }
+
+    /** Head h's own columns of wq, which is where it reads its queries from. */
+    void bump_query_head(unsigned int h, float by) {
+        for(unsigned int r = 0; r < D; r++)
+            for(unsigned int c = h * dh; c < (h + 1) * dh; c++)
+                wq(r,c) = T(float(wq(r,c)) + by);
+    }
+
+    /** And head h's own *rows* of wo, which is where it reaches the output. */
+    void silence_output_head(unsigned int h) {
+        for(unsigned int r = h * dh; r < (h + 1) * dh; r++)
+            for(unsigned int c = 0; c < D; c++)
+                wo(r,c) = T(0.0f);
+    }
+
+    void bump_kv_head(unsigned int g, float by) {
+        for(unsigned int r = 0; r < D; r++)
+            for(unsigned int c = g * dh; c < (g + 1) * dh; c++)
+                wk(r,c) = T(float(wk(r,c)) + by);
+    }
 };
 
 template<typename T>
 static void load(ai::block<T>& blk, const weights<T>& w) {
-    for(unsigned int h = 0; h < w.heads; h++) {
-        blk.wq(h)->write(w.wq[h]);
-        blk.wo(h)->write(w.wo[h]);
-    }
-
-    for(unsigned int g = 0; g < w.kv; g++) {
-        blk.wk(g)->write(w.wk[g]);
-        blk.wv(g)->write(w.wv[g]);
-    }
+    blk.wq()->write(w.wq);
+    blk.wk()->write(w.wk);
+    blk.wv()->write(w.wv);
+    blk.wo()->write(w.wo);
 
     blk.w_gate()->write(w.w1);
     blk.w_up()->write(w.w3);
@@ -167,10 +180,7 @@ static void a_zeroed_block_is_the_identity(const char* name,
 
     weights<T> w(gen);
 
-    for(unsigned int h = 0; h < H; h++)
-        for(unsigned int r = 0; r < D; r++)
-            for(unsigned int c = 0; c < D / H; c++)
-                w.wo[h](r,c) = T(0.0f);
+    for(unsigned int h = 0; h < H; h++) w.silence_output_head(h);
 
     for(unsigned int r = 0; r < F; r++)
         for(unsigned int c = 0; c < D; c++)
@@ -258,20 +268,15 @@ static void heads_are_routed_separately(const char* name,
 
     weights<T> w(gen);
 
-    for(unsigned int r = 0; r < D; r++)
-        for(unsigned int c = 0; c < D / H; c++)
-            w.wo[1](r,c) = T(0.0f);
+    w.silence_output_head(1);
 
     const matrix<T> x = random_matrix<T>(D, N, gen);
 
     weights<T> bumped_1 = w;
     weights<T> bumped_0 = w;
 
-    for(unsigned int r = 0; r < D / H; r++)
-        for(unsigned int c = 0; c < D; c++) {
-            bumped_1.wq[1](r,c) = T(float(bumped_1.wq[1](r,c)) + 1.0f);
-            bumped_0.wq[0](r,c) = T(float(bumped_0.wq[0](r,c)) + 1.0f);
-        }
+    bumped_1.bump_query_head(1, 1.0f);
+    bumped_0.bump_query_head(0, 1.0f);
 
     for(ai::backend<T>* b : backends) {
         const matrix<T> base = run(*b, w, x);
@@ -303,27 +308,32 @@ static void the_heads_are_summed(const char* name,
 
     weights<T> one(gen);
 
-    one.wq[1] = one.wq[0];
-    one.wk[1] = one.wk[0];
-    one.wv[1] = one.wv[0];
-    one.wo[1] = one.wo[0];
+    // Both heads given the same weights, so they compute the same thing.
+    for(unsigned int r = 0; r < D; r++)
+        for(unsigned int c = 0; c < one.dh; c++) {
+            one.wq(r, one.dh + c) = one.wq(r, c);
+            one.wk(r, one.dh + c) = one.wk(r, c);
+            one.wv(r, one.dh + c) = one.wv(r, c);
+        }
+
+    for(unsigned int r = 0; r < one.dh; r++)
+        for(unsigned int c = 0; c < D; c++)
+            one.wo(one.dh + r, c) = one.wo(r, c);
 
     weights<T> split = one;
 
-    for(unsigned int r = 0; r < D; r++)
-        for(unsigned int c = 0; c < D / H; c++) {
-            const float half = float(one.wo[0](r,c)) * 0.5f;
+    for(unsigned int r = 0; r < one.dh; r++)
+        for(unsigned int c = 0; c < D; c++) {
+            const float half = float(one.wo(r,c)) * 0.5f;
 
-            split.wo[0](r,c) = T(half);
-            split.wo[1](r,c) = T(half);
+            split.wo(r,c) = T(half);
+            split.wo(one.dh + r, c) = T(half);
         }
 
     // And the single-head reference: all of it through head 0, none through 1.
     weights<T> only_0 = one;
 
-    for(unsigned int r = 0; r < D; r++)
-        for(unsigned int c = 0; c < D / H; c++)
-            only_0.wo[1](r,c) = T(0.0f);
+    only_0.silence_output_head(1);
 
     const matrix<T> x = random_matrix<T>(D, N, gen);
 
@@ -595,11 +605,22 @@ static void sharing_a_head_equals_duplicating_it(
 
     // And the same thing spelled out: four query heads with four key-value
     // heads that are all copies of the one above.
-    weights<T> spelled = grouped;
+    // The same key and value repeated across four heads, which is what one
+    // shared between four means.
+    weights<T> spelled(gen, 4, 4);
 
-    spelled.kv = 4;
-    spelled.wk.assign(4, grouped.wk[0]);
-    spelled.wv.assign(4, grouped.wv[0]);
+    spelled.wq = grouped.wq;
+    spelled.wo = grouped.wo;
+    spelled.w1 = grouped.w1;
+    spelled.w3 = grouped.w3;
+    spelled.w2 = grouped.w2;
+
+    for(unsigned int g = 0; g < 4; g++)
+        for(unsigned int r = 0; r < D; r++)
+            for(unsigned int c = 0; c < spelled.dh; c++) {
+                spelled.wk(r, g * spelled.dh + c) = grouped.wk(r, c);
+                spelled.wv(r, g * spelled.dh + c) = grouped.wv(r, c);
+            }
 
     const matrix<T> x = random_matrix<T>(D, N, gen);
 
@@ -636,22 +657,16 @@ static void the_grouping_is_contiguous(const char* name,
 
     weights<T> w(gen, 4, 2);
 
-    for(unsigned int r = 0; r < D; r++)
-        for(unsigned int c = 0; c < D / 4; c++) {
-            w.wo[2](r,c) = T(0.0f);
-            w.wo[3](r,c) = T(0.0f);
-        }
+    w.silence_output_head(2);
+    w.silence_output_head(3);
 
     const matrix<T> x = random_matrix<T>(D, N, gen);
 
     weights<T> bump_kv1 = w;
     weights<T> bump_kv0 = w;
 
-    for(unsigned int r = 0; r < D / 4; r++)
-        for(unsigned int c = 0; c < D; c++) {
-            bump_kv1.wk[1](r,c) = T(float(bump_kv1.wk[1](r,c)) + 1.0f);
-            bump_kv0.wk[0](r,c) = T(float(bump_kv0.wk[0](r,c)) + 1.0f);
-        }
+    bump_kv1.bump_kv_head(1, 1.0f);
+    bump_kv0.bump_kv_head(0, 1.0f);
 
     for(ai::backend<T>* b : backends) {
         const matrix<T> base = run(*b, w, x);
@@ -693,9 +708,8 @@ static void a_tinyllama_shaped_block(const char* name, ai::backend<T>& b) {
     // Which makes the key projection a quarter the width of the query
     // projection -- exactly the [2048, 256] against [2048, 2048] in the file.
     ok("  so the key weights are a quarter the width of the query weights",
-       blk.wk(0)->rows() * blk.kv_heads() == 256 &&
-       blk.wq(0)->rows() * blk.heads() == 2048,
-       std::to_string(blk.wk(0)->rows() * blk.kv_heads()));
+       blk.wk()->cols() == 256 && blk.wq()->cols() == 2048,
+       std::to_string(blk.wk()->cols()));
 }
 
 template<typename T>


### PR DESCRIPTION
# Attention, all heads at once

The last branch found the per-head attention loop was most of the cost of a
token and filed #163. This is that.

```
$ jchat model.gguf "write a Hello World program in Erlang"
[loaded in 0.887s]
...
[230 tokens in 6.23s, 36.89/s]
```

| | decode step | tokens/s |
| --- | --- | --- |
| before | 105.7 ms | 8.01 |
| after | **24.4 ms** | **36.89** |

**4.6x**, and the 230 tokens are byte-identical to every earlier version.

## What the measurement said to do

Timing a decode step with parts removed, before any of this was written:

| | decode step |
| --- | --- |
| everything | 105.7 ms |
| attention only, feed-forward skipped | 95.6 ms |
| feed-forward only, per-head loop skipped | 24.2 ms |

**The per-head loop was 81.5ms of 105.7 -- 77% of a token.** Not arithmetic:
4928 small multiplies per token, each about 16us to ask for and almost nothing
to do. A (2048 x 64) projection, which is what one head is, runs at 12.3 GB/s;
the same arithmetic for all 32 heads in one call runs at 118.8.

The prediction from that was ~3.3x. It came out 4.6x, and the residual decode
step is 24.4ms against the 24.2ms the feed-forward-only measurement predicted --
so the loop's cost is gone rather than reduced.

## What changed

The head index moved **inside the kernels**. Two new backend operations,
`attention_scores` and `attention_weighted`, each doing every head in one
dispatch; `causal_mask` learned how wide one head's queries are, so it can mask
each head from its own first query; and `rope` learned how tall a head is, so it
rotates within one and never across the boundary between two.

No tensor views, no batched MPS, no restructuring of how anything is stored --
the arithmetic that used to select a head by slicing now selects it by index.

Per layer that takes ~244 dispatches to ~11:

```
before   4 kv heads x 5 ops + 32 query heads x 7 ops    = 244
after    3 projections + 2 ropes + 2 copies
         + scores + mask + softmax + weighted + output  =  11
```

## What fell out of it

**The weights are one matrix each, in the file's orientation.** `wq(h)` became
`wq()`, and `model::load` -- which used to transpose a column range per head for
q, k and v and a *row* range for the output projection -- is now a copy.

Which closes the part of #158 that was blocked. Q8_0 blocks run along the
contiguous dimension and do not survive a transpose, so `attn_output` could not
be quantised while it was being row-sliced. It is not sliced any more, so all
four attention weights are now kept in the file's encoding along with the
feed-forward's and the head. That is **every weight in the model except the
embedding table**, and it shows up in the load time and the footprint:

| | load | memory |
| --- | --- | --- |
| two branches ago | 4.28s | 4.05GB |
| now | **0.89s** | **1.62GB** |

## The bug my own tests caught

The first version passed `at` -- where the batch sits in the sequence -- as the
mask's key offset in every case. That is right with a cache and wrong without
one: the offset is how many keys *precede* the queries, and without a cache
every key belongs to the current batch, so it is zero however far along the
sequence the batch is.

`sliding_the_window_changes_nothing` failed, and so did **its control** -- the
assertion that without rope, `base_pos` is ignored rather than honoured. That
control existed because a test that only checks the interesting case can pass
for the wrong reason; here it was the half that identified the bug, since a mask
shifting with `base_pos` is exactly what "not ignored" looks like.

## Tests

- **every head at once** gives what one head at a time gave, checked against the
  per-head arithmetic written out by hand. Both element types, both backends,
  agreement 0.
- **the mask knows where a head ends** -- each head masked from its own first
  query, and *different* from what it does when not told the width, so the
  parameter is shown to matter.
- every existing block test still passes with the weights as whole matrices:
  the zeroed identity, causality, head routing, grouped-query equivalence, the
  scale invariance, and the rope properties.
- `ai_model_test` still answers **Rome** and still continues with the exact
  string it did before.

## Verification

- macOS `make check`: 75 tests, 71 pass, 4 skip, 0 fail.
- Container: the new kernels have host implementations, so they run there.
- By hand: 230 tokens byte-identical to the pre-cache, pre-quantisation and
  pre-batching versions of the same prompt.

## What this does not establish

**That the kernels are good, only that they are enough.** `attention_scores` is
one thread per output element with a serial loop over the head dimension, and
`attention_weighted` likewise over the keys. Neither uses threadgroup memory or
cooperates across a warp. At decode, where there is one query, that is fine
because the work is small; at prefill over a long prompt these become the naive
GEMM they look like, and MPS would beat them.

**Nothing about long contexts.** The scores matrix is now
`capacity x (queries * heads)`, so it grows with the head count as well as the
context -- at 2048 context and 32 heads that is 128K entries per layer for a
single token, which is fine, and would not be if the head count were much larger.

**And the arc's numbers are for one model on one machine.** TinyLlama 1.1B in
fp16 on an M5. The shape of the argument -- that asking costs more than doing,
until you stop asking so often -- should carry; the constants will not.
