### PR TITLE
Bound the mail clients' reads, and the TLS handshake too, which needs the deadline in the constructor rather than after

### DIFF
--- a/jlib/net/Imap4.cc
+++ b/jlib/net/Imap4.cc
@@ -451,7 +451,10 @@ namespace jlib {
                                                                  phost, 
                                                                  pport);
                         } else {
-                            sock = new sys::sslstream(m_host,m_port);
+                            // In the constructor because that is where the
+                            // handshake is; see Pop3::connect.
+                            sock = new sys::sslstream(m_host, m_port, false,
+                                                      -1, m_timeout);
                         }
                     }
                     else if(use_starttls()) {
@@ -468,7 +471,8 @@ namespace jlib {
                             sock = new sys::tlsproxystream(m_host, m_port,
                                                            phost, pport, true);
                         } else {
-                            sock = new sys::tlsstream(m_host, m_port, true);
+                            sock = new sys::tlsstream(m_host, m_port, true,
+                                                      -1, m_timeout);
                         }
                     }
                     else {
@@ -500,7 +504,12 @@ namespace jlib {
             if(getenv("JLIB_NET_IMAP4_DEBUG")) std::cout << "done opening"<<std::endl;
 
             sock->exceptions(std::ios_base::failbit | std::ios_base::badbit | std::ios_base::eofbit );
-            
+
+            // The proxying paths do not take it in their constructors yet, so
+            // they get it here -- which covers the greeting below but not a
+            // handshake inside a constructor. The two direct paths pass it in.
+            if(m_timeout > 0) sock->set_timeout(m_timeout);
+
             std::string buf;
             sys::getline(*sock, buf);
             if(getenv("JLIB_NET_IMAP4_DEBUG")) std::cout << "read first line: " << buf << std::endl;

--- a/jlib/net/Imap4.hh
+++ b/jlib/net/Imap4.hh
@@ -150,6 +150,29 @@ namespace jlib {
             void upgrade(jlib::sys::socketstream& sock);
 
             jlib::sys::socketstream* connect();
+
+            /**
+             * How long a read or write may block, in seconds; 0 waits forever.
+             *
+             * **Forever is the default, and it is the wrong thing to leave it
+             * at.** A server that accepts the connection and then says nothing
+             * -- because it is wedged, or because it is waiting for a TLS
+             * handshake this end is not going to send -- leaves the client
+             * blocked with no way out. Nothing here notices; the connection is
+             * open and the read simply never returns.
+             *
+             * That is not hypothetical. Pointing a STARTTLS session at an
+             * implicit-TLS port is exactly the case, and it cost the test suite
+             * three minutes per occurrence: each side waited for the other
+             * until *dovecot's* own login timeout closed the socket. Against a
+             * server with no such timeout it would have waited indefinitely.
+             *
+             * The default is unchanged rather than fixed because changing it
+             * changes behaviour for every existing caller; see the issue.
+             */
+            void set_timeout(double seconds) { m_timeout = seconds; }
+            double get_timeout() const { return m_timeout; }
+
             void disconnect(jlib::sys::socketstream& sock);
 
             // 6.1.    Client Commands - Any State
@@ -723,6 +746,9 @@ namespace jlib {
             int m_width;
             State m_state;
             jlib::util::URL m_url;
+
+            /** Seconds a read or write may block; 0 is forever. */
+            double m_timeout = 0;
             bool m_idle = false;
         };
         

--- a/jlib/net/Pop3.cc
+++ b/jlib/net/Pop3.cc
@@ -240,7 +240,13 @@ namespace jlib {
                                                          phost, pport);
                 }
                 else {
-                    sock = new jlib::sys::sslstream(m_url.get_host(), m_url.get_port_val());
+                    // The deadline goes in the constructor because the
+                    // handshake happens there: pointed at a port that does not
+                    // speak TLS, this blocks inside the call and there is no
+                    // later moment at which to bound it.
+                    sock = new jlib::sys::sslstream(m_url.get_host(),
+                                                    m_url.get_port_val(), false,
+                                                    -1, m_timeout);
                 }
             }
             else if(use_starttls(m_url)) {
@@ -254,7 +260,8 @@ namespace jlib {
                 }
                 else {
                     sock = new jlib::sys::tlsstream(m_url.get_host(),
-                                                    m_url.get_port_val(), true);
+                                                    m_url.get_port_val(), true,
+                                                    -1, m_timeout);
                 }
             }
             else {
@@ -268,6 +275,12 @@ namespace jlib {
                 }
             }
 
