### PR TITLE
Share one attention scratch across the layers: 13.8 GB becomes 627 MB, and a full-context prefill stops dying

### DIFF
--- a/jlib/ai/model.hh
+++ b/jlib/ai/model.hh
@@ -171,6 +171,18 @@ public:
     void reserve(unsigned int seq);
 
     /**
+     * Elements of working memory the layers share, or 0 before reserve().
+     *
+     * One block's worth however many layers there are, because that is what
+     * is allocated -- see block::scratch and #187.  Quadratic in the sequence
+     * length, which is the number a caller sizing a context needs and could
+     * not previously get.
+     */
+    std::size_t scratch() const {
+        return m_layers.empty() ? 0 : m_layers[0]->scratch_elements();
+    }
+
+    /**
      * ids -> logits, which come back (vocab x positions).
      *
      * One column of logits per input position, not just for the last one. A
@@ -525,8 +537,15 @@ void model<T>::reserve(unsigned int seq) {
     m_x = m_b.make(m_conf.d_model, seq);
     m_y = m_b.make(m_conf.d_model, seq);
 
-    for(std::size_t i = 0; i < m_layers.size(); i++)
-        m_layers[i]->reserve(seq);
+    // One block allocates and the rest share it.  Nothing in that scratch
+    // survives a forward and the layers run in sequence, so a private copy
+    // per block is N times the memory to do one block's work -- 13.8 GB
+    // rather than 627 MB at 2048 positions on TinyLlama.  See #187, which is
+    // the prefill that died of it.
+    m_layers[0]->reserve(seq);
+
+    for(std::size_t i = 1; i < m_layers.size(); i++)
+        m_layers[i]->share_scratch(*m_layers[0]);
 }
 
 template<typename T>

--- a/jlib/ai/transformer.hh
+++ b/jlib/ai/transformer.hh
@@ -253,6 +253,51 @@ public:
     void set_gate_activation(activation a) { m_gate_act = a; }
 
     /**
+     * Use another block's scratch rather than allocating a second copy.
+     *
+     * Safe because the layers run one at a time and nothing in `scratch`
+     * outlives a forward.  See the struct for what that buys and for what is
+     * deliberately not in it.
+     *
+     * Sets the sequence length too, so a later reserve() of the same length
+     * is the no-op it is for the block that allocated.
+     */
+    /**
+     * How many elements the shared scratch holds, or 0 before reserve().
+     *
+     * Exposed because sizing a context is a decision a caller has to make and
+     * could not previously inform: the cost is quadratic in the sequence
+     * (see the scratch struct) and nothing said so until it failed.
+     *
+     * Counts the scratch once however many blocks share it, which is the
+     * point -- ask the model rather than a block, and see model::scratch().
+     */
+    std::size_t scratch_elements() const {
+        if(!m_s) return 0;
+
+        std::size_t n = 0;
+
+        const tensor_ptr* all[] = { &m_s->norm, &m_s->qs, &m_s->ks, &m_s->vs,
+                                    &m_s->heads_out, &m_s->scores, &m_s->probs,
+                                    &m_s->attn, &m_s->h1, &m_s->h3, &m_s->ffn };
+
+        for(const tensor_ptr* t : all)
+            if(*t) n += std::size_t((*t)->rows()) * (*t)->cols();
+
+        return n;
+    }
+
+    /** Whether this block's scratch is the same object as another's. */
+    bool shares_scratch_with(const block& other) const {
+        return m_s && m_s == other.m_s;
+    }
+
+    void share_scratch(const block& from) {
+        m_s = from.m_s;
+        m_seq = from.m_seq;
+    }
+
+    /**
      * Cap the attention logits at `cap` before the mask; 0 is no cap.
      *
      * Before the mask and not after: the mask writes -infinity, and capping
@@ -354,6 +399,37 @@ private:
     /** Made on first use, so a file without biases allocates nothing. */
     tensor_ptr& want(tensor_ptr& t, unsigned int rows);
 
