### PR TITLE
generate() takes a set of stop ids rather than one, and the Metal fallback stops swallowing every error inside a run

### DIFF
--- a/jlib/ai/generate.hh
+++ b/jlib/ai/generate.hh
@@ -23,6 +23,9 @@
 
 #include <jlib/ai/model.hh>
 #include <jlib/ai/sampler.hh>
+#include <jlib/ai/tokenizer.hh>
+
+#include <cstdlib>
 
 #include <functional>
 #include <vector>
@@ -102,6 +105,8 @@ std::vector<float> last_logits(const math::matrix<T>& logits) {
  * because it shrinks a nine percent slice of the cost rather than the ninety
  * percent one. It does buy 4.5x on load and 1.5x on memory.
  *
+ * @param ends the ids that end the reply; see stops.  Converts from an int,
+ *             so passing `tok.eos()` is the single id the file names.
  * @param on_token called with each new token as it is produced, for a caller
  *                 that wants to stream rather than wait.  **Return false to
  *                 stop**, which ends the generation after that token rather
@@ -116,12 +121,109 @@ std::vector<float> last_logits(const math::matrix<T>& logits) {
  *                 honest consequence of there being nothing to ask.
  * @return the prompt followed by everything generated
  */
+/**
+ * The ids that end a reply.
+ *
+ * A parameter of type `int` is a claim that there is one of them, and there
+ * is not: Qwen 2.5 names `[151645, 151643]` and Llama 3.2 names
+ * `[128001, 128008, 128009]`.  A GGUF cannot say so -- `tokenizer.ggml.
+ * eos_token_id` is a scalar -- so the file names one and the rest live in the
+ * vendor's generation_config.json, which is not in the file.
+ *
+ * **jlib therefore knows one and this type does not pretend otherwise.**  It
+ * exists so that a caller who knows more can say so, and so that the signature
+ * stops making a claim the format cannot support.  Guessing the others from
+ * the vocabulary was considered and rejected: a control token is not the same
+ * thing as an ending, and stopping on one a template legitimately writes
+ * would truncate a reply mid-turn.
+ *
+ * Converts from an int, so every existing call site reads the same and passes
+ * the one id it has.  A negative id is *no* id rather than a stop that can
+ * never match, which is what tokenizer::eos() returns for a file without one.
+ */
+class stops {
+public:
+    stops() {}
+
+    /** Implicit, so `generate(..., tok.eos())` still says what it did. */
+    stops(int id) { add(id); }
+
+    stops(std::initializer_list<int> ids) {
+        for(int id : ids) add(id);
+    }
+
+    explicit stops(const std::vector<int>& ids) {
+        for(int id : ids) add(id);
+    }
+
+    /** Ignores a negative id, and a repeat. */
+    void add(int id) {
+        if(id < 0 || contains(id)) return;
+
+        m_ids.push_back(id);
+    }
+
+    bool contains(int id) const {
+        for(std::size_t i = 0; i < m_ids.size(); i++)
+            if(m_ids[i] == id) return true;
+
+        return false;
+    }
+
+    bool empty() const { return m_ids.empty(); }
+    std::size_t size() const { return m_ids.size(); }
+
+    const std::vector<int>& ids() const { return m_ids; }
+
+private:
+    // A vector rather than a set: there are one or three of these and the
+    // lookup happens once per token, so a linear scan over three ints beats a
+    // tree, and the order stays the order a caller gave.
+    std::vector<int> m_ids;
+};
+
+/**
+ * A stop named on a command line, as an id.
+ *
+ * Takes the token's own text or a number -- `<|endoftext|>` or `151643` --
+ * because a user knows a model's markers by name and not by number, and
+ * looking one up is what the vocabulary is for.
+ *
+ * **The name wins.**  A spelling can be both: `5` is a token in every
+ * byte-level vocabulary *and* a valid id, and `--stop 5` reads as the digit
+ * rather than as whatever token happens to sit at index 5.  That is the
+ * reading a person means, and the other one is available by id for a token
+ * whose text is a number -- which is why the fallback is the number rather
+ * than the name.
+ *
+ * @throws tokenizer::exception if it is neither, which is better than
+ *         silently adding a stop that can never fire.
+ */
+inline int stop_id(const tokenizer& t, const std::string& spec) {
+    const int named = t.id_of(spec);
+
+    if(named >= 0) return named;
+
+    if(!spec.empty() &&
+       spec.find_first_not_of("0123456789") == std::string::npos) {
+        const int id = std::atoi(spec.c_str());
+
+        if(id >= 0 && std::size_t(id) < t.size()) return id;
+
+        throw tokenizer::exception("stop " + spec + " is outside a vocabulary "
+                                   "of " + std::to_string(t.size()));
+    }
+
+    throw tokenizer::exception("no token in this vocabulary is called \"" +
+                               spec + "\", and it is not an id");
+}
+
 template<typename T>
 std::vector<int> generate(model<T>& m, backend<T>& b,
                           const std::vector<int>& prompt,
                           unsigned int max_new,
                           sampler& s,
-                          int eos = -1,
+                          const stops& ends = stops(),
                           std::function<bool(int)> on_token = nullptr)
 {
     if(prompt.empty())
@@ -169,7 +271,7 @@ std::vector<int> generate(model<T>& m, backend<T>& b,
 
         if(on_token && !on_token(next)) break;
 
-        if(eos >= 0 && next == eos) break;
+        if(ends.contains(next)) break;
     }
 
     return ids;

--- a/jlib/apps/jalpaca.cc
+++ b/jlib/apps/jalpaca.cc
@@ -544,6 +544,9 @@ struct options {
     unsigned int tokens = 512;
 
     ai::sampler::config sampling;
+
+    /** Extra ids or token names that end a reply, from --stop. */
+    std::vector<std::string> stop;
 };
 
 bool parse(int argc, char** argv, options& o) {
@@ -571,6 +574,8 @@ bool parse(int argc, char** argv, options& o) {
                       << "  --temp F        0 is greedy (default 0.8)\n"
                       << "  --top-k N       (default 40)\n"
                       << "  --top-p F       (default 0.95)\n"
+                      << "  --stop TOKEN    also end a reply on this, by\n"
+                      << "                  name or id; repeatable\n"
                       << "  --repeat F      discourage a token already\n"
                       << "                  seen; 1 is off (default 1)\n"
                       << "  --seed N\n";
@@ -591,6 +596,7 @@ bool parse(int argc, char** argv, options& o) {
             else if(a == "--temp") o.sampling.temperature = float(std::atof(v.c_str()));
             else if(a == "--top-k") o.sampling.top_k = unsigned(std::atoi(v.c_str()));
             else if(a == "--top-p") o.sampling.top_p = float(std::atof(v.c_str()));
+            else if(a == "--stop") o.stop.push_back(v);
             else if(a == "--repeat") o.sampling.repetition_penalty = float(std::atof(v.c_str()));
             else if(a == "--seed") o.sampling.seed = std::uint64_t(std::atoll(v.c_str()));
             else {
@@ -617,6 +623,12 @@ template<typename T>
 int converse(ai::backend<T>& b, const ai::gguf& g, const options& o) {
     const ai::tokenizer tok(g);
     const ai::chat ch(g, tok.token(tok.eos()));
+
+    // Resolved before the screen is built, so a mistyped --stop is a message
+    // on a terminal rather than one painted into a curses window and lost.
+    ai::stops ends(tok.eos());
+
+    for(const std::string& spec : o.stop) ends.add(ai::stop_id(tok, spec));
 
     typename ai::model<T>::config c = ai::model<T>::config::from(g);
 
@@ -739,7 +751,7 @@ int converse(ai::backend<T>& b, const ai::gguf& g, const options& o) {
         }
 
         const std::vector<int> out = ai::generate<T>(
-            m, b, ids, budget, sampler, tok.eos(),
+            m, b, ids, budget, sampler, ends,
             [&](int id) {
                 std::string p = tok.piece(id);
 
@@ -825,14 +837,19 @@ int main(int argc, char** argv) {
         const ai::gguf g(o.model);
 
 #ifdef HAVE_METAL
-        try {
-            jlib::metal::backend<_Float16> b;
+        // Constructing the backend only.  Wrapping the whole conversation in
+        // this reported every failure inside it as "no Metal backend" and
+        // then started again on the CPU -- and in a curses app that means
+        // tearing the screen down and rebuilding it to report something that
+        // was never about the GPU.
+        std::shared_ptr<jlib::metal::backend<_Float16> > gpu;
 
-            return converse<_Float16>(b, g, o);
-        }
+        try { gpu.reset(new jlib::metal::backend<_Float16>); }
         catch(std::exception& e) {
             std::cerr << "jalpaca: no Metal backend (" << e.what() << ")\n";
         }
+
+        if(gpu) return converse<_Float16>(*gpu, g, o);
 #endif
 
         std::cerr << "jalpaca: running on the CPU in float -- this will be very "

--- a/jlib/apps/jchat.cc
+++ b/jlib/apps/jchat.cc
@@ -99,6 +99,15 @@ struct options {
 
     /** Continue the text rather than laying it out as a conversation. */
     bool raw = false;
+
+    /**
+     * Extra ids or token names that end a reply, from --stop.
+     *
+     * The file names one and a model may have several; see ai::stops.  Held
+     * as text because the vocabulary is not open yet when the arguments are
+     * read.
+     */
+    std::vector<std::string> stop;
 };
 
 void usage(std::ostream& o, const char* argv0) {
@@ -112,6 +121,9 @@ void usage(std::ostream& o, const char* argv0) {
       << "  --temp F        0 is greedy and repeatable (default 0.8)\n"
       << "  --top-k N       keep the N likeliest, 0 for all (default 40)\n"
       << "  --top-p F       keep the likeliest summing to F (default 0.95)\n"
+      << "  --stop TOKEN    also end a reply on this, by name or id;\n"
+      << "                  repeatable. The file names one and a model\n"
+      << "                  may have several\n"
       << "  --repeat F      discourage a token already seen; 1 is\n"
       << "                  off (default 1). Qwen 2.5 asks for 1.1,\n"
       << "                  Llama 3.2 for none\n"
@@ -143,6 +155,7 @@ bool parse(int argc, char** argv, options& o) {
             else if(a == "--temp") o.sampling.temperature = float(std::atof(v.c_str()));
             else if(a == "--top-k") o.sampling.top_k = unsigned(std::atoi(v.c_str()));
             else if(a == "--top-p") o.sampling.top_p = float(std::atof(v.c_str()));
+            else if(a == "--stop") o.stop.push_back(v);
             else if(a == "--repeat")
                 o.sampling.repetition_penalty = float(std::atof(v.c_str()));
             else if(a == "--seed") o.sampling.seed = std::uint64_t(std::atoll(v.c_str()));
@@ -204,8 +217,13 @@ reply answer(ai::model<T>& m, ai::backend<T>& b, const ai::tokenizer& tok,
 
     const double start = now();
 
+    // What the file said, plus whatever the caller knew that it could not.
+    ai::stops ends(tok.eos());
+
+    for(const std::string& spec : o.stop) ends.add(ai::stop_id(tok, spec));
+
     const std::vector<int> out = ai::generate<T>(
-        m, b, ids, o.tokens, s, tok.eos(),
+        m, b, ids, o.tokens, s, ends,
         [&](int id) {
             std::string p = tok.piece(id);
 
@@ -396,14 +414,19 @@ int main(int argc, char** argv) {
 #ifdef HAVE_METAL
         // fp16 on the GPU, which halves the weights and is what MPS is built
         // for -- and whose GEMM accumulates wider than it stores.
-        try {
-            jlib::metal::backend<_Float16> b;
+        //
+        // The fallback covers *constructing* the backend and nothing else.
+        // Wrapping the whole run in it reported every failure inside as "no
+        // Metal backend" -- a mistyped --stop said the GPU was missing, then
+        // reloaded the model on the CPU, produced nothing and exited 0.
+        std::shared_ptr<jlib::metal::backend<_Float16> > gpu;
 
-            return run<_Float16>(b, g, o);
-        }
+        try { gpu.reset(new jlib::metal::backend<_Float16>); }
         catch(std::exception& e) {
             std::cerr << "jchat: no Metal backend (" << e.what() << ")\n";
         }
+
+        if(gpu) return run<_Float16>(*gpu, g, o);
 #endif
 
         // float, not fp16: the host GEMM accumulates in the element type, and

--- a/tests/ai_model_test.cc
+++ b/tests/ai_model_test.cc
@@ -419,6 +419,120 @@ static void it_answers_a_question(const char* name, ai::backend<T>& b,
  * interrupt reaches the generation through, and a signal is not something the
  * piped tests can send.
  */
+/**
+ * A reply ends on any of several tokens, not on one.
+ *
+ * No model file: an untrained model at temperature zero produces a
+ * deterministic stream, so the test runs it once to find out what it says and
+ * then asks for one of those tokens to end it.  That is stronger than
+ * asserting against a token chosen in advance, which would be asserting
+ * against this test's own arithmetic.
+ */
+static void a_reply_ends_on_any_of_several_tokens() {
+    std::cout << "\na reply ends on any of several tokens:\n";
+
+    // The type first, which has no model in it at all.
+    ok("  a default stops is empty and matches nothing",
+       ai::stops().empty() && !ai::stops().contains(0));
+
+    ok("  it converts from an int, which is how every call site reads",
+       ai::stops(7).contains(7) && ai::stops(7).size() == 1);
+
+    // -1 is what tokenizer::eos() returns for a file without one, and it must
+    // be no stop rather than a stop that can never match.
+    ok("  a negative id is no id", ai::stops(-1).empty());
+
+    ai::stops several{ 3, 5, 3, -1 };
+
+    ok("  and a list keeps each id once, dropping the negative",
+       several.size() == 2 && several.contains(3) && several.contains(5),
+       std::to_string(several.size()));
+
+    typename ai::model<float>::config c;
+
+    c.d_model = 8;
+    c.heads = 2;
+    c.kv_heads = 1;
+    c.d_ff = 16;
+    c.layers = 1;
+    c.vocab = 32;
+    c.context = 64;
+
+    ai::host_backend<float> b;
+    ai::model<float> m(b, c);
+
+    // Sampled with a fixed seed rather than greedy.  Greedy on an untrained
+    // model emits a *constant* argmax, so any token picked out of the stream
+    // occurs at position 0 and a stop can only ever fire immediately -- which
+    // tests the plumbing and not a stop arriving in the middle of a reply.
+    // A seed makes the stream vary and stay reproducible, since the logits
+    // depend only on the ids so far and those agree until the stop.
+    ai::sampler::config sc;
+    sc.temperature = 1.0f;
+    sc.seed = 20260902;
+
+    const std::vector<int> prompt{ 1, 2, 3 };
+
+    ai::sampler s0(sc);
+
+    const std::vector<int> plain = ai::generate<float>(m, b, prompt, 10, s0);
+
+    ok("  the untrained model runs to the limit with no stop",
+       plain.size() == prompt.size() + 10);
+
+    // Whatever it said fourth is what we now ask it to stop on -- and where
+    // generation should end is the *first* time that token appears, which
+    // need not be the fourth position.  Assuming it was is how this assertion
+    // failed the first time it ran.
+    const int fourth = plain[prompt.size() + 3];
+
+    std::size_t first = 0;
+
+    while(plain[prompt.size() + first] != fourth) first++;
+
+    ai::sampler s1(sc);
+
+    const std::vector<int> cut =
+        ai::generate<float>(m, b, prompt, 10, s1, fourth);
+
+    ok("  and stops on the single id it is given",
+       cut.size() == prompt.size() + first + 1 && cut.back() == fourth,
+       std::to_string(cut.size() - prompt.size()) + " tokens, first occurrence "
+       + std::to_string(first));
+
+    // The point of the type: a stop that never occurs must not mask one that
+    // does, and the one that fires need not be the first in the list.
+    // A token the run did not produce, found rather than guessed.
+    int never = -1;
+
+    for(int id = 0; id < 32 && never < 0; id++) {
+        bool seen = false;
+
+        for(std::size_t i = prompt.size(); i < plain.size(); i++)
+            if(plain[i] == id) seen = true;
+
+        if(!seen) never = id;
+    }
+
+    ok("  and there is a token the run never produced", never >= 0,
+       std::to_string(never));
+
+    ai::sampler s2(sc);
+
+    const std::vector<int> both =
+        ai::generate<float>(m, b, prompt, 10, s2,
+                            ai::stops{ never, fourth });
+
+    ok("  and on any member of a set, not merely the first",
+       both.size() == cut.size() && both.back() == fourth,
+       std::to_string(both.size() - prompt.size()));
+
+    // And the stop is kept.  A reply that ends on a marker contains it, the
+    // way it did when this took one int -- callers strip it, and one that
+    // did not would otherwise lose a token silently.
+    ok("  the token that ended it is in the result", both.back() == fourth);
+}
+
 static void generation_stops_when_asked() {
     std::cout << "\ngeneration stops when asked:\n";
 
@@ -641,6 +755,7 @@ int main(int argc, char** argv) {
     // Runs with or without a model, so the generation loop is covered on a
     // machine that has neither the file nor a GPU.
     generation_stops_when_asked();
+    a_reply_ends_on_any_of_several_tokens();
     the_cache_changes_nothing();
     a_qwen_file_reads_with_its_own_conventions();
 
@@ -692,6 +807,14 @@ int main(int argc, char** argv) {
         return 1;
     }
 
+    // That the several-stops path matters for any model here.  Every GGUF on
+    // this machine names exactly one ending token, because
+    // tokenizer.ggml.eos_token_id is a scalar and the rest of a model's list
+    // lives in a generation_config.json the file does not carry -- so the set
+    // is exercised against a toy model and a --stop nobody has needed yet.
+    // What it buys is that the signature no longer claims there is one.  See
+    // #178.
+    //
     // What a green run does not establish.
     //
     // That the numbers match llama.cpp, only that the answer is right.  A small

--- a/tests/ai_tokenizer_test.cc
+++ b/tests/ai_tokenizer_test.cc
@@ -20,6 +20,7 @@
 
 #include <jlib/ai/tokenizer.hh>
 #include <jlib/ai/pretokenizer.hh>
+#include <jlib/ai/generate.hh>
 
 #include "llama3_tokens.hh"
 #include "llama3_splits.hh"
@@ -659,6 +660,50 @@ static void an_overlong_form_is_not_the_character_it_spells() {
     }
 }
 
+/**
+ * A stop named on a command line, resolved against the vocabulary.
+ *
+ * The file names one ending token and a model may have several, so a caller
+ * has to be able to say -- and a person says `<|im_end|>`, not 151645.
+ */
+static void a_stop_is_named_or_numbered(const std::string& path) {
+    std::cout << "\na stop is named or numbered:\n";
+
+    const ai::gguf g(path);
+    const ai::tokenizer t(g);
+
+    ok("  by name", ai::stop_id(t, "<|im_end|>") == 151645,
+       std::to_string(ai::stop_id(t, "<|im_end|>")));
+
+    ok("  and by id, for a marker whose name nobody remembers",
+       ai::stop_id(t, "151643") == 151643);
+
+    // The ambiguity, and it is a real one: "5" is a token in this vocabulary
+    // *and* a valid index.  The name wins, because that is what a person
+    // typing --stop 5 means.
+    const int five = t.id_of("5");
+
+    ok("  a spelling that is both a token and an id reads as the token",
+       five >= 0 && five != 5 && ai::stop_id(t, "5") == five,
+       "token \"5\" is id " + std::to_string(five));
+
+    bool threw = false;
+
+    try { ai::stop_id(t, "<|nope|>"); }
+    catch(ai::tokenizer::exception&) { threw = true; }
+
+    ok("  a name in no vocabulary is refused, not ignored", threw);
+
+    threw = false;
+
+    try { ai::stop_id(t, "999999999"); }
+    catch(ai::tokenizer::exception&) { threw = true; }
+
+    // Silently accepting it would add a stop that can never fire, which looks
+    // exactly like the flag not working.
+    ok("  and so is an id past the end of the vocabulary", threw);
+}
+
 /** SentencePiece is untouched by any of it. */
 static void the_sentencepiece_path_is_unchanged(const ai::tokenizer& t) {
     std::cout << "\nthe sentencepiece path is unchanged:\n";
@@ -743,8 +788,10 @@ int main(int argc, char** argv) {
 
         if(qwen.empty())
             std::cout << "\n(no Qwen file; its vocabulary is unchecked)\n";
-        else
+        else {
             the_qwen_vocabulary_matches_its_reference(qwen);
+            a_stop_is_named_or_numbered(qwen);
+        }
 
     }
     catch(std::exception& e) {


### PR DESCRIPTION
# `int eos` was a claim that there is one, and there is not

#178. `generate()` took a single `int eos` and broke on it. Models name
several:

| file | GGUF says | the vendor's generation_config says |
| --- | --- | --- |
| Qwen 2.5 | 151645 | `[151645, 151643]` |
| Llama 3.2 | 128009 | `[128001, 128008, 128009]` |
| TinyLlama | 2 | -- |

`tokenizer.ggml.eos_token_id` is a **scalar**, so a GGUF can only ever name
one. Checked all four files on this machine for an `eot_token_id` or anything
like it: there is none. The rest of a model's list lives in
`generation_config.json`, which is not in the file.

## What this does and does not fix

Both conversions picked a sensible id -- Qwen's `<|im_end|>` and Llama's
`<|eot_id|>` are the chat-turn enders -- so **nothing was broken and nothing
here starts working**. This is an interface change: `int eos` in a signature
asserts something the format cannot support, and now it does not.

`ai::stops` converts implicitly from an int, so **every existing call site
compiles and reads exactly as before** -- which is the whole check that the
conversion is right. A negative id is *no* id rather than a stop that can never
match, which is what `tokenizer::eos()` returns for a file without one.

Guessing the rest from the vocabulary was considered and rejected: a control
token is not an ending, and stopping on one a template legitimately writes
would truncate a reply mid-turn. jlib knows one and says so.

## So it needed a user

A mechanism nothing can reach is a mechanism nobody can be wrong about.
`--stop TOKEN` on both apps, repeatable, taking **either** the token's text or
an id:

```
jchat --stop '<|im_end|>' model.gguf
jchat --stop 151643 model.gguf
```

**The name wins**, and the ambiguity is real rather than theoretical: `5` is a
token in every byte-level vocabulary *and* a valid index, and in Qwen's the
token `"5"` is id **20**. `--stop 5` reads as the digit, because that is what a
person means; an id is still available for a token whose text is a number,
which is why the fallback runs that way round and not the other.

Neither an unknown name nor an out-of-range id is ignored. Silently accepting
one adds a stop that can never fire, which looks exactly like the flag not
working.

## The bug this uncovered, which is the more serious half

The first bad `--stop` produced this:

```
$ jchat --stop '<|nope|>' qwen2.5-0.5b-instruct-q8_0.gguf
jchat: no Metal backend (jlib::ai::tokenizer::exception: no token ... )
jchat: running on the CPU in float -- this will be very slow and will want 4GB
[host, 24 layers, 896 wide, 14 heads over 2]
>
$ echo $?
0
```

A typo said the GPU was missing, reloaded 500M parameters on the CPU, produced
nothing, and **exited 0**.

Both apps wrapped the *entire run* in the try that falls back from Metal, so
every failure inside became "no Metal backend". The fallback now covers
constructing the backend and nothing else -- the shape `ai_model_test` already
used. A bad `--stop` is now a message and exit 1, before the model is loaded.

This is a class of bug rather than an instance: any error inside a run was
being reported as the wrong thing and then retried on hardware that could not
fix it. In jalpaca it is worse, because reporting it means tearing down a
curses screen and rebuilding it to say something that was never about the GPU.

## Tested

`ai::stops` itself needs no model: empty by default, converts from an int,
drops a negative, keeps each id once.

The generate path uses an untrained model, and **the first version of that
assertion was wrong**. Greedy on an untrained model emits a *constant* argmax,
so any token picked out of the stream occurs at position 0 and a stop can only
ever fire immediately -- the test passed while exercising nothing. It now
samples with a fixed seed, so the stream varies and the stop lands at position
3, in the middle of a reply. The token that must *not* fire is found by
searching the run rather than guessed.

`stop_id` is checked against Qwen's real vocabulary: by name, by id, the
`"5"`-is-id-20 ambiguity, and both refusals.

## Measured

macOS `make check`: 72 pass, 4 skip, 0 fail.
Container (Ubuntu 24.04, gcc 13): 72 pass, 3 skip, 0 fail.

Every prior call site unchanged. `jchat` and `jalpaca` answer as before, and a
bad `--stop` exits 1 with the reason.

## What a green run does not establish

**That the several-stops path matters for any model here.** Every GGUF on this
machine names exactly one ending token, so the set is exercised against a toy
model and a flag nobody has needed. What it buys is that the signature stops
lying.

**That the narrowed fallback is complete.** It fixes the two apps. Anywhere
else that catches broadly around a run has the same shape and was not audited.

The failure that would make this urgent is written down in #178: a conversion
naming the *wrong* one of a model's stop tokens, where replies would never
terminate and the symptom would look exactly like the sampling degeneration in
#177 while having nothing to do with sampling.
