### PR TITLE
Make --tokens a reservation rather than a cap on the reply, never trim the newest turn, and show how full the context is

### DIFF
--- a/jlib/apps/jalpaca.cc
+++ b/jlib/apps/jalpaca.cc
@@ -102,6 +102,15 @@ enum tone { plain = 1, you = 2, note = 3 };
 enum { KEY_WORD_LEFT = 0x1000, KEY_WORD_RIGHT, KEY_BARE_ESC };
 
 /**
+ * Fewest tokens worth generating a reply into.
+ *
+ * Below this there is no answer to be had, only the beginning of one, and
+ * saying the prompt does not fit is more use than a truncated fragment of a
+ * sentence.
+ */
+const unsigned int MIN_REPLY = 16;
+
+/**
  * The screen: a transcript with scrollback, and a prompt that stays put.
  *
  * endwin() runs from the destructor, so a throw on the way out of main still
@@ -557,7 +566,8 @@ bool parse(int argc, char** argv, options& o) {
                       << "  Opt-Left/Right   move a word at a time\n"
                       << "\n"
                       << "  --system TEXT   a system turn before the conversation\n"
-                      << "  --tokens N      most tokens in one reply (default 512)\n"
+                      << "  --tokens N      room always kept free for a reply,\n"
+                      << "                  in tokens (default 512)\n"
                       << "  --temp F        0 is greedy (default 0.8)\n"
                       << "  --top-k N       (default 40)\n"
                       << "  --top-p F       (default 0.95)\n"
@@ -654,17 +664,34 @@ int converse(ai::backend<T>& b, const ai::gguf& g, const options& o) {
 
         turns.push_back({ "user", line });
 
+        // Room to keep free for the answer -- a floor, not a ceiling.  The
+        // reply is allowed everything the context has left (below); this is
+        // only how much of that room the trimmer will give up history to
+        // guarantee.  Asking for more than the context can hold is therefore
+        // harmless: the trimmer drops what it may and stops, rather than
+        // deleting the question to satisfy a reservation nothing can meet.
+        const std::size_t want = o.tokens;
+
         // Drop the oldest turns if the conversation has outgrown the context,
         // keeping the system prompt, which is instructions rather than history.
         for(;;) {
-            if(ch.encode(turns, tok).size() + o.tokens <= c.context) break;
+            // A model file that declares no context gives nothing to fit
+            // into; without this the comparison below is against zero and the
+            // loop drops every turn it is allowed to, every time.
+            if(!c.context) break;
 
+            if(ch.encode(turns, tok).size() + want <= c.context) break;
+
+            // i + 1 < size, so the newest turn is never a candidate.  It is
+            // the question, and a question deleted to make room for its own
+            // answer leaves the model continuing a conversation that does not
+            // contain it -- which it does fluently, and about something else.
             std::size_t at = turns.size();
 
-            for(std::size_t i = 0; i < turns.size(); i++)
+            for(std::size_t i = 0; i + 1 < turns.size(); i++)
                 if(turns[i].role != "system") { at = i; break; }
 
-            if(at == turns.size()) break;
+            if(at == turns.size()) break;       // no history left to give
 
             turns.erase(turns.begin() + long(at));
         }
@@ -677,8 +704,39 @@ int converse(ai::backend<T>& b, const ai::gguf& g, const options& o) {
 
         const std::vector<int> ids = ch.encode(turns, tok);
 
+        // Whatever the context has left, all of it.  There is no application
+        // cap on a reply: the model stops when it has finished, or when the
+        // context is full, and Escape stops it in between.  That interrupt is
+        // what makes a cap unnecessary rather than merely unhelpful -- it was
+        // never buying safety, only truncating answers that had room to run.
+        //
+        // The arithmetic lands exactly.  generate() breaks when ids.size()
+        // exceeds the context, checked at the top of each step, so a budget of
+        // context - prompt runs out at the step where the sequence is one
+        // short of full: the guard never fires and nothing overruns.
+        const unsigned int budget = c.context
+            ? static_cast<unsigned int>(c.context > ids.size()
+                                        ? c.context - ids.size() : 0)
+            : o.tokens;
+
+        // The trimmer is best-effort, and stops when there is no more history
+        // to give -- which is exactly when the system prompt and the question
+        // alone leave no room to answer.  Say so.  Answering with the tokens
+        // that remain produces a fragment; answering without the question,
+        // which is what this used to do, produces a fluent reply to nothing.
+        if(budget < MIN_REPLY) {
+            s.say_line("[that prompt is " + std::to_string(ids.size()) +
+                       " tokens and the context is " + std::to_string(c.context) +
+                       " -- too long to answer.  Try a shorter question.]", note);
+            s.say_line("");
+
+            turns.pop_back();
+
+            continue;
+        }
+
         const std::vector<int> out = ai::generate<T>(
-            m, b, ids, o.tokens, sampler, tok.eos(),
+            m, b, ids, budget, sampler, tok.eos(),
             [&](int id) {
                 std::string p = tok.piece(id);
 
@@ -715,9 +773,25 @@ int converse(ai::backend<T>& b, const ai::gguf& g, const options& o) {
         const double rate = (now() - began) > 0
             ? double(out.size() - ids.size()) / (now() - began) : 0.0;
 
+        // How full the context is after this turn.  out holds the prompt as
+        // well as what was generated, so its size is what the conversation now
+        // occupies -- and roughly what the next turn starts from, since the
+        // reply about to be appended is history like any other.
+        //
+        // Worth showing rather than computing silently: trimming and the
+        // distance to the wall are otherwise invisible, and a reply cut short
+        // by a full context reads as the model being bad at the question
+        // rather than as the context being spent.  A model file that declares
+        // no context length leaves nothing to compare against, so the figure
+        // is omitted rather than guessed at.
+        const std::string room = c.context
+            ? ", " + std::to_string(out.size()) + "/" +
+              std::to_string(c.context) + " context"
+            : std::string();
+
         s.say_line("");
         s.say_line(std::string("[") + std::to_string(out.size() - ids.size()) +
-                   " tokens, " + std::to_string(rate).substr(0, 5) + "/s" +
+                   " tokens, " + std::to_string(rate).substr(0, 5) + "/s" + room +
                    (stopped ? ", stopped]" : "]"), note);
         s.say_line("");
 


### PR DESCRIPTION
# jalpaca: spend the context you have

Closes #169. `--tokens` stops being a ceiling on the reply and becomes a
reservation on the prompt; the trimmer stops being able to delete the question;
and the closing note says how full the context is, which is the thing whose
absence let the bug look like a bad model.

```
 > What is the capital of France?
 The capital of France is Paris.
 [8 tokens, 20.60/s, 31/2048 context]

 > And Italy?
 Italy's capital city is Rome.
 [10 tokens, 16.64/s, 60/2048 context]
```

## The flag was doing two jobs, and they disagreed

`o.tokens` was both the reservation the trimmer tried to satisfy and the
ceiling handed to `ai::generate`. As a ceiling it truncated good answers; as a
reservation it could be made unsatisfiable, and the trimmer would then delete
every turn trying to meet it -- including the question, because the loop always
picked the *first* non-system turn and the question is the *last*. The model
was left continuing a conversation that did not contain what was asked, which
it did fluently and about something else. That is #169.

Both halves were visible from the terminal. `--tokens 256` with an empty
history truncated a reply while about 2,000 tokens sat unused; `--tokens 2048`
deleted the question outright. Same flag, opposite failures.

Separating them turned out to mean deleting one of the two roles rather than
reconciling them:

- **No cap on the reply.** The budget is `context - prompt`. A reply ends when
  the model emits EOS or the context fills -- the two conditions that mean
  something -- and Escape stops it in between. That interrupt is what makes a
  cap unnecessary rather than merely unhelpful: it was never buying safety,
  only truncating answers that had room to run.
- **`--tokens N` is a floor.** Room always kept free for an answer. Because the
  trimmer works to `prompt + want <= context`, the budget is at least `want`
  whenever the trimmer can get there -- a promise about the worst case, not a
  limit on the best one.
- **The newest turn is never trimmed** (`i + 1 < turns.size()`).
- **A prompt that cannot fit is refused**, with its size and the context's, in
  place of a fluent answer to nothing.

An oversized `--tokens` is now inert: the trimmer drops what it may, stops, and
the reply gets whatever is left.

## The arithmetic lands exactly

`generate` breaks when `ids.size()` exceeds the context, checked at the top of
each step. With `max_new = context - prompt` the loop exhausts `max_new` at the
step where the sequence is one short of full, so the guard never fires and
nothing overruns. Measured rather than argued: two turns below ended at exactly
`2048/2048` and terminated cleanly.

## Why the note is part of the fix

`ch.encode(turns, tok).size()` was already computed and thrown away. Showing it
makes visible the thing this application had no way to say: **the model's own
replies are history**. They are re-sent every turn exactly as questions are, so
a long answer is a permanent cost rather than a one-off.

That invisibility is why #169 presented as it did. A deleted question produces
a confident answer to something else and no hint that anything was dropped --
it reads as the model being bad at the question. The same held for the trimmer
working normally: it discarded turns and said nothing.

## Measured

Through a pty harness against TinyLlama-1.1B-chat, 2048-token context:

- `--tokens 64`, room available: reply runs past 64. No cap.
- `--tokens 16384`: answers the question. Previously nonsense.
- ~1,800-token question: refused with its size, and does not answer anyway.
- Five turns at `--tokens 300`: still answering, history trimmed to keep the
  reservation free, two turns ending at exactly `2048/2048`.

macOS `make check`: 71 pass, 4 skip, 0 fail.
Container (Ubuntu 24.04, gcc): 71 pass, 3 skip, 0 fail.

## What this does not settle

A guarded harness tripped at 3.25 GB during an early five-turn run, and the
systematic measurement afterwards did not reproduce it -- peak resident size
*fell* from 1.63 GB to 0.11 GB as the prompt grew from 28 to 1,581 tokens.
The cause of the decline is that the model is memory-mapped, so its weights are
clean pages the kernel reclaims: RSS measures how much of the model is still
paged in, not what the process is using. Recorded on #171, along with the
correction it forces to the earlier RSS-vs-footprint check there, which held
only early in a process's life.