+
+            // The proxying paths above do not take it in their constructors
+            // yet, so they get it here -- which covers the greeting below but
+            // not a handshake inside the constructor. The two direct paths
+            // pass it in and do not need this.
+            if(m_timeout > 0) sock->set_timeout(m_timeout);
 
             std::string buf;
             jlib::sys::getline(*sock, buf);

--- a/jlib/net/Pop3.hh
+++ b/jlib/net/Pop3.hh
@@ -54,6 +54,29 @@ namespace jlib {
             Pop3(jlib::util::URL url, bool remove=true);
 
             /**
+             * How long a read or write may block, in seconds; 0 waits forever.
+             *
+             * **Forever is the default, and it is the wrong thing to leave it
+             * at.** A server that accepts the connection and then says nothing
+             * -- because it is wedged, or because it is waiting for a TLS
+             * handshake this end is not going to send -- leaves the client
+             * blocked with no way out. Nothing here notices; the connection is
+             * open and the read simply never returns.
+             *
+             * That is not hypothetical. Pointing a STARTTLS session at an
+             * implicit-TLS port is exactly the case, and it cost the test suite
+             * three minutes per occurrence: each side waited for the other
+             * until *dovecot's* own login timeout closed the socket. Against a
+             * server with no such timeout it would have waited indefinitely.
+             *
+             * The default is unchanged rather than fixed because changing it
+             * changes behaviour for every existing caller; see the issue.
+             */
+            void set_timeout(double seconds) { m_timeout = seconds; }
+            double get_timeout() const { return m_timeout; }
+
+
+            /**
              * Does this URL's scheme mean TLS?
              *
              * "pop3s" and "spop", compared whole.  It used to be
@@ -137,6 +160,9 @@ namespace jlib {
             std::string handshake(jlib::sys::socketstream& sock, const std::string& data, const std::string& ok);
             
             jlib::util::URL m_url;
+
+            /** Seconds a read or write may block; 0 is forever. */
+            double m_timeout = 0;
             bool m_remove;
         };
         

