### PR TITLE
jalpaca: setlocale before initscr, or curses draws a four-byte emoji as four cells of garbage

### DIFF
--- a/jlib/apps/jalpaca.cc
+++ b/jlib/apps/jalpaca.cc
@@ -63,6 +63,7 @@
 #include <csignal>
 #include <cstdlib>
 #include <cstring>
+#include <clocale>
 #include <iostream>
 #include <memory>
 #include <string>
@@ -129,6 +130,16 @@ public:
     static const int PAD_ROWS = 4000;
 
     screen() {
+        // Before initscr, and not optional: without it ncurses runs in the
+        // C locale and draws each *byte* as its own cell, so a four-byte
+        // emoji comes out as four cells of garbage.  jchat writes to stdout
+        // and never had the problem, which is why it took a model that
+        // answers with emoji to notice.
+        //
+        // "" is the environment's locale rather than a named one, so a user
+        // in a non-UTF-8 locale still gets what they asked for.
+        setlocale(LC_ALL, "");
+
         initscr();
         cbreak();               // keys arrive unbuffered, which Escape needs
         noecho();               // the input window draws the line itself


### PR DESCRIPTION
# jalpaca drew a four-byte emoji as four cells of garbage

Gemma 2 answers with emoji, and jalpaca rendered them like this:

```
Ah, a classic question!  ?~_~X~D
```

One line. `setlocale(LC_ALL, "")` before `initscr`.

Without it ncurses runs in the **C locale**, where a character is a byte, so
the four bytes of U+1F604 are drawn as four separate cells. It is the
documented requirement for multi-byte output and jalpaca never did it.

`jchat` writes to stdout and was never affected, which is why this survived
until a model that answers with emoji arrived. The two front ends look alike
and only one of them goes through curses.

`""` is the environment's locale rather than a named one, so a user in a
non-UTF-8 locale still gets what they asked for.

## Measured, with a control

```
without   hi ?~_~N~I there
with      hi 🎉 there
```

The control is the point. The fix is obvious enough to apply without checking,
and applying it without checking would not have established that it was the
cause -- the same reasoning that killed the fp16 hypothesis in #180.

`harness/utf8_test.py`, alongside the other durable jalpaca tests.

## What the test does not do, deliberately

**It runs no inference.** The first version asked Gemma 2 for an emoji, which
needs a 2.4 GB model and tripped the harness's 3.0 GB RSS guard -- so I raised
the guard to 6.0, and then put it back.

The question is how curses *renders* a multi-byte character, and the **prompt
line** answers that with no model work at all. Raising a limit to fit a test is
how the limit stops meaning anything, and that one exists because of the
10.26 GB panic in #171. The comment on `KILL_RSS_GB` now records the episode so
the next person is not tempted the same way.

## An assertion that passed while failing

The first cut checked that the raw bytes were not on screen:

```python
ok("and its bytes are not drawn separately", chr(0xF0) not in line)
```

It passed in the **failure** case. pyte decodes the stray bytes into
replacement characters rather than leaving them raw, so `0xF0` is never on the
screen either way and the assertion could not fail.

It now asserts the rendered **width** -- that the line occupies as many cells
as it has characters -- and that no replacement character is present. Those do
fail without the fix.

## What a green run does not establish

**That every multi-byte path in jalpaca is right.** This is one character on
one line. Wide (double-width) characters, combining marks, and a character
split across a scrollback boundary are all untested.

**That streaming a partial character works**, and it does not. Measured on
TinyLlama, U+1F604 encodes to five tokens whose pieces are single bytes:

```
29871[20] 243[f0] 162[9f] 155[98] 135[84]
```

Each reaches the screen as its own `waddstr` of an incomplete UTF-8 sequence,
which the locale cannot fix. Gemma has the emoji as one token, so it renders --
but a byte-fallback vocabulary will still break, and the fix is to hold
incomplete sequences until they complete rather than to change the locale.
That is a separate bug and is not in this change.
