### PR TITLE
Add jalpaca, a curses front end: transcript above, prompt below, Escape stops a reply without ending the conversation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         pkg-config \
         autoconf-archive \
         ca-certificates \
+        libncurses-dev \
         libjson-c-dev \
         libgpgme-dev \
         libssl-dev \

--- a/configure.ac
+++ b/configure.ac
@@ -158,6 +158,17 @@ dnl GLFW replaces GLUT as the portable windowing backend.
 PKG_CHECK_MODULES([GLFW], [glfw3 >= 3.3], [have_glfw=yes], [have_glfw=no])
 AM_CONDITIONAL([HAVE_GLFW], [test "x$have_glfw" = xyes])
 
+dnl ncurses, for the jtui front end.  Two names because Apple ships a .pc for
+dnl "ncurses" while several Linuxes only have "ncursesw", and a plain -lncurses
+dnl as a last resort for the ones with the library and no pkg-config file at
+dnl all -- which is where macOS was before its Command Line Tools grew one.
+PKG_CHECK_MODULES([CURSES], [ncursesw], [have_curses=yes],
+  [PKG_CHECK_MODULES([CURSES], [ncurses], [have_curses=yes],
+    [AC_CHECK_LIB([ncurses], [initscr],
+      [have_curses=yes; CURSES_LIBS=-lncurses; CURSES_CFLAGS=],
+      [have_curses=no])])])
+AM_CONDITIONAL([HAVE_CURSES], [test "x$have_curses" = xyes])
+
 dnl ImageMagick++ is only used by the jneural image classifiers.  IM7
 dnl renamed the module, so try the new spelling before the old one.
 PKG_CHECK_MODULES([MAGICK], [Magick++-7.Q16HDRI], [have_magick=yes],
@@ -371,6 +382,7 @@ AC_MSG_NOTICE([
     libsodium/ristretto .. $have_sodium/$have_ristretto
     portaudio ............ $have_portaudio
     glfw ................. $have_glfw
+    ncurses .............. $have_curses
     ImageMagick++ ........ $have_magick
     cuda ................. $have_cuda
     metal ................ $have_metal

--- a/jlib/apps/Makefile.am
+++ b/jlib/apps/Makefile.am
@@ -9,6 +9,10 @@ AM_CPPFLAGS = -I$(top_srcdir) \
 # libraries themselves are conditional, so an ungated program would fail at
 # link rather than being skipped cleanly.
 
+if HAVE_CURSES
+alpaca_programs = jalpaca
+endif
+
 if HAVE_SODIUM
 curve_programs = jcurve
 endif
@@ -49,6 +53,7 @@ glfw_programs = jglfwhyper jgltorus jhardhyper
 endif
 
 bin_PROGRAMS = jlib-mail jcrypt jm3u jchat \
+	$(alpaca_programs) \
 	$(curve_programs) \
 	$(neural_programs) \
 	$(cuda_programs) \
@@ -85,6 +90,10 @@ jcrypt_LDADD   = $(JCRYPT_LA) $(JSYS_LA)
 
 jm3u_SOURCES = jm3u.cc
 jm3u_LDADD   = $(JSYS_LA) $(JUTIL_LA)
+
+jalpaca_SOURCES  = jalpaca.cc
+jalpaca_CPPFLAGS = $(AM_CPPFLAGS) $(METAL_CPPFLAGS) $(CURSES_CFLAGS)
+jalpaca_LDADD    = $(JAI_LA) $(JUTIL_LA) $(JSYS_LA) $(METAL_LA) $(CURSES_LIBS)
 
 jchat_SOURCES  = jchat.cc
 jchat_CPPFLAGS = $(AM_CPPFLAGS) $(METAL_CPPFLAGS)

--- a/jlib/apps/jalpaca.cc
+++ b/jlib/apps/jalpaca.cc
@@ -1,0 +1,431 @@
+/* -*- mode: C++ c-basic-offset: 4  -*-
+ *
+ * Copyright (c) 2026 Joey Yandle <xoloki@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+
+/**
+ * jalpaca -- jchat with a transcript that stays put.
+ *
+ * A scrolling transcript above, a prompt pinned below, and the reply arriving
+ * into the transcript a token at a time. Escape stops a reply without ending
+ * the conversation.
+ *
+ * ### Why this is a second program rather than a flag on the first
+ *
+ * jchat is the tested one. Its argument handling, its answers and its
+ * conversation memory are checked in `app_jchat_test`, which drives it down a
+ * pipe -- and a curses program cannot be driven down a pipe, because it wants a
+ * terminal and refuses to start without one. Folding the two together would
+ * mean either giving up that test or carrying two output paths through every
+ * function in it.
+ *
+ * So the loop below is deliberately the same loop, and the pieces underneath --
+ * gguf, tokenizer, chat, model, generate -- are the same pieces. What differs
+ * is where the characters go.
+ *
+ * ### What curses buys beyond appearance
+ *
+ * Escape. Reading a keystroke *while* generating needs the terminal out of
+ * canonical mode, which otherwise buffers input until Return; and having taken
+ * it out, something has to put it back on exit, on an exception and on a
+ * signal, or the shell is left with no echo. curses owns both halves. Doing it
+ * by hand with tcsetattr is about forty lines and every one of them is a way to
+ * strand a terminal.
+ */
+
+#include <jlib/ai/chat.hh>
+#include <jlib/ai/generate.hh>
+#include <jlib/ai/model.hh>
+#include <jlib/ai/tokenizer.hh>
+
+#ifdef HAVE_METAL
+#include <jlib/metal/backend.hh>
+#endif
+
+#include <ncurses.h>
+
+#include <chrono>
+#include <csignal>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace ai = jlib::ai;
+
+namespace {
+
+volatile std::sig_atomic_t g_interrupted = 0;
+
+void interrupted(int) { g_interrupted = 1; }
+
+double now() {
+    using namespace std::chrono;
+
+    return duration<double>(steady_clock::now().time_since_epoch()).count();
+}
+
+/**
+ * The screen: a transcript that scrolls and a prompt that does not.
+ *
+ * endwin() runs from the destructor, so a throw on the way out of main still
+ * hands the terminal back. That is the whole reason this is a class.
+ */
+class screen {
+public:
+    screen() {
+        initscr();
+        cbreak();               // keys arrive unbuffered, which Escape needs
+        noecho();               // the input window draws the line itself
+        keypad(stdscr, TRUE);
+        curs_set(1);
+
+        layout();
+    }
+
+    ~screen() {
+        endwin();
+    }
+
+    screen(const screen&) = delete;
+    screen& operator=(const screen&) = delete;
+
+    /** Rebuild both windows for the terminal's current size. */
+    void layout() {
+        int rows = 0, cols = 0;
+
+        getmaxyx(stdscr, rows, cols);
+
+        if(m_transcript) delwin(m_transcript);
+        if(m_input) delwin(m_input);
+
+        // Two rows at the bottom: one for the prompt, one for the rule above
+        // it, so a long reply never runs into what is being typed.
+        m_rows = rows;
+        m_cols = cols;
+
+        m_transcript = newwin(rows - 2, cols, 0, 0);
+        m_input = newwin(1, cols, rows - 1, 0);
+
+        scrollok(m_transcript, TRUE);
+        idlok(m_transcript, TRUE);
+        nodelay(m_input, TRUE);
+        keypad(m_input, TRUE);
+
+        redraw_rule();
+    }
+
+    void redraw_rule() {
+        mvhline(m_rows - 2, 0, ACS_HLINE, m_cols);
+        refresh();
+    }
+
+    /** Add text to the transcript, wrapping as the window does. */
+    void say(const std::string& text) {
+        waddstr(m_transcript, text.c_str());
+        wrefresh(m_transcript);
+    }
+
+    void say_line(const std::string& text) { say(text + "\n"); }
+
+    void prompt(const std::string& so_far) {
+        werase(m_input);
+        mvwaddstr(m_input, 0, 0, "> ");
+        waddnstr(m_input, so_far.c_str(), m_cols - 3);
+        wrefresh(m_input);
+    }
+
+    /** A keystroke if one is waiting, or ERR. Never blocks. */
+    int poll_key() { return wgetch(m_input); }
+
+    /**
+     * Read a line, redrawing as it is typed.
+     *
+     * @return false at end of input or on a second interrupt
+     */
+    bool read_line(std::string& out) {
+        out.clear();
+
+        for(;;) {
+            prompt(out);
+
+            const int c = wgetch(m_input);
+
+            if(c == ERR) {
+                napms(20);      // nothing waiting; do not spin
+
+                if(g_interrupted) { g_interrupted = 0; return false; }
+
+                continue;
+            }
+
+            if(c == KEY_RESIZE) { layout(); continue; }
+
+            if(c == '\n' || c == '\r') return true;
+
+            if(c == 27) { out.clear(); continue; }          // Escape clears
+
+            if(c == KEY_BACKSPACE || c == 127 || c == 8) {
+                if(!out.empty()) out.erase(out.size() - 1);
+
+                continue;
+            }
+
+            if(c == 4) return false;                        // Ctrl-D
+
+            if(c >= 32 && c < 256) out += char(c);
+        }
+    }
+
+private:
+    WINDOW* m_transcript = 0;
+    WINDOW* m_input = 0;
+
+    int m_rows = 0;
+    int m_cols = 0;
+};
+
+struct options {
+    std::string model;
+    std::string system;
+
+    unsigned int tokens = 512;
+
+    ai::sampler::config sampling;
+};
+
+bool parse(int argc, char** argv, options& o) {
+    int i = 1;
+
+    for(; i < argc; i++) {
+        const std::string a = argv[i];
+
+        if(a == "--help" || a == "-h") {
+            std::cout << "usage: " << argv[0] << " [options] <model.gguf>\n"
+                      << "\n"
+                      << "  A transcript above, a prompt below.  Escape stops a\n"
+                      << "  reply; Ctrl-D or an empty Escape at the prompt quits.\n"
+                      << "\n"
+                      << "  --system TEXT   a system turn before the conversation\n"
+                      << "  --tokens N      most tokens in one reply (default 512)\n"
+                      << "  --temp F        0 is greedy (default 0.8)\n"
+                      << "  --top-k N       (default 40)\n"
+                      << "  --top-p F       (default 0.95)\n"
+                      << "  --seed N\n";
+
+            std::exit(0);
+        }
+        else if(a.size() > 2 && a.compare(0, 2, "--") == 0) {
+            if(i + 1 >= argc) {
+                std::cerr << "jalpaca: " << a << " wants a value\n";
+
+                return false;
+            }
+
+            const std::string v = argv[++i];
+
+            if(a == "--system") o.system = v;
+            else if(a == "--tokens") o.tokens = unsigned(std::atoi(v.c_str()));
+            else if(a == "--temp") o.sampling.temperature = float(std::atof(v.c_str()));
+            else if(a == "--top-k") o.sampling.top_k = unsigned(std::atoi(v.c_str()));
+            else if(a == "--top-p") o.sampling.top_p = float(std::atof(v.c_str()));
+            else if(a == "--seed") o.sampling.seed = std::uint64_t(std::atoll(v.c_str()));
+            else {
+                std::cerr << "jalpaca: no such option " << a << "\n";
+
+                return false;
+            }
+        }
+        else break;
+    }
+
+    if(i >= argc) {
+        std::cerr << "usage: " << argv[0] << " [options] <model.gguf>\n";
+
+        return false;
+    }
+
+    o.model = argv[i];
+
+    return true;
+}
+
+template<typename T>
+int converse(ai::backend<T>& b, const ai::gguf& g, const options& o) {
+    const ai::tokenizer tok(g);
+    const ai::chat ch(g, tok.token(tok.eos()));
+
+    typename ai::model<T>::config c = ai::model<T>::config::from(g);
+
+    ai::model<T> m(b, c);
+
+    // Loaded before curses starts, so the progress and any failure land on a
+    // normal terminal rather than inside a window that is about to be torn down.
+    std::cerr << "[" << b.name() << ", " << c.layers << " layers, "
+              << c.d_model << " wide]\n[loading]\n";
+
+    const double t0 = now();
+
+    m.load(g);
+
+    const double took = now() - t0;
+
+    m.enable_cache();
+
+    screen s;
+
+    s.say_line("jlib " + std::string(b.name()) + " -- " +
+               std::to_string(c.layers) + " layers, loaded in " +
+               std::to_string(took).substr(0, 4) + "s");
+    s.say_line("Escape stops a reply.  Ctrl-D quits.");
+    s.say_line("");
+
+    ai::sampler sampler(o.sampling);
+
+    std::vector<ai::message> turns;
+
+    if(!o.system.empty()) turns.push_back({ "system", o.system });
+
+    for(;;) {
+        std::string line;
+
+        if(!s.read_line(line)) break;
+
+        if(line.empty()) continue;
+
+        // Into the transcript, and out of the input window: the prompt should
+        // be empty while the reply arrives, or what was asked appears twice --
+        // once where it was typed and once where it now belongs.
+        s.say_line("> " + line);
+        s.prompt("");
+
+        turns.push_back({ "user", line });
+
+        // Drop the oldest turns if the conversation has outgrown the context,
+        // keeping the system prompt, which is instructions rather than history.
+        for(;;) {
+            if(ch.encode(turns, tok).size() + o.tokens <= c.context) break;
+
+            std::size_t at = turns.size();
+
+            for(std::size_t i = 0; i < turns.size(); i++)
+                if(turns[i].role != "system") { at = i; break; }
+
+            if(at == turns.size()) break;
+
+            turns.erase(turns.begin() + long(at));
+        }
+
+        std::string reply;
+        bool first = true;
+        bool stopped = false;
+
+        const double began = now();
+
+        const std::vector<int> ids = ch.encode(turns, tok);
+
+        const std::vector<int> out = ai::generate<T>(
+            m, b, ids, o.tokens, sampler, tok.eos(),
+            [&](int id) {
+                std::string p = tok.piece(id);
+
+                if(first) {
+                    while(!p.empty() && p[0] == ' ') p.erase(0, 1);
+
+                    first = false;
+                }
+
+                reply += p;
+
+                s.say(p);
+
+                // Between tokens, which is where stopping is safe and where a
+                // keystroke can be looked for without blocking.
+                const int key = s.poll_key();
+
+                if(key == 27 || g_interrupted) { stopped = true; return false; }
+
+                if(key == KEY_RESIZE) s.layout();
+
+                return true;
+            });
+
+        g_interrupted = 0;
+
+        const double rate = (now() - began) > 0
+            ? double(out.size() - ids.size()) / (now() - began) : 0.0;
+
+        s.say_line("");
+        s.say_line(std::string("[") + std::to_string(out.size() - ids.size()) +
+                   " tokens, " + std::to_string(rate).substr(0, 5) + "/s" +
+                   (stopped ? ", stopped]" : "]"));
+        s.say_line("");
+
+        turns.push_back({ "assistant", reply });
+    }
+
+    return 0;
+}
+
+}
+
+int main(int argc, char** argv) {
+    options o;
+
+    if(!parse(argc, argv, o)) return 2;
+
+    struct sigaction sa;
+
+    std::memset(&sa, 0, sizeof(sa));
+
+    sa.sa_handler = interrupted;
+
+    sigemptyset(&sa.sa_mask);
+
+    sigaction(SIGINT, &sa, 0);
+
+    try {
+        const ai::gguf g(o.model);
+
+#ifdef HAVE_METAL
+        try {
+            jlib::metal::backend<_Float16> b;
+
+            return converse<_Float16>(b, g, o);
+        }
+        catch(std::exception& e) {
+            std::cerr << "jalpaca: no Metal backend (" << e.what() << ")\n";
+        }
+#endif
+
+        std::cerr << "jalpaca: running on the CPU in float -- this will be very "
+                  << "slow and will want about 4GB\n";
+
+        ai::host_backend<float> b;
+
+        return converse<float>(b, g, o);
+    }
+    catch(std::exception& e) {
+        // endwin() has already run if a screen was up: it is a destructor.
+        std::cerr << "jalpaca: " << e.what() << "\n";
+
+        return 1;
+    }
+}

--- a/tests/app_jchat_test.cc
+++ b/tests/app_jchat_test.cc
@@ -108,6 +108,48 @@ static void it_explains_itself(const std::string& jchat) {
        none != 0 && err.find("usage:") != std::string::npos, std::to_string(none));
 }
 
+/**
+ * jalpaca's argument handling, which is all of it that can be tested here.
+ *
+ * The program wants a terminal and refuses to start without one, so nothing
+ * below the option parsing is reachable down a pipe -- which is the reason it
+ * is a second program rather than a flag on jchat, and the reason jchat is the
+ * one with the answers tested. What this does catch is the case that has bitten
+ * twice already: a program that links on one platform and not the other.
+ */
+static void the_alpaca_explains_itself() {
+    std::cout << "\nthe alpaca explains itself:\n";
+
+    const char* names[] = {
+        "../jlib/apps/jalpaca", "./jlib/apps/jalpaca", "../../build/jlib/apps/jalpaca"
+    };
+
+    std::string jalpaca = find_one(names, sizeof(names) / sizeof(names[0]));
+
+    if(jalpaca.empty()) {
+        std::cout << "  (no jalpaca built -- ncurses was not found at configure "
+                  << "time)\n";
+
+        return;
+    }
+
+    std::string out, err;
+
+    const int rc = jlib::sys::run({ jalpaca, "--help" }, out, err);
+
+    ok("  --help succeeds without a terminal", rc == 0, std::to_string(rc));
+
+    ok("  and describes what it is",
+       out.find("transcript") != std::string::npos &&
+       out.find("Escape") != std::string::npos, out.substr(0, 60));
+
+    out.clear(); err.clear();
+
+    const int bad = jlib::sys::run({ jalpaca, "--nonesuch", "x" }, out, err);
+
+    ok("  an option it does not have is refused", bad != 0, std::to_string(bad));
+}
+
 static void it_answers_from_the_command_line(const std::string& jchat,
                                              const std::string& model)
 {
@@ -202,6 +244,7 @@ int main(int argc, char** argv) {
 
     try {
         it_explains_itself(jchat);
+        the_alpaca_explains_itself();
 
         const std::string model = find_model();
 


### PR DESCRIPTION
# jalpaca

The front end asked for three branches ago, deferred twice on the grounds that
the loop underneath was not proven and not interruptible. It is both now, and at
37 tokens/s a reply arriving into a transcript is worth watching.

```
 jlib Apple M5 (unified memory) -- 22 layers, loaded in 0.88s
 Escape stops a reply.  Ctrl-D quits.

 > What is the capital of France?
 The capital of France is Paris.
 [8 tokens, 14.4/s]

 > And Italy?
 Italy's capital city is Rome.
 [10 tokens, 13.9/s]
 ────────────────────────────────
 > _
```

## Why a second program rather than a flag on jchat

jchat is the tested one: its options, its answers and its conversation memory
are checked in `app_jchat_test`, which drives it down a pipe. **A curses program
cannot be driven down a pipe** -- it wants a terminal and will not start without
one. Folding the two together would mean giving up that test or carrying two
output paths through every function in it.

So the loop is deliberately the same loop and the pieces underneath are the same
pieces. What differs is where the characters go.

## What curses is actually for here

Escape. Reading a keystroke *while* generating needs the terminal out of
canonical mode, which otherwise buffers input until Return -- and having taken
it out, something must put it back on exit, on an exception, and on a signal, or
the shell is left with no echo. curses owns both halves.

That was the argument for deferring it in the first place: doing it by hand with
`tcsetattr` is about forty lines, and every one of them is a way to strand a
terminal. Here `endwin()` runs from a destructor, so a throw on the way out of
`main` still hands the terminal back.

The stop reaches the generation the same way `jchat`'s Ctrl-C does -- through
`on_token` returning false -- so nothing new was needed below the app.

## Built on both platforms, deliberately

ncurses was **not** in the container image. The `AM_CONDITIONAL` would have
skipped `jalpaca` there quietly, which is how two bugs already got through this
session: `pstream.hh`'s missing `<cstring>` and `sys_socket_test`'s missing
`$(OPENSSL_LIBS)`, each fine on one toolchain and broken on the other.

So `libncurses-dev` goes into the Dockerfile and the program compiles in both
places. `configure.ac` looks for `ncursesw`, then `ncurses`, then falls back to
`AC_CHECK_LIB` for systems that ship the library without a pkg-config file, and
reports it in the summary alongside the other optional dependencies.

## Tests

`app_jchat_test` gains what can be tested without a terminal: `--help` succeeds
and describes the program, and an unknown option is refused. That is not much,
and it is the part that catches the failure mode above -- a program that links
on one platform and not the other.

Everything below the option parsing was checked **through a pty**, which is the
only way to run it at all: it loads, draws, answers "The capital of Italy is
Rome.", remembers across turns, reports a rate, and quits on Ctrl-D.

One thing that pty check cannot do, having tried: verify the layout. A pty
capture is a byte stream and not a screen. The submitted line appears twice in
it -- once as the input window echoes it and once as the transcript records it
-- which on a terminal are different cells and in a byte stream are two writes.
Stripping the cursor-positioning escapes, which is what makes the capture
readable, is exactly what destroys the information needed to tell them apart. A
real check would need a terminal emulator, and the assertion I first wrote was
measuring a stream as though it were a screen.

The related fix is real though: without clearing the prompt on submit, what was
typed sits at the bottom of the screen for the whole time the reply is arriving.

## Verification

- macOS `make check`: 75 tests, 71 pass, 4 skip, 0 fail.
- Container: **74 tests, 71 pass, 3 skip, 0 fail**. `configure` reports
  `ncurses .............. yes`, jalpaca builds, `--help` runs, and a missing model
  gives a clean error rather than a crash inside a window that never opened.

  Worth noting how nearly that verification fooled me: I grepped the *check* log
  for "jalpaca" and found nothing, which looked like the program had been skipped.
  Apps are built by `make all` during the image build, not by `make check`, so
  it was never going to appear there. Looking in the container itself took one
  command and answered it properly.
- By hand through a pty: load, answer, follow-up, quit.

## What this does not establish

**Almost anything about the interface.** No test looks at the screen. Wrapping,
scrollback, resizing and the rule between the panes were checked by eye and by
reading the code, and the pty harness cannot see any of them.

**Nothing about Escape.** Stopping a reply needs a keystroke mid-generation,
which means a pty *and* timing, and the assertion would be "it stopped early" --
true also if the model simply finished. It is the feature the branch exists for
and it is checked by hand.

**And no editing to speak of.** The prompt takes printable characters, backspace,
Return, Escape to clear and Ctrl-D to quit. No cursor movement, no history, no
kill-line. A person who expects readline will notice within about ten seconds.