+    /**
+     * What one forward pass needs and nothing keeps.
+     *
+     * Every tensor here is dead between calls: it holds one layer's working
+     * values for the length of one forward and is overwritten by the next
+     * layer.  The layers run one at a time, so a private copy per block is
+     * N times the memory for one block's worth of use.
+     *
+     * On TinyLlama at 2048 positions that is **13.8 GB against 627 MB**, and
+     * 86% of it is `scores` and `probs`, which grow as seq^2 where everything
+     * else grows as seq.  A prefill at the model's own advertised context died
+     * with kIOGPUCommandBufferCallbackErrorOutOfMemory before this existed --
+     * see #187.
+     *
+     * A struct behind one shared_ptr rather than eleven shared tensors,
+     * because grow_cache() *replaces* scores and probs when the cache moves,
+     * and a replacement has to be visible to every block rather than to the
+     * one that made it.
+     *
+     * The key-value cache is deliberately **not** here: m_kc and m_vc are a
+     * layer's own keys and values and must survive between forwards, which is
+     * the property everything in this struct lacks.
+     */
+    struct scratch {
+        tensor_ptr norm, qs, ks, vs, heads_out;
+        tensor_ptr scores, probs;
+        tensor_ptr attn, h1, h3, ffn;
+    };
+
+    std::shared_ptr<scratch> m_s;
+
     tensor_ptr m_bq, m_bk, m_bv;
 
     /** Gemma's post-sublayer norms; null unless the file carried them. */
@@ -365,10 +441,6 @@ private:
     quantised_ptr m_gate_q, m_up_q, m_down_q;
     tensor_ptr m_attn_norm, m_ffn_norm;
 
-    tensor_ptr m_norm, m_scores, m_probs, m_attn;
-
-    /** Every head side by side: q is d_model tall, k and v narrower. */
-    tensor_ptr m_qs, m_ks, m_vs, m_heads_out;
 
     /** ((kv_heads * d_head) x capacity), one tensor rather than one per head. */
     tensor_ptr m_kc, m_vc;
@@ -377,7 +449,6 @@ private:
     unsigned int m_capacity = 0;
 
     void grow_cache(unsigned int need);
-    tensor_ptr m_h1, m_h3, m_ffn;
 };
 
 template<typename T>
@@ -490,9 +561,16 @@ void block<T>::grow_cache(unsigned int need) {
 
     m_capacity = want;
 
-    // The scores are as tall as the cache, so they move with it.
-    m_scores = m_b.make(m_capacity, m_seq * m_heads);
-    m_probs = m_b.make(m_capacity, m_seq * m_heads);
+    // The scores are as tall as the cache, so they move with it -- and the
+    // scratch is shared, so the block that grows first remakes them for
+    // everyone.  The others arrive to find the shape already right, which is
+    // what this guard is: without it each of N blocks would remake the same
+    // pair and throw away N-1 of them.
+    if(!m_s->scores || m_s->scores->rows() != m_capacity ||
+       m_s->scores->cols() != m_seq * m_heads) {
+        m_s->scores = m_b.make(m_capacity, m_seq * m_heads);
+        m_s->probs = m_b.make(m_capacity, m_seq * m_heads);
+    }
 }
 
 template<typename T>