--- a/jlib/sys/socketstream.hh
+++ b/jlib/sys/socketstream.hh
@@ -85,8 +85,24 @@ namespace jlib {
              *                 sys::get_default_connect_timeout(), zero waits
              *                 forever.
              */
-            basic_socketbuf(const std::string& host, unsigned int port, double timeout = -1) {
+            /**
+             * @param timeout    seconds to allow the *connect*
+             * @param io_timeout seconds a later read or write may block, 0 for
+             *        forever.  Separate from the connect deadline and set here
+             *        rather than afterwards for the same reason the adopting
+             *        constructor below takes one: configure() applies it, and a
+             *        TLS handshake started by a derived buffer happens before
+             *        any caller has a chance to set it.  A client pointed at a
+             *        port that does not speak TLS blocks in the handshake, and
+             *        set_timeout() called after construction is already too
+             *        late to matter.
+             */
+            basic_socketbuf(const std::string& host, unsigned int port,
+                            double timeout = -1, double io_timeout = 0) {
                 init_buffers();
+
+                // Before open_socket, which calls configure, which applies it.
+                m_io_timeout = io_timeout;
 
                 // A constructor that throws gets no destructor, so the two
                 // buffers just allocated would be lost -- and a failing
@@ -484,12 +500,13 @@ namespace jlib {
                 //exceptions(std::ios_base::badbit);
             }
 
-            basic_socketstream(const std::string& host, unsigned int port, double timeout = -1)
+            basic_socketstream(const std::string& host, unsigned int port,
+                               double timeout = -1, double io_timeout = 0)
                 : std::basic_iostream<charT,traitT>(NULL)
             {
                 m_buf = 0;
                 //exceptions(std::ios_base::badbit);
-                m_buf=new basic_socketbuf<charT,traitT>(host,port,timeout);
+                m_buf=new basic_socketbuf<charT,traitT>(host,port,timeout,io_timeout);
                 this->init(m_buf);
             }
 
@@ -508,10 +525,11 @@ namespace jlib {
                     delete m_buf;
             }
             
-            void open(const std::string& host, unsigned int port, double timeout = -1) {
+            void open(const std::string& host, unsigned int port, double timeout = -1,
+                      double io_timeout = 0) {
                 if(m_buf != 0)
                     delete m_buf;
-                m_buf=new basic_socketbuf<charT,traitT>(host,port,timeout);
+                m_buf=new basic_socketbuf<charT,traitT>(host,port,timeout,io_timeout);
                 this->init(m_buf);
             }
 

--- a/jlib/sys/sslstream.hh
+++ b/jlib/sys/sslstream.hh
@@ -416,12 +416,27 @@ namespace jlib {
                 : basic_socketstream<charT,traitT>()
             {}
 
-            basic_tlsstream(const std::string& host, unsigned int port, bool delay = false) 
+            /**
+             * @param timeout    seconds to allow the connect
+             * @param io_timeout seconds a read or write may block, 0 forever.
+             *
+             * Taken here rather than set afterwards because with delay false
+             * the handshake happens **inside this constructor** -- pointed at a
+             * port that does not speak TLS, it blocks in the call, and there is
+             * no later moment at which set_timeout() could help. The adopting
+             * constructor in socketstream.hh takes one for the same reason on
+             * the server side, and says so.
+             */
+            basic_tlsstream(const std::string& host, unsigned int port,
+                            bool delay = false, double timeout = -1,
+                            double io_timeout = 0)
                 : basic_socketstream<charT,traitT>()
             {
                 if(getenv("JLIB_SYS_SOCKET_DEBUG"))
                     std::cerr << "basic_tlsstream::basic_tlsstream(" << host << ", " << port << ", " << std::boolalpha << delay << ")"<<std::endl;
-                this->m_buf = new basic_sslbuf<charT,traitT>(host, delay, host, port);
+                this->m_buf = new basic_sslbuf<charT,traitT>(host, delay, host,
+                                                             port, timeout,
+                                                             io_timeout);
                 this->init(this->m_buf);
             }
             

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -232,7 +232,10 @@ sys_servent_test_SOURCES = sys_servent_test.cc
 sys_servent_test_LDADD   = $(JSYS_LA)
 
 sys_socket_test_SOURCES = sys_socket_test.cc
-sys_socket_test_LDADD   = $(JSYS_LA)
+# OPENSSL_LIBS since the silent-server handshake test uses sslstream.  macOS
+# resolved it transitively through libjsys; gcc with --as-needed does not, so
+# this failed only in the container.
+sys_socket_test_LDADD   = $(JSYS_LA) $(OPENSSL_LIBS)
 
 sys_tls_server_test_SOURCES = sys_tls_server_test.cc
 sys_tls_server_test_LDADD   = $(JSYS_LA) $(OPENSSL_LIBS)

--- a/tests/net_imap_live_test.cc
+++ b/tests/net_imap_live_test.cc
@@ -453,8 +453,15 @@ int main() {
 
         bool threw = false;
 
+        // Bounded, for the same reason as its POP3 twin: this connection is
+        // expected to fail and the failure is a silence, so without a deadline
+        // it waits for the *server* to give up. Three minutes, each time.
         try {
             jlib::net::Imap4 imap(nope);
+
+            imap.set_timeout(2);
+
+            // connect() reads the greeting itself, so this is where it fails.
             std::unique_ptr<jlib::sys::socketstream> sock(imap.connect());
         }
         catch(std::exception&) { threw = true; }

--- a/tests/net_pop3_live_test.cc
+++ b/tests/net_pop3_live_test.cc
@@ -24,6 +24,7 @@
 // POP3 and choosing port 110 -- was asserted by reading the code and by
 // nothing else.  This is the test that was missing.
 
+#include <chrono>
 #include "mailserver.hh"
 
 #include <jlib/net/Pop3.hh>
@@ -214,10 +215,60 @@ int main() {
 
         bool threw = false;
 
-        try { jlib::net::Pop3(nope, false).retrieve(); }
+        // Bounded, because this connection is *expected* to fail and the
+        // failure is a silence: a plaintext session on the implicit-TLS port
+        // waits for a greeting while the server waits for a handshake. Left
+        // unbounded it took three minutes -- dovecot's own login timeout, not
+        // ours -- and was 180 of this test's 181 seconds.
+        try {
+            jlib::net::Pop3 p(nope, false);
+
+            p.set_timeout(2);
+            p.retrieve();
+        }
         catch(std::exception&) { threw = true; }
 
         ok("asking for STLS where it is not offered fails", threw);
+    }
+
+    {
+        // And the mirror image, which is the case a timeout set *after*
+        // construction cannot reach: implicit TLS pointed at the plaintext
+        // port. The handshake happens inside the stream's constructor, so a
+        // client blocks in there waiting for a ServerHello that is never
+        // coming -- and until the deadline was passed in rather than applied
+        // afterwards, nothing bounded it.
+        jlib::util::URL nope = account("pop3s", s.pop_port);
+
+        nope.set_pass(PASSWORD);
+
+        bool threw = false;
+
+        const auto began = std::chrono::steady_clock::now();
+
+        try {
+            jlib::net::Pop3 p(nope, false);
+
+            p.set_timeout(2);
+            p.retrieve();
+        }
+        catch(std::exception&) { threw = true; }
+
+        const double took = std::chrono::duration<double>(
+            std::chrono::steady_clock::now() - began).count();
+
+        ok("implicit TLS on the plaintext port fails", threw);
+
+        // Promptly, but **not** because of the deadline -- measured at about
+        // ten milliseconds. Dovecot's plaintext port greets the moment it
+        // accepts, so the handshake reads "+OK ..." where a ServerHello should
+        // be and errors out at once. Nothing here waits, so nothing here
+        // exercises the timeout.
+        //
+        // The case that does is a server which accepts and then says nothing,
+        // and no real server obliges. sys_socket_test builds one.
+        ok("and quickly, because the greeting is not a ServerHello",
+           took < 1.0, std::to_string(took) + "s");
     }
 
     // The control, as on the IMAP side: read the same message the way the old

--- a/tests/sys_socket_test.cc
+++ b/tests/sys_socket_test.cc
@@ -32,6 +32,7 @@
 #include <jlib/sys/listener.hh>
 #include <jlib/sys/pipe.hh>
 #include <jlib/sys/socketstream.hh>
+#include <jlib/sys/sslstream.hh>
 #include <jlib/sys/sys.hh>
 
 #include <fcntl.h>
@@ -70,6 +71,46 @@ struct pair {
         peer = server.accept_stream(5);
     }
 };
+
+/**
+ * A TLS handshake against a server that never says anything gives up.
+ *
+ * The listener here is never accept()ed, which the harness note above explains
+ * is enough: the kernel completes the three-way handshake out of the backlog,
+ * so the client connects to something that will never speak. No real server
+ * behaves that way, which is why nothing else in the suite covers it -- and why
+ * a client that waits forever looks fine until it does not.
+ *
+ * The deadline has to be in the **constructor**. With delay false the handshake
+ * happens inside it, so there is no later moment at which set_timeout() could
+ * be reached: the call has not returned. That is the same reason the adopting
+ * constructor in socketstream.hh takes one for the server side.
+ */
+static void a_handshake_against_a_silent_server_gives_up() {
+    std::cout << "a handshake against a silent server gives up\n";
+
+    jlib::sys::listener server;
+
+    const auto began = std::chrono::steady_clock::now();
+
+    bool threw = false;
+
+    try {
+        // Never accepted, so nothing will ever answer the ClientHello.
+        jlib::sys::sslstream s("127.0.0.1", server.port(), false, -1, 1.0);
+    }
+    catch(std::exception&) { threw = true; }
+
+    const double took = std::chrono::duration<double>(
+        std::chrono::steady_clock::now() - began).count();
+
+    ok("it fails rather than waiting", threw, std::to_string(took) + "s");
+
+    // The number is the assertion. Without a deadline this waits for the peer,
+    // and the peer is this process, which is not going to say anything.
+    ok("on its own deadline", took > 0.5 && took < 5.0,
+       std::to_string(took) + "s");
+}
 
 static void a_listener_accepts_a_connection() {
     std::cout << "a listener accepts a connection\n";
@@ -313,6 +354,7 @@ static void a_read_can_be_bounded() {
 
 int main() {
     a_listener_accepts_a_connection();
+    a_handshake_against_a_silent_server_gives_up();
     a_connect_that_will_never_answer_gives_up();
     an_ipv6_literal_resolves();
     a_listener_says_who_connected();


### PR DESCRIPTION
# A read timeout for the mail clients

`make check` in the container took about seven minutes, and the assumption was
that live tests are slow because they start real servers. They are not.

| test | before | after |
| --- | --- | --- |
| `net_pop3_live_test` | 181.4s | **3.4s** |
| `net_imap_live_test` | 187.1s | **9.5s** |
| `net_http_live_test` | 0.25s | 0.25s |
| `sys_proxy_live_test` | 1.36s | 1.36s |

**368 seconds of a 390-second run were two assertions**, each waiting three
minutes for a connection it already expected to fail.

## Finding it

Two of my guesses were wrong first, which is most of why this is worth writing
down.

**"It must be compilation."** The container builds no test binaries -- automake
defers `check_PROGRAMS` to `make check` -- so every run compiles about
seventy-five programs. Measured by running `make check` twice in one container:
449s then 390s. Compilation is 59s, **13%**. The other 87% is tests running.

**"It must be a 30-second timeout."** Timestamping each assertion as it printed
showed everything up to the STLS section completing in 32 *milliseconds*,
followed by a wall of 180.1 seconds on one line:

```
241.1s    ok   and the dot-stuffed message is still whole
421.2s    ok   asking for STLS where it is not offered fails   <<<< 180.1s
```

Three minutes exactly, which is not a client timeout because there is no client
timeout. It is **dovecot's** login timeout. The test points a plaintext STARTTLS
session at the implicit-TLS port: the client waits for a greeting, the server
waits for a ClientHello, and the only thing that ends it is the server giving
up. `net_imap_live_test` has the identical assertion and the identical cost.

## The defect behind it

Neither `Pop3` nor `Imap4` could bound a read **at all**. Against a server that
accepts a connection and then says nothing, a caller waits indefinitely -- here
it merely looked finite because dovecot has a timeout of its own.

The fix needed nothing new. `basic_socketstream::set_timeout()` already exists
and every stream these clients use inherits it -- `tlsstream`, `tlsproxystream`,
`proxystream`, plain `socketstream`. The clients simply never called it. So each
gains `set_timeout()` / `get_timeout()` and applies it to the socket it just
opened.

**Where it is applied is the whole fix, and it took two goes.**

The first version put it at the end of `connect()`, which does nothing:
`connect()` reads the greeting itself several lines earlier, and that read is
the one that hangs. A deadline applied after the thing it was meant to bound is
decoration.

Moving it before the greeting fixed the case in front of us and was still not
right, because it cannot reach the case behind it. With `delay` false a
`tlsstream` performs the **handshake inside its constructor**, so a client
pointed at a port that does not speak TLS blocks in the call -- and there is no
"after construction" in which `set_timeout()` could be called. The deadline has
to be a constructor argument.

The codebase already knew this and said so, about the server side, in
`socketstream.hh`'s adopting constructor:

> That is why this parameter exists rather than the caller setting the option
> itself: a server has to bound the TLS handshake, and the handshake happens
> inside the constructor that adopts the descriptor.

The same reasoning, in the same file, for the mirror-image case. So the client
chain now carries an `io_timeout` too: `basic_socketbuf` sets it before
`configure()` applies it, `basic_socketstream` and `basic_tlsstream` forward it,
and `basic_tlsbuf`'s variadic pack carried it the rest of the way without
changing.

`Pop3` and `Imap4` pass it at construction on the two direct paths. The
**proxying** paths still take it afterwards and so remain unbounded through a
handshake; each site says which it is rather than leaving that to be discovered.

## The test that was missing

Neither the old assertion nor the obvious new one exercises the constructor
deadline, and it is worth being exact about why, because both *pass*.

Adding "implicit TLS on the plaintext port fails" looked like the mirror-image
test. It fails in **ten milliseconds** -- dovecot greets the instant it accepts,
the handshake reads `+OK ...` where a ServerHello should be, and errors out at
once. Nothing waits, so nothing is bounded, and a green tick would have implied
coverage that was not there. That test is kept, with its comment corrected to
say what it actually demonstrates.

The case that does exercise it needs a server which accepts and then says
*nothing*, and no real server obliges. `sys_socket_test` builds one out of a
listener that is never accepted -- which works for the reason that file already
documents, that the kernel completes the three-way handshake out of the backlog.
The client connects to something that will never speak:

```
a handshake against a silent server gives up
  ok   it fails rather than waiting: 1.021942s
  ok   on its own deadline: 1.021942s
```

And the number is the assertion, so it was checked against the parameter: 3.026s
at a three-second deadline, 1.014s at a one-second one.

## What the tests do now

The two assertions that expect a failure say how long they will wait for it. A
test asserting that something fails should bound its patience; leaving it
unbounded means asserting that *someone else's* timeout works.

## The default is unchanged, deliberately

Zero, meaning forever -- so no existing caller behaves differently. That is a
decision rather than a fix, and #166 argues it out: a client whose default is to
hang is a footgun, but a default deadline turns a legitimately slow transfer
into a failure. The header now says plainly that forever is the default and that
it is the wrong thing to leave it at.

## Verification

- macOS `make check`: the live tests skip there for want of the servers, so the
  timing change is not visible; nothing regresses.
- Container: **74 tests, 71 pass, 3 skip, 0 fail**, and the whole run now takes
  **94 seconds** where it took 449. Both assertions still pass -- the connection
  still fails, just promptly.

  Which also settles the compilation question with a number: 95s total against
  the 59s of compiling measured earlier, so building the tests is now most of
  what a container run does. If it ever wants to be quicker again, that is where
  to look next -- and it was not where to look this time.

## What this does not establish

**That two seconds is the right bound.** It is comfortably longer than a
localhost handshake and comfortably shorter than three minutes, and nothing
finer was measured. On a slow or loaded machine a legitimate exchange could in
principle exceed it, and the test would then fail for the right reason with the
wrong explanation.

**Nothing about the other clients.** `Smtp` and the HTTP client were not looked
at and may have the same gap.

**And one more thing found only by building twice.** The silent-server test uses
`sslstream`, and `sys_socket_test` did not list `$(OPENSSL_LIBS)`. Apple's
linker resolved it transitively through libjsys; gcc with `--as-needed` refused,
so the test was green on macOS and would not link in the container. Same shape
as the missing `<cstring>` in `pstream.hh` two branches ago: a difference
between toolchains that only building on both can find.

Worth noting how it nearly slipped past. The verification wrapper reported
`exit=0` on a *failed* build, because the shell script's status came from its
trailing `echo` rather than from make. What caught it was checking for the
`# TOTAL` summary line and not finding one -- an exit code passed through a
shell wrapper is not evidence that anything ran.

**And the proxying paths are still unbounded through a handshake.**
`tlsproxystream` and `proxystream` do not take a timeout in their constructors,
so a proxied connection to a port that does not speak TLS blocks where a direct
one no longer does. The direct paths were what the tests reached; finishing the
proxied ones is the same change again and is not done here.

**And nothing about writes.** `set_timeout` bounds both directions, but only the
read path was the problem here and only the read path was exercised.
