### PR TITLE
Tile the q8 multiply over columns: a weight block is read once and spent eight times, and prefill is 2.5-4x

### DIFF
--- a/jlib/metal/tensor.mm
+++ b/jlib/metal/tensor.mm
@@ -470,6 +470,37 @@ kernel void k_gather(device const T* table [[buffer(0)]],
  * moves 2, and measured against MPS on a 2048-square matrix-vector product it
  * takes 39us to MPS's 68us at about the same bandwidth.
  */
+/**
+ * How many columns of x one thread carries.
+ *
+ * The kernel below reads a weight block once and uses it for this many
+ * columns, so the weight traffic falls by this factor.  Eight because the
+ * accumulators and the unpacked block have to live in registers: at eight it
+ * is 8 floats of accumulator and 32 of block per thread, and going wider
+ * starts spilling and costs more than the traffic it saves.
+ *
+ * One is exactly the old kernel.  Decode passes ncols = 1 and takes the same
+ * path it always did, with the tile loop running once.
+ */
+constant uint Q8_TILE = 8;
+
+/**
+ * y = alpha * (W^T x) + beta * y, with W held as q8_0 and never expanded.
+ *
+ * The dequantisation is inside the multiply -- a weight block is 34 bytes,
+ * one f16 scale and thirty-two signed quants, and it is turned into floats in
+ * registers and used there.  That much is #164's.
+ *
+ * **The tiling is what makes it a GEMM rather than N GEMVs.**  It was one
+ * thread per output element, each streaming a whole weight row from global
+ * memory, so every column of x re-read all 1.1 GB of weights: at 2048 columns
+ * that is 2.2 TB of traffic where 1.1 GB would do, and prefill cost a flat
+ * ~7 ms per token however long the prompt -- the signature of no reuse at all.
+ * See #158.
+ *
+ * Each thread now owns one output row and Q8_TILE columns, so a block is
+ * fetched once and spent eight times.
+ */
 template<typename T>
 kernel void k_q8_gemv(device const uchar* w [[buffer(0)]],
                       device const T* x [[buffer(1)]],
@@ -481,17 +512,23 @@ kernel void k_q8_gemv(device const uchar* w [[buffer(0)]],
                       constant float& beta [[buffer(7)]],
                       uint gid [[thread_position_in_grid]])
 {
-    const uint j = gid % N;
-    const uint c = gid / N;
+    const uint tiles = (ncols + Q8_TILE - 1) / Q8_TILE;
 
-    if(c >= ncols) return;
+    const uint j = gid % N;
+    const uint t = gid / N;
+
+    if(t >= tiles) return;
+
+    const uint c0 = t * Q8_TILE;
+    const uint have = min(Q8_TILE, ncols - c0);
 
     const uint nb = K / 32;
 
     device const uchar* base = w + (ulong)j * nb * 34;
-    device const T* xc = x + (ulong)c * K;
 
-    float sum = 0.0f;
+    float sum[Q8_TILE];
+
+    for(uint i = 0; i < Q8_TILE; i++) sum[i] = 0.0f;
 
     for(uint b = 0; b < nb; b++) {
         device const uchar* p = base + (ulong)b * 34;
@@ -501,20 +538,32 @@ kernel void k_q8_gemv(device const uchar* w [[buffer(0)]],
 
         device const char* q = (device const char*)(p + 2);
 
-        float acc = 0.0f;
+        // Unpacked once, here, and then spent on every column in the tile.
+        // This array is the whole optimisation: without it each column would
+        // go back to global memory for the same thirty-two bytes.
+        float qs[32];
 
-        for(uint i = 0; i < 32; i++)
-            acc += float(q[i]) * float(xc[b * 32 + i]);
+        for(uint i = 0; i < 32; i++) qs[i] = float(q[i]);
 
-        sum += d * acc;
+        for(uint cc = 0; cc < have; cc++) {
+            device const T* xc = x + (ulong)(c0 + cc) * K + b * 32;
+
+            float acc = 0.0f;
+
+            for(uint i = 0; i < 32; i++) acc += qs[i] * float(xc[i]);
+
+            sum[cc] += d * acc;
+        }
     }
 
-    const ulong at = (ulong)c * N + j;
+    for(uint cc = 0; cc < have; cc++) {
+        const ulong at = (ulong)(c0 + cc) * N + j;
 
-    // beta of zero does not read y, which is what BLAS specifies -- and what
-    // the host got wrong until a cache left -infinity in an output.
-    y[at] = T(beta == 0.0f ? alpha * sum
-                           : alpha * sum + beta * float(y[at]));
+        // beta of zero does not read y, which is what BLAS specifies -- and
+        // what the host got wrong until a cache left -infinity in an output.
+        y[at] = T(beta == 0.0f ? alpha * sum[cc]
+                               : alpha * sum[cc] + beta * float(y[at]));
+    }
 }
 
 #define INSTANTIATE(NAME, T, SUFFIX)                                        \
@@ -1276,7 +1325,12 @@ void stream<T>::multiply_tn(const qweight& w, const tensor<T>& x, tensor<T>& y,
     [m_impl->enc setBytes:&alpha length:sizeof(alpha) atIndex:6];
     [m_impl->enc setBytes:&beta length:sizeof(beta) atIndex:7];
 
-    dispatch(m_impl->enc, m_impl->q8_gemv, N * ncols);
+    // One thread per output row per tile of columns, not per element: the
+    // kernel now carries Q8_TILE columns each.  Kept in step with the
+    // constant in the shader by name rather than by number.
+    const unsigned int tiles = (ncols + 8 - 1) / 8;
+
+    dispatch(m_impl->enc, m_impl->q8_gemv, N * tiles);
 
     m_impl->pending++;
 }

--- a/tests/ai_backend_test.cc
+++ b/tests/ai_backend_test.cc
@@ -1188,6 +1188,17 @@ static matrix<T> from_q8_0(const std::vector<char>& raw, uint rows, uint cols) {
 }
 
 /**
+ * The quantised multiply is right at a tile boundary and either side of one.
+ *
+ * The kernel carries Q8_TILE columns per thread (8), so the interesting
+ * counts are the ones that do not divide by it: a partial tile takes a
+ * different path through the tail, and 1 is the decode case where the tile
+ * loop runs once.  #158 tiled this and the shapes below are what a tiling bug
+ * would show up in.
+ */
+static const unsigned int Q8_COLUMN_COUNTS[] = { 1, 5, 7, 8, 9, 16, 17 };
+
+/**
  * A weight kept quantised multiplies like the same weight dequantised.
  *
  * That is the whole contract: the kernel dequantises as it reads, so what
@@ -1216,7 +1227,7 @@ static void a_quantised_weight_multiplies(const char* name,
     const std::vector<char> raw = as_q8_0(w);
     const matrix<T> dequantised = from_q8_0<T>(raw, K, N);
 
-    for(uint ncols : { 1u, 5u }) {
+    for(uint ncols : Q8_COLUMN_COUNTS) {
         const matrix<T> x = random_matrix<T>(K, ncols, gen);
 
         for(ai::backend<T>* b : backends) {


### PR DESCRIPTION
# One thread was reading a whole weight row per output element

#158. Prefill cost a flat ~7 ms per token however long the prompt, which is
the signature of no reuse at all: `k_q8_gemv` gave each thread one output
element and had it stream an entire weight row from global memory, so every
column of x re-read all 1.10 GB of weights.

At 2048 columns that is **2.2 TB of traffic where 1.1 GB would do**.

```
ctx      128     512    1024    2048
before  0.915s  3.572s  7.828s  17.65s
after   0.226s  1.042s  2.532s   6.96s
              4.0x    3.4x    3.1x    2.5x
```

Per token: 7.15 ms -> 1.77 at 128, 7.64 -> 2.47 at 1024. **No longer flat**,
which is the point — what remains growing with length is the quadratic
attention, not the weights.

## The change

Each thread now owns one output row and `Q8_TILE` columns. A weight block —
34 bytes, one f16 scale and thirty-two quants — is fetched once, unpacked into
registers, and spent on every column in the tile.

The dequantisation stays exactly where #164 put it, inside the multiply. What
changes is only how many times each block is fetched to be dequantised.

The dispatch follows: one thread per output row per *tile* of columns rather
than per element.

## Decode does not regress, which was the thing to check

`ncols` is 1 there, so the tile loop runs once and the kernel does what it did.
Measured slightly faster, not slower:

```
at ctx      32       128       512      1024
before  0.0241s   0.0262s   0.0322s   0.0334s
after   0.0229s   0.0244s   0.0307s   0.0319s
```

## The tile width is in a flat region, not at a peak

One 2048-token pass: **4 gives 6.970s, 8 gives 6.960s, 16 gives 7.159s.**

Four and eight are the same and sixteen is worse. So the win saturates once
the weight traffic stops being the bottleneck, and past that the registers —
8 accumulators plus 32 for the unpacked block — cost more than the traffic
they save.

Eight rather than four is for margin on a model with a higher
weight-to-activation ratio, and that is a guess rather than a measurement.
Both numbers are in the comment so the next person does not repeat the sweep.

## Tested at the boundaries the tiling created

`a_quantised_weight_multiplies` ran at 1 and 5 columns. It now runs at
**1, 5, 7, 8, 9, 16, 17** — either side of a tile edge, exactly on one, and
1 for the decode path — against the same oracle it always used, the same
weight dequantised first and multiplied densely.

All four models answer unchanged.

## Measured

macOS `make check`: 72 pass, 4 skip, 0 fail.
Container (Ubuntu 24.04, gcc 13): 72 pass, 3 skip, 0 fail.

The container has no Metal, so it checks that the host path is untouched and
that nothing else moved; the kernel itself is verified on macOS only.

## What a green run does not establish

**That this is the best tiling.** It reuses the weight across columns and does
nothing about x, which every thread in a row-group re-reads. A threadgroup
that cooperated over rows as well would cut that too, and the flatness between
tile 4 and 8 suggests the next bottleneck is already something other than the
weights — probably exactly that.

**That prefill is now fast.** 2048 tokens is 6.96s, about 3.4 ms per token and
rising with length. Better than 8.6 and not good; the remaining growth is the
attention, which is #187's leftover — the scratch is still O(seq^2) and
chunking it is the next bound.

**Nothing about accuracy.** The arithmetic is unchanged: the same quants, the
same scale, the same order of accumulation within a block. The test asserts
agreement with a dense dequantised multiply, which is what it asserted before.