@@ -510,23 +588,25 @@ void block<T>::reserve(unsigned int seq) {
 
     m_seq = seq;
 
-    m_norm       = m_b.make(m_d_model, seq);
-    m_qs         = m_b.make(m_heads * m_d_head, seq);
-    m_ks         = m_b.make(m_kv_heads * m_d_head, seq);
-    m_vs         = m_b.make(m_kv_heads * m_d_head, seq);
-    m_heads_out  = m_b.make(m_heads * m_d_head, seq);
+    if(!m_s) m_s.reset(new scratch);
+
+    m_s->norm       = m_b.make(m_d_model, seq);
+    m_s->qs         = m_b.make(m_heads * m_d_head, seq);
+    m_s->ks         = m_b.make(m_kv_heads * m_d_head, seq);
+    m_s->vs         = m_b.make(m_kv_heads * m_d_head, seq);
+    m_s->heads_out  = m_b.make(m_heads * m_d_head, seq);
 
     // As tall as the cache when there is one, and as wide as every head's
     // queries side by side.  grow_cache() remakes these when the capacity
     // changes.
-    m_scores = m_b.make(m_capacity ? m_capacity : seq, seq * m_heads);
+    m_s->scores = m_b.make(m_capacity ? m_capacity : seq, seq * m_heads);
 
 
-    m_probs  = m_b.make(m_capacity ? m_capacity : seq, seq * m_heads);
-    m_attn   = m_b.make(m_d_model, seq);
-    m_h1     = m_b.make(m_d_ff, seq);
-    m_h3     = m_b.make(m_d_ff, seq);
-    m_ffn    = m_b.make(m_d_model, seq);
+    m_s->probs  = m_b.make(m_capacity ? m_capacity : seq, seq * m_heads);
+    m_s->attn   = m_b.make(m_d_model, seq);
+    m_s->h1     = m_b.make(m_d_ff, seq);
+    m_s->h3     = m_b.make(m_d_ff, seq);
+    m_s->ffn    = m_b.make(m_d_model, seq);
 }
 
 template<typename T>
@@ -544,7 +624,7 @@ void block<T>::forward(const tensor_ptr& x, tensor_ptr& out, bool causal,
 
     // --- attention, around a residual ---
 
-    m_b.rms_norm(x, m_attn_norm, m_norm, m_eps);
+    m_b.rms_norm(x, m_attn_norm, m_s->norm, m_eps);
 
     // Where in the sequence these columns sit.  The cache knows; a caller
     // only knows when there is no cache to disagree with.
@@ -555,42 +635,42 @@ void block<T>::forward(const tensor_ptr& x, tensor_ptr& out, bool causal,
     // One call for every head's queries, and one each for the keys and values.
     // These were thirty-two and four calls; the arithmetic is identical and the
     // asking is not.
-    if(m_wq_q) m_b.multiply_tn(m_wq_q, m_norm, m_qs);
-    else m_b.multiply_tn(m_wq, m_norm, m_qs);
+    if(m_wq_q) m_b.multiply_tn(m_wq_q, m_s->norm, m_s->qs);
+    else m_b.multiply_tn(m_wq, m_s->norm, m_s->qs);
 
-    if(m_wk_q) m_b.multiply_tn(m_wk_q, m_norm, m_ks);
-    else m_b.multiply_tn(m_wk, m_norm, m_ks);
+    if(m_wk_q) m_b.multiply_tn(m_wk_q, m_s->norm, m_s->ks);
+    else m_b.multiply_tn(m_wk, m_s->norm, m_s->ks);
 
-    if(m_wv_q) m_b.multiply_tn(m_wv_q, m_norm, m_vs);
-    else m_b.multiply_tn(m_wv, m_norm, m_vs);
+    if(m_wv_q) m_b.multiply_tn(m_wv_q, m_s->norm, m_s->vs);
+    else m_b.multiply_tn(m_wv, m_s->norm, m_s->vs);
 
     // Before rope, which is where a bias goes: the rotation is applied to the
     // projected vector, and the vector is the multiply plus the bias.  After
     // it would rotate Wx and then add b unrotated, which is a different model.
-    if(m_bq) m_b.add_columns(m_bq, m_qs);
-    if(m_bk) m_b.add_columns(m_bk, m_ks);
-    if(m_bv) m_b.add_columns(m_bv, m_vs);
+    if(m_bq) m_b.add_columns(m_bq, m_s->qs);
+    if(m_bk) m_b.add_columns(m_bk, m_s->ks);
+    if(m_bv) m_b.add_columns(m_bv, m_s->vs);
 
     // Rotated inside each head, never across the boundary between two.  Values
     // are not rotated at all -- see set_rope.
     if(m_rope) {
-        m_b.rope(m_qs, at, m_theta, m_layout, m_d_head);
-        m_b.rope(m_ks, at, m_theta, m_layout, m_d_head);
+        m_b.rope(m_s->qs, at, m_theta, m_layout, m_d_head);
+        m_b.rope(m_s->ks, at, m_theta, m_layout, m_d_head);
     }
 
     // Rotated before they are stored, so a key is rotated once however many
     // times it is later read.
     if(m_context) {
-        m_b.copy_columns(m_ks, m_kc, at);
-        m_b.copy_columns(m_vs, m_vc, at);
+        m_b.copy_columns(m_s->ks, m_kc, at);
+        m_b.copy_columns(m_s->vs, m_vc, at);
     }
 
-    const tensor_ptr& keys = m_context ? m_kc : m_ks;
-    const tensor_ptr& values = m_context ? m_vc : m_vs;
+    const tensor_ptr& keys = m_context ? m_kc : m_s->ks;
+    const tensor_ptr& values = m_context ? m_vc : m_s->vs;
 
     // And the attention itself, four calls for every head rather than four per
     // head.  The scale rides here rather than in a pass of its own.
-    m_b.attention_scores(m_qs, keys, m_scores, m_heads, m_kv_heads, m_d_head,
+    m_b.attention_scores(m_s->qs, keys, m_s->scores, m_heads, m_kv_heads, m_d_head,
                          T(1.0f / std::sqrt(float(m_d_head))));
 
     // The offset is how many keys precede the queries, which is not the same
@@ -600,50 +680,50 @@ void block<T>::forward(const tensor_ptr& x, tensor_ptr& out, bool causal,
     // batch sits. Passing `at` here regardless made base_pos shift the mask,
     // which the uncached rope test caught immediately -- including its control,
     // where base_pos should not have mattered at all.
-    m_b.softcap(m_scores, m_attn_cap);
+    m_b.softcap(m_s->scores, m_attn_cap);
 
-    if(causal) m_b.causal_mask(m_scores, m_context ? at : 0, m_seq);
+    if(causal) m_b.causal_mask(m_s->scores, m_context ? at : 0, m_seq);
 
-    m_b.softmax(m_scores, m_probs);
+    m_b.softmax(m_s->scores, m_s->probs);
 
-    m_b.attention_weighted(values, m_probs, m_heads_out, m_heads, m_kv_heads,
+    m_b.attention_weighted(values, m_s->probs, m_s->heads_out, m_heads, m_kv_heads,
                            m_d_head);
 
     // The heads arrive concatenated, so summing them is one multiply against
     // the whole output projection rather than an accumulation per head.
-    if(m_wo_q) m_b.multiply_tn(m_wo_q, m_heads_out, m_attn);
-    else m_b.multiply_tn(m_wo, m_heads_out, m_attn);
+    if(m_wo_q) m_b.multiply_tn(m_wo_q, m_s->heads_out, m_s->attn);
+    else m_b.multiply_tn(m_wo, m_s->heads_out, m_s->attn);
 
-    // Normalised on the way out, then added.  m_attn is both source and
+    // Normalised on the way out, then added.  m_s->attn is both source and
     // destination, which rms_norm allows -- it reads a whole column before it
     // writes one.
-    if(m_post_attn) m_b.rms_norm(m_attn, m_post_attn, m_attn, m_eps);
+    if(m_post_attn) m_b.rms_norm(m_s->attn, m_post_attn, m_s->attn, m_eps);
 
     m_b.assign(x, out);
-    m_b.add_scaled(T(1), m_attn, out);
+    m_b.add_scaled(T(1), m_s->attn, out);
 
     // --- gated feed-forward, around a second residual ---
 
-    m_b.rms_norm(out, m_ffn_norm, m_norm, m_eps);
+    m_b.rms_norm(out, m_ffn_norm, m_s->norm, m_eps);
 
-    if(m_gate_q) m_b.multiply_tn(m_gate_q, m_norm, m_h1);
-    else m_b.multiply_tn(m_gate, m_norm, m_h1);
+    if(m_gate_q) m_b.multiply_tn(m_gate_q, m_s->norm, m_s->h1);
+    else m_b.multiply_tn(m_gate, m_s->norm, m_s->h1);
 
-    if(m_up_q) m_b.multiply_tn(m_up_q, m_norm, m_h3);
-    else m_b.multiply_tn(m_up, m_norm, m_h3);
+    if(m_up_q) m_b.multiply_tn(m_up_q, m_s->norm, m_s->h3);
+    else m_b.multiply_tn(m_up, m_s->norm, m_s->h3);
 
     // Both in place; see the note on aliasing above.  silu on the gate and not
     // on the up projection, which is the whole of what makes this SwiGLU --
     // and is a convention rather than something the arithmetic forces.
-    m_b.activate(m_gate_act, m_h1, m_h1);
-    m_b.hadamard(m_h1, m_h3, m_h1);
+    m_b.activate(m_gate_act, m_s->h1, m_s->h1);
+    m_b.hadamard(m_s->h1, m_s->h3, m_s->h1);
 
-    if(m_down_q) m_b.multiply_tn(m_down_q, m_h1, m_ffn);
-    else m_b.multiply_tn(m_down, m_h1, m_ffn);
+    if(m_down_q) m_b.multiply_tn(m_down_q, m_s->h1, m_s->ffn);
+    else m_b.multiply_tn(m_down, m_s->h1, m_s->ffn);
 
-    if(m_post_ffn) m_b.rms_norm(m_ffn, m_post_ffn, m_ffn, m_eps);
+    if(m_post_ffn) m_b.rms_norm(m_s->ffn, m_post_ffn, m_s->ffn, m_eps);
 
-    m_b.add_scaled(T(1), m_ffn, out);
+    m_b.add_scaled(T(1), m_s->ffn, out);
 
     // Advanced after everything has read it, since `at` is the position these
     // columns occupy rather than the position after them.

--- a/jlib/metal/gemm.mm
+++ b/jlib/metal/gemm.mm
@@ -169,7 +169,7 @@ void matrix_multiply::operator()(const math::matrix<float>& a,
     [cmd waitUntilCompleted];
 
     if([cmd status] == MTLCommandBufferStatusError)
-        throw exception("the command buffer failed");
+        throw exception(command_buffer_error(cmd));
 
     std::memcpy(pc, [bc contents], csize);
 }

--- a/jlib/metal/impl.hh
+++ b/jlib/metal/impl.hh
@@ -29,6 +29,8 @@
 
 #include <jlib/metal/device.hh>
 
+#include <string>
+
 namespace jlib {
 namespace metal {
 
@@ -36,6 +38,35 @@ struct device::impl {
     id<MTLDevice> gpu = nil;
     id<MTLCommandQueue> queue = nil;
 };
+
+/**
+ * Why a command buffer failed, as a sentence.
+ *
+ * `[cmd status] == Error` says only that something went wrong; `[cmd error]`
+ * says what, and the two callers used to throw the first and discard the
+ * second.  "the command buffer failed" is what an out-of-memory looks like
+ * from the outside, and it looks identical to every other cause.
+ *
+ * Must be called *before* the command buffer is released, which is the reason
+ * this is a function rather than a line at each throw: the caller that gets
+ * it wrong reads a nil error and reports nothing.
+ */
+inline std::string command_buffer_error(id<MTLCommandBuffer> cmd) {
+    NSError* e = [cmd error];
+
+    if(!e) return "the command buffer failed, and Metal gave no reason";
+
+    std::string what = "the command buffer failed: ";
+
+    what += [[e localizedDescription] UTF8String];
+
+    // The code is worth having as well as the text: MTLCommandBufferError
+    // names the limits, and 8 is out-of-memory.
+    what += " (" + std::string([[e domain] UTF8String]) + " "
+         +  std::to_string(long([e code])) + ")";
+
+    return what;
+}
 
 }
 }

--- a/jlib/metal/tensor.mm
+++ b/jlib/metal/tensor.mm
@@ -1485,13 +1485,16 @@ void stream<T>::wait() {
 
     const bool failed = ([m_impl->cmd status] == MTLCommandBufferStatusError);
 
+    // Read before the buffer is let go, or the reason goes with it.
+    const std::string why = failed ? command_buffer_error(m_impl->cmd)
+                                   : std::string();
+
     m_impl->cmd = nil;
     m_impl->pending = 0;
 
     [m_impl->held removeAllObjects];
 
-    if(failed)
-        throw exception("the command buffer failed");
+    if(failed) throw exception(why);
 }
 
 // Objective-C++ cannot be a template header, so the instantiations live here.

--- a/tests/ai_model_test.cc
+++ b/tests/ai_model_test.cc
@@ -599,6 +599,73 @@ static void a_reply_ends_on_any_of_several_tokens() {
     ok("  the token that ended it is in the result", both.back() == fourth);
 }
 
+/**
+ * The layers share one scratch, so working memory does not scale with depth.
+ *
+ * Nothing in a block's scratch outlives a forward and the layers run one at a
+ * time, so a private copy per block is N times the memory to do one block's
+ * work.  On TinyLlama at 2048 positions that was 13.8 GB against 627 MB, and
+ * a prefill at the model's own advertised context died of it -- #187.
+ *
+ * Asserted structurally rather than by measuring the process: a Metal buffer
+ * does not appear in RSS until it is touched and does not appear in
+ * phys_footprint reliably either, which is how the size of this went unnoticed.
+ */
+static void the_layers_share_one_scratch() {
+    std::cout << "\nthe layers share one scratch:\n";
+
+    typename ai::model<float>::config c;
+
+    c.d_model = 64;
+    c.heads = 4;
+    c.kv_heads = 2;
+    c.d_ff = 128;
+    c.vocab = 32;
+    c.context = 256;
+
+    ai::host_backend<float> b;
+
+    const unsigned int seq = 64;
+
+    std::size_t one = 0, many = 0;
+
+    {
+        c.layers = 1;
+
+        ai::model<float> m(b, c);
+
+        m.reserve(seq);
+        one = m.scratch();
+    }
+
+    c.layers = 16;
+
+    ai::model<float> m(b, c);
+
+    m.reserve(seq);
+    many = m.scratch();
+
+    ok("  sixteen layers reserve what one does", one == many && one > 0,
+       std::to_string(one) + " elements either way");
+
+    // And it really is one object, not two of equal size.
+    ok("  because it is the same scratch, not a copy of the same shape",
+       m.layer(0).shares_scratch_with(m.layer(15)));
+
+    ok("  and a layer does not share it with a different model's",
+       !m.layer(0).shares_scratch_with(ai::model<float>(b, c).layer(0)));
+
+    // Quadratic in the sequence, which is the reason it matters and the
+    // number a caller sizing a context needs.
+    ai::model<float> wide(b, c);
+
+    wide.reserve(seq * 2);
+
+    ok("  and doubling the sequence more than doubles it",
+       wide.scratch() > 2 * many,
+       std::to_string(many) + " -> " + std::to_string(wide.scratch()));
+}
+
 static void generation_stops_when_asked() {
     std::cout << "\ngeneration stops when asked:\n";
 
@@ -822,6 +889,7 @@ int main(int argc, char** argv) {
     // machine that has neither the file nor a GPU.
     generation_stops_when_asked();
     a_reply_ends_on_any_of_several_tokens();
+    the_layers_share_one_scratch();
     the_cache_changes_nothing();
     a_qwen_file_reads_with_its_own_conventions();
     a_gemma_file_reads_with_its_own_conventions();


### PR DESCRIPTION
# Twenty-two layers were each allocating the scratch for one

#187. A 2048-token prefill died, and 2048 is TinyLlama's own advertised
context — the largest prompt the file claims to accept could not be run.

```
before   1792 tokens  21.9s, ~7 GB     2048 tokens  fails
after    2048 tokens  17.7s, 1.74 GB
```

## Step one was to ask what actually failed

The error was `the command buffer failed`, which is what an out-of-memory
looks like from the outside and is indistinguishable from every other cause.
Both call sites checked `[cmd status]` and discarded `[cmd error]`.

```
the command buffer failed: Insufficient Memory
  (00000008:kIOGPUCommandBufferCallbackErrorOutOfMemory)
  (MTLCommandBufferErrorDomain 8)
```

So not a buffer limit to raise. Real exhaustion.

In `tensor.mm` the reason has to be read **before** the command buffer is
released, which is why this is a function in `impl.hh` rather than a line at
each throw: the caller who gets that order wrong reads a nil error and reports
nothing.

## What was consuming it

`block::reserve` allocates eleven tensors, and `model::reserve` called it on
every block. Only one block runs at a time.

```
 seq   scores+probs      rest    per block    x22 layers
 256       8.4 MB     11.3 MB      19.7 MB      0.43 GB
1024     134.2 MB     45.1 MB     179.3 MB      3.94 GB
2048     536.9 MB     90.2 MB     627.0 MB     13.80 GB
```

**Twenty-one twenty-seconds of that is idle at any moment.** And 86% of it is
`scores` and `probs`, the two that grow as seq² where everything else grows as
seq — so the waste is worst exactly where it hurts.

One shared scratch: 13.8 GB becomes 627 MB.

## Why it is a shared struct rather than shared pointers

`tensor_ptr` is a `shared_ptr`, so the obvious fix is to hand every block the
same eleven pointers. That breaks on the first cache growth: `grow_cache()`
**replaces** `scores` and `probs` when the cache moves, and a replacement made
by one block would not be seen by the others — they would quietly diverge,
some pointing at a tensor sized for the old capacity.

So it is one `scratch` struct behind one `shared_ptr`, and a replacement is
visible to everyone by construction.

A second consequence needed handling: every block grows on the same schedule,
so without a guard each of N blocks remakes the same pair and throws away
N-1 of them. `grow_cache` now remakes only when the shape actually changed.

The key-value cache is deliberately **not** shared. `m_kc` and `m_vc` are a
layer's own keys and values and must survive between forwards, which is the
property everything in the scratch lacks — and that distinction is what makes
the sharing safe rather than lucky.

## Measuring this is where it hides

Two probes reported **zero**: a Metal buffer appears in neither `resident_size`
nor `phys_footprint` until it is touched. That is not a detail of the
investigation, it is why 13.8 GB went unnoticed — the allocation is invisible
to the two things anyone would check.

So the test asserts the property **structurally**, not by measuring the
process: sixteen layers reserve what one does, it is the same object rather
than two of equal shape, a different model's is not shared, and doubling the
sequence more than doubles it. Those run on the host backend with no model
file, so the container checks them too.

`model::scratch()` is exposed as real API rather than a test hook. Sizing a
context is a decision a caller has to make, the cost is quadratic in the
sequence, and nothing said so until it failed.

## Measured

macOS `make check`: 72 pass, 4 skip, 0 fail.
Container (Ubuntu 24.04, gcc 13): 72 pass, 3 skip, 0 fail.

All four models answer unchanged — TinyLlama, Llama 3.2, Qwen 2.5 and Gemma 2.

## What this does not fix

**Prefill is still slow**: 17.7s for 2048 tokens, about 7 ms per token and
flat, which is #158 — every column re-reads the whole weight matrix because
`k_q8_gemv` has no tiling. This change makes that measurable at full context
rather than fatal; it does not make it fast.

**The scratch is still quadratic.** 627 MB at 2048 is affordable and 2.4 GB at
4096 is less so, and Llama 3.2 advertises 131072. Chunking the queries — a
band of rows at a time against one smaller scratch — is the next bound, and is
now a performance question rather than a crash.

**A note on how this was found.** The measurements that led here ran unguarded
and contributed to exhausting the machine, on a laptop that took a watchdog
panic under memory pressure a day earlier (#171). The pty harness carries an
RSS guard for exactly that reason; the one-off probes used here did not, which
is how a diagnostic became part of the problem it was diagnosing.
